### PR TITLE
Refactor imports and update test patches to use the new flip_api modu…

### DIFF
--- a/flip-api/src/flip_api/auth/access_manager.py
+++ b/flip-api/src/flip_api/auth/access_manager.py
@@ -17,10 +17,10 @@ from fastapi.security.api_key import APIKeyHeader
 from sqlmodel import Session, select
 
 from flip_api.auth.auth_utils import has_permissions
-from flip.config import get_settings
-from flip.db.models.main_models import Model, Projects, ProjectUserAccess, Queries
-from flip.db.models.user_models import PermissionRef
-from flip.utils.logger import logger
+from flip_api.config import get_settings
+from flip_api.db.models.main_models import Model, Projects, ProjectUserAccess, Queries
+from flip_api.db.models.user_models import PermissionRef
+from flip_api.utils.logger import logger
 
 
 def can_access_project(user_id: UUID, project_id: UUID, db: Session) -> bool:

--- a/flip-api/src/flip_api/auth/auth_utils.py
+++ b/flip-api/src/flip_api/auth/auth_utils.py
@@ -19,7 +19,7 @@ from pydantic import BaseModel
 from sqlmodel import Session, select
 
 from flip_api.db.models.user_models import PermissionRef, Role, RolePermission, UserRole
-from flip.utils.logger import logger
+from flip_api.utils.logger import logger
 
 # OAuth2 scheme for token authentication
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="token")

--- a/flip-api/src/flip_api/auth/dependencies.py
+++ b/flip-api/src/flip_api/auth/dependencies.py
@@ -19,7 +19,7 @@ from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from jwt import PyJWKClient
 
 from flip_api.config import get_settings
-from flip.utils.logger import logger
+from flip_api.utils.logger import logger
 
 security = HTTPBearer()
 AWS_REGION = get_settings().AWS_REGION

--- a/flip-api/src/flip_api/cohort_services/get_cohort_query_results.py
+++ b/flip-api/src/flip_api/cohort_services/get_cohort_query_results.py
@@ -17,11 +17,11 @@ from fastapi import APIRouter, Depends, HTTPException, Path
 from sqlmodel import Session, select
 
 from flip_api.auth.access_manager import can_access_cohort_query
-from flip.auth.dependencies import verify_token
-from flip.db.database import get_session
-from flip.db.models.main_models import QueryStats
-from flip.domain.schemas.cohort import OmopCohortResultsResponse
-from flip.utils.logger import logger
+from flip_api.auth.dependencies import verify_token
+from flip_api.db.database import get_session
+from flip_api.db.models.main_models import QueryStats
+from flip_api.domain.schemas.cohort import OmopCohortResultsResponse
+from flip_api.utils.logger import logger
 
 router = APIRouter(prefix="/cohort", tags=["cohort_services"])
 

--- a/flip-api/src/flip_api/cohort_services/save_cohort_query.py
+++ b/flip-api/src/flip_api/cohort_services/save_cohort_query.py
@@ -16,12 +16,12 @@ from fastapi import APIRouter, Depends, HTTPException, Request, status
 from sqlmodel import Session
 
 from flip_api.auth.dependencies import verify_token
-from flip.db.database import get_session
-from flip.db.models.main_models import Queries
-from flip.domain.schemas.cohort import CohortQueryInput, SubmitCohortQueryInput
-from flip.domain.schemas.status import ProjectStatus
-from flip.utils.logger import logger
-from flip.utils.project_manager import has_project_status
+from flip_api.db.database import get_session
+from flip_api.db.models.main_models import Queries
+from flip_api.domain.schemas.cohort import CohortQueryInput, SubmitCohortQueryInput
+from flip_api.domain.schemas.status import ProjectStatus
+from flip_api.utils.logger import logger
+from flip_api.utils.project_manager import has_project_status
 
 router = APIRouter(prefix="/cohort", tags=["cohort_services"])
 

--- a/flip-api/src/flip_api/cohort_services/submit_cohort_query.py
+++ b/flip-api/src/flip_api/cohort_services/submit_cohort_query.py
@@ -23,16 +23,16 @@ from fastapi import APIRouter, Body, Depends, HTTPException, Request
 from sqlmodel import Session, select
 
 from flip_api.auth.dependencies import verify_token
-from flip.db.database import get_session
-from flip.db.models.main_models import Trust
-from flip.domain.schemas.cohort import (
+from flip_api.db.database import get_session
+from flip_api.db.models.main_models import Trust
+from flip_api.domain.schemas.cohort import (
     SubmitCohortQuery,
     SubmitCohortQueryBody,
     SubmitCohortQueryOutput,
     TrustDetails,
 )
-from flip.utils.encryption import encrypt
-from flip.utils.logger import logger
+from flip_api.utils.encryption import encrypt
+from flip_api.utils.logger import logger
 
 router = APIRouter(prefix="/cohort", tags=["cohort_services"])
 

--- a/flip-api/src/flip_api/db/database.py
+++ b/flip-api/src/flip_api/db/database.py
@@ -16,7 +16,7 @@ from urllib.parse import quote_plus
 from sqlmodel import Session, create_engine
 
 from flip_api.config import get_settings
-from flip.utils.get_secrets import get_secret
+from flip_api.utils.get_secrets import get_secret
 
 # Get database settings
 stt = get_settings()

--- a/flip-api/src/flip_api/db/models/main_models.py
+++ b/flip-api/src/flip_api/db/models/main_models.py
@@ -18,9 +18,9 @@ from sqlalchemy import JSON, Column
 from sqlmodel import Field, Relationship, SQLModel
 
 from flip_api.domain.schemas.actions import ModelAuditAction, ProjectAuditAction
-from flip.domain.schemas.file import FileUploadStatus
-from flip.domain.schemas.images import ImageType
-from flip.domain.schemas.status import (
+from flip_api.domain.schemas.file import FileUploadStatus
+from flip_api.domain.schemas.images import ImageType
+from flip_api.domain.schemas.status import (
     JobStatus,
     ModelStatus,
     NetStatus,

--- a/flip-api/src/flip_api/db/seed/fl_nets.py
+++ b/flip-api/src/flip_api/db/seed/fl_nets.py
@@ -16,9 +16,9 @@ from typing import Dict, List
 from sqlmodel import Session, select
 
 from flip_api.db.database import engine
-from flip.db.models.main_models import FLNets
-from flip.utils.get_secrets import get_secret
-from flip.utils.logger import logger
+from flip_api.db.models.main_models import FLNets
+from flip_api.utils.get_secrets import get_secret
+from flip_api.utils.logger import logger
 
 
 def seed_fl_nets(session: Session) -> List[FLNets]:

--- a/flip-api/src/flip_api/db/seed/fl_scheduler.py
+++ b/flip-api/src/flip_api/db/seed/fl_scheduler.py
@@ -15,9 +15,9 @@ from typing import List
 from sqlmodel import Session, col, select
 
 from flip_api.db.database import engine
-from flip.db.models.main_models import FLNets, FLScheduler
-from flip.domain.schemas.status import NetStatus
-from flip.utils.logger import logger
+from flip_api.db.models.main_models import FLNets, FLScheduler
+from flip_api.domain.schemas.status import NetStatus
+from flip_api.utils.logger import logger
 
 
 def seed_fl_scheduler(session: Session, nets: List[FLNets]) -> List[FLScheduler]:

--- a/flip-api/src/flip_api/db/seed/main_users.py
+++ b/flip-api/src/flip_api/db/seed/main_users.py
@@ -13,12 +13,12 @@
 from sqlmodel import Session, select
 
 from flip_api.config import get_settings
-from flip.db.models.user_models import RoleRef, User, UserRole
-from flip.utils.cognito_helpers import (
+from flip_api.db.models.user_models import RoleRef, User, UserRole
+from flip_api.utils.cognito_helpers import (
     get_user_by_email_or_id,
 )
-from flip.utils.constants import ADMIN_EMAIL, RESEARCHER_EMAIL
-from flip.utils.logger import logger
+from flip_api.utils.constants import ADMIN_EMAIL, RESEARCHER_EMAIL
+from flip_api.utils.logger import logger
 
 
 def ensure_user_and_role(email: str, role_ref: RoleRef, session: Session) -> None:

--- a/flip-api/src/flip_api/db/seed/role_permissions.py
+++ b/flip-api/src/flip_api/db/seed/role_permissions.py
@@ -17,8 +17,8 @@ import psycopg2
 from sqlmodel import Session, delete, select
 
 from flip_api.db.database import engine
-from flip.db.models.user_models import Permission, PermissionRef, Role, RolePermission
-from flip.utils.logger import logger
+from flip_api.db.models.user_models import Permission, PermissionRef, Role, RolePermission
+from flip_api.utils.logger import logger
 
 
 def seed_role_permissions(session: Session) -> None:

--- a/flip-api/src/flip_api/db/seed/seed_essential_data.py
+++ b/flip-api/src/flip_api/db/seed/seed_essential_data.py
@@ -13,16 +13,16 @@
 from sqlmodel import Session, SQLModel
 
 from flip_api.db.database import engine
-from flip.db.seed.banner import seed_banner
-from flip.db.seed.fl_nets import seed_fl_nets
-from flip.db.seed.fl_scheduler import seed_fl_scheduler
-from flip.db.seed.main_users import seed_main_users
-from flip.db.seed.permissions import seed_permissions
-from flip.db.seed.role_permissions import seed_role_permissions
-from flip.db.seed.roles import seed_roles
-from flip.db.seed.site_config import seed_config
-from flip.db.seed.trusts import seed_trusts
-from flip.utils.logger import logger
+from flip_api.db.seed.banner import seed_banner
+from flip_api.db.seed.fl_nets import seed_fl_nets
+from flip_api.db.seed.fl_scheduler import seed_fl_scheduler
+from flip_api.db.seed.main_users import seed_main_users
+from flip_api.db.seed.permissions import seed_permissions
+from flip_api.db.seed.role_permissions import seed_role_permissions
+from flip_api.db.seed.roles import seed_roles
+from flip_api.db.seed.site_config import seed_config
+from flip_api.db.seed.trusts import seed_trusts
+from flip_api.utils.logger import logger
 
 
 def main() -> None:

--- a/flip-api/src/flip_api/db/seed/trusts.py
+++ b/flip-api/src/flip_api/db/seed/trusts.py
@@ -15,8 +15,8 @@ from typing import Dict, List
 from sqlmodel import Session, col, select
 
 from flip_api.db.database import engine
-from flip.db.models.main_models import Trust
-from flip.utils.get_secrets import get_secret
+from flip_api.db.models.main_models import Trust
+from flip_api.utils.get_secrets import get_secret
 
 
 def seed_trusts(session: Session) -> List[Dict[str, str]]:

--- a/flip-api/src/flip_api/domain/interfaces/fl.py
+++ b/flip-api/src/flip_api/domain/interfaces/fl.py
@@ -19,7 +19,7 @@ from uuid import UUID
 from pydantic import BaseModel, Field, field_validator, model_validator
 
 from flip_api.domain.interfaces.shared import TrainingRound
-from flip.domain.schemas.status import NVFlareTargets
+from flip_api.domain.schemas.status import NVFlareTargets
 
 # Path to the JSON file containing job types and required files (relative to this file)
 REQUIRED_JOB_TYPES_FILE = Path(__file__).parent.parent.parent / "assets" / "required_job_types.json"

--- a/flip-api/src/flip_api/domain/interfaces/model.py
+++ b/flip-api/src/flip_api/domain/interfaces/model.py
@@ -18,8 +18,8 @@ from uuid import UUID
 from pydantic import BaseModel, ConfigDict, Field, validator
 
 from flip_api.db.models.main_models import UploadedFiles
-from flip.domain.schemas.actions import ModelAuditAction
-from flip.domain.schemas.status import ModelStatus, TrustIntersectStatus
+from flip_api.domain.schemas.actions import ModelAuditAction
+from flip_api.domain.schemas.status import ModelStatus, TrustIntersectStatus
 
 
 class ModelStatusEdit(str, Enum):

--- a/flip-api/src/flip_api/file_services/delete_file.py
+++ b/flip-api/src/flip_api/file_services/delete_file.py
@@ -16,13 +16,13 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from sqlmodel import Session, select
 
 from flip_api.auth.access_manager import can_access_model
-from flip.auth.dependencies import verify_token
-from flip.config import get_settings
-from flip.db.database import get_session
-from flip.db.models.main_models import UploadedFiles
-from flip.domain.schemas.file import ModelFileDelete
-from flip.utils.logger import logger
-from flip.utils.s3_client import S3Client
+from flip_api.auth.dependencies import verify_token
+from flip_api.config import get_settings
+from flip_api.db.database import get_session
+from flip_api.db.models.main_models import UploadedFiles
+from flip_api.domain.schemas.file import ModelFileDelete
+from flip_api.utils.logger import logger
+from flip_api.utils.s3_client import S3Client
 
 router = APIRouter(prefix="/files", tags=["file_services"])
 

--- a/flip-api/src/flip_api/file_services/download_file.py
+++ b/flip-api/src/flip_api/file_services/download_file.py
@@ -18,12 +18,12 @@ from fastapi.responses import StreamingResponse
 from sqlmodel import Session, select
 
 from flip_api.auth.access_manager import can_access_model
-from flip.auth.dependencies import verify_token
-from flip.config import get_settings
-from flip.db.database import get_session
-from flip.db.models.main_models import UploadedFiles
-from flip.utils.logger import logger
-from flip.utils.s3_client import S3Client
+from flip_api.auth.dependencies import verify_token
+from flip_api.config import get_settings
+from flip_api.db.database import get_session
+from flip_api.db.models.main_models import UploadedFiles
+from flip_api.utils.logger import logger
+from flip_api.utils.s3_client import S3Client
 
 router = APIRouter(prefix="/files", tags=["file_services"])
 

--- a/flip-api/src/flip_api/file_services/get_model_files_list.py
+++ b/flip-api/src/flip_api/file_services/get_model_files_list.py
@@ -17,10 +17,10 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from sqlmodel import Session, select
 
 from flip_api.auth.access_manager import can_access_model
-from flip.auth.dependencies import verify_token
-from flip.db.database import get_session
-from flip.db.models.main_models import UploadedFiles
-from flip.utils.logger import logger
+from flip_api.auth.dependencies import verify_token
+from flip_api.db.database import get_session
+from flip_api.db.models.main_models import UploadedFiles
+from flip_api.utils.logger import logger
 
 router = APIRouter(prefix="/files", tags=["file_services"])
 

--- a/flip-api/src/flip_api/file_services/presigned_url_for_upload.py
+++ b/flip-api/src/flip_api/file_services/presigned_url_for_upload.py
@@ -16,12 +16,12 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from sqlmodel import Session, col, select
 
 from flip_api.auth.dependencies import verify_token
-from flip.config import get_settings
-from flip.db.database import get_session
-from flip.db.models.main_models import Model, Projects
-from flip.domain.schemas.file import UploadFileBody
-from flip.utils.logger import logger
-from flip.utils.s3_client import S3Client
+from flip_api.config import get_settings
+from flip_api.db.database import get_session
+from flip_api.db.models.main_models import Model, Projects
+from flip_api.domain.schemas.file import UploadFileBody
+from flip_api.utils.logger import logger
+from flip_api.utils.s3_client import S3Client
 
 router = APIRouter(prefix="/files", tags=["file_services"])
 

--- a/flip-api/src/flip_api/file_services/retrieve_federated_results.py
+++ b/flip-api/src/flip_api/file_services/retrieve_federated_results.py
@@ -19,12 +19,12 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from sqlmodel import Session, col, select
 
 from flip_api.auth.access_manager import can_access_model
-from flip.auth.dependencies import verify_token
-from flip.config import get_settings
-from flip.db.database import get_session
-from flip.db.models.main_models import Model, Projects
-from flip.utils.logger import logger
-from flip.utils.s3_client import S3Client
+from flip_api.auth.dependencies import verify_token
+from flip_api.config import get_settings
+from flip_api.db.database import get_session
+from flip_api.db.models.main_models import Model, Projects
+from flip_api.utils.logger import logger
+from flip_api.utils.s3_client import S3Client
 
 router = APIRouter(prefix="/files", tags=["file_services"])
 

--- a/flip-api/src/flip_api/file_services/retrieve_model_files_list.py
+++ b/flip-api/src/flip_api/file_services/retrieve_model_files_list.py
@@ -16,12 +16,12 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from sqlmodel import Session
 
 from flip_api.auth.access_manager import can_access_model
-from flip.auth.dependencies import verify_token
-from flip.config import get_settings
-from flip.db.database import get_session
-from flip.domain.schemas.file import ModelFiles, ModelFilesList
-from flip.utils.logger import logger
-from flip.utils.s3_client import S3Client
+from flip_api.auth.dependencies import verify_token
+from flip_api.config import get_settings
+from flip_api.db.database import get_session
+from flip_api.domain.schemas.file import ModelFiles, ModelFilesList
+from flip_api.utils.logger import logger
+from flip_api.utils.s3_client import S3Client
 
 router = APIRouter(prefix="/files", tags=["file_services"])
 

--- a/flip-api/src/flip_api/file_services/retrieve_uploaded_file_info.py
+++ b/flip-api/src/flip_api/file_services/retrieve_uploaded_file_info.py
@@ -17,10 +17,10 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from sqlmodel import Session, col, select
 
 from flip_api.auth.dependencies import verify_token
-from flip.db.database import get_session
-from flip.db.models.main_models import UploadedFiles
-from flip.domain.schemas.file import IdList
-from flip.utils.logger import logger
+from flip_api.db.database import get_session
+from flip_api.db.models.main_models import UploadedFiles
+from flip_api.domain.schemas.file import IdList
+from flip_api.utils.logger import logger
 
 router = APIRouter(prefix="/files", tags=["file_services"])
 

--- a/flip-api/src/flip_api/file_services/uploaded_file.py
+++ b/flip-api/src/flip_api/file_services/uploaded_file.py
@@ -16,12 +16,12 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from sqlmodel import Session, select
 
 from flip_api.auth.dependencies import verify_token
-from flip.config import get_settings
-from flip.db.database import get_session
-from flip.db.models.main_models import UploadedFiles
-from flip.domain.schemas.file import FileUploadStatus
-from flip.utils.logger import logger
-from flip.utils.s3_client import S3Client
+from flip_api.config import get_settings
+from flip_api.db.database import get_session
+from flip_api.db.models.main_models import UploadedFiles
+from flip_api.domain.schemas.file import FileUploadStatus
+from flip_api.utils.logger import logger
+from flip_api.utils.s3_client import S3Client
 
 router = APIRouter(prefix="/files", tags=["file_services"])
 

--- a/flip-api/src/flip_api/fl_services/get_net_status.py
+++ b/flip-api/src/flip_api/fl_services/get_net_status.py
@@ -17,12 +17,12 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 from sqlmodel import Session
 
 from flip_api.auth.dependencies import verify_token
-from flip.db.database import get_session
-from flip.domain.interfaces.fl import IClientStatus, INetStatus
-from flip.fl_services.get_status import fetch_client_status
-from flip.fl_services.services.fl_scheduler_service import get_net_by_name
-from flip.trusts_services.services.trust import get_trusts
-from flip.utils.logger import logger
+from flip_api.db.database import get_session
+from flip_api.domain.interfaces.fl import IClientStatus, INetStatus
+from flip_api.fl_services.get_status import fetch_client_status
+from flip_api.fl_services.services.fl_scheduler_service import get_net_by_name
+from flip_api.trusts_services.services.trust import get_trusts
+from flip_api.utils.logger import logger
 
 router = APIRouter(prefix="/fl", tags=["fl_services"])
 

--- a/flip-api/src/flip_api/fl_services/get_status.py
+++ b/flip-api/src/flip_api/fl_services/get_status.py
@@ -17,17 +17,17 @@ from fastapi import APIRouter, Depends, HTTPException, Request, status
 from sqlmodel import Session
 
 from flip_api.auth.dependencies import verify_token
-from flip.db.database import get_session
-from flip.domain.interfaces.fl import (
+from flip_api.db.database import get_session
+from flip_api.domain.interfaces.fl import (
     IClientStatus,
     INetStatus,
     IServerStatus,
 )
-from flip.domain.schemas.status import ServerEngineStatus
-from flip.fl_services.services.fl_scheduler_service import get_nets
-from flip.fl_services.services.fl_service import fetch_client_status, fetch_server_status
-from flip.trusts_services.services.trust import get_trusts
-from flip.utils.logger import logger
+from flip_api.domain.schemas.status import ServerEngineStatus
+from flip_api.fl_services.services.fl_scheduler_service import get_nets
+from flip_api.fl_services.services.fl_service import fetch_client_status, fetch_server_status
+from flip_api.trusts_services.services.trust import get_trusts
+from flip_api.utils.logger import logger
 
 router = APIRouter(prefix="/fl", tags=["fl_services"])
 

--- a/flip-api/src/flip_api/fl_services/initiate_training.py
+++ b/flip-api/src/flip_api/fl_services/initiate_training.py
@@ -16,13 +16,13 @@ from fastapi import APIRouter, Depends, HTTPException, Request, status
 from sqlmodel import Session
 
 from flip_api.auth.access_manager import can_access_model
-from flip.auth.dependencies import verify_token
-from flip.db.database import get_session
-from flip.domain.interfaces.fl import IInitiateTrainingInputPayload
-from flip.domain.schemas.status import ModelStatus
-from flip.fl_services.services.fl_service import add_fl_job
-from flip.model_services.services.model_service import add_log, update_model_status
-from flip.utils.logger import logger
+from flip_api.auth.dependencies import verify_token
+from flip_api.db.database import get_session
+from flip_api.domain.interfaces.fl import IInitiateTrainingInputPayload
+from flip_api.domain.schemas.status import ModelStatus
+from flip_api.fl_services.services.fl_service import add_fl_job
+from flip_api.model_services.services.model_service import add_log, update_model_status
+from flip_api.utils.logger import logger
 
 router = APIRouter(prefix="/fl", tags=["fl_services"])
 

--- a/flip-api/src/flip_api/fl_services/run_jobs.py
+++ b/flip-api/src/flip_api/fl_services/run_jobs.py
@@ -16,13 +16,13 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from sqlmodel import Session
 
 from flip_api.auth.dependencies import verify_token
-from flip.db.database import engine, get_session
-from flip.fl_services.services.fl_scheduler_service import (
+from flip_api.db.database import engine, get_session
+from flip_api.fl_services.services.fl_scheduler_service import (
     check_for_available_net,
     check_for_queued_jobs,
     prepare_and_start_training,
 )
-from flip.utils.logger import logger
+from flip_api.utils.logger import logger
 
 router = APIRouter(prefix="/fl", tags=["fl_services"])
 

--- a/flip-api/src/flip_api/fl_services/services/fl_scheduler_service.py
+++ b/flip-api/src/flip_api/fl_services/services/fl_scheduler_service.py
@@ -25,26 +25,26 @@ from flip_api.db.models.main_models import (
     Model,
     Queries,
 )
-from flip.domain.interfaces.fl import (
+from flip_api.domain.interfaces.fl import (
     IJobResponse,
     INetDetails,
     IRequiredTrainingInformation,
     ISchedulerResponse,
 )
-from flip.domain.schemas.status import (
+from flip_api.domain.schemas.status import (
     JobStatus,
     ModelStatus,
     NetStatus,
 )
-from flip.fl_services.services.fl_service import (
+from flip_api.fl_services.services.fl_service import (
     bundle_application,
     get_bundle_urls,
     start_training,
     validate_client_availability,
 )
-from flip.model_services.services.model_service import add_log, update_model_status, validate_trusts
-from flip.utils.exceptions import DatabaseError, NotFoundError
-from flip.utils.logger import logger
+from flip_api.model_services.services.model_service import add_log, update_model_status, validate_trusts
+from flip_api.utils.exceptions import DatabaseError, NotFoundError
+from flip_api.utils.logger import logger
 
 
 def remove_job(job_id: UUID, session: Session):

--- a/flip-api/src/flip_api/fl_services/services/fl_service.py
+++ b/flip-api/src/flip_api/fl_services/services/fl_service.py
@@ -20,9 +20,9 @@ from fastapi import Request
 from sqlmodel import Session, select
 
 from flip_api.config import get_settings
-from flip.db.database import engine
-from flip.db.models.main_models import FLJob
-from flip.domain.interfaces.fl import (
+from flip_api.db.database import engine
+from flip_api.db.models.main_models import FLJob
+from flip_api.domain.interfaces.fl import (
     AggregationWeights,
     FLAggregators,
     IClientStatus,
@@ -33,14 +33,14 @@ from flip.domain.interfaces.fl import (
     JobRequiredFiles,
     JobTypes,
 )
-from flip.domain.interfaces.shared import TrainingRound
-from flip.domain.schemas.fl import ClientInfoModel
-from flip.domain.schemas.status import ClientStatus, NVFlareTargets
-from flip.model_services.services.model_service import add_log
-from flip.utils.encryption import encrypt
-from flip.utils.http import http_delete, http_get, http_post
-from flip.utils.logger import logger
-from flip.utils.s3_client import S3Client
+from flip_api.domain.interfaces.shared import TrainingRound
+from flip_api.domain.schemas.fl import ClientInfoModel
+from flip_api.domain.schemas.status import ClientStatus, NVFlareTargets
+from flip_api.model_services.services.model_service import add_log
+from flip_api.utils.encryption import encrypt
+from flip_api.utils.http import http_delete, http_get, http_post
+from flip_api.utils.logger import logger
+from flip_api.utils.s3_client import S3Client
 
 
 class UnknownJobTypeError(Exception):
@@ -361,7 +361,7 @@ def start_training(
     Raises:
         ValueError: If the NVFlare job ID is not returned in the response.
     """
-    from flip.fl_services.services import fl_scheduler_service
+    from flip_api.fl_services.services import fl_scheduler_service
 
     required_info = fl_scheduler_service.get_required_training_details(model_id, session)
     encrypted_project_id = encrypt(required_info.project_id)
@@ -705,7 +705,7 @@ def abort_model_training(request: Request, model_id: UUID, session: Session) -> 
     logger.debug(f"Checking if model {model_id} is currently running...")
 
     try:
-        from flip.fl_services.services import fl_scheduler_service
+        from flip_api.fl_services.services import fl_scheduler_service
 
         # Always try to remove the job from queue
         fl_scheduler_service.remove_job_from_queue(model_id, session)
@@ -795,8 +795,8 @@ def keep_fl_api_session_alive() -> None:
     This is useful to prevent the session from going idle or being shut down by the server.
     See https://github.com/NVIDIA/NVFlare/discussions/3526#discussioncomment-13574644
     """
-    from flip.fl_services.get_status import fetch_server_status
-    from flip.fl_services.services import fl_scheduler_service
+    from flip_api.fl_services.get_status import fetch_server_status
+    from flip_api.fl_services.services import fl_scheduler_service
 
     logger.info("🛟 Keeping FL API NVFLARE session alive ...")
 

--- a/flip-api/src/flip_api/fl_services/services/pull_required_files.py
+++ b/flip-api/src/flip_api/fl_services/services/pull_required_files.py
@@ -14,8 +14,8 @@ import json
 import os
 
 from flip_api.config import get_settings
-from flip.utils.logger import logger
-from flip.utils.s3_client import S3Client
+from flip_api.utils.logger import logger
+from flip_api.utils.s3_client import S3Client
 
 
 # TODO Review: This is disruptive for development if the file on the s3 bucket is not in sync with the current codebase.

--- a/flip-api/src/flip_api/fl_services/stop_training.py
+++ b/flip-api/src/flip_api/fl_services/stop_training.py
@@ -16,11 +16,11 @@ from fastapi import APIRouter, Depends, HTTPException, Request, status
 from sqlmodel import Session
 
 from flip_api.auth.access_manager import can_access_model
-from flip.auth.dependencies import verify_token
-from flip.db.database import get_session
-from flip.domain.schemas.status import ModelStatus
-from flip.fl_services.services.fl_service import abort_model_training
-from flip.model_services.services.model_service import update_model_status
+from flip_api.auth.dependencies import verify_token
+from flip_api.db.database import get_session
+from flip_api.domain.schemas.status import ModelStatus
+from flip_api.fl_services.services.fl_service import abort_model_training
+from flip_api.model_services.services.model_service import update_model_status
 
 router = APIRouter(prefix="/fl", tags=["fl_services"])
 

--- a/flip-api/src/flip_api/main.py
+++ b/flip-api/src/flip_api/main.py
@@ -22,7 +22,7 @@ from flip_api.cohort_services import (
     save_cohort_query,
     submit_cohort_query,
 )
-from flip.file_services import (
+from flip_api.file_services import (
     delete_file,
     download_file,
     get_model_files_list,
@@ -32,14 +32,14 @@ from flip.file_services import (
     retrieve_uploaded_file_info,
     uploaded_file,
 )
-from flip.fl_services import (
+from flip_api.fl_services import (
     get_net_status,
     get_status,
     initiate_training,
     run_jobs,
     stop_training,
 )
-from flip.model_services import (
+from flip_api.model_services import (
     delete_model,
     edit_model,
     get_job_types,
@@ -50,13 +50,13 @@ from flip.model_services import (
     save_model,
     update_model_status,
 )
-from flip.private_services import (
+from flip_api.private_services import (
     add_log,
     invoke_model_status_update,
     receive_cohort_results,
     save_training_metrics,
 )
-from flip.project_services import (
+from flip_api.project_services import (
     approve_project,
     create_project,
     delete_project,
@@ -69,21 +69,21 @@ from flip.project_services import (
     stage_project,
     unstage_project,
 )
-from flip.role_services import get_roles
-from flip.scheduler.apscheduler_runner import start_scheduler
-from flip.site_services import details
-from flip.step_functions_services import (
+from flip_api.role_services import get_roles
+from flip_api.scheduler.apscheduler_runner import start_scheduler
+from flip_api.site_services import details
+from flip_api.step_functions_services import (
     approve_project_step_function,
     cohort_query_step_function,
     register_user_step_function,
     retrieve_model_step_function,
 )
-from flip.trusts_services import (
+from flip_api.trusts_services import (
     get_trusts,
     trusts_health_check,
     update_trust_status,
 )
-from flip.user_services import (
+from flip_api.user_services import (
     access_request,
     delete_user,
     get_user,
@@ -203,7 +203,7 @@ def health_check():
 
 def main():
     """Entry point for the application script"""
-    uvicorn.run("flip.main:app", host="0.0.0.0", port=81, reload=True)
+    uvicorn.run("flip_api.main:app", host="0.0.0.0", port=81, reload=True)
 
 
 if __name__ == "__main__":

--- a/flip-api/src/flip_api/model_services/delete_model.py
+++ b/flip-api/src/flip_api/model_services/delete_model.py
@@ -17,11 +17,11 @@ from sqlalchemy.exc import SQLAlchemyError
 from sqlmodel import Session
 
 from flip_api.auth.access_manager import can_access_model
-from flip.auth.dependencies import verify_token
-from flip.db.database import get_session
-from flip.fl_services.services.fl_service import abort_model_training
-from flip.model_services.services.model_service import delete_model, get_model_status
-from flip.utils.logger import logger
+from flip_api.auth.dependencies import verify_token
+from flip_api.db.database import get_session
+from flip_api.fl_services.services.fl_service import abort_model_training
+from flip_api.model_services.services.model_service import delete_model, get_model_status
+from flip_api.utils.logger import logger
 
 router = APIRouter(prefix="/model", tags=["model_services"])
 

--- a/flip-api/src/flip_api/model_services/edit_model.py
+++ b/flip-api/src/flip_api/model_services/edit_model.py
@@ -17,11 +17,11 @@ from sqlalchemy.exc import SQLAlchemyError
 from sqlmodel import Session
 
 from flip_api.auth.access_manager import can_access_model
-from flip.auth.dependencies import verify_token
-from flip.db.database import get_session
-from flip.domain.interfaces.model import IModelDetails, ModelStatusEdit
-from flip.model_services.services.model_service import edit_model, get_model_status
-from flip.utils.logger import logger
+from flip_api.auth.dependencies import verify_token
+from flip_api.db.database import get_session
+from flip_api.domain.interfaces.model import IModelDetails, ModelStatusEdit
+from flip_api.model_services.services.model_service import edit_model, get_model_status
+from flip_api.utils.logger import logger
 
 router = APIRouter(prefix="/model", tags=["model_services"])
 

--- a/flip-api/src/flip_api/model_services/get_job_types.py
+++ b/flip-api/src/flip_api/model_services/get_job_types.py
@@ -17,7 +17,7 @@ from typing import Dict, List
 from fastapi import APIRouter
 
 from flip_api.domain.interfaces.fl import JobRequiredFiles
-from flip.utils.logger import logger
+from flip_api.utils.logger import logger
 
 router = APIRouter(prefix="/model", tags=["model_services"])
 

--- a/flip-api/src/flip_api/model_services/get_metrics.py
+++ b/flip-api/src/flip_api/model_services/get_metrics.py
@@ -18,11 +18,11 @@ from sqlalchemy.exc import SQLAlchemyError
 from sqlmodel import Session
 
 from flip_api.auth.access_manager import can_access_model
-from flip.auth.dependencies import verify_token
-from flip.db.database import get_session
-from flip.domain.interfaces.model import IModelMetrics
-from flip.model_services.services.model_service import get_metrics, get_model_status
-from flip.utils.logger import logger
+from flip_api.auth.dependencies import verify_token
+from flip_api.db.database import get_session
+from flip_api.domain.interfaces.model import IModelMetrics
+from flip_api.model_services.services.model_service import get_metrics, get_model_status
+from flip_api.utils.logger import logger
 
 router = APIRouter(prefix="/model", tags=["model_services"])
 

--- a/flip-api/src/flip_api/model_services/retrieve_logs_for_model.py
+++ b/flip-api/src/flip_api/model_services/retrieve_logs_for_model.py
@@ -18,12 +18,12 @@ from sqlalchemy.exc import SQLAlchemyError
 from sqlmodel import Session, col, select
 
 from flip_api.auth.access_manager import can_access_model
-from flip.auth.dependencies import verify_token
-from flip.db.database import get_session
-from flip.db.models.main_models import FLLogs, Model, Projects
-from flip.domain.interfaces.model import ILog
-from flip.model_services.services.model_service import get_model_status
-from flip.utils.logger import logger
+from flip_api.auth.dependencies import verify_token
+from flip_api.db.database import get_session
+from flip_api.db.models.main_models import FLLogs, Model, Projects
+from flip_api.domain.interfaces.model import ILog
+from flip_api.model_services.services.model_service import get_model_status
+from flip_api.utils.logger import logger
 
 router = APIRouter(prefix="/model", tags=["model_services"])
 

--- a/flip-api/src/flip_api/model_services/retrieve_model.py
+++ b/flip-api/src/flip_api/model_services/retrieve_model.py
@@ -20,12 +20,12 @@ from sqlalchemy.exc import SQLAlchemyError
 from sqlmodel import Session
 
 from flip_api.auth.access_manager import can_access_model
-from flip.auth.dependencies import verify_token
-from flip.db.database import get_session
-from flip.db.models.main_models import UploadedFiles
-from flip.domain.interfaces.model import IModelResponse, IQuery
-from flip.domain.schemas.status import FileUploadStatus, ModelStatus
-from flip.utils.logger import logger
+from flip_api.auth.dependencies import verify_token
+from flip_api.db.database import get_session
+from flip_api.db.models.main_models import UploadedFiles
+from flip_api.domain.interfaces.model import IModelResponse, IQuery
+from flip_api.domain.schemas.status import FileUploadStatus, ModelStatus
+from flip_api.utils.logger import logger
 
 RETRIEVE_MODEL_QUERY_FILE = f"{os.path.dirname(os.path.abspath(__file__))}/retrieve_model_query.sql"
 

--- a/flip-api/src/flip_api/model_services/retrieve_model_status_from_logs.py
+++ b/flip-api/src/flip_api/model_services/retrieve_model_status_from_logs.py
@@ -19,10 +19,10 @@ from sqlalchemy import text
 from sqlmodel import Session
 
 from flip_api.auth.access_manager import can_access_model
-from flip.auth.dependencies import verify_token
-from flip.db.database import get_session
-from flip.model_services.services.model_service import get_model_status
-from flip.utils.logger import logger
+from flip_api.auth.dependencies import verify_token
+from flip_api.db.database import get_session
+from flip_api.model_services.services.model_service import get_model_status
+from flip_api.utils.logger import logger
 
 router = APIRouter(prefix="/model", tags=["model_services"])
 

--- a/flip-api/src/flip_api/model_services/retrieve_trusts_in_model.py
+++ b/flip-api/src/flip_api/model_services/retrieve_trusts_in_model.py
@@ -18,13 +18,13 @@ from sqlalchemy.exc import SQLAlchemyError
 from sqlmodel import Session, select
 
 from flip_api.auth.access_manager import can_access_model
-from flip.auth.dependencies import verify_token
-from flip.db.database import get_session
-from flip.db.models.main_models import ModelTrustIntersect, Trust
-from flip.model_services.services.model_service import get_model_status
-from flip.utils.constants import SERVICE_UNAVAILABLE_MESSAGE
-from flip.utils.logger import logger
-from flip.utils.site_manager import is_deployment_mode_enabled
+from flip_api.auth.dependencies import verify_token
+from flip_api.db.database import get_session
+from flip_api.db.models.main_models import ModelTrustIntersect, Trust
+from flip_api.model_services.services.model_service import get_model_status
+from flip_api.utils.constants import SERVICE_UNAVAILABLE_MESSAGE
+from flip_api.utils.logger import logger
+from flip_api.utils.site_manager import is_deployment_mode_enabled
 
 router = APIRouter(prefix="/model", tags=["model_services"])
 

--- a/flip-api/src/flip_api/model_services/save_model.py
+++ b/flip-api/src/flip_api/model_services/save_model.py
@@ -17,15 +17,15 @@ from sqlalchemy.exc import SQLAlchemyError
 from sqlmodel import Session, select
 
 from flip_api.auth.access_manager import can_access_project
-from flip.auth.dependencies import verify_token
-from flip.db.database import get_session
-from flip.db.models.main_models import Model, ModelTrustIntersect, ProjectTrustIntersect
-from flip.domain.interfaces.model import ISaveModel
-from flip.domain.interfaces.shared import IId
-from flip.domain.schemas.status import ModelStatus, ProjectStatus, TrustIntersectStatus
-from flip.fl_services.services.pull_required_files import pull_required_files_json_to_assets
-from flip.utils.logger import logger
-from flip.utils.project_manager import get_project_by_id
+from flip_api.auth.dependencies import verify_token
+from flip_api.db.database import get_session
+from flip_api.db.models.main_models import Model, ModelTrustIntersect, ProjectTrustIntersect
+from flip_api.domain.interfaces.model import ISaveModel
+from flip_api.domain.interfaces.shared import IId
+from flip_api.domain.schemas.status import ModelStatus, ProjectStatus, TrustIntersectStatus
+from flip_api.fl_services.services.pull_required_files import pull_required_files_json_to_assets
+from flip_api.utils.logger import logger
+from flip_api.utils.project_manager import get_project_by_id
 
 router = APIRouter(prefix="/model", tags=["model_services"])
 

--- a/flip-api/src/flip_api/model_services/services/model_service.py
+++ b/flip-api/src/flip_api/model_services/services/model_service.py
@@ -16,7 +16,7 @@ from uuid import UUID
 from sqlmodel import Session, select
 
 from flip_api.db.models.main_models import FLLogs, FLMetrics, Model, ModelTrustIntersect, Trust
-from flip.domain.interfaces.model import (
+from flip_api.domain.interfaces.model import (
     IDetailedModelStatus,
     IModelAuditAction,
     IModelDetails,
@@ -24,12 +24,12 @@ from flip.domain.interfaces.model import (
     IModelMetricsData,
     IModelMetricsValue,
 )
-from flip.domain.schemas.actions import ModelAuditAction
-from flip.domain.schemas.status import ModelStatus
-from flip.fl_services.services import fl_scheduler_service
-from flip.fl_services.services.pull_required_files import pull_required_files_json_to_assets
-from flip.model_services.utils.audit_helper import audit_model_action, audit_model_actions
-from flip.utils.logger import logger
+from flip_api.domain.schemas.actions import ModelAuditAction
+from flip_api.domain.schemas.status import ModelStatus
+from flip_api.fl_services.services import fl_scheduler_service
+from flip_api.fl_services.services.pull_required_files import pull_required_files_json_to_assets
+from flip_api.model_services.utils.audit_helper import audit_model_action, audit_model_actions
+from flip_api.utils.logger import logger
 
 
 def edit_model(model_id: UUID, model_details: IModelDetails, user_id: UUID, session: Session) -> None:

--- a/flip-api/src/flip_api/model_services/update_model_status.py
+++ b/flip-api/src/flip_api/model_services/update_model_status.py
@@ -18,13 +18,13 @@ from sqlalchemy.exc import SQLAlchemyError
 from sqlmodel import Session
 
 from flip_api.auth.access_manager import can_access_model
-from flip.auth.dependencies import verify_token
-from flip.db.database import get_session
-from flip.domain.schemas.status import ModelStatus
-from flip.model_services.services.model_service import add_log, update_model_status
-from flip.utils.constants import SERVICE_UNAVAILABLE_MESSAGE
-from flip.utils.logger import logger
-from flip.utils.site_manager import is_deployment_mode_enabled
+from flip_api.auth.dependencies import verify_token
+from flip_api.db.database import get_session
+from flip_api.domain.schemas.status import ModelStatus
+from flip_api.model_services.services.model_service import add_log, update_model_status
+from flip_api.utils.constants import SERVICE_UNAVAILABLE_MESSAGE
+from flip_api.utils.logger import logger
+from flip_api.utils.site_manager import is_deployment_mode_enabled
 
 router = APIRouter(prefix="/model", tags=["model_services"])
 

--- a/flip-api/src/flip_api/model_services/utils/audit_helper.py
+++ b/flip-api/src/flip_api/model_services/utils/audit_helper.py
@@ -16,9 +16,9 @@ from uuid import UUID
 from sqlmodel import Session
 
 from flip_api.db.models.main_models import ModelsAudit
-from flip.domain.interfaces.model import IModelAuditAction
-from flip.domain.schemas.actions import ModelAuditAction
-from flip.utils.logger import logger
+from flip_api.domain.interfaces.model import IModelAuditAction
+from flip_api.domain.schemas.actions import ModelAuditAction
+from flip_api.utils.logger import logger
 
 
 def audit_model_action(model_id: UUID, action: ModelAuditAction, user_id: UUID, session: Session) -> ModelsAudit:

--- a/flip-api/src/flip_api/private_services/add_log.py
+++ b/flip-api/src/flip_api/private_services/add_log.py
@@ -16,10 +16,10 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from sqlmodel import Session
 
 from flip_api.auth.access_manager import check_authorization_token
-from flip.db.database import get_session
-from flip.domain.schemas.private import TrainingLog
-from flip.model_services.services.model_service import add_log, validate_trusts
-from flip.utils.logger import logger
+from flip_api.db.database import get_session
+from flip_api.domain.schemas.private import TrainingLog
+from flip_api.model_services.services.model_service import add_log, validate_trusts
+from flip_api.utils.logger import logger
 
 router = APIRouter(tags=["private_services"])
 

--- a/flip-api/src/flip_api/private_services/invoke_model_status_update.py
+++ b/flip-api/src/flip_api/private_services/invoke_model_status_update.py
@@ -16,10 +16,10 @@ from fastapi import APIRouter, Depends, HTTPException, Path, status
 from sqlmodel import Session
 
 from flip_api.auth.access_manager import check_authorization_token
-from flip.db.database import get_session
-from flip.domain.schemas.status import ModelStatus
-from flip.model_services.update_model_status import update_model_status_endpoint
-from flip.utils.logger import logger
+from flip_api.db.database import get_session
+from flip_api.domain.schemas.status import ModelStatus
+from flip_api.model_services.update_model_status import update_model_status_endpoint
+from flip_api.utils.logger import logger
 
 router = APIRouter(tags=["private_services"])
 

--- a/flip-api/src/flip_api/private_services/receive_cohort_results.py
+++ b/flip-api/src/flip_api/private_services/receive_cohort_results.py
@@ -18,9 +18,9 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from sqlmodel import Session, col, select
 
 from flip_api.auth.access_manager import check_authorization_token
-from flip.db.database import get_session
-from flip.db.models.main_models import QueryResult, QueryStats, Trust
-from flip.domain.schemas.private import (
+from flip_api.db.database import get_session
+from flip_api.db.models.main_models import QueryResult, QueryStats, Trust
+from flip_api.domain.schemas.private import (
     AggregatedCohortStats,
     AggregatedFieldResult,
     AggregatedTrustFieldResult,
@@ -28,7 +28,7 @@ from flip.domain.schemas.private import (
     OmopCohortResults,
     TrustSpecificData,
 )
-from flip.utils.logger import logger
+from flip_api.utils.logger import logger
 
 router = APIRouter(tags=["private_services"])
 

--- a/flip-api/src/flip_api/private_services/save_training_metrics.py
+++ b/flip-api/src/flip_api/private_services/save_training_metrics.py
@@ -16,11 +16,11 @@ from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
 from sqlmodel import Session
 
 from flip_api.auth.access_manager import check_authorization_token
-from flip.db.database import get_session
-from flip.domain.schemas.private import TrainingMetrics
-from flip.model_services.services.model_service import validate_trusts
-from flip.private_services.services.private_service import save_training_metrics
-from flip.utils.logger import logger
+from flip_api.db.database import get_session
+from flip_api.domain.schemas.private import TrainingMetrics
+from flip_api.model_services.services.model_service import validate_trusts
+from flip_api.private_services.services.private_service import save_training_metrics
+from flip_api.utils.logger import logger
 
 router = APIRouter(tags=["private_services"])
 
@@ -68,7 +68,7 @@ def save_training_metrics_endpoint(
     # If ModelIdSchema is not used or validation is different, this block should be adjusted/removed.
     # For now, it's commented out to rely on path param typing and specific checks if needed.
     # ---
-    # from flip.domain.schemas.model import ModelIdSchema # Hypothetical import
+    # from flip_api.domain.schemas.model import ModelIdSchema # Hypothetical import
     # model_id_error = ModelIdSchema.validate(model_id)
     # if model_id_error:
     #     logger.error(f"Invalid model_id '{model_id}' in {endpoint_path}: {model_id_error}")

--- a/flip-api/src/flip_api/private_services/services/private_service.py
+++ b/flip-api/src/flip_api/private_services/services/private_service.py
@@ -15,8 +15,8 @@ from uuid import UUID
 from sqlmodel import Session
 
 from flip_api.db.models.main_models import FLMetrics
-from flip.domain.schemas.private import TrainingMetrics
-from flip.utils.logger import logger
+from flip_api.domain.schemas.private import TrainingMetrics
+from flip_api.utils.logger import logger
 
 
 def save_training_metrics(model_id: UUID, training_metrics: TrainingMetrics, db: Session) -> None:

--- a/flip-api/src/flip_api/project_services/approve_project.py
+++ b/flip-api/src/flip_api/project_services/approve_project.py
@@ -17,17 +17,17 @@ from fastapi import APIRouter, Body, Depends, HTTPException, Path, status
 from sqlmodel import Session
 
 from flip_api.auth.auth_utils import has_permissions
-from flip.auth.dependencies import verify_token
-from flip.db.database import get_session
-from flip.db.models.main_models import Projects
-from flip.db.models.user_models import PermissionRef
-from flip.domain.interfaces.project import IProjectApproval
-from flip.domain.interfaces.trust import ITrust
-from flip.domain.schemas.projects import ApproveProjectBodyPayload
-from flip.domain.schemas.status import ProjectStatus
-from flip.project_services.services.project_services import approve_project
-from flip.trusts_services.services.trust import get_trusts
-from flip.utils.logger import logger
+from flip_api.auth.dependencies import verify_token
+from flip_api.db.database import get_session
+from flip_api.db.models.main_models import Projects
+from flip_api.db.models.user_models import PermissionRef
+from flip_api.domain.interfaces.project import IProjectApproval
+from flip_api.domain.interfaces.trust import ITrust
+from flip_api.domain.schemas.projects import ApproveProjectBodyPayload
+from flip_api.domain.schemas.status import ProjectStatus
+from flip_api.project_services.services.project_services import approve_project
+from flip_api.trusts_services.services.trust import get_trusts
+from flip_api.utils.logger import logger
 
 router = APIRouter(prefix="/projects", tags=["project_services"])
 

--- a/flip-api/src/flip_api/project_services/create_project.py
+++ b/flip-api/src/flip_api/project_services/create_project.py
@@ -16,15 +16,15 @@ from fastapi import APIRouter, Body, Depends, HTTPException, status
 from sqlmodel import Session
 
 from flip_api.auth.auth_utils import has_permissions
-from flip.auth.dependencies import verify_token
-from flip.db.database import get_session
-from flip.db.models.user_models import PermissionRef
-from flip.domain.interfaces.shared import IId
-from flip.domain.schemas.projects import ProjectDetails
-from flip.project_services.services.project_services import (
+from flip_api.auth.dependencies import verify_token
+from flip_api.db.database import get_session
+from flip_api.db.models.user_models import PermissionRef
+from flip_api.domain.interfaces.shared import IId
+from flip_api.domain.schemas.projects import ProjectDetails
+from flip_api.project_services.services.project_services import (
     create_project,
 )
-from flip.utils.logger import logger
+from flip_api.utils.logger import logger
 
 router = APIRouter(prefix="/projects", tags=["project_services"])
 

--- a/flip-api/src/flip_api/project_services/delete_project.py
+++ b/flip-api/src/flip_api/project_services/delete_project.py
@@ -16,12 +16,12 @@ from fastapi import APIRouter, Depends, HTTPException, Path, Request, status
 from sqlmodel import Session
 
 from flip_api.auth.access_manager import can_access_project
-from flip.auth.dependencies import verify_token
-from flip.db.database import get_session
-from flip.fl_services.services.fl_service import abort_model_training
-from flip.project_services.services.image_service import delete_imaging_project, get_imaging_projects
-from flip.project_services.services.project_services import delete_project, get_project_models_service
-from flip.utils.logger import logger
+from flip_api.auth.dependencies import verify_token
+from flip_api.db.database import get_session
+from flip_api.fl_services.services.fl_service import abort_model_training
+from flip_api.project_services.services.image_service import delete_imaging_project, get_imaging_projects
+from flip_api.project_services.services.project_services import delete_project, get_project_models_service
+from flip_api.utils.logger import logger
 
 router = APIRouter(prefix="/projects", tags=["project_services"])
 

--- a/flip-api/src/flip_api/project_services/edit_project.py
+++ b/flip-api/src/flip_api/project_services/edit_project.py
@@ -16,14 +16,14 @@ from fastapi import APIRouter, Body, Depends, HTTPException, Path, Request, stat
 from sqlmodel import Session
 
 from flip_api.auth.access_manager import can_access_project
-from flip.auth.dependencies import verify_token
-from flip.db.database import get_session
-from flip.db.models.main_models import Projects
-from flip.domain.interfaces.project import IEditProject, IProjectDetails
-from flip.domain.schemas.status import ProjectStatus
-from flip.project_services.services.project_services import edit_project_service
-from flip.utils.cognito_helpers import filter_enabled_users, get_user_pool_id
-from flip.utils.logger import logger
+from flip_api.auth.dependencies import verify_token
+from flip_api.db.database import get_session
+from flip_api.db.models.main_models import Projects
+from flip_api.domain.interfaces.project import IEditProject, IProjectDetails
+from flip_api.domain.schemas.status import ProjectStatus
+from flip_api.project_services.services.project_services import edit_project_service
+from flip_api.utils.cognito_helpers import filter_enabled_users, get_user_pool_id
+from flip_api.utils.logger import logger
 
 router = APIRouter(prefix="/projects", tags=["project_services"])
 

--- a/flip-api/src/flip_api/project_services/get_imaging_project_status.py
+++ b/flip-api/src/flip_api/project_services/get_imaging_project_status.py
@@ -17,16 +17,16 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from sqlmodel import Session
 
 from flip_api.auth.access_manager import can_access_project
-from flip.auth.dependencies import verify_token
-from flip.db.database import get_session
-from flip.domain.interfaces.project import IImagingStatus
-from flip.project_services.services.image_service import (
+from flip_api.auth.dependencies import verify_token
+from flip_api.db.database import get_session
+from flip_api.domain.interfaces.project import IImagingStatus
+from flip_api.project_services.services.image_service import (
     base64_url_encode,
     get_imaging_project_statuses,
     get_imaging_projects,
 )
-from flip.project_services.services.project_services import get_project
-from flip.utils.logger import logger
+from flip_api.project_services.services.project_services import get_project
+from flip_api.utils.logger import logger
 
 router = APIRouter(prefix="/projects", tags=["project_services"])
 

--- a/flip-api/src/flip_api/project_services/get_models.py
+++ b/flip-api/src/flip_api/project_services/get_models.py
@@ -16,12 +16,12 @@ from fastapi import APIRouter, Depends, HTTPException, Request, status
 from sqlmodel import Session
 
 from flip_api.auth.access_manager import can_access_project
-from flip.auth.dependencies import verify_token
-from flip.db.database import get_session
-from flip.domain.interfaces.project import IModelsInfoResponse
-from flip.project_services.services.project_services import get_project, get_project_models_service
-from flip.utils.logger import logger
-from flip.utils.paging_utils import IPagedData, get_total_pages
+from flip_api.auth.dependencies import verify_token
+from flip_api.db.database import get_session
+from flip_api.domain.interfaces.project import IModelsInfoResponse
+from flip_api.project_services.services.project_services import get_project, get_project_models_service
+from flip_api.utils.logger import logger
+from flip_api.utils.paging_utils import IPagedData, get_total_pages
 
 router = APIRouter(prefix="/projects", tags=["project_services"])
 

--- a/flip-api/src/flip_api/project_services/get_project.py
+++ b/flip-api/src/flip_api/project_services/get_project.py
@@ -16,21 +16,21 @@ from fastapi import APIRouter, Depends, HTTPException, Request, status
 from sqlmodel import Session
 
 from flip_api.auth.access_manager import can_access_project
-from flip.auth.dependencies import verify_token
-from flip.config import get_settings
-from flip.db.database import get_session
-from flip.domain.interfaces.project import IReturnedProject
-from flip.domain.schemas.status import ProjectStatus
-from flip.project_services.services.project_services import (
+from flip_api.auth.dependencies import verify_token
+from flip_api.config import get_settings
+from flip_api.db.database import get_session
+from flip_api.domain.interfaces.project import IReturnedProject
+from flip_api.domain.schemas.status import ProjectStatus
+from flip_api.project_services.services.project_services import (
     get_project,
     get_project_query,
     get_trusts_approval_status_for_project,
     get_users_with_access,
 )
-from flip.utils.cognito_helpers import (
+from flip_api.utils.cognito_helpers import (
     get_user_by_email_or_id,
 )
-from flip.utils.logger import logger
+from flip_api.utils.logger import logger
 
 router = APIRouter(prefix="/projects", tags=["project_services"])
 

--- a/flip-api/src/flip_api/project_services/get_project_approved_trusts.py
+++ b/flip-api/src/flip_api/project_services/get_project_approved_trusts.py
@@ -17,12 +17,12 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from sqlmodel import Session
 
 from flip_api.auth.access_manager import can_access_project
-from flip.auth.dependencies import verify_token
-from flip.db.database import get_session
-from flip.domain.interfaces.trust import ITrust
-from flip.domain.schemas.status import ProjectStatus
-from flip.project_services.services.project_services import get_approved_trusts_for_project, get_project
-from flip.utils.logger import logger
+from flip_api.auth.dependencies import verify_token
+from flip_api.db.database import get_session
+from flip_api.domain.interfaces.trust import ITrust
+from flip_api.domain.schemas.status import ProjectStatus
+from flip_api.project_services.services.project_services import get_approved_trusts_for_project, get_project
+from flip_api.utils.logger import logger
 
 router = APIRouter(prefix="/projects", tags=["project_services"])
 

--- a/flip-api/src/flip_api/project_services/get_projects.py
+++ b/flip-api/src/flip_api/project_services/get_projects.py
@@ -17,13 +17,13 @@ from fastapi import APIRouter, Depends, HTTPException, Request, status
 from sqlmodel import Session, and_, desc, func, or_, select
 
 from flip_api.auth.auth_utils import has_permissions
-from flip.auth.dependencies import verify_token
-from flip.db.database import get_session
-from flip.db.models.main_models import Projects, ProjectUserAccess
-from flip.db.models.user_models import PermissionRef
-from flip.domain.interfaces.project import IProject
-from flip.utils.logger import logger
-from flip.utils.paging_utils import (
+from flip_api.auth.dependencies import verify_token
+from flip_api.db.database import get_session
+from flip_api.db.models.main_models import Projects, ProjectUserAccess
+from flip_api.db.models.user_models import PermissionRef
+from flip_api.domain.interfaces.project import IProject
+from flip_api.utils.logger import logger
+from flip_api.utils.paging_utils import (
     FilterInfo,
     IPagedData,
     IPagedResponse,

--- a/flip-api/src/flip_api/project_services/reimport_imaging_project_studies.py
+++ b/flip-api/src/flip_api/project_services/reimport_imaging_project_studies.py
@@ -14,10 +14,10 @@ from fastapi import HTTPException, status
 from sqlmodel import Session
 
 from flip_api.config import get_settings
-from flip.db.database import engine
-from flip.project_services.services.image_service import reimport_failed_studies
-from flip.project_services.services.project_services import get_reimport_queries_service
-from flip.utils.logger import logger
+from flip_api.db.database import engine
+from flip_api.project_services.services.image_service import reimport_failed_studies
+from flip_api.project_services.services.project_services import get_reimport_queries_service
+from flip_api.utils.logger import logger
 
 
 def reimport_imaging_project_studies(db: Session) -> None:

--- a/flip-api/src/flip_api/project_services/services/image_service.py
+++ b/flip-api/src/flip_api/project_services/services/image_service.py
@@ -21,20 +21,20 @@ from sqlalchemy.exc import SQLAlchemyError  # For more specific DB error handlin
 from sqlmodel import Session, col, select, update
 
 from flip_api.db.models.main_models import Trust as DBTrust
-from flip.db.models.main_models import XNATProjectStatus  # Assuming these exist
-from flip.domain.interfaces.project import (
+from flip_api.db.models.main_models import XNATProjectStatus  # Assuming these exist
+from flip_api.domain.interfaces.project import (
     IImagingStatus,
     IImagingStatusResponse,
     IReimportQuery,
     IUpdateXnatProfile,
 )
-from flip.domain.schemas.projects import (
+from flip_api.domain.schemas.projects import (
     ImagingProject,
     XnatProjectStatusInfo,
 )
-from flip.domain.schemas.status import XNATImageStatus
-from flip.trusts_services.services.trust import get_trusts
-from flip.utils.logger import logger
+from flip_api.domain.schemas.status import XNATImageStatus
+from flip_api.trusts_services.services.trust import get_trusts
+from flip_api.utils.logger import logger
 
 
 def to_utc_aware(dt: datetime | None) -> datetime:

--- a/flip-api/src/flip_api/project_services/services/project_services.py
+++ b/flip-api/src/flip_api/project_services/services/project_services.py
@@ -32,7 +32,7 @@ from flip_api.db.models.main_models import (
     Trust,
     XNATProjectStatus,
 )
-from flip.domain.interfaces.project import (
+from flip_api.domain.interfaces.project import (
     IApprovedTrust,
     IModelsInfoResponse,
     IProjectApproval,
@@ -41,19 +41,19 @@ from flip.domain.interfaces.project import (
     IProjectResponse,
     IReimportQuery,
 )
-from flip.domain.schemas.actions import ProjectAuditAction
-from flip.domain.schemas.projects import (
+from flip_api.domain.schemas.actions import ProjectAuditAction
+from flip_api.domain.schemas.projects import (
     ProjectDetails,
     UserAccessInfo,
 )
-from flip.domain.schemas.status import (
+from flip_api.domain.schemas.status import (
     ProjectStatus,
     XNATImageStatus,
 )
-from flip.model_services.services.model_service import delete_models
-from flip.project_services.utils.audit_helper import audit_project_action
-from flip.utils.logger import logger
-from flip.utils.paging_utils import IPagedResponse, PagingInfo, get_paging_details
+from flip_api.model_services.services.model_service import delete_models
+from flip_api.project_services.utils.audit_helper import audit_project_action
+from flip_api.utils.logger import logger
+from flip_api.utils.paging_utils import IPagedResponse, PagingInfo, get_paging_details
 
 
 def update_project_user_access(project_id: UUID, user_ids: List[UUID], session: Session) -> None:

--- a/flip-api/src/flip_api/project_services/stage_project.py
+++ b/flip-api/src/flip_api/project_services/stage_project.py
@@ -16,15 +16,15 @@ from fastapi import APIRouter, Depends, HTTPException, Response, status
 from sqlmodel import Session
 
 from flip_api.auth.access_manager import can_access_project
-from flip.auth.dependencies import verify_token
-from flip.db.database import get_session
-from flip.domain.interfaces.project import ProjectStatus
-from flip.domain.schemas.projects import StageProjectRequest
-from flip.project_services.services.project_services import (
+from flip_api.auth.dependencies import verify_token
+from flip_api.db.database import get_session
+from flip_api.domain.interfaces.project import ProjectStatus
+from flip_api.domain.schemas.projects import StageProjectRequest
+from flip_api.project_services.services.project_services import (
     get_project,
     stage_project_service,
 )
-from flip.utils.logger import logger
+from flip_api.utils.logger import logger
 
 router = APIRouter(prefix="/projects", tags=["project_services"])
 

--- a/flip-api/src/flip_api/project_services/unstage_project.py
+++ b/flip-api/src/flip_api/project_services/unstage_project.py
@@ -16,12 +16,12 @@ from fastapi import APIRouter, Depends, HTTPException, Response, status
 from sqlmodel import Session
 
 from flip_api.auth.auth_utils import has_permissions
-from flip.auth.dependencies import verify_token
-from flip.db.database import get_session
-from flip.db.models.user_models import PermissionRef
-from flip.domain.interfaces.project import ProjectStatus
-from flip.project_services.services.project_services import get_project, unstage_project_service
-from flip.utils.logger import logger
+from flip_api.auth.dependencies import verify_token
+from flip_api.db.database import get_session
+from flip_api.db.models.user_models import PermissionRef
+from flip_api.domain.interfaces.project import ProjectStatus
+from flip_api.project_services.services.project_services import get_project, unstage_project_service
+from flip_api.utils.logger import logger
 
 router = APIRouter(prefix="/projects", tags=["project_services"])
 

--- a/flip-api/src/flip_api/project_services/utils/audit_helper.py
+++ b/flip-api/src/flip_api/project_services/utils/audit_helper.py
@@ -15,8 +15,8 @@ from uuid import UUID
 from sqlmodel import Session
 
 from flip_api.db.models.main_models import ProjectsAudit
-from flip.domain.schemas.actions import ProjectAuditAction
-from flip.utils.logger import logger
+from flip_api.domain.schemas.actions import ProjectAuditAction
+from flip_api.utils.logger import logger
 
 
 def audit_project_action(

--- a/flip-api/src/flip_api/role_services/get_roles.py
+++ b/flip-api/src/flip_api/role_services/get_roles.py
@@ -16,11 +16,11 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from sqlmodel import Session, select
 
 from flip_api.auth.auth_utils import has_permissions
-from flip.auth.dependencies import verify_token
-from flip.db.database import get_session
-from flip.db.models.user_models import PermissionRef, Role
-from flip.domain.interfaces.role import IRole, IRolesResponse
-from flip.utils.logger import logger
+from flip_api.auth.dependencies import verify_token
+from flip_api.db.database import get_session
+from flip_api.db.models.user_models import PermissionRef, Role
+from flip_api.domain.interfaces.role import IRole, IRolesResponse
+from flip_api.utils.logger import logger
 
 router = APIRouter(prefix="/roles", tags=["role_services"])
 

--- a/flip-api/src/flip_api/scheduler/apscheduler_runner.py
+++ b/flip-api/src/flip_api/scheduler/apscheduler_runner.py
@@ -13,9 +13,9 @@
 from apscheduler.schedulers.background import BackgroundScheduler
 
 from flip_api.config import get_settings
-from flip.fl_services.run_jobs import run_jobs_scheduled_task
-from flip.fl_services.services.fl_service import keep_fl_api_session_alive
-from flip.project_services.reimport_imaging_project_studies import (
+from flip_api.fl_services.run_jobs import run_jobs_scheduled_task
+from flip_api.fl_services.services.fl_service import keep_fl_api_session_alive
+from flip_api.project_services.reimport_imaging_project_studies import (
     reimport_imaging_project_studies_scheduled_task,
 )
 

--- a/flip-api/src/flip_api/site_services/details.py
+++ b/flip-api/src/flip_api/site_services/details.py
@@ -16,10 +16,10 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from sqlmodel import Session
 
 from flip_api.auth.dependencies import verify_token
-from flip.db.database import get_session
-from flip.domain.interfaces.site import ISiteDetails
-from flip.site_services.services.details_service import get_site_details, update_site_details
-from flip.utils.logger import logger
+from flip_api.db.database import get_session
+from flip_api.domain.interfaces.site import ISiteDetails
+from flip_api.site_services.services.details_service import get_site_details, update_site_details
+from flip_api.utils.logger import logger
 
 router = APIRouter(prefix="/site", tags=["site_services"])
 

--- a/flip-api/src/flip_api/site_services/services/details_service.py
+++ b/flip-api/src/flip_api/site_services/services/details_service.py
@@ -14,8 +14,8 @@ from fastapi import HTTPException, status
 from sqlmodel import Session, select
 
 from flip_api.db.models.main_models import SiteBanner, SiteConfig
-from flip.domain.interfaces.site import ISiteBanner, ISiteDetails
-from flip.utils.logger import logger
+from flip_api.domain.interfaces.site import ISiteBanner, ISiteDetails
+from flip_api.utils.logger import logger
 
 
 def get_site_details(db: Session) -> ISiteDetails:

--- a/flip-api/src/flip_api/step_functions_services/approve_project_step_function.py
+++ b/flip-api/src/flip_api/step_functions_services/approve_project_step_function.py
@@ -17,12 +17,12 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 from sqlmodel import Session
 
 from flip_api.auth.dependencies import verify_token
-from flip.db.database import get_session
-from flip.domain.schemas.private import ProjectApprovalBody
-from flip.domain.schemas.projects import ApproveProjectBodyPayload
-from flip.project_services.approve_project import approve_project_endpoint
-from flip.trusts_services.start_project_imaging_creation import start_project_imaging_creation
-from flip.utils.logger import logger
+from flip_api.db.database import get_session
+from flip_api.domain.schemas.private import ProjectApprovalBody
+from flip_api.domain.schemas.projects import ApproveProjectBodyPayload
+from flip_api.project_services.approve_project import approve_project_endpoint
+from flip_api.trusts_services.start_project_imaging_creation import start_project_imaging_creation
+from flip_api.utils.logger import logger
 
 router = APIRouter(prefix="/step", tags=["step_functions_services"])
 

--- a/flip-api/src/flip_api/step_functions_services/cohort_query_step_function.py
+++ b/flip-api/src/flip_api/step_functions_services/cohort_query_step_function.py
@@ -16,16 +16,16 @@ from fastapi import APIRouter, Depends, HTTPException, Request, status
 from sqlmodel import Session
 
 from flip_api.auth.dependencies import verify_token
-from flip.cohort_services.save_cohort_query import save_cohort_query
-from flip.cohort_services.submit_cohort_query import submit_cohort_query
-from flip.db.database import get_session
-from flip.domain.schemas.cohort import (
+from flip_api.cohort_services.save_cohort_query import save_cohort_query
+from flip_api.cohort_services.submit_cohort_query import submit_cohort_query
+from flip_api.db.database import get_session
+from flip_api.domain.schemas.cohort import (
     CohortQueryInput,
     SubmitCohortQuery,
     SubmitCohortQueryOutput,
 )
-from flip.utils.logger import logger
-from flip.utils.project_manager import get_project_by_id
+from flip_api.utils.logger import logger
+from flip_api.utils.project_manager import get_project_by_id
 
 router = APIRouter(prefix="/step", tags=["step_functions_services"])
 

--- a/flip-api/src/flip_api/step_functions_services/register_user_step_function.py
+++ b/flip-api/src/flip_api/step_functions_services/register_user_step_function.py
@@ -16,12 +16,12 @@ from fastapi import APIRouter, Depends, HTTPException, Request, status
 from sqlmodel import Session
 
 from flip_api.auth.dependencies import verify_token
-from flip.db.database import get_session
-from flip.domain.interfaces.user import IRegisterUser, IRegisterUserDto, IRoles
-from flip.user_services.delete_user import delete_user
-from flip.user_services.register_user import register_user
-from flip.user_services.set_user_roles import set_user_roles
-from flip.utils.logger import logger
+from flip_api.db.database import get_session
+from flip_api.domain.interfaces.user import IRegisterUser, IRegisterUserDto, IRoles
+from flip_api.user_services.delete_user import delete_user
+from flip_api.user_services.register_user import register_user
+from flip_api.user_services.set_user_roles import set_user_roles
+from flip_api.utils.logger import logger
 
 router = APIRouter(prefix="/step", tags=["step_functions_services"])
 

--- a/flip-api/src/flip_api/step_functions_services/retrieve_model_step_function.py
+++ b/flip-api/src/flip_api/step_functions_services/retrieve_model_step_function.py
@@ -16,11 +16,11 @@ from fastapi import APIRouter, Depends, HTTPException, Request, status
 from sqlmodel import Session
 
 from flip_api.auth.dependencies import verify_token
-from flip.db.database import get_session
-from flip.domain.interfaces.model import IModelResponse
-from flip.model_services.retrieve_model import retrieve_model
-from flip.model_services.update_model_status import update_model_status
-from flip.utils.logger import logger
+from flip_api.db.database import get_session
+from flip_api.domain.interfaces.model import IModelResponse
+from flip_api.model_services.retrieve_model import retrieve_model
+from flip_api.model_services.update_model_status import update_model_status
+from flip_api.utils.logger import logger
 
 router = APIRouter(prefix="/step", tags=["step_functions_services"])
 

--- a/flip-api/src/flip_api/trusts_services/get_trusts.py
+++ b/flip-api/src/flip_api/trusts_services/get_trusts.py
@@ -17,9 +17,9 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from sqlmodel import Session, select
 
 from flip_api.auth.dependencies import verify_token
-from flip.db.database import get_session
-from flip.db.models.main_models import Trust
-from flip.domain.interfaces.trust import IBasicTrust
+from flip_api.db.database import get_session
+from flip_api.db.models.main_models import Trust
+from flip_api.domain.interfaces.trust import IBasicTrust
 
 router = APIRouter(prefix="/trust", tags=["trusts_services"])
 

--- a/flip-api/src/flip_api/trusts_services/services/trust.py
+++ b/flip-api/src/flip_api/trusts_services/services/trust.py
@@ -17,8 +17,8 @@ from uuid import UUID
 from sqlmodel import Session, col, select
 
 from flip_api.db.models.main_models import Trust
-from flip.domain.interfaces.trust import ITrust
-from flip.utils.logger import logger
+from flip_api.domain.interfaces.trust import ITrust
+from flip_api.utils.logger import logger
 
 
 def get_trusts(session: Session, ids: Optional[List[UUID]] = None) -> List[ITrust]:

--- a/flip-api/src/flip_api/trusts_services/start_project_imaging_creation.py
+++ b/flip-api/src/flip_api/trusts_services/start_project_imaging_creation.py
@@ -20,24 +20,24 @@ from fastapi import APIRouter, Body, Depends, HTTPException, Path, Request
 from sqlmodel import Session
 
 from flip_api.auth.auth_utils import has_permissions
-from flip.auth.dependencies import verify_token
-from flip.config import get_settings
-from flip.db.database import get_session
-from flip.db.models.main_models import XNATImageStatus
-from flip.db.models.user_models import PermissionRef
-from flip.domain.interfaces.trust import (
+from flip_api.auth.dependencies import verify_token
+from flip_api.config import get_settings
+from flip_api.db.database import get_session
+from flip_api.db.models.main_models import XNATImageStatus
+from flip_api.db.models.user_models import PermissionRef
+from flip_api.domain.interfaces.trust import (
     ICreatedImagingProject,
     ICreatedImagingUser,
     ICreateImagingProject,
     ISesTemplateData,
     ITrust,
 )
-from flip.private_services.project_images_helpers import insert_status
-from flip.project_services.services.project_services import get_project, get_users_with_access
-from flip.utils.cognito_helpers import get_cognito_users, get_user_pool_id
-from flip.utils.constants import IMAGING_CREDENTIALS_TEMPLATE_NAME
-from flip.utils.encryption import decrypt
-from flip.utils.logger import logger
+from flip_api.private_services.project_images_helpers import insert_status
+from flip_api.project_services.services.project_services import get_project, get_users_with_access
+from flip_api.utils.cognito_helpers import get_cognito_users, get_user_pool_id
+from flip_api.utils.constants import IMAGING_CREDENTIALS_TEMPLATE_NAME
+from flip_api.utils.encryption import decrypt
+from flip_api.utils.logger import logger
 
 router = APIRouter(prefix="/trust", tags=["trusts_services"])
 

--- a/flip-api/src/flip_api/trusts_services/trusts_health_check.py
+++ b/flip-api/src/flip_api/trusts_services/trusts_health_check.py
@@ -17,9 +17,9 @@ from fastapi import APIRouter, Depends, HTTPException, Request, status
 from sqlmodel import Session, select
 
 from flip_api.db.database import get_session
-from flip.db.models.main_models import Trust
-from flip.domain.interfaces.trust import ITrustHealth
-from flip.utils.logger import logger
+from flip_api.db.models.main_models import Trust
+from flip_api.domain.interfaces.trust import ITrustHealth
+from flip_api.utils.logger import logger
 
 router = APIRouter(prefix="/trust", tags=["trusts_services"])
 

--- a/flip-api/src/flip_api/trusts_services/update_trust_status.py
+++ b/flip-api/src/flip_api/trusts_services/update_trust_status.py
@@ -17,13 +17,13 @@ from fastapi import APIRouter, Body, Depends, HTTPException, Path, Request, stat
 from sqlmodel import Session, select
 
 from flip_api.auth.access_manager import can_access_model
-from flip.auth.dependencies import verify_token
-from flip.db.database import get_session
-from flip.db.models.main_models import ModelTrustIntersect, Trust, TrustIntersectStatus
-from flip.domain.schemas.trusts import UpdateTrustStatusSchema
-from flip.utils.constants import SERVICE_UNAVAILABLE_MESSAGE
-from flip.utils.logger import logger
-from flip.utils.site_manager import is_deployment_mode_enabled
+from flip_api.auth.dependencies import verify_token
+from flip_api.db.database import get_session
+from flip_api.db.models.main_models import ModelTrustIntersect, Trust, TrustIntersectStatus
+from flip_api.domain.schemas.trusts import UpdateTrustStatusSchema
+from flip_api.utils.constants import SERVICE_UNAVAILABLE_MESSAGE
+from flip_api.utils.logger import logger
+from flip_api.utils.site_manager import is_deployment_mode_enabled
 
 router = APIRouter(prefix="/trust", tags=["trusts_services"])
 

--- a/flip-api/src/flip_api/user_services/access_request.py
+++ b/flip-api/src/flip_api/user_services/access_request.py
@@ -17,9 +17,9 @@ from botocore.exceptions import ClientError
 from fastapi import APIRouter, HTTPException, status
 
 from flip_api.config import get_settings
-from flip.domain.interfaces.shared import IAccessRequest
-from flip.utils.constants import ACCESS_REQUEST_TEMPLATE_NAME
-from flip.utils.logger import logger
+from flip_api.domain.interfaces.shared import IAccessRequest
+from flip_api.utils.constants import ACCESS_REQUEST_TEMPLATE_NAME
+from flip_api.utils.logger import logger
 
 router = APIRouter(prefix="/users", tags=["user_services"])
 

--- a/flip-api/src/flip_api/user_services/delete_user.py
+++ b/flip-api/src/flip_api/user_services/delete_user.py
@@ -17,12 +17,12 @@ from fastapi import APIRouter, Depends, HTTPException, Request, status
 from sqlmodel import Session
 
 from flip_api.auth.auth_utils import has_permissions
-from flip.auth.dependencies import verify_token
-from flip.config import get_settings
-from flip.db.database import get_session
-from flip.db.models.user_models import PermissionRef
-from flip.utils.cognito_helpers import delete_cognito_user, get_username
-from flip.utils.logger import logger
+from flip_api.auth.dependencies import verify_token
+from flip_api.config import get_settings
+from flip_api.db.database import get_session
+from flip_api.db.models.user_models import PermissionRef
+from flip_api.utils.cognito_helpers import delete_cognito_user, get_username
+from flip_api.utils.logger import logger
 
 router = APIRouter(prefix="/users", tags=["user_services"])
 

--- a/flip-api/src/flip_api/user_services/get_user.py
+++ b/flip-api/src/flip_api/user_services/get_user.py
@@ -16,9 +16,9 @@ from fastapi import APIRouter, Depends, HTTPException, Request, status
 from pydantic import ValidationError
 
 from flip_api.auth.dependencies import verify_token
-from flip.domain.schemas.users import GetUserByEmail, GetUserById
-from flip.utils.cognito_helpers import get_user_by_email_or_id, get_user_pool_id
-from flip.utils.logger import logger
+from flip_api.domain.schemas.users import GetUserByEmail, GetUserById
+from flip_api.utils.cognito_helpers import get_user_by_email_or_id, get_user_pool_id
+from flip_api.utils.logger import logger
 
 router = APIRouter(prefix="/users", tags=["user_services"])
 

--- a/flip-api/src/flip_api/user_services/get_users.py
+++ b/flip-api/src/flip_api/user_services/get_users.py
@@ -17,13 +17,13 @@ from fastapi import APIRouter, Depends, HTTPException, Request, status
 from sqlmodel import Session
 
 from flip_api.auth.auth_utils import has_permissions
-from flip.auth.dependencies import verify_token
-from flip.db.database import get_session
-from flip.db.models.user_models import PermissionRef
-from flip.domain.schemas.users import IUser
-from flip.utils.cognito_helpers import get_cognito_users, get_pool_id, get_user_role_data
-from flip.utils.logger import logger
-from flip.utils.paging_utils import IPagedData, get_paging_details, get_total_pages
+from flip_api.auth.dependencies import verify_token
+from flip_api.db.database import get_session
+from flip_api.db.models.user_models import PermissionRef
+from flip_api.domain.schemas.users import IUser
+from flip_api.utils.cognito_helpers import get_cognito_users, get_pool_id, get_user_role_data
+from flip_api.utils.logger import logger
+from flip_api.utils.paging_utils import IPagedData, get_paging_details, get_total_pages
 
 router = APIRouter(prefix="/users", tags=["user_services"])
 

--- a/flip-api/src/flip_api/user_services/post_authentication.py
+++ b/flip-api/src/flip_api/user_services/post_authentication.py
@@ -16,7 +16,7 @@ from sqlalchemy.exc import SQLAlchemyError
 from sqlmodel import Session
 
 from flip_api.db.models.user_models import User
-from flip.utils.logger import logger
+from flip_api.utils.logger import logger
 
 
 def sync_user_on_authentication(user_id: UUID, email: str, db: Session) -> User:

--- a/flip-api/src/flip_api/user_services/register_user.py
+++ b/flip-api/src/flip_api/user_services/register_user.py
@@ -16,12 +16,12 @@ from fastapi import APIRouter, Depends, HTTPException, Request, status
 from sqlmodel import Session
 
 from flip_api.auth.auth_utils import has_permissions
-from flip.auth.dependencies import verify_token
-from flip.db.database import get_session
-from flip.db.models.user_models import PermissionRef, User
-from flip.domain.interfaces.user import IRegisterUser, IUserResponse
-from flip.utils.cognito_helpers import create_cognito_user, get_all_roles, get_user_pool_id, validate_roles
-from flip.utils.logger import logger
+from flip_api.auth.dependencies import verify_token
+from flip_api.db.database import get_session
+from flip_api.db.models.user_models import PermissionRef, User
+from flip_api.domain.interfaces.user import IRegisterUser, IUserResponse
+from flip_api.utils.cognito_helpers import create_cognito_user, get_all_roles, get_user_pool_id, validate_roles
+from flip_api.utils.logger import logger
 
 router = APIRouter(prefix="/users", tags=["user_services"])
 

--- a/flip-api/src/flip_api/user_services/retrieve_user_permissions.py
+++ b/flip-api/src/flip_api/user_services/retrieve_user_permissions.py
@@ -17,11 +17,11 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from sqlmodel import Session, col, select
 
 from flip_api.auth.dependencies import verify_token
-from flip.db.database import get_session
-from flip.db.models.user_models import Permission, RolePermission, UserRole
-from flip.domain.schemas.users import UserPermissionsResponse
-from flip.utils.formatters import to_pascal_case
-from flip.utils.logger import logger
+from flip_api.db.database import get_session
+from flip_api.db.models.user_models import Permission, RolePermission, UserRole
+from flip_api.domain.schemas.users import UserPermissionsResponse
+from flip_api.utils.formatters import to_pascal_case
+from flip_api.utils.logger import logger
 
 router = APIRouter(prefix="/users", tags=["user_services"])
 

--- a/flip-api/src/flip_api/user_services/set_user_roles.py
+++ b/flip-api/src/flip_api/user_services/set_user_roles.py
@@ -17,12 +17,12 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from sqlmodel import Session, col, delete, select
 
 from flip_api.auth.auth_utils import has_permissions
-from flip.auth.dependencies import verify_token
-from flip.db.database import get_session
-from flip.db.models.user_models import PermissionRef, User, UserRole, UsersAudit
-from flip.domain.interfaces.user import IRoles
-from flip.utils.cognito_helpers import validate_roles
-from flip.utils.logger import logger
+from flip_api.auth.dependencies import verify_token
+from flip_api.db.database import get_session
+from flip_api.db.models.user_models import PermissionRef, User, UserRole, UsersAudit
+from flip_api.domain.interfaces.user import IRoles
+from flip_api.utils.cognito_helpers import validate_roles
+from flip_api.utils.logger import logger
 
 router = APIRouter(prefix="/users", tags=["user_services"])
 

--- a/flip-api/src/flip_api/user_services/update_user.py
+++ b/flip-api/src/flip_api/user_services/update_user.py
@@ -16,14 +16,14 @@ from fastapi import APIRouter, Depends, HTTPException, Request, status
 from sqlmodel import Session
 
 from flip_api.auth.auth_utils import has_permissions
-from flip.auth.dependencies import verify_token
-from flip.db.database import get_session
-from flip.db.models.user_models import PermissionRef
-from flip.domain.interfaces.project import IUpdateXnatProfile
-from flip.domain.schemas.users import Disabled
-from flip.project_services.services.image_service import update_xnat_user_profile
-from flip.utils.cognito_helpers import get_user_pool_id, get_username, update_user
-from flip.utils.logger import logger
+from flip_api.auth.dependencies import verify_token
+from flip_api.db.database import get_session
+from flip_api.db.models.user_models import PermissionRef
+from flip_api.domain.interfaces.project import IUpdateXnatProfile
+from flip_api.domain.schemas.users import Disabled
+from flip_api.project_services.services.image_service import update_xnat_user_profile
+from flip_api.utils.cognito_helpers import get_user_pool_id, get_username, update_user
+from flip_api.utils.logger import logger
 
 router = APIRouter(prefix="/users", tags=["user_services"])
 

--- a/flip-api/src/flip_api/utils/cognito_helpers.py
+++ b/flip-api/src/flip_api/utils/cognito_helpers.py
@@ -21,10 +21,10 @@ from fastapi import HTTPException, Request, status
 from sqlmodel import Session, col, select
 
 from flip_api.config import get_settings
-from flip.db.models.user_models import Role, UserRole
-from flip.domain.schemas.users import CognitoUser, Disabled, IRole, IUser
-from flip.utils.logger import logger
-from flip.utils.paging_utils import PagingInfo
+from flip_api.db.models.user_models import Role, UserRole
+from flip_api.domain.schemas.users import CognitoUser, Disabled, IRole, IUser
+from flip_api.utils.logger import logger
+from flip_api.utils.paging_utils import PagingInfo
 
 boto3.set_stream_logger("boto3.resources", logging.INFO)
 

--- a/flip-api/src/flip_api/utils/project_manager.py
+++ b/flip-api/src/flip_api/utils/project_manager.py
@@ -18,8 +18,8 @@ from sqlmodel import Session
 from flip_api.db.models.main_models import (
     Projects,
 )
-from flip.domain.schemas.status import ProjectStatus
-from flip.utils.logger import logger
+from flip_api.domain.schemas.status import ProjectStatus
+from flip_api.utils.logger import logger
 
 
 def get_project_by_id(project_id: UUID, db: Session) -> Optional[Projects]:

--- a/flip-api/src/flip_api/utils/s3_client.py
+++ b/flip-api/src/flip_api/utils/s3_client.py
@@ -18,7 +18,7 @@ import boto3
 from botocore.exceptions import ClientError, EndpointConnectionError
 
 from flip_api.config import get_settings
-from flip.utils.logger import logger
+from flip_api.utils.logger import logger
 
 
 def parse_s3_path(s3_path: str) -> Tuple[str, str]:

--- a/flip-api/src/flip_api/utils/site_manager.py
+++ b/flip-api/src/flip_api/utils/site_manager.py
@@ -13,7 +13,7 @@
 from sqlmodel import Session, col, select
 
 from flip_api.db.models.main_models import SiteConfig
-from flip.utils.logger import logger
+from flip_api.utils.logger import logger
 
 
 def is_deployment_mode_enabled(db: Session) -> bool:

--- a/flip-api/tests/integration/test_presigned_url_for_uploads.py
+++ b/flip-api/tests/integration/test_presigned_url_for_uploads.py
@@ -15,7 +15,7 @@ from uuid import uuid4
 import pytest
 
 from flip_api.config import get_settings
-from flip.db.models.main_models import Model, Projects
+from flip_api.db.models.main_models import Model, Projects
 from tests.integration.utils import admin_authentication
 
 

--- a/flip-api/tests/integration/test_receive_cohort_results.py
+++ b/flip-api/tests/integration/test_receive_cohort_results.py
@@ -16,7 +16,7 @@ import pytest
 from fastapi import status
 
 from flip_api.config import get_settings
-from flip.domain.schemas.private import OmopCohortResults
+from flip_api.domain.schemas.private import OmopCohortResults
 
 
 @pytest.fixture

--- a/flip-api/tests/integration/test_retrieve_uploaded_file_info.py
+++ b/flip-api/tests/integration/test_retrieve_uploaded_file_info.py
@@ -24,7 +24,7 @@ from flip_api.db.models.main_models import UploadedFiles
 @pytest.fixture
 def mock_logger():
     """Mock logger for testing."""
-    with patch("flip.file_services.retrieve_uploaded_file_info.logger") as mock_logger:
+    with patch("flip_api.file_services.retrieve_uploaded_file_info.logger") as mock_logger:
         yield mock_logger
 
 
@@ -109,7 +109,7 @@ class TestIntegration:
         _, sample_file_ids, _ = sample_files
         file_ids_str = ",".join(str(fid) for fid in sample_file_ids[:2])
 
-        with patch("flip.auth.dependencies.verify_token", return_value="test-user-id"):
+        with patch("flip_api.auth.dependencies.verify_token", return_value="test-user-id"):
             with patch("sqlmodel.Session.exec") as mock_exec:
                 mock_result = MagicMock()
                 mock_result.all.return_value = sample_files[0]
@@ -126,7 +126,7 @@ class TestIntegration:
         """Integration test for the POST endpoint."""
         _, sample_file_ids, _ = sample_files
 
-        with patch("flip.auth.dependencies.verify_token", return_value="test-user-id"):
+        with patch("flip_api.auth.dependencies.verify_token", return_value="test-user-id"):
             with patch("sqlmodel.Session.exec") as mock_exec:
                 mock_result = MagicMock()
                 mock_result.all.return_value = sample_files[0]

--- a/flip-api/tests/integration/test_set_user_roles.py
+++ b/flip-api/tests/integration/test_set_user_roles.py
@@ -18,7 +18,7 @@ import pytest
 from sqlmodel import delete, insert
 
 from flip_api.db.models.user_models import Role, User, UserRole, UsersAudit
-from flip.user_services.set_user_roles import set_user_roles
+from flip_api.user_services.set_user_roles import set_user_roles
 
 
 @pytest.fixture
@@ -108,8 +108,8 @@ def test_audit_record_creation(mock_db, user_id, token_id, roles_data):
     mock_db.exec.return_value.all.return_value = role_instances
 
     with (
-        patch("flip.user_services.set_user_roles.has_permissions") as mock_has_permissions,
-        patch("flip.user_services.set_user_roles.UsersAudit") as mock_audit_class,
+        patch("flip_api.user_services.set_user_roles.has_permissions") as mock_has_permissions,
+        patch("flip_api.user_services.set_user_roles.UsersAudit") as mock_audit_class,
     ):
         mock_has_permissions.return_value = True
 

--- a/flip-api/tests/integration/test_user_registration_real_api.py
+++ b/flip-api/tests/integration/test_user_registration_real_api.py
@@ -17,11 +17,11 @@ import pytest
 from sqlmodel import Session, select
 
 from flip_api.config import get_settings
-from flip.db.database import engine
-from flip.db.models.user_models import Role
+from flip_api.db.database import engine
+from flip_api.db.models.user_models import Role
 from tests.integration.utils import admin_authentication
 
-REGISTER_USER_MODULE = "flip.user_services.register_user"
+REGISTER_USER_MODULE = "flip_api.user_services.register_user"
 
 
 @pytest.fixture

--- a/flip-api/tests/integration/utils.py
+++ b/flip-api/tests/integration/utils.py
@@ -14,7 +14,7 @@ import boto3
 from botocore.exceptions import ProfileNotFound
 
 from flip_api.config import get_settings
-from flip.utils.constants import ADMIN_EMAIL
+from flip_api.utils.constants import ADMIN_EMAIL
 
 
 def admin_authentication():

--- a/flip-api/tests/step_functions_services/test_approve_project_step_function.py
+++ b/flip-api/tests/step_functions_services/test_approve_project_step_function.py
@@ -17,8 +17,8 @@ import pytest
 from fastapi.testclient import TestClient
 
 from flip_api.domain.interfaces.trust import ITrust
-from flip.main import app
-from flip.step_functions_services.approve_project_step_function import (
+from flip_api.main import app
+from flip_api.step_functions_services.approve_project_step_function import (
     get_session,
     verify_token,
 )
@@ -66,9 +66,9 @@ def override_dependencies():
     app.dependency_overrides = {}
 
 
-@patch("flip.step_functions_services.approve_project_step_function.approve_project_endpoint")
+@patch("flip_api.step_functions_services.approve_project_step_function.approve_project_endpoint")
 @patch(
-    "flip.step_functions_services.approve_project_step_function.start_project_imaging_creation",
+    "flip_api.step_functions_services.approve_project_step_function.start_project_imaging_creation",
     new_callable=AsyncMock,
 )
 def test_approve_project_success(
@@ -96,9 +96,9 @@ def test_approve_project_success(
     assert mock_start_imaging.await_count == 2
 
 
-@patch("flip.step_functions_services.approve_project_step_function.approve_project_endpoint")
+@patch("flip_api.step_functions_services.approve_project_step_function.approve_project_endpoint")
 @patch(
-    "flip.step_functions_services.approve_project_step_function.start_project_imaging_creation",
+    "flip_api.step_functions_services.approve_project_step_function.start_project_imaging_creation",
     new_callable=AsyncMock,
 )
 def test_approve_project_with_failure_in_trust(
@@ -129,7 +129,7 @@ def test_approve_project_with_failure_in_trust(
     assert data["trusts"]["succeeded"] == 1
 
 
-@patch("flip.step_functions_services.approve_project_step_function.approve_project_endpoint")
+@patch("flip_api.step_functions_services.approve_project_step_function.approve_project_endpoint")
 def test_approve_project_with_empty_trusts(
     mock_approve_project,
     project_id,

--- a/flip-api/tests/step_functions_services/test_cohort_query_step_function.py
+++ b/flip-api/tests/step_functions_services/test_cohort_query_step_function.py
@@ -20,8 +20,8 @@ from flip_api.domain.schemas.cohort import (
     SubmitCohortQueryOutput,
     TrustDetails,
 )
-from flip.main import app
-from flip.step_functions_services.retrieve_model_step_function import (
+from flip_api.main import app
+from flip_api.step_functions_services.retrieve_model_step_function import (
     get_session,
     verify_token,
 )
@@ -47,9 +47,9 @@ def override_dependencies():
     app.dependency_overrides = {}
 
 
-@patch("flip.step_functions_services.cohort_query_step_function.get_project_by_id")
-@patch("flip.step_functions_services.cohort_query_step_function.save_cohort_query")
-@patch("flip.step_functions_services.cohort_query_step_function.submit_cohort_query")
+@patch("flip_api.step_functions_services.cohort_query_step_function.get_project_by_id")
+@patch("flip_api.step_functions_services.cohort_query_step_function.save_cohort_query")
+@patch("flip_api.step_functions_services.cohort_query_step_function.submit_cohort_query")
 def test_cohort_query_success(
     mock_submit,
     mock_save,
@@ -85,7 +85,7 @@ def test_cohort_query_success(
     mock_submit.assert_called_once()
 
 
-@patch("flip.step_functions_services.cohort_query_step_function.get_project_by_id")
+@patch("flip_api.step_functions_services.cohort_query_step_function.get_project_by_id")
 def test_cohort_query_project_not_found(mock_get_project, cohort_query_input):
     mock_get_project.return_value = None
 
@@ -96,8 +96,8 @@ def test_cohort_query_project_not_found(mock_get_project, cohort_query_input):
     mock_get_project.assert_called_once()
 
 
-@patch("flip.step_functions_services.cohort_query_step_function.get_project_by_id")
-@patch("flip.step_functions_services.cohort_query_step_function.save_cohort_query")
+@patch("flip_api.step_functions_services.cohort_query_step_function.get_project_by_id")
+@patch("flip_api.step_functions_services.cohort_query_step_function.save_cohort_query")
 def test_cohort_query_unexpected_exception(mock_save, mock_get_project, cohort_query_input):
     mock_get_project.return_value = True
     mock_save.side_effect = Exception("Database error")

--- a/flip-api/tests/step_functions_services/test_register_user_step_function.py
+++ b/flip-api/tests/step_functions_services/test_register_user_step_function.py
@@ -17,8 +17,8 @@ import pytest
 from fastapi.testclient import TestClient
 
 from flip_api.domain.interfaces.user import IUserResponse
-from flip.main import app
-from flip.step_functions_services.register_user_step_function import (
+from flip_api.main import app
+from flip_api.step_functions_services.register_user_step_function import (
     get_session,
     verify_token,
 )
@@ -52,8 +52,8 @@ def override_dependencies():
     app.dependency_overrides = {}
 
 
-@patch("flip.step_functions_services.register_user_step_function.set_user_roles")
-@patch("flip.step_functions_services.register_user_step_function.register_user")
+@patch("flip_api.step_functions_services.register_user_step_function.set_user_roles")
+@patch("flip_api.step_functions_services.register_user_step_function.register_user")
 def test_register_user_success(mock_register, mock_set_roles, user_payload, mock_register_response):
     mock_register.return_value = mock_register_response
     mock_set_roles.return_value = user_payload["roles"]
@@ -70,9 +70,9 @@ def test_register_user_success(mock_register, mock_set_roles, user_payload, mock
     mock_set_roles.assert_called_once()
 
 
-@patch("flip.step_functions_services.register_user_step_function.delete_user")
-@patch("flip.step_functions_services.register_user_step_function.set_user_roles")
-@patch("flip.step_functions_services.register_user_step_function.register_user")
+@patch("flip_api.step_functions_services.register_user_step_function.delete_user")
+@patch("flip_api.step_functions_services.register_user_step_function.set_user_roles")
+@patch("flip_api.step_functions_services.register_user_step_function.register_user")
 def test_register_user_role_assignment_fails(
     mock_register, mock_set_roles, mock_delete_user, user_payload, mock_register_response
 ):
@@ -94,7 +94,7 @@ def test_register_user_role_assignment_fails(
     mock_delete_user.assert_called_once()
 
 
-@patch("flip.step_functions_services.register_user_step_function.register_user")
+@patch("flip_api.step_functions_services.register_user_step_function.register_user")
 def test_register_user_unexpected_exception(mock_register, user_payload):
     mock_register.side_effect = Exception("DB failure")
 

--- a/flip-api/tests/step_functions_services/test_retrieve_model_step_function.py
+++ b/flip-api/tests/step_functions_services/test_retrieve_model_step_function.py
@@ -17,8 +17,8 @@ import pytest
 from fastapi.testclient import TestClient
 
 from flip_api.domain.interfaces.model import IModelResponse
-from flip.main import app
-from flip.step_functions_services.retrieve_model_step_function import (
+from flip_api.main import app
+from flip_api.step_functions_services.retrieve_model_step_function import (
     get_session,
     verify_token,
 )
@@ -58,7 +58,7 @@ def mock_model_response(model_id):
 # @pytest.fixture
 # def mock_retrieve_model_status_from_logs():
 #     with patch(
-#         "flip.step_functions_services.retrieve_model_step_function.retrieve_model_status_from_logs"
+#         "flip_api.step_functions_services.retrieve_model_step_function.retrieve_model_status_from_logs"
 #     ) as mock:
 #         mock.return_value = {"modelStatus": "TRAINING_STARTED"}
 #         yield mock
@@ -77,8 +77,8 @@ def override_dependencies():
     app.dependency_overrides = {}
 
 
-@patch("flip.step_functions_services.retrieve_model_step_function.update_model_status")
-@patch("flip.step_functions_services.retrieve_model_step_function.retrieve_model")
+@patch("flip_api.step_functions_services.retrieve_model_step_function.update_model_status")
+@patch("flip_api.step_functions_services.retrieve_model_step_function.retrieve_model")
 def test_retrieve_model_success(
     mock_retrieve_model,
     mock_update_status,
@@ -96,8 +96,8 @@ def test_retrieve_model_success(
     mock_retrieve_model.assert_called_once()
 
 
-@patch("flip.step_functions_services.retrieve_model_step_function.update_model_status")
-@patch("flip.step_functions_services.retrieve_model_step_function.retrieve_model")
+@patch("flip_api.step_functions_services.retrieve_model_step_function.update_model_status")
+@patch("flip_api.step_functions_services.retrieve_model_step_function.retrieve_model")
 def test_update_model_status_fails(
     mock_retrieve_model,
     mock_update_status,
@@ -111,8 +111,8 @@ def test_update_model_status_fails(
     assert response.json()["detail"] == "Failed to update model status"
 
 
-@patch("flip.step_functions_services.retrieve_model_step_function.update_model_status")
-@patch("flip.step_functions_services.retrieve_model_step_function.retrieve_model")
+@patch("flip_api.step_functions_services.retrieve_model_step_function.update_model_status")
+@patch("flip_api.step_functions_services.retrieve_model_step_function.retrieve_model")
 def test_retrieve_model_raises_exception(
     mock_retrieve_model,
     mock_update_status,

--- a/flip-api/tests/unit/db/seed/test_banner.py
+++ b/flip-api/tests/unit/db/seed/test_banner.py
@@ -16,7 +16,7 @@ import pytest
 from sqlmodel import Session
 
 from flip_api.db.models.main_models import SiteBanner
-from flip.db.seed.banner import seed_banner
+from flip_api.db.seed.banner import seed_banner
 
 
 @pytest.fixture

--- a/flip-api/tests/unit/db/seed/test_fl_nets.py
+++ b/flip-api/tests/unit/db/seed/test_fl_nets.py
@@ -16,7 +16,7 @@ import pytest
 from sqlmodel import Session
 
 from flip_api.db.models.main_models import FLNets
-from flip.db.seed.fl_nets import seed_fl_nets
+from flip_api.db.seed.fl_nets import seed_fl_nets
 
 
 @pytest.fixture
@@ -40,7 +40,7 @@ def sample_secret():
     return "{'net1': 'http://net1.com', 'net2': 'http://net2.com'}"
 
 
-@patch("flip.db.seed.fl_nets.get_secret")
+@patch("flip_api.db.seed.fl_nets.get_secret")
 def test_seed_fl_nets_creates_new_nets_when_none_exist(mock_get_secret, mock_session, sample_secret):
     """Test that seed_fl_nets creates new nets when none exist."""
     # Arrange
@@ -67,7 +67,7 @@ def test_seed_fl_nets_creates_new_nets_when_none_exist(mock_get_secret, mock_ses
     assert {added_net1.endpoint, added_net2.endpoint} == {"http://net1.com", "http://net2.com"}
 
 
-@patch("flip.db.seed.fl_nets.get_secret")
+@patch("flip_api.db.seed.fl_nets.get_secret")
 def test_seed_fl_nets_skips_existing_nets(mock_get_secret, mock_session, sample_secret, mock_fl_net):
     """Test that seed_fl_nets skips existing nets and only adds new ones."""
     # Arrange
@@ -91,7 +91,7 @@ def test_seed_fl_nets_skips_existing_nets(mock_get_secret, mock_session, sample_
     assert added_net.endpoint == "http://new.com"
 
 
-@patch("flip.db.seed.fl_nets.get_secret")
+@patch("flip_api.db.seed.fl_nets.get_secret")
 def test_seed_fl_nets_handles_json_with_single_quotes(mock_get_secret, mock_session):
     """Test that seed_fl_nets correctly handles JSON with single quotes."""
     # Arrange
@@ -109,7 +109,7 @@ def test_seed_fl_nets_handles_json_with_single_quotes(mock_get_secret, mock_sess
     assert added_net.endpoint == "http://test.com"
 
 
-@patch("flip.db.seed.fl_nets.get_secret")
+@patch("flip_api.db.seed.fl_nets.get_secret")
 def test_seed_fl_nets_returns_all_nets(mock_get_secret, mock_session, sample_secret):
     """Test that seed_fl_nets returns all nets from database."""
     # Arrange
@@ -129,7 +129,7 @@ def test_seed_fl_nets_returns_all_nets(mock_get_secret, mock_session, sample_sec
     assert result == final_nets
 
 
-@patch("flip.db.seed.fl_nets.get_secret")
+@patch("flip_api.db.seed.fl_nets.get_secret")
 def test_seed_fl_nets_with_empty_secrets(mock_get_secret, mock_session):
     """Test that seed_fl_nets handles empty net endpoints."""
     # Arrange

--- a/flip-api/tests/unit/db/seed/test_fl_schedule.py
+++ b/flip-api/tests/unit/db/seed/test_fl_schedule.py
@@ -16,8 +16,8 @@ import pytest
 from sqlmodel import Session
 
 from flip_api.db.models.main_models import FLNets, FLScheduler
-from flip.db.seed.fl_scheduler import seed_fl_scheduler
-from flip.domain.schemas.status import NetStatus
+from flip_api.db.seed.fl_scheduler import seed_fl_scheduler
+from flip_api.domain.schemas.status import NetStatus
 
 
 @pytest.fixture
@@ -76,10 +76,10 @@ def sample_all_schedulers():
     return [scheduler1, scheduler2, scheduler3]
 
 
-@patch("flip.db.seed.fl_scheduler.logger")
-@patch("flip.db.seed.fl_scheduler.select")
-@patch("flip.db.seed.fl_scheduler.col")
-@patch("flip.db.seed.fl_scheduler.FLScheduler")
+@patch("flip_api.db.seed.fl_scheduler.logger")
+@patch("flip_api.db.seed.fl_scheduler.select")
+@patch("flip_api.db.seed.fl_scheduler.col")
+@patch("flip_api.db.seed.fl_scheduler.FLScheduler")
 def test_seed_fl_scheduler_no_existing_schedulers(
     mock_fl_scheduler_class, mock_col, mock_select, mock_logger, mock_session, sample_nets, sample_all_schedulers
 ):
@@ -113,10 +113,10 @@ def test_seed_fl_scheduler_no_existing_schedulers(
     assert len(result) == 3
 
 
-@patch("flip.db.seed.fl_scheduler.logger")
-@patch("flip.db.seed.fl_scheduler.select")
-@patch("flip.db.seed.fl_scheduler.col")
-@patch("flip.db.seed.fl_scheduler.FLScheduler")
+@patch("flip_api.db.seed.fl_scheduler.logger")
+@patch("flip_api.db.seed.fl_scheduler.select")
+@patch("flip_api.db.seed.fl_scheduler.col")
+@patch("flip_api.db.seed.fl_scheduler.FLScheduler")
 def test_seed_fl_scheduler_some_existing_schedulers(
     mock_fl_scheduler_class,
     mock_col,
@@ -151,10 +151,10 @@ def test_seed_fl_scheduler_some_existing_schedulers(
     assert result == sample_all_schedulers
 
 
-@patch("flip.db.seed.fl_scheduler.logger")
-@patch("flip.db.seed.fl_scheduler.select")
-@patch("flip.db.seed.fl_scheduler.col")
-@patch("flip.db.seed.fl_scheduler.FLScheduler")
+@patch("flip_api.db.seed.fl_scheduler.logger")
+@patch("flip_api.db.seed.fl_scheduler.select")
+@patch("flip_api.db.seed.fl_scheduler.col")
+@patch("flip_api.db.seed.fl_scheduler.FLScheduler")
 def test_seed_fl_scheduler_all_existing_schedulers(
     mock_fl_scheduler_class,
     mock_col,
@@ -186,10 +186,10 @@ def test_seed_fl_scheduler_all_existing_schedulers(
     assert result == sample_all_schedulers
 
 
-@patch("flip.db.seed.fl_scheduler.logger")
-@patch("flip.db.seed.fl_scheduler.select")
-@patch("flip.db.seed.fl_scheduler.col")
-@patch("flip.db.seed.fl_scheduler.FLScheduler")
+@patch("flip_api.db.seed.fl_scheduler.logger")
+@patch("flip_api.db.seed.fl_scheduler.select")
+@patch("flip_api.db.seed.fl_scheduler.col")
+@patch("flip_api.db.seed.fl_scheduler.FLScheduler")
 def test_seed_fl_scheduler_empty_nets_list(mock_fl_scheduler_class, mock_col, mock_select, mock_logger, mock_session):
     """Test seeding with empty nets list."""
     # Setup mocks
@@ -207,9 +207,9 @@ def test_seed_fl_scheduler_empty_nets_list(mock_fl_scheduler_class, mock_col, mo
     assert result == []
 
 
-@patch("flip.db.seed.fl_scheduler.logger")
-@patch("flip.db.seed.fl_scheduler.select")
-@patch("flip.db.seed.fl_scheduler.col")
+@patch("flip_api.db.seed.fl_scheduler.logger")
+@patch("flip_api.db.seed.fl_scheduler.select")
+@patch("flip_api.db.seed.fl_scheduler.col")
 def test_seed_fl_scheduler_query_construction(mock_col, mock_select, mock_logger, mock_session, sample_nets):
     """Test that database queries are constructed correctly."""
     # Setup mocks
@@ -231,7 +231,7 @@ def test_seed_fl_scheduler_query_construction(mock_col, mock_select, mock_logger
     mock_select.assert_any_call(FLScheduler)
 
 
-@patch("flip.db.seed.fl_scheduler.logger")
+@patch("flip_api.db.seed.fl_scheduler.logger")
 def test_seed_fl_scheduler_logging(mock_logger, mock_session, sample_nets):
     """Test that appropriate logging occurs."""
     # Setup mocks
@@ -243,9 +243,9 @@ def test_seed_fl_scheduler_logging(mock_logger, mock_session, sample_nets):
     ]
 
     with (
-        patch("flip.db.seed.fl_scheduler.select"),
-        patch("flip.db.seed.fl_scheduler.col"),
-        patch("flip.db.seed.fl_scheduler.FLScheduler"),
+        patch("flip_api.db.seed.fl_scheduler.select"),
+        patch("flip_api.db.seed.fl_scheduler.col"),
+        patch("flip_api.db.seed.fl_scheduler.FLScheduler"),
     ):
         # Execute
         seed_fl_scheduler(mock_session, sample_nets)

--- a/flip-api/tests/unit/db/seed/test_main_users.py
+++ b/flip-api/tests/unit/db/seed/test_main_users.py
@@ -16,8 +16,8 @@ import pytest
 from sqlmodel import Session
 
 from flip_api.db.models.user_models import RoleRef
-from flip.db.seed.main_users import seed_main_users
-from flip.utils.constants import ADMIN_EMAIL, RESEARCHER_EMAIL
+from flip_api.db.seed.main_users import seed_main_users
+from flip_api.utils.constants import ADMIN_EMAIL, RESEARCHER_EMAIL
 
 
 @pytest.fixture
@@ -25,8 +25,8 @@ def mock_session():
     return MagicMock(spec=Session)
 
 
-@patch("flip.db.seed.main_users.ensure_user_and_role")
-@patch("flip.db.seed.main_users.logger")
+@patch("flip_api.db.seed.main_users.ensure_user_and_role")
+@patch("flip_api.db.seed.main_users.logger")
 def test_seed_main_users_calls_ensure_user_and_role(mock_logger, mock_ensure_user_and_role, mock_session):
     """Test that seed_main_users calls ensure_user_and_role for admin and researcher."""
     seed_main_users(mock_session)
@@ -42,8 +42,8 @@ def test_seed_main_users_calls_ensure_user_and_role(mock_logger, mock_ensure_use
     mock_logger.info.assert_called_with("✅ Finished seeding main users.")
 
 
-@patch("flip.db.seed.main_users.ensure_user_and_role")
-@patch("flip.db.seed.main_users.logger")
+@patch("flip_api.db.seed.main_users.ensure_user_and_role")
+@patch("flip_api.db.seed.main_users.logger")
 def test_seed_main_users_propagates_errors(mock_logger, mock_ensure_user_and_role, mock_session):
     """Test that errors in ensure_user_and_role propagate up."""
     mock_ensure_user_and_role.side_effect = Exception("Cognito failure")
@@ -55,8 +55,8 @@ def test_seed_main_users_propagates_errors(mock_logger, mock_ensure_user_and_rol
     mock_ensure_user_and_role.assert_called_once_with(ADMIN_EMAIL, RoleRef.ADMIN, mock_session)
 
 
-@patch("flip.db.seed.main_users.ensure_user_and_role")
-@patch("flip.db.seed.main_users.logger")
+@patch("flip_api.db.seed.main_users.ensure_user_and_role")
+@patch("flip_api.db.seed.main_users.logger")
 def test_seed_main_users_runs_both_even_if_first_succeeds(mock_logger, mock_ensure_user_and_role, mock_session):
     """Test that both users are seeded when ensure_user_and_role succeeds."""
     mock_ensure_user_and_role.return_value = None

--- a/flip-api/tests/unit/domain/interfaces/test_project_interfaces.py
+++ b/flip-api/tests/unit/domain/interfaces/test_project_interfaces.py
@@ -32,8 +32,8 @@ from flip_api.domain.interfaces.project import (
     IReturnedProject,
     IUpdateXnatProfile,
 )
-from flip.domain.schemas.status import ModelStatus, ProjectStatus
-from flip.utils.paging_utils import IPagedData, IPagedResponse
+from flip_api.domain.schemas.status import ModelStatus, ProjectStatus
+from flip_api.utils.paging_utils import IPagedData, IPagedResponse
 
 # Common timestamp used for testing
 now = datetime.utcnow().isoformat(timespec="milliseconds")

--- a/flip-api/tests/unit/file_services/test_delete_file.py
+++ b/flip-api/tests/unit/file_services/test_delete_file.py
@@ -19,7 +19,7 @@ from fastapi import HTTPException, status
 from sqlmodel import Session
 
 from flip_api.config import Settings
-from flip.file_services.delete_file import (
+from flip_api.file_services.delete_file import (
     S3Client,
     delete_model_file,
 )
@@ -36,16 +36,16 @@ def mocked_settings():
     mock = Settings(
         SCANNED_MODEL_FILES_BUCKET=bucket_name,
     )
-    with patch("flip.file_services.delete_file.get_settings", return_value=mock):
+    with patch("flip_api.file_services.delete_file.get_settings", return_value=mock):
         yield mock
 
 
-@patch("flip.file_services.delete_file.can_access_model", return_value=True)
+@patch("flip_api.file_services.delete_file.can_access_model", return_value=True)
 def test_delete_model_file_success(session: Session, monkeypatch, mocked_settings):
     """Test successful file deletion from S3 and database."""
     # Mock S3 client
     s3_client_mock = mock.Mock(spec=S3Client)
-    monkeypatch.setattr("flip.file_services.delete_file.S3Client", lambda: s3_client_mock)
+    monkeypatch.setattr("flip_api.file_services.delete_file.S3Client", lambda: s3_client_mock)
 
     # Mock database operations
     db_mock = mock.Mock(spec=Session)
@@ -64,7 +64,7 @@ def test_delete_model_file_success(session: Session, monkeypatch, mocked_setting
 def test_delete_model_file_no_access(session: Session, monkeypatch):
     """Test when the user does not have access to the model."""
     # Mock can_access_model to return False
-    monkeypatch.setattr("flip.file_services.delete_file.can_access_model", lambda *args: False)
+    monkeypatch.setattr("flip_api.file_services.delete_file.can_access_model", lambda *args: False)
 
     # Call the function and assert HTTPException is raised
     with pytest.raises(HTTPException) as exc_info:
@@ -75,13 +75,13 @@ def test_delete_model_file_no_access(session: Session, monkeypatch):
     assert str(user_id) in exc_info.value.detail
 
 
-@patch("flip.file_services.delete_file.can_access_model", return_value=True)
+@patch("flip_api.file_services.delete_file.can_access_model", return_value=True)
 def test_delete_model_file_s3_error(session: Session, monkeypatch):
     """Test when there is an error deleting from S3."""
     # Mock S3 client to raise an exception
     s3_client_mock = mock.Mock(spec=S3Client)
     s3_client_mock.delete_object.side_effect = Exception("S3 error")
-    monkeypatch.setattr("flip.file_services.delete_file.S3Client", lambda: s3_client_mock)
+    monkeypatch.setattr("flip_api.file_services.delete_file.S3Client", lambda: s3_client_mock)
 
     # Mock database operations
     db_mock = mock.Mock(spec=Session)
@@ -103,7 +103,7 @@ def test_delete_model_file_general_exception(session: Session, monkeypatch):
     """Test when a general exception occurs."""
     # Mock ModelFileDelete to raise an exception
     monkeypatch.setattr(
-        "flip.file_services.delete_file.ModelFileDelete",
+        "flip_api.file_services.delete_file.ModelFileDelete",
         lambda *args, **kwargs: (_ for _ in ()).throw(Exception("General error")),
     )
 

--- a/flip-api/tests/unit/file_services/test_download_file.py
+++ b/flip-api/tests/unit/file_services/test_download_file.py
@@ -21,7 +21,7 @@ from fastapi.exceptions import HTTPException
 from fastapi.responses import StreamingResponse
 
 from flip_api.config import Settings
-from flip.file_services.download_file import download_file
+from flip_api.file_services.download_file import download_file
 
 bucket = "s3://test-secure-bucket"
 
@@ -29,7 +29,7 @@ bucket = "s3://test-secure-bucket"
 @pytest.fixture
 def mock_s3_client():
     """Mock S3Client for testing."""
-    with patch("flip.file_services.download_file.S3Client") as mock_client:
+    with patch("flip_api.file_services.download_file.S3Client") as mock_client:
         s3_instance = MagicMock()
         mock_client.return_value = s3_instance
 
@@ -43,7 +43,7 @@ def mock_s3_client():
 @pytest.fixture
 def mock_access_manager():
     """Mock can_access_model function."""
-    with patch("flip.file_services.download_file.can_access_model") as mock_access:
+    with patch("flip_api.file_services.download_file.can_access_model") as mock_access:
         # Default to allowing access
         mock_access.return_value = True
         yield mock_access
@@ -54,7 +54,7 @@ def mocked_settings():
     mock = Settings(
         SCANNED_MODEL_FILES_BUCKET=bucket,
     )
-    with patch("flip.file_services.download_file.get_settings", return_value=mock):
+    with patch("flip_api.file_services.download_file.get_settings", return_value=mock):
         yield mock
 
 

--- a/flip-api/tests/unit/file_services/test_get_model_files_list.py
+++ b/flip-api/tests/unit/file_services/test_get_model_files_list.py
@@ -18,7 +18,7 @@ import pytest
 from fastapi import HTTPException, status
 
 from flip_api.db.models.main_models import UploadedFiles
-from flip.file_services.get_model_files_list import get_model_files_list
+from flip_api.file_services.get_model_files_list import get_model_files_list
 
 # filepath: /app/src/flip/file_services/test_get_model_files_list.py
 
@@ -70,7 +70,7 @@ def test_get_model_files_list_success(mock_session, mock_db_files):
     """Test successfully retrieving model files."""
     files, model_id = mock_db_files
 
-    with patch("flip.file_services.get_model_files_list.can_access_model", return_value=True):
+    with patch("flip_api.file_services.get_model_files_list.can_access_model", return_value=True):
         result = get_model_files_list(model_id=model_id, db=mock_session, user_id="test-user-id")
 
         assert len(result) == 2
@@ -87,7 +87,7 @@ def test_get_model_files_list_access_denied(mock_session, mock_db_files):
     """Test access denied when user doesn't have permission."""
     _, model_id = mock_db_files
 
-    with patch("flip.file_services.get_model_files_list.can_access_model", return_value=False):
+    with patch("flip_api.file_services.get_model_files_list.can_access_model", return_value=False):
         with pytest.raises(HTTPException) as exc_info:
             get_model_files_list(model_id=model_id, db=mock_session, user_id="unauthorized-user")
 
@@ -107,7 +107,7 @@ def test_get_model_files_list_empty_result():
 
             return MockResult()
 
-    with patch("flip.file_services.get_model_files_list.can_access_model", return_value=True):
+    with patch("flip_api.file_services.get_model_files_list.can_access_model", return_value=True):
         result = get_model_files_list(model_id=model_id, db=EmptyMockSession(), user_id="test-user-id")
 
         assert isinstance(result, list)
@@ -118,7 +118,7 @@ def test_get_model_files_list_unexpected_error(mock_session, mock_db_files):
     """Test handling of unexpected errors."""
     _, model_id = mock_db_files
 
-    with patch("flip.file_services.get_model_files_list.can_access_model", return_value=True):
+    with patch("flip_api.file_services.get_model_files_list.can_access_model", return_value=True):
         with patch.object(mock_session, "exec", side_effect=Exception("Unexpected database error")):
             with pytest.raises(HTTPException) as exc_info:
                 get_model_files_list(model_id=model_id, db=mock_session, user_id="test-user-id")

--- a/flip-api/tests/unit/file_services/test_retrieve_federated_results.py
+++ b/flip-api/tests/unit/file_services/test_retrieve_federated_results.py
@@ -20,19 +20,19 @@ from fastapi import HTTPException, status
 from fastapi.testclient import TestClient
 
 from flip_api.auth.dependencies import verify_token
-from flip.config import Settings
-from flip.db.database import get_session
-from flip.db.models.main_models import Model
-from flip.file_services.retrieve_federated_results import retrieve_federated_results
-from flip.main import app
-from flip.utils.s3_client import S3Client
+from flip_api.config import Settings
+from flip_api.db.database import get_session
+from flip_api.db.models.main_models import Model
+from flip_api.file_services.retrieve_federated_results import retrieve_federated_results
+from flip_api.main import app
+from flip_api.utils.s3_client import S3Client
 from tests.fixtures.db_fixtures import ModelFactory, ProjectFactory
 
 
 @pytest.fixture
 def mock_logger():
     """Mock logger for testing."""
-    with patch("flip.file_services.retrieve_federated_results.logger") as mock_logger:
+    with patch("flip_api.file_services.retrieve_federated_results.logger") as mock_logger:
         yield mock_logger
 
 
@@ -68,7 +68,7 @@ def empty_db_session():
 @pytest.fixture
 def s3_mock_success():
     """Mock S3 client for success case."""
-    with patch("flip.file_services.retrieve_federated_results.S3Client") as mock_s3:
+    with patch("flip_api.file_services.retrieve_federated_results.S3Client") as mock_s3:
         mock_instance = MagicMock()
         mock_s3.return_value = mock_instance
 
@@ -88,7 +88,7 @@ def s3_mock_success():
 @pytest.fixture
 def s3_mock_empty():
     """Mock S3 client returning empty results."""
-    with patch("flip.file_services.retrieve_federated_results.S3Client") as mock_s3:
+    with patch("flip_api.file_services.retrieve_federated_results.S3Client") as mock_s3:
         mock_instance = MagicMock()
         mock_s3.return_value = mock_instance
         mock_instance.list_objects.return_value = []
@@ -98,7 +98,7 @@ def s3_mock_empty():
 @pytest.fixture
 def s3_mock_error():
     """Mock S3 client that raises an error."""
-    with patch("flip.file_services.retrieve_federated_results.S3Client") as mock_s3:
+    with patch("flip_api.file_services.retrieve_federated_results.S3Client") as mock_s3:
         mock_instance = MagicMock()
         mock_s3.return_value = mock_instance
         mock_instance.list_objects.side_effect = Exception("S3 error")
@@ -108,7 +108,7 @@ def s3_mock_error():
 @pytest.fixture
 def s3_mock_presigned_error():
     """Mock S3 client with presigned URL error."""
-    with patch("flip.file_services.retrieve_federated_results.S3Client") as mock_s3:
+    with patch("flip_api.file_services.retrieve_federated_results.S3Client") as mock_s3:
         mock_instance = MagicMock()
         mock_s3.return_value = mock_instance
         mock_instance.list_objects.return_value = ["model-id/file1.csv"]
@@ -130,7 +130,7 @@ def mocked_settings():
         SCANNED_MODEL_FILES_BUCKET="s3://mock-bucket-scanned/model_files",
         FL_APP_DESTINATION_BUCKET="s3://mock-bucket-dest/dest_files",
     )
-    with patch("flip.file_services.retrieve_federated_results.get_settings", return_value=mock):
+    with patch("flip_api.file_services.retrieve_federated_results.get_settings", return_value=mock):
         yield mock
 
 
@@ -159,8 +159,8 @@ def test_retrieve_federated_results_endpoint_calls_function(override_dependencie
     override_dependencies.exec.return_value.first.return_value = mock_model
 
     with (
-        patch("flip.file_services.retrieve_federated_results.can_access_model", return_value=True),
-        patch("flip.file_services.retrieve_federated_results.S3Client") as mock_s3_client,
+        patch("flip_api.file_services.retrieve_federated_results.can_access_model", return_value=True),
+        patch("flip_api.file_services.retrieve_federated_results.S3Client") as mock_s3_client,
     ):
         # Mock S3 list_objects and get_presigned_url
         mock_s3 = mock_s3_client.return_value
@@ -179,7 +179,7 @@ class TestRetrieveFederatedResults:
 
     def test_retrieve_success(self, mock_db_session, s3_mock_success, mocked_settings, sample_model_id, user_id):
         """Test successful retrieval of federated results."""
-        with patch("flip.file_services.retrieve_federated_results.can_access_model", return_value=True):
+        with patch("flip_api.file_services.retrieve_federated_results.can_access_model", return_value=True):
             result = retrieve_federated_results(model_id=sample_model_id, db=mock_db_session, user_id=user_id)
             assert len(result) == 2
             assert result[0] == "https://test-bucket.s3.amazonaws.com/model-id/file1.csv"
@@ -187,7 +187,7 @@ class TestRetrieveFederatedResults:
 
     def test_access_denied(self, mock_db_session, mocked_settings, sample_model_id, user_id):
         """Test handling of unauthorized access to model."""
-        with patch("flip.file_services.retrieve_federated_results.can_access_model", return_value=False):
+        with patch("flip_api.file_services.retrieve_federated_results.can_access_model", return_value=False):
             with pytest.raises(HTTPException) as exc_info:
                 retrieve_federated_results(model_id=sample_model_id, db=mock_db_session, user_id=user_id)
 
@@ -196,7 +196,7 @@ class TestRetrieveFederatedResults:
 
     def test_model_not_found(self, empty_db_session, mocked_settings, sample_model_id, user_id):
         """Test handling of non-existent model."""
-        with patch("flip.file_services.retrieve_federated_results.can_access_model", return_value=True):
+        with patch("flip_api.file_services.retrieve_federated_results.can_access_model", return_value=True):
             with pytest.raises(HTTPException) as exc_info:
                 retrieve_federated_results(model_id=sample_model_id, db=empty_db_session, user_id=user_id)
 
@@ -205,7 +205,7 @@ class TestRetrieveFederatedResults:
 
     def test_s3_listing_error(self, mock_db_session, s3_mock_error, mocked_settings, sample_model_id, user_id):
         """Test handling of S3 listing error."""
-        with patch("flip.file_services.retrieve_federated_results.can_access_model", return_value=True):
+        with patch("flip_api.file_services.retrieve_federated_results.can_access_model", return_value=True):
             with pytest.raises(HTTPException) as exc_info:
                 retrieve_federated_results(model_id=sample_model_id, db=mock_db_session, user_id=user_id)
 
@@ -214,7 +214,7 @@ class TestRetrieveFederatedResults:
 
     def test_no_files_found(self, mock_db_session, s3_mock_empty, mocked_settings, sample_model_id, user_id):
         """Test handling of no files found in S3."""
-        with patch("flip.file_services.retrieve_federated_results.can_access_model", return_value=True):
+        with patch("flip_api.file_services.retrieve_federated_results.can_access_model", return_value=True):
             with pytest.raises(HTTPException) as exc_info:
                 retrieve_federated_results(model_id=sample_model_id, db=mock_db_session, user_id=user_id)
 
@@ -225,7 +225,7 @@ class TestRetrieveFederatedResults:
         self, mock_db_session, s3_mock_presigned_error, mocked_settings, sample_model_id, user_id
     ):
         """Test handling of error when generating presigned URLs."""
-        with patch("flip.file_services.retrieve_federated_results.can_access_model", return_value=True):
+        with patch("flip_api.file_services.retrieve_federated_results.can_access_model", return_value=True):
             with pytest.raises(HTTPException) as exc_info:
                 retrieve_federated_results(model_id=sample_model_id, db=mock_db_session, user_id=user_id)
 
@@ -235,7 +235,7 @@ class TestRetrieveFederatedResults:
     def test_unexpected_error(self, mock_db_session, mocked_settings, sample_model_id, user_id):
         """Test handling of unexpected general errors."""
         with patch(
-            "flip.file_services.retrieve_federated_results.can_access_model",
+            "flip_api.file_services.retrieve_federated_results.can_access_model",
             side_effect=Exception("Unexpected error"),
         ):
             with pytest.raises(HTTPException) as exc_info:

--- a/flip-api/tests/unit/file_services/test_retrieve_model_files_list.py
+++ b/flip-api/tests/unit/file_services/test_retrieve_model_files_list.py
@@ -17,7 +17,7 @@ import pytest
 from fastapi import HTTPException, status
 
 from flip_api.config import Settings
-from flip.file_services.retrieve_model_files_list import (
+from flip_api.file_services.retrieve_model_files_list import (
     ModelFiles,
     ModelFilesList,
     retrieve_model_files_list,
@@ -28,7 +28,7 @@ from tests.fixtures.db_fixtures import ModelFactory, ProjectFactory
 @pytest.fixture
 def mock_logger():
     """Mock logger for testing."""
-    with patch("flip.file_services.retrieve_model_files_list.logger") as mock_logger:
+    with patch("flip_api.file_services.retrieve_model_files_list.logger") as mock_logger:
         yield mock_logger
 
 
@@ -49,7 +49,7 @@ def sample_model(sample_model_id):
 @pytest.fixture
 def s3_mock_success():
     """Mock S3 client for success case with various file types."""
-    with patch("flip.file_services.retrieve_model_files_list.S3Client") as mock_s3:
+    with patch("flip_api.file_services.retrieve_model_files_list.S3Client") as mock_s3:
         mock_instance = MagicMock()
         mock_s3.return_value = mock_instance
 
@@ -69,7 +69,7 @@ def s3_mock_success():
 @pytest.fixture
 def s3_mock_empty():
     """Mock S3 client returning empty results."""
-    with patch("flip.file_services.retrieve_model_files_list.S3Client") as mock_s3:
+    with patch("flip_api.file_services.retrieve_model_files_list.S3Client") as mock_s3:
         mock_instance = MagicMock()
         mock_s3.return_value = mock_instance
         mock_instance.list_objects.return_value = {}
@@ -79,7 +79,7 @@ def s3_mock_empty():
 @pytest.fixture
 def s3_mock_error():
     """Mock S3 client that raises an error."""
-    with patch("flip.file_services.retrieve_model_files_list.S3Client") as mock_s3:
+    with patch("flip_api.file_services.retrieve_model_files_list.S3Client") as mock_s3:
         mock_instance = MagicMock()
         mock_s3.return_value = mock_instance
         mock_instance.list_objects.side_effect = Exception("S3 error")
@@ -91,7 +91,7 @@ def mocked_settings():
     mock = Settings(
         SCANNED_MODEL_FILES_BUCKET="test-bucket",
     )
-    with patch("flip.file_services.retrieve_model_files_list.get_settings", return_value=mock):
+    with patch("flip_api.file_services.retrieve_model_files_list.get_settings", return_value=mock):
         yield mock
 
 
@@ -142,7 +142,7 @@ class TestRetrieveModelFilesList:
 
     def test_access_denied(self, mock_db_session, sample_model_id):
         """Test handling of unauthorized access to model."""
-        with patch("flip.file_services.retrieve_model_files_list.can_access_model", return_value=False):
+        with patch("flip_api.file_services.retrieve_model_files_list.can_access_model", return_value=False):
             with pytest.raises(HTTPException) as exc_info:
                 retrieve_model_files_list(model_id=sample_model_id, db=mock_db_session, user_id="test-user-id")
 
@@ -151,7 +151,7 @@ class TestRetrieveModelFilesList:
 
     def test_s3_listing_error(self, mock_db_session, s3_mock_error, sample_model_id):
         """Test handling of S3 listing error."""
-        with patch("flip.file_services.retrieve_model_files_list.can_access_model", return_value=True):
+        with patch("flip_api.file_services.retrieve_model_files_list.can_access_model", return_value=True):
             with pytest.raises(HTTPException) as exc_info:
                 retrieve_model_files_list(model_id=sample_model_id, db=mock_db_session, user_id="test-user-id")
 
@@ -167,7 +167,7 @@ class TestRetrieveModelFilesList:
     def test_unexpected_error(self, mock_db_session, sample_model_id):
         """Test handling of unexpected general errors."""
         with patch(
-            "flip.file_services.retrieve_model_files_list.can_access_model",
+            "flip_api.file_services.retrieve_model_files_list.can_access_model",
             side_effect=Exception("Unexpected error"),
         ):
             with pytest.raises(HTTPException) as exc_info:

--- a/flip-api/tests/unit/file_services/test_retrieve_uploaded_file_info.py
+++ b/flip-api/tests/unit/file_services/test_retrieve_uploaded_file_info.py
@@ -18,8 +18,8 @@ import pytest
 from fastapi import HTTPException, status
 
 from flip_api.db.models.main_models import UploadedFiles
-from flip.domain.schemas.file import IdList
-from flip.file_services.retrieve_uploaded_file_info import get_uploaded_files_info, get_uploaded_files_info_post
+from flip_api.domain.schemas.file import IdList
+from flip_api.file_services.retrieve_uploaded_file_info import get_uploaded_files_info, get_uploaded_files_info_post
 
 # filepath: /app/src/flip/file_services/test_retrieve_uploaded_file_info.py
 
@@ -27,7 +27,7 @@ from flip.file_services.retrieve_uploaded_file_info import get_uploaded_files_in
 @pytest.fixture
 def mock_logger():
     """Mock logger for testing."""
-    with patch("flip.file_services.retrieve_uploaded_file_info.logger") as mock_logger:
+    with patch("flip_api.file_services.retrieve_uploaded_file_info.logger") as mock_logger:
         yield mock_logger
 
 

--- a/flip-api/tests/unit/file_services/test_uploaded_file.py
+++ b/flip-api/tests/unit/file_services/test_uploaded_file.py
@@ -18,15 +18,15 @@ import pytest
 from fastapi.exceptions import HTTPException
 
 from flip_api.config import Settings
-from flip.db.models.main_models import UploadedFiles
-from flip.domain.schemas.file import BucketStatus, FileUploadStatus, ScannedFileInput
-from flip.file_services.uploaded_file import process_scanned_file
+from flip_api.db.models.main_models import UploadedFiles
+from flip_api.domain.schemas.file import BucketStatus, FileUploadStatus, ScannedFileInput
+from flip_api.file_services.uploaded_file import process_scanned_file
 
 
 @pytest.fixture
 def mock_s3_client():
     """Mock S3Client for testing."""
-    with patch("flip.file_services.uploaded_file.S3Client") as mock_client:
+    with patch("flip_api.file_services.uploaded_file.S3Client") as mock_client:
         s3_instance = MagicMock()
         mock_client.return_value = s3_instance
         # Mock head_object to return file metadata
@@ -39,7 +39,7 @@ def mocked_settings():
     mock = Settings(
         SCANNED_MODEL_FILES_BUCKET="test-secure-bucket",
     )
-    with patch("flip.file_services.uploaded_file.get_settings", return_value=mock):
+    with patch("flip_api.file_services.uploaded_file.get_settings", return_value=mock):
         yield mock
 
 

--- a/flip-api/tests/unit/fl_services/services/test_fl_scheduler_service.py
+++ b/flip-api/tests/unit/fl_services/services/test_fl_scheduler_service.py
@@ -21,9 +21,9 @@ from flip_api.domain.interfaces.fl import (
     IRequiredTrainingInformation,
     ISchedulerResponse,
 )
-from flip.domain.schemas.status import JobStatus, ModelStatus, NetStatus
-from flip.fl_services.services import fl_scheduler_service
-from flip.utils.exceptions import NotFoundError
+from flip_api.domain.schemas.status import JobStatus, ModelStatus, NetStatus
+from flip_api.fl_services.services import fl_scheduler_service
+from flip_api.utils.exceptions import NotFoundError
 
 
 @pytest.fixture
@@ -47,20 +47,20 @@ def scheduler_id():
 
 
 def test_prepare_and_start_training_success(fake_session, model_id, fl_job_id):
-    from flip.domain.interfaces.fl import JobTypes
+    from flip_api.domain.interfaces.fl import JobTypes
 
     with (
         patch(
-            "flip.fl_services.services.fl_scheduler_service.bundle_application",
+            "flip_api.fl_services.services.fl_scheduler_service.bundle_application",
             return_value=(2, JobTypes.standard),
         ) as mock_bundle,
-        patch("flip.fl_services.services.fl_scheduler_service.get_net_by_model_id") as mock_get_net,
+        patch("flip_api.fl_services.services.fl_scheduler_service.get_net_by_model_id") as mock_get_net,
         patch(
-            "flip.fl_services.services.fl_scheduler_service.validate_client_availability"
+            "flip_api.fl_services.services.fl_scheduler_service.validate_client_availability"
         ) as mock_validate_clients,
-        patch("flip.fl_services.services.fl_scheduler_service.get_bundle_urls", return_value=["url1", "url2"]),
-        patch("flip.fl_services.services.fl_scheduler_service.start_training") as mock_start,
-        patch("flip.fl_services.services.fl_scheduler_service.add_log") as mock_log,
+        patch("flip_api.fl_services.services.fl_scheduler_service.get_bundle_urls", return_value=["url1", "url2"]),
+        patch("flip_api.fl_services.services.fl_scheduler_service.start_training") as mock_start,
+        patch("flip_api.fl_services.services.fl_scheduler_service.add_log") as mock_log,
     ):
         mock_get_net.return_value = INetDetails(endpoint="endpoint", name="net-name")
 
@@ -81,12 +81,12 @@ def test_prepare_and_start_training_success(fake_session, model_id, fl_job_id):
 def test_prepare_and_start_training_failure(fake_session, model_id, fl_job_id):
     with (
         patch(
-            "flip.fl_services.services.fl_scheduler_service.bundle_application",
+            "flip_api.fl_services.services.fl_scheduler_service.bundle_application",
             side_effect=Exception("bundle failed"),
         ),
-        patch("flip.fl_services.services.fl_scheduler_service.remove_job") as mock_remove,
-        patch("flip.fl_services.services.fl_scheduler_service.add_log") as mock_log,
-        patch("flip.fl_services.services.fl_scheduler_service.update_model_status") as mock_status,
+        patch("flip_api.fl_services.services.fl_scheduler_service.remove_job") as mock_remove,
+        patch("flip_api.fl_services.services.fl_scheduler_service.add_log") as mock_log,
+        patch("flip_api.fl_services.services.fl_scheduler_service.update_model_status") as mock_status,
     ):
         with pytest.raises(Exception, match="bundle failed"):
             fl_scheduler_service.prepare_and_start_training(
@@ -263,7 +263,7 @@ def test_check_for_queued_jobs_success(fake_session, scheduler_id, model_id):
     ]
     fake_session.get.return_value = scheduler
 
-    with patch("flip.fl_services.services.fl_scheduler_service.validate_trusts", return_value=True):
+    with patch("flip_api.fl_services.services.fl_scheduler_service.validate_trusts", return_value=True):
         result = fl_scheduler_service.check_for_queued_jobs(scheduler_id, fake_session)
 
     assert isinstance(result, IJobResponse)
@@ -274,7 +274,7 @@ def test_check_for_queued_jobs_success(fake_session, scheduler_id, model_id):
 def test_check_for_queued_jobs_none(fake_session, scheduler_id):
     fake_session.exec.return_value.first.return_value = None
 
-    with patch("flip.fl_services.services.fl_scheduler_service.revert_scheduler_pickup") as mock_revert:
+    with patch("flip_api.fl_services.services.fl_scheduler_service.revert_scheduler_pickup") as mock_revert:
         result = fl_scheduler_service.check_for_queued_jobs(scheduler_id, fake_session)
         assert result is None
         mock_revert.assert_called_once()

--- a/flip-api/tests/unit/fl_services/services/test_fl_service.py
+++ b/flip-api/tests/unit/fl_services/services/test_fl_service.py
@@ -17,11 +17,11 @@ from uuid import uuid4
 import pytest
 
 from flip_api.config import Settings
-from flip.domain.interfaces.fl import (
+from flip_api.domain.interfaces.fl import (
     IStartTrainingBody,
 )
-from flip.domain.schemas.status import ClientStatus
-from flip.fl_services.services import fl_service
+from flip_api.domain.schemas.status import ClientStatus
+from flip_api.fl_services.services import fl_service
 
 
 @pytest.fixture
@@ -46,7 +46,7 @@ def mocked_settings():
         SCANNED_MODEL_FILES_BUCKET="s3://mock-bucket-scanned/model_files",
         FL_APP_DESTINATION_BUCKET="s3://mock-bucket-dest/dest_files",
     )
-    with patch("flip.fl_services.services.fl_service.get_settings", return_value=mock):
+    with patch("flip_api.fl_services.services.fl_service.get_settings", return_value=mock):
         yield mock
 
 
@@ -102,24 +102,24 @@ def test_validate_config_invalid_weights():
         fl_service.validate_config(bad_weights)
 
 
-@patch("flip.fl_services.services.fl_service.http_get")
+@patch("flip_api.fl_services.services.fl_service.http_get")
 def test_download_config_returns_config(mock_get, model_id):
     mock_get.return_value = {"LOCAL_ROUNDS": 1, "GLOBAL_ROUNDS": 1}
-    with patch("flip.fl_services.services.fl_service.validate_config") as mock_validate:
+    with patch("flip_api.fl_services.services.fl_service.validate_config") as mock_validate:
         mock_validate.return_value = "validated_config"
         urls = [f"http://host/{model_id}/custom/config.json"]
         config = fl_service.download_config(urls, model_id)
         assert config == "validated_config"
 
 
-@patch("flip.fl_services.services.fl_service.http_get")
+@patch("flip_api.fl_services.services.fl_service.http_get")
 def test_download_config_no_config_found(mock_get, model_id):
     urls = [f"http://host/{model_id}/other/file.txt"]
     result = fl_service.download_config(urls, model_id)
     assert result is None
 
 
-@patch("flip.fl_services.services.fl_service.http_post")
+@patch("flip_api.fl_services.services.fl_service.http_post")
 def test_upload_app_calls_http_post(mock_post, model_id):
     body = IStartTrainingBody(
         project_id="proj",
@@ -156,14 +156,14 @@ def test_add_nvflare_job_id_updates_db(fl_job_id, fake_session):
     fake_session.commit.assert_called_once()
 
 
-@patch("flip.fl_services.services.fl_service.http_post")
+@patch("flip_api.fl_services.services.fl_service.http_post")
 def test_submit_job_raises_when_no_job_id(mock_post, fl_job_id, model_id, fake_session):
     mock_post.return_value = ""
     with pytest.raises(ValueError, match="No nvflare job id returned"):
         fl_service.submit_job("req-id", fl_job_id, "endpoint", model_id, fake_session)
 
 
-@patch("flip.fl_services.services.fl_service.http_get")
+@patch("flip_api.fl_services.services.fl_service.http_get")
 def test_get_status_with_clients(mock_get):
     details = MagicMock()
     details.target.value = "SERVER"
@@ -186,7 +186,7 @@ def test_add_nvflare_job_id_raises_if_job_missing(fl_job_id, fake_session):
         fl_service.add_nvflare_job_id(fl_job_id, str(uuid4()), fake_session)
 
 
-@patch("flip.fl_services.services.fl_service.get_status")
+@patch("flip_api.fl_services.services.fl_service.get_status")
 def test_validate_client_availability_all_offline(mock_get_status):
     mock_get_status.return_value = [
         {"name": "Trust_2", "last_connect_time": "12345", "status": ClientStatus.NO_REPLY},
@@ -197,7 +197,7 @@ def test_validate_client_availability_all_offline(mock_get_status):
         fl_service.validate_client_availability(["trust-1"], "endpoint", "req-id")
 
 
-@patch("flip.fl_services.services.fl_service.get_status")
+@patch("flip_api.fl_services.services.fl_service.get_status")
 def test_validate_client_availability_some_online(mock_get_status):
     mock_get_status.return_value = [
         {"name": "Trust_2", "last_connect_time": "12345", "status": ClientStatus.NO_REPLY},
@@ -209,7 +209,7 @@ def test_validate_client_availability_some_online(mock_get_status):
         fl_service.validate_client_availability(["Trust_2", "Trust_1"], "endpoint", "req-id")
 
 
-@patch("flip.fl_services.services.fl_service.get_status")
+@patch("flip_api.fl_services.services.fl_service.get_status")
 def test_validate_client_availability_empty_statuses(mock_get_status):
     mock_get_status.return_value = []
 
@@ -217,19 +217,19 @@ def test_validate_client_availability_empty_statuses(mock_get_status):
         fl_service.validate_client_availability(["trust-1"], "endpoint", "req-id")
 
 
-@patch("flip.fl_services.services.fl_service.http_delete")
+@patch("flip_api.fl_services.services.fl_service.http_delete")
 def test_abort_job_success(mock_delete):
     mock_delete.return_value = {"status": "aborted"}
     result = fl_service.abort_job("req-id", "endpoint", "job-id")
     assert result == {"status": "aborted"}
 
 
-@patch("flip.fl_services.services.fl_service.submit_job")
-@patch("flip.fl_services.services.fl_service.upload_app")
-@patch("flip.fl_services.services.fl_service.download_config")
-@patch("flip.fl_services.services.fl_service.add_log")
-@patch("flip.fl_services.services.fl_service.encrypt")
-@patch("flip.fl_services.services.fl_scheduler_service.get_required_training_details")
+@patch("flip_api.fl_services.services.fl_service.submit_job")
+@patch("flip_api.fl_services.services.fl_service.upload_app")
+@patch("flip_api.fl_services.services.fl_service.download_config")
+@patch("flip_api.fl_services.services.fl_service.add_log")
+@patch("flip_api.fl_services.services.fl_service.encrypt")
+@patch("flip_api.fl_services.services.fl_scheduler_service.get_required_training_details")
 def test_start_training_with_config(
     mock_get_required,
     mock_encrypt,
@@ -257,8 +257,8 @@ def test_start_training_with_config(
     mock_add_log.assert_called()
 
 
-@patch("flip.fl_services.services.fl_service.JobRequiredFiles.get_required_files")
-@patch("flip.fl_services.services.fl_service.S3Client")
+@patch("flip_api.fl_services.services.fl_service.JobRequiredFiles.get_required_files")
+@patch("flip_api.fl_services.services.fl_service.S3Client")
 def test_bundle_application_success(mock_s3, mock_required, model_id, mocked_settings):
     base_bucket = mocked_settings.FL_APP_BASE_BUCKET
     model_bucket = mocked_settings.SCANNED_MODEL_FILES_BUCKET
@@ -296,8 +296,8 @@ def test_bundle_application_success(mock_s3, mock_required, model_id, mocked_set
     )
 
 
-@patch("flip.fl_services.services.fl_service.JobRequiredFiles.get_required_files")
-@patch("flip.fl_services.services.fl_service.S3Client")
+@patch("flip_api.fl_services.services.fl_service.JobRequiredFiles.get_required_files")
+@patch("flip_api.fl_services.services.fl_service.S3Client")
 @pytest.mark.parametrize(
     "job_type",
     [
@@ -345,7 +345,7 @@ def test_bundle_application_file_wrong_job_type_in_config(mock_s3, mock_required
         assert returned_job_type.value == job_type
 
 
-@patch("flip.fl_services.services.fl_service.S3Client")
+@patch("flip_api.fl_services.services.fl_service.S3Client")
 def test_bundle_application_wrong_files(mock_s3, model_id, mocked_settings):
     mock_client = mock_s3.return_value
     # Provide an empty JSON config for tests that include config.json in model files
@@ -363,7 +363,7 @@ def test_bundle_application_wrong_files(mock_s3, model_id, mocked_settings):
         _ = fl_service.bundle_application(model_id)
 
 
-@patch("flip.fl_services.services.fl_service.S3Client")
+@patch("flip_api.fl_services.services.fl_service.S3Client")
 def test_get_bundle_urls_retry_success(mock_s3, mocked_settings, model_id):
     mock_client = mock_s3.return_value
     mock_client.list_objects.return_value = [
@@ -380,9 +380,9 @@ def test_get_bundle_urls_retry_success(mock_s3, mocked_settings, model_id):
     assert all(url.startswith("https://dest/") for url in urls)
 
 
-@patch("flip.fl_services.services.fl_service.http_get")
+@patch("flip_api.fl_services.services.fl_service.http_get")
 def test_extract_current_job_data_success(mock_http_get):
-    from flip.fl_services.services.fl_service import extract_current_job_data
+    from flip_api.fl_services.services.fl_service import extract_current_job_data
 
     net_endpoint = "http://flare-endpoint"
     nvflare_job_id = "job123"
@@ -403,9 +403,9 @@ def test_extract_current_job_data_success(mock_http_get):
     mock_http_get.assert_called_once_with(f"{net_endpoint}/list_jobs")
 
 
-@patch("flip.fl_services.services.fl_service.http_get")
+@patch("flip_api.fl_services.services.fl_service.http_get")
 def test_extract_current_job_data_not_found(mock_http_get):
-    from flip.fl_services.services.fl_service import extract_current_job_data
+    from flip_api.fl_services.services.fl_service import extract_current_job_data
 
     mock_http_get.return_value = [{"job_id": "other", "status": "RUNNING"}]
     net_endpoint = "http://flare-endpoint"
@@ -415,9 +415,9 @@ def test_extract_current_job_data_not_found(mock_http_get):
         extract_current_job_data(net_endpoint, nvflare_job_id)
 
 
-@patch("flip.fl_services.services.fl_service.http_get")
+@patch("flip_api.fl_services.services.fl_service.http_get")
 def test_extract_current_job_data_multiple_found(mock_http_get):
-    from flip.fl_services.services.fl_service import extract_current_job_data
+    from flip_api.fl_services.services.fl_service import extract_current_job_data
 
     net_endpoint = "http://flare-endpoint"
     nvflare_job_id = "duplicate-job"
@@ -431,12 +431,12 @@ def test_extract_current_job_data_multiple_found(mock_http_get):
         extract_current_job_data(net_endpoint, nvflare_job_id)
 
 
-@patch("flip.fl_services.services.fl_service.extract_current_job_data")
-@patch("flip.fl_services.services.fl_service.get_nvflare_job_id_by_model_id")
-@patch("flip.fl_services.services.fl_service.fetch_server_status")
-@patch("flip.fl_services.services.fl_service.abort_job")
-@patch("flip.fl_services.services.fl_scheduler_service.get_net_by_model_id")
-@patch("flip.fl_services.services.fl_scheduler_service.remove_job_from_queue")
+@patch("flip_api.fl_services.services.fl_service.extract_current_job_data")
+@patch("flip_api.fl_services.services.fl_service.get_nvflare_job_id_by_model_id")
+@patch("flip_api.fl_services.services.fl_service.fetch_server_status")
+@patch("flip_api.fl_services.services.fl_service.abort_job")
+@patch("flip_api.fl_services.services.fl_scheduler_service.get_net_by_model_id")
+@patch("flip_api.fl_services.services.fl_scheduler_service.remove_job_from_queue")
 def test_abort_model_training_success(
     mock_remove,
     mock_get_net,

--- a/flip-api/tests/unit/fl_services/test_get_net_status.py
+++ b/flip-api/tests/unit/fl_services/test_get_net_status.py
@@ -16,13 +16,13 @@ import pytest
 from fastapi import HTTPException, Request
 
 from flip_api.domain.interfaces.fl import IClientStatus
-from flip.domain.schemas.status import ClientStatus
-from flip.fl_services.get_net_status import get_net_status
+from flip_api.domain.schemas.status import ClientStatus
+from flip_api.fl_services.get_net_status import get_net_status
 
 
 @pytest.fixture
 def mock_db():
-    with patch("flip.fl_services.get_net_status.get_session") as mock_get_session:
+    with patch("flip_api.fl_services.get_net_status.get_session") as mock_get_session:
         mock_db = MagicMock()
         mock_get_session.return_value = mock_db
         yield mock_db
@@ -37,14 +37,14 @@ def fake_request():
 
 @pytest.fixture
 def mock_get_net_by_name():
-    with patch("flip.fl_services.get_net_status.get_net_by_name") as mock:
+    with patch("flip_api.fl_services.get_net_status.get_net_by_name") as mock:
         mock.return_value = MagicMock(endpoint="endpoint", name="net-name")
         yield mock
 
 
 @pytest.fixture
 def mock_get_status():
-    with patch("flip.fl_services.get_net_status.fetch_client_status") as mock:
+    with patch("flip_api.fl_services.get_net_status.fetch_client_status") as mock:
         mock.return_value = [
             IClientStatus(name="client1", online=True, status=ClientStatus.NO_JOBS),
             IClientStatus(name="client2", online=False, status=ClientStatus.NO_REPLY),
@@ -59,7 +59,7 @@ def mock_get_trusts():
         def __init__(self, name):
             self.name = name
 
-    with patch("flip.fl_services.get_net_status.get_trusts") as mock:
+    with patch("flip_api.fl_services.get_net_status.get_trusts") as mock:
         mock.return_value = [Trust("client1"), Trust("client2"), Trust("client3")]
         yield mock
 
@@ -74,14 +74,14 @@ def test_get_net_status_success(fake_request, mock_db, mock_get_net_by_name, moc
 
 
 def test_get_net_status_net_not_found(fake_request, mock_db):
-    with patch("flip.fl_services.get_net_status.get_net_by_name", return_value=None):
+    with patch("flip_api.fl_services.get_net_status.get_net_by_name", return_value=None):
         with pytest.raises(HTTPException) as exc:
             get_net_status("unknown", fake_request, mock_db)
         assert exc.value.status_code == 404
 
 
 def test_get_net_status_status_missing(fake_request, mock_db, mock_get_net_by_name):
-    with patch("flip.fl_services.get_net_status.fetch_client_status", return_value=None):
+    with patch("flip_api.fl_services.get_net_status.fetch_client_status", return_value=None):
         with pytest.raises(HTTPException) as exc:
             get_net_status("net-name", fake_request, mock_db)
         assert exc.value.status_code == 502

--- a/flip-api/tests/unit/fl_services/test_get_status.py
+++ b/flip-api/tests/unit/fl_services/test_get_status.py
@@ -19,12 +19,12 @@ from flip_api.domain.interfaces.fl import (
     IClientStatus,
     IServerStatus,
 )
-from flip.fl_services.get_status import get_status_endpoint
+from flip_api.fl_services.get_status import get_status_endpoint
 
 
 @pytest.fixture
 def mock_db():
-    with patch("flip.fl_services.run_jobs.get_session") as mock_get_session:
+    with patch("flip_api.fl_services.run_jobs.get_session") as mock_get_session:
         mock_db = MagicMock()
         mock_get_session.return_value = mock_db
         yield mock_db
@@ -44,7 +44,7 @@ def mock_get_nets():
             self.name = name
             self.endpoint = endpoint
 
-    with patch("flip.fl_services.get_status.get_nets") as mock:
+    with patch("flip_api.fl_services.get_status.get_nets") as mock:
         mock.return_value = [Net("net-1", "endpoint1")]
         yield mock
 
@@ -55,14 +55,14 @@ def mock_get_trusts():
         def __init__(self, name):
             self.name = name
 
-    with patch("flip.fl_services.get_status.get_trusts") as mock:
+    with patch("flip_api.fl_services.get_status.get_trusts") as mock:
         mock.return_value = [Trust("trust-1"), Trust("trust-2")]
         yield mock
 
 
 @pytest.fixture
 def mock_fetch_server_status():
-    with patch("flip.fl_services.get_status.fetch_server_status") as mock:
+    with patch("flip_api.fl_services.get_status.fetch_server_status") as mock:
         mock.return_value = IServerStatus(
             status="started",
             start_time=1750067408.3509645,
@@ -72,7 +72,7 @@ def mock_fetch_server_status():
 
 @pytest.fixture
 def mock_fetch_client_status():
-    with patch("flip.fl_services.get_status.fetch_client_status") as mock:
+    with patch("flip_api.fl_services.get_status.fetch_client_status") as mock:
         mock.return_value = [
             IClientStatus(name="trust-1", online=True, status="no_jobs", last_connected=1750086492.088829),
         ]
@@ -95,7 +95,7 @@ def test_get_status_endpoint_success(
 
 
 def test_get_status_endpoint_error(fake_request, mock_db):
-    with patch("flip.fl_services.get_status.get_nets", side_effect=Exception("boom")):
+    with patch("flip_api.fl_services.get_status.get_nets", side_effect=Exception("boom")):
         with pytest.raises(HTTPException) as exc:
             get_status_endpoint(fake_request, mock_db, user_id="user-1")
         assert exc.value.status_code == 500

--- a/flip-api/tests/unit/fl_services/test_initiate_training.py
+++ b/flip-api/tests/unit/fl_services/test_initiate_training.py
@@ -17,12 +17,12 @@ import pytest
 from fastapi import HTTPException, Request, status
 
 from flip_api.domain.interfaces.fl import IInitiateTrainingInputPayload
-from flip.fl_services.initiate_training import initiate_training
+from flip_api.fl_services.initiate_training import initiate_training
 
 
 @pytest.fixture
 def mock_db():
-    with patch("flip.fl_services.run_jobs.get_session") as mock_get_session:
+    with patch("flip_api.fl_services.run_jobs.get_session") as mock_get_session:
         mock_db = MagicMock()
         mock_get_session.return_value = mock_db
         yield mock_db
@@ -42,27 +42,27 @@ def fake_request():
 
 @pytest.fixture
 def mock_can_access_model():
-    with patch("flip.fl_services.initiate_training.can_access_model") as mock:
+    with patch("flip_api.fl_services.initiate_training.can_access_model") as mock:
         mock.return_value = True
         yield mock
 
 
 @pytest.fixture
 def mock_add_fl_job():
-    with patch("flip.fl_services.initiate_training.add_fl_job") as mock:
+    with patch("flip_api.fl_services.initiate_training.add_fl_job") as mock:
         yield mock
 
 
 @pytest.fixture
 def mock_update_model_status():
-    with patch("flip.fl_services.initiate_training.update_model_status") as mock:
+    with patch("flip_api.fl_services.initiate_training.update_model_status") as mock:
         mock.return_value = True
         yield mock
 
 
 @pytest.fixture
 def mock_add_log():
-    with patch("flip.fl_services.initiate_training.add_log") as mock:
+    with patch("flip_api.fl_services.initiate_training.add_log") as mock:
         yield mock
 
 
@@ -89,7 +89,7 @@ def test_initiate_training_forbidden(model_id, fake_request, mock_db, mock_can_a
 def test_initiate_training_model_not_found(
     model_id, fake_request, mock_db, mock_can_access_model, mock_add_fl_job, mock_add_log
 ):
-    with patch("flip.fl_services.initiate_training.update_model_status", return_value=False):
+    with patch("flip_api.fl_services.initiate_training.update_model_status", return_value=False):
         payload = IInitiateTrainingInputPayload(trusts=["client1"])
         with pytest.raises(HTTPException) as exc_info:
             initiate_training(model_id, payload, fake_request, mock_db, user_id="user123")
@@ -97,7 +97,7 @@ def test_initiate_training_model_not_found(
 
 
 def test_initiate_training_failure(model_id, fake_request, mock_db, mock_can_access_model):
-    with patch("flip.fl_services.initiate_training.add_fl_job", side_effect=Exception("Unexpected error")):
+    with patch("flip_api.fl_services.initiate_training.add_fl_job", side_effect=Exception("Unexpected error")):
         payload = IInitiateTrainingInputPayload(trusts=["client1"])
         with pytest.raises(HTTPException) as exc_info:
             initiate_training(model_id, payload, fake_request, mock_db, user_id="user123")

--- a/flip-api/tests/unit/fl_services/test_run_jobs.py
+++ b/flip-api/tests/unit/fl_services/test_run_jobs.py
@@ -17,12 +17,12 @@ import pytest
 from fastapi import HTTPException
 
 from flip_api.domain.interfaces.fl import IJobResponse
-from flip.fl_services.run_jobs import run_jobs
+from flip_api.fl_services.run_jobs import run_jobs
 
 
 @pytest.fixture
 def mock_db():
-    with patch("flip.fl_services.run_jobs.get_session") as mock_get_session:
+    with patch("flip_api.fl_services.run_jobs.get_session") as mock_get_session:
         mock_db = MagicMock()
         mock_get_session.return_value = mock_db
         yield mock_db
@@ -30,7 +30,7 @@ def mock_db():
 
 @pytest.fixture
 def mock_check_for_available_net():
-    with patch("flip.fl_services.run_jobs.check_for_available_net") as mock_check:
+    with patch("flip_api.fl_services.run_jobs.check_for_available_net") as mock_check:
         scheduler = MagicMock(id="sched-id", netId="net-123")
         mock_check.return_value = scheduler
         yield mock_check
@@ -38,7 +38,7 @@ def mock_check_for_available_net():
 
 @pytest.fixture
 def mock_check_for_queued_jobs():
-    with patch("flip.fl_services.run_jobs.check_for_queued_jobs") as mock_check:
+    with patch("flip_api.fl_services.run_jobs.check_for_queued_jobs") as mock_check:
         job = IJobResponse(id=uuid4(), model_id=uuid4(), clients=["client1"])
         mock_check.return_value = job
         yield mock_check
@@ -51,7 +51,7 @@ def model_id():
 
 def test_run_jobs_success(mock_db, mock_check_for_available_net, mock_check_for_queued_jobs, caplog):
     with (
-        patch("flip.fl_services.run_jobs.prepare_and_start_training") as mock_prepare,
+        patch("flip_api.fl_services.run_jobs.prepare_and_start_training") as mock_prepare,
     ):
         response = run_jobs(mock_db)
 
@@ -83,7 +83,7 @@ def test_run_jobs_no_queued_job(mock_db, mock_check_for_available_net, mock_chec
 
 def test_run_jobs_failure(mock_db, mock_check_for_available_net, mock_check_for_queued_jobs):
     with (
-        patch("flip.fl_services.run_jobs.prepare_and_start_training", side_effect=Exception("start error")),
+        patch("flip_api.fl_services.run_jobs.prepare_and_start_training", side_effect=Exception("start error")),
     ):
         with pytest.raises(HTTPException) as exc_info:
             run_jobs(mock_db)

--- a/flip-api/tests/unit/fl_services/test_stop_training.py
+++ b/flip-api/tests/unit/fl_services/test_stop_training.py
@@ -17,7 +17,7 @@ import pytest
 from fastapi import HTTPException, Request
 
 from flip_api.domain.schemas.status import ModelStatus
-from flip.fl_services.stop_training import stop_training
+from flip_api.fl_services.stop_training import stop_training
 
 
 @pytest.fixture
@@ -35,7 +35,7 @@ def fake_request():
 
 @pytest.fixture
 def mock_db():
-    with patch("flip.fl_services.stop_training.get_session") as mock_get_session:
+    with patch("flip_api.fl_services.stop_training.get_session") as mock_get_session:
         mock_db = MagicMock()
         mock_get_session.return_value = mock_db
         yield mock_db
@@ -43,7 +43,7 @@ def mock_db():
 
 @pytest.fixture
 def mock_can_access_model():
-    with patch("flip.fl_services.stop_training.can_access_model") as mock:
+    with patch("flip_api.fl_services.stop_training.can_access_model") as mock:
         mock.return_value = True
         yield mock
 
@@ -55,13 +55,13 @@ def user_id():
 
 @pytest.fixture
 def mock_abort_model_training():
-    with patch("flip.fl_services.stop_training.abort_model_training") as mock:
+    with patch("flip_api.fl_services.stop_training.abort_model_training") as mock:
         yield mock
 
 
 @pytest.fixture
 def mock_update_status():
-    with patch("flip.fl_services.stop_training.update_model_status") as mock:
+    with patch("flip_api.fl_services.stop_training.update_model_status") as mock:
         yield mock
 
 

--- a/flip-api/tests/unit/private_services/test_add_log.py
+++ b/flip-api/tests/unit/private_services/test_add_log.py
@@ -16,8 +16,8 @@ import pytest
 from fastapi import HTTPException
 
 from flip_api.domain.schemas.private import TrainingLog
-from flip.private_services.add_log import add_log_endpoint
-from flip.utils.logger import logger  # To assert logger calls
+from flip_api.private_services.add_log import add_log_endpoint
+from flip_api.utils.logger import logger  # To assert logger calls
 
 # Mock schema validation functions if they are complex or have side effects
 # For this example, we'll patch them directly in the tests.
@@ -43,8 +43,8 @@ def sample_training_log():
 class TestAddLogEndpoint:
     """Tests for the add_log FastAPI endpoint."""
 
-    @patch("flip.private_services.add_log.validate_trusts", return_value=True)
-    @patch("flip.private_services.add_log.add_log")
+    @patch("flip_api.private_services.add_log.validate_trusts", return_value=True)
+    @patch("flip_api.private_services.add_log.add_log")
     def test_add_log_success(self, mock_add_log, mock_validate_trusts, mock_db_session, sample_training_log):
         """Test successful log creation via the endpoint."""
 
@@ -56,8 +56,8 @@ class TestAddLogEndpoint:
         mock_add_log.assert_called_once_with(model_id=model_id, log=sample_training_log.log, session=session)
         assert response == {"detail": "Created"}
 
-    @patch("flip.private_services.add_log.validate_trusts", return_value=True)
-    @patch("flip.private_services.add_log.add_log")
+    @patch("flip_api.private_services.add_log.validate_trusts", return_value=True)
+    @patch("flip_api.private_services.add_log.add_log")
     def test_add_log_http_exception_from_add_log(
         self, mock_add_log, mock_validate_trusts, mock_db_session, sample_training_log
     ):
@@ -74,8 +74,8 @@ class TestAddLogEndpoint:
         assert exc_info.value.status_code == 409
         assert exc_info.value.detail == "Conflict in logging"
 
-    @patch("flip.private_services.add_log.validate_trusts", return_value=True)
-    @patch("flip.private_services.add_log.add_log")
+    @patch("flip_api.private_services.add_log.validate_trusts", return_value=True)
+    @patch("flip_api.private_services.add_log.add_log")
     @patch.object(logger, "error")
     def test_add_log_general_exception_from_add_log(
         self,
@@ -110,7 +110,7 @@ class TestAddLogEndpoint:
         session = mock_db_session
 
         # Mock the trust validation to return False
-        with patch("flip.private_services.add_log.validate_trusts", return_value=False):
+        with patch("flip_api.private_services.add_log.validate_trusts", return_value=False):
             with pytest.raises(HTTPException) as exc_info:
                 add_log_endpoint(model_id, sample_training_log, session, token="fake_token")
 

--- a/flip-api/tests/unit/private_services/test_invoke_model_status_update.py
+++ b/flip-api/tests/unit/private_services/test_invoke_model_status_update.py
@@ -19,16 +19,16 @@ from fastapi import FastAPI, HTTPException, status
 from fastapi.testclient import TestClient
 
 from flip_api.domain.schemas.status import ModelStatus
-from flip.private_services.invoke_model_status_update import (
+from flip_api.private_services.invoke_model_status_update import (
     check_authorization_token,
     get_session,
 )
-from flip.private_services.invoke_model_status_update import router as invoke_model_status_update_router
+from flip_api.private_services.invoke_model_status_update import router as invoke_model_status_update_router
 
 test_app = FastAPI()
 test_app.include_router(invoke_model_status_update_router)
 
-MOCKED_SERVICE_FUNCTION_PATH = "flip.private_services.invoke_model_status_update.update_model_status_endpoint"
+MOCKED_SERVICE_FUNCTION_PATH = "flip_api.private_services.invoke_model_status_update.update_model_status_endpoint"
 
 
 @pytest.fixture
@@ -75,7 +75,7 @@ class TestInvokeModelStatusUpdateEndpoint:
         # Check logs if specific logging is implemented in the endpoint for success
 
     @patch(MOCKED_SERVICE_FUNCTION_PATH)
-    @patch("flip.private_services.invoke_model_status_update.logger.error")
+    @patch("flip_api.private_services.invoke_model_status_update.logger.error")
     def test_invoke_update_service_raises_http_exception(
         self,
         mock_logger_error: MagicMock,
@@ -97,7 +97,7 @@ class TestInvokeModelStatusUpdateEndpoint:
         assert response.json() == {"detail": error_detail}
 
     @patch(MOCKED_SERVICE_FUNCTION_PATH)
-    @patch("flip.private_services.invoke_model_status_update.logger.error")
+    @patch("flip_api.private_services.invoke_model_status_update.logger.error")
     def test_invoke_update_service_raises_general_exception(
         self,
         mock_logger_error: MagicMock,

--- a/flip-api/tests/unit/private_services/test_project_images_helpers.py
+++ b/flip-api/tests/unit/private_services/test_project_images_helpers.py
@@ -14,7 +14,7 @@ import uuid
 from unittest.mock import MagicMock
 
 from flip_api.db.models.main_models import XNATImageStatus, XNATProjectStatus
-from flip.private_services.project_images_helpers import (
+from flip_api.private_services.project_images_helpers import (
     insert_status,
     update_status,
 )

--- a/flip-api/tests/unit/private_services/test_receive_cohort_results.py
+++ b/flip-api/tests/unit/private_services/test_receive_cohort_results.py
@@ -27,7 +27,7 @@ from flip_api.domain.schemas.private import (
     Results,
     TrustSpecificData,
 )
-from flip.private_services.receive_cohort_results import (
+from flip_api.private_services.receive_cohort_results import (
     _aggregate_and_save_results,
     _save_individual_result,
 )

--- a/flip-api/tests/unit/private_services/test_save_training_metrics.py
+++ b/flip-api/tests/unit/private_services/test_save_training_metrics.py
@@ -20,15 +20,15 @@ from pydantic import ValidationError
 from sqlmodel import Session
 
 from flip_api.auth.access_manager import check_authorization_token
-from flip.domain.schemas.private import TrainingMetrics
-from flip.main import app
-from flip.private_services.services.private_service import save_training_metrics
+from flip_api.domain.schemas.private import TrainingMetrics
+from flip_api.main import app
+from flip_api.private_services.services.private_service import save_training_metrics
 
 # Path for mocking ModelIdSchema if it's a custom validator like in add_log.py
 # If ModelIdSchema is not used, this can be removed.
-# MOCKED_MODEL_ID_SCHEMA_VALIDATE_PATH = "flip.private_services.save_training_metrics.ModelIdSchema.validate"
-# MOCKED_IS_TRUST_ASSOCIATED_PATH = "flip.private_services.save_training_metrics.validate_trusts"
-# MOCKED_STORE_METRICS_PATH = "flip.private_services.save_training_metrics._store_training_metrics_in_db"
+# MOCKED_MODEL_ID_SCHEMA_VALIDATE_PATH = "flip_api.private_services.save_training_metrics.ModelIdSchema.validate"
+# MOCKED_IS_TRUST_ASSOCIATED_PATH = "flip_api.private_services.save_training_metrics.validate_trusts"
+# MOCKED_STORE_METRICS_PATH = "flip_api.private_services.save_training_metrics._store_training_metrics_in_db"
 
 # Test client to test the endpoint
 client = TestClient(app)
@@ -122,8 +122,8 @@ class TestSaveTrainingMetricsEndpoint:
     def teardown_class(cls):
         app.dependency_overrides = {}
 
-    @patch("flip.private_services.save_training_metrics.save_training_metrics")
-    @patch("flip.private_services.save_training_metrics.validate_trusts")
+    @patch("flip_api.private_services.save_training_metrics.save_training_metrics")
+    @patch("flip_api.private_services.save_training_metrics.validate_trusts")
     def test_save_metrics_success(self, mock_validate_trusts, mock_save_metrics, sample_metrics_payload_dict):
         mock_validate_trusts.return_value = True
         mock_save_metrics.return_value = None
@@ -133,7 +133,7 @@ class TestSaveTrainingMetricsEndpoint:
         assert response.status_code == 204
         mock_save_metrics.assert_called_once()
 
-    @patch("flip.private_services.save_training_metrics.validate_trusts")
+    @patch("flip_api.private_services.save_training_metrics.validate_trusts")
     def test_save_metrics_invalid_trust(self, mock_validate_trusts, sample_metrics_payload_dict):
         mock_validate_trusts.return_value = False
 
@@ -142,8 +142,8 @@ class TestSaveTrainingMetricsEndpoint:
         assert response.status_code == 400
         assert "trust" in response.json()["detail"].lower()
 
-    @patch("flip.private_services.save_training_metrics.save_training_metrics")
-    @patch("flip.private_services.save_training_metrics.validate_trusts")
+    @patch("flip_api.private_services.save_training_metrics.save_training_metrics")
+    @patch("flip_api.private_services.save_training_metrics.validate_trusts")
     def test_save_metrics_internal_error(self, mock_validate_trusts, mock_save_metrics, sample_metrics_payload_dict):
         mock_validate_trusts.return_value = True
         mock_save_metrics.side_effect = Exception("Simulated DB failure")

--- a/flip-api/tests/unit/project_services/services/test_image_services.py
+++ b/flip-api/tests/unit/project_services/services/test_image_services.py
@@ -22,13 +22,13 @@ from flip_api.domain.interfaces.project import (
     IReimportQuery,
     IUpdateXnatProfile,
 )
-from flip.domain.interfaces.trust import ITrust
-from flip.domain.schemas.projects import (
+from flip_api.domain.interfaces.trust import ITrust
+from flip_api.domain.schemas.projects import (
     ImagingProject,
     XnatProjectStatusInfo,
 )
-from flip.domain.schemas.status import XNATImageStatus
-from flip.project_services.services.image_service import (
+from flip_api.domain.schemas.status import XNATImageStatus
+from flip_api.project_services.services.image_service import (
     delete_imaging_project,
     get_imaging_project_statuses,
     get_imaging_projects,
@@ -38,7 +38,7 @@ from flip.project_services.services.image_service import (
 )
 
 # Mocking paths
-MOCK_SERVICE_PATH = "flip.project_services.services.image_service"
+MOCK_SERVICE_PATH = "flip_api.project_services.services.image_service"
 MOCK_LOGGER_PATH = f"{MOCK_SERVICE_PATH}.logger"
 # MOCK_API_REQUEST_PATH = f"{MOCK_SERVICE_PATH}.api_request_to_trust"  # Placeholder for actual path
 MOCK_HTTP_REQUEST_PATH = f"{MOCK_SERVICE_PATH}.http_request"  # Placeholder for actual path

--- a/flip-api/tests/unit/project_services/services/test_project_services.py
+++ b/flip-api/tests/unit/project_services/services/test_project_services.py
@@ -26,19 +26,19 @@ from flip_api.db.models.main_models import (
     Trust,
     XNATProjectStatus,
 )
-from flip.domain.interfaces.project import (
+from flip_api.domain.interfaces.project import (
     IProjectApproval,
     IProjectDetails,
     IProjectQuery,
     IProjectResponse,
     IReimportQuery,
 )
-from flip.domain.schemas.projects import ProjectDetails
-from flip.domain.schemas.status import (
+from flip_api.domain.schemas.projects import ProjectDetails
+from flip_api.domain.schemas.status import (
     ProjectStatus,
     XNATImageStatus,
 )
-from flip.project_services.services.project_services import (
+from flip_api.project_services.services.project_services import (
     approve_project,
     create_project,
     delete_project,
@@ -52,9 +52,9 @@ from flip.project_services.services.project_services import (
     unstage_project_service,
     update_project_status,
 )
-from flip.utils.project_manager import get_project_by_id
+from flip_api.utils.project_manager import get_project_by_id
 
-MOCK_SERVICE_PATH = "flip.project_services.services.project_services"
+MOCK_SERVICE_PATH = "flip_api.project_services.services.project_services"
 
 
 @pytest.fixture

--- a/flip-api/tests/unit/project_services/test_approve_project.py
+++ b/flip-api/tests/unit/project_services/test_approve_project.py
@@ -17,10 +17,10 @@ import pytest
 from fastapi import HTTPException, status
 
 from flip_api.db.models.main_models import Projects, Trust
-from flip.db.models.user_models import PermissionRef
-from flip.domain.schemas.projects import ApproveProjectBodyPayload
-from flip.domain.schemas.status import ProjectStatus
-from flip.project_services.approve_project import approve_project_endpoint
+from flip_api.db.models.user_models import PermissionRef
+from flip_api.domain.schemas.projects import ApproveProjectBodyPayload
+from flip_api.domain.schemas.status import ProjectStatus
+from flip_api.project_services.approve_project import approve_project_endpoint
 
 # Imports from the module to be tested
 # Assuming sqlmodel.Session is used for type hinting or spec
@@ -47,10 +47,10 @@ def mock_staged_project():
     return project
 
 
-@patch("flip.project_services.approve_project.logger")
-@patch("flip.project_services.approve_project.get_trusts")
-@patch("flip.project_services.approve_project.approve_project", return_value=True)
-@patch("flip.project_services.approve_project.has_permissions", return_value=True)
+@patch("flip_api.project_services.approve_project.logger")
+@patch("flip_api.project_services.approve_project.get_trusts")
+@patch("flip_api.project_services.approve_project.approve_project", return_value=True)
+@patch("flip_api.project_services.approve_project.has_permissions", return_value=True)
 def test_approve_project_endpoint_success(
     mock_has_permissions,
     mock_approve_project,  # This is the approve_project function
@@ -84,8 +84,8 @@ def test_approve_project_endpoint_success(
     assert result == mock_trust_list
 
 
-@patch("flip.project_services.approve_project.logger")
-@patch("flip.project_services.approve_project.has_permissions")
+@patch("flip_api.project_services.approve_project.logger")
+@patch("flip_api.project_services.approve_project.has_permissions")
 def test_approve_project_endpoint_no_permission(mock_has_permissions, mock_logger, mock_db_session, mock_payload):
     # Arrange
     mock_has_permissions.return_value = False
@@ -107,8 +107,8 @@ def test_approve_project_endpoint_no_permission(mock_has_permissions, mock_logge
     )
 
 
-@patch("flip.project_services.approve_project.logger")
-@patch("flip.project_services.approve_project.has_permissions", return_value=True)
+@patch("flip_api.project_services.approve_project.logger")
+@patch("flip_api.project_services.approve_project.has_permissions", return_value=True)
 def test_approve_project_endpoint_project_not_found(
     mock_has_permissions,  # Patched with return_value=True
     mock_logger,
@@ -133,8 +133,8 @@ def test_approve_project_endpoint_project_not_found(
     mock_logger.error.assert_called_once_with(f"Project with ID {TEST_PROJECT_ID} not found for approval.")
 
 
-@patch("flip.project_services.approve_project.logger")
-@patch("flip.project_services.approve_project.has_permissions", return_value=True)
+@patch("flip_api.project_services.approve_project.logger")
+@patch("flip_api.project_services.approve_project.has_permissions", return_value=True)
 def test_approve_project_endpoint_project_not_staged(
     mock_has_permissions,
     mock_logger,
@@ -160,10 +160,10 @@ def test_approve_project_endpoint_project_not_staged(
     mock_logger.error.assert_called_once_with(f"Project {TEST_PROJECT_ID} is not in STAGED status, cannot approve.")
 
 
-@patch("flip.project_services.approve_project.logger")
-@patch("flip.project_services.approve_project.get_trusts")
-@patch("flip.project_services.approve_project.approve_project")
-@patch("flip.project_services.approve_project.has_permissions", return_value=True)
+@patch("flip_api.project_services.approve_project.logger")
+@patch("flip_api.project_services.approve_project.get_trusts")
+@patch("flip_api.project_services.approve_project.approve_project")
+@patch("flip_api.project_services.approve_project.has_permissions", return_value=True)
 def test_approve_project_endpoint_commit_status_fails(
     mock_has_permissions,
     mock_approve_project,  # This is the approve_project function
@@ -192,10 +192,10 @@ def test_approve_project_endpoint_commit_status_fails(
     assert exc_info.value.detail == "DB Commit Error"
 
 
-@patch("flip.project_services.approve_project.logger")
-@patch("flip.project_services.approve_project.get_trusts")
-@patch("flip.project_services.approve_project.approve_project", return_value=True)
-@patch("flip.project_services.approve_project.has_permissions", return_value=True)
+@patch("flip_api.project_services.approve_project.logger")
+@patch("flip_api.project_services.approve_project.get_trusts")
+@patch("flip_api.project_services.approve_project.approve_project", return_value=True)
+@patch("flip_api.project_services.approve_project.has_permissions", return_value=True)
 def test_approve_project_endpoint_fetch_trusts_exec_fails(
     mock_has_permissions,
     mock_approve_project,  # This is the approve_project function

--- a/flip-api/tests/unit/project_services/test_create_project.py
+++ b/flip-api/tests/unit/project_services/test_create_project.py
@@ -18,9 +18,9 @@ from fastapi import HTTPException, status
 from psycopg2 import DatabaseError
 
 from flip_api.db.models.main_models import Projects
-from flip.db.models.user_models import PermissionRef
-from flip.domain.schemas.projects import ProjectDetails
-from flip.project_services.create_project import create_project_endpoint
+from flip_api.db.models.user_models import PermissionRef
+from flip_api.domain.schemas.projects import ProjectDetails
+from flip_api.project_services.create_project import create_project_endpoint
 
 # Common test data
 TEST_USER_ID = uuid.uuid4()
@@ -45,8 +45,8 @@ def mock_valid_payload():
     return payload
 
 
-@patch("flip.project_services.create_project.logger")
-@patch("flip.project_services.create_project.has_permissions")
+@patch("flip_api.project_services.create_project.logger")
+@patch("flip_api.project_services.create_project.has_permissions")
 def test_create_project_endpoint_success(
     mock_has_permissions: MagicMock,
     mock_logger: MagicMock,
@@ -72,8 +72,8 @@ def test_create_project_endpoint_success(
     assert str(result.id) in logged_message
 
 
-@patch("flip.project_services.create_project.logger")
-@patch("flip.project_services.create_project.has_permissions")
+@patch("flip_api.project_services.create_project.logger")
+@patch("flip_api.project_services.create_project.has_permissions")
 def test_create_project_endpoint_no_permission(
     mock_has_permissions: MagicMock,
     mock_logger: MagicMock,
@@ -101,8 +101,8 @@ def test_create_project_endpoint_no_permission(
     mock_db_session.commit.assert_not_called()
 
 
-@patch("flip.project_services.create_project.logger")
-@patch("flip.project_services.create_project.has_permissions")
+@patch("flip_api.project_services.create_project.logger")
+@patch("flip_api.project_services.create_project.has_permissions")
 def test_create_project_endpoint_missing_name(
     mock_has_permissions: MagicMock,
     mock_logger: MagicMock,
@@ -130,8 +130,8 @@ def test_create_project_endpoint_missing_name(
     mock_db_session.add.assert_not_called()
 
 
-@patch("flip.project_services.create_project.logger")
-@patch("flip.project_services.create_project.has_permissions")
+@patch("flip_api.project_services.create_project.logger")
+@patch("flip_api.project_services.create_project.has_permissions")
 def test_create_project_endpoint_db_commit_fails(
     mock_has_permissions: MagicMock,
     mock_logger: MagicMock,

--- a/flip-api/tests/unit/project_services/test_delete_project.py
+++ b/flip-api/tests/unit/project_services/test_delete_project.py
@@ -18,9 +18,9 @@ from fastapi import status
 from fastapi.testclient import TestClient
 
 from flip_api.auth.dependencies import verify_token
-from flip.db.database import get_session
-from flip.main import app
-from flip.project_services import delete_project as delete_project_module
+from flip_api.db.database import get_session
+from flip_api.main import app
+from flip_api.project_services import delete_project as delete_project_module
 
 # Mount the router once
 app.include_router(delete_project_module.router)

--- a/flip-api/tests/unit/project_services/test_edit_project.py
+++ b/flip-api/tests/unit/project_services/test_edit_project.py
@@ -18,9 +18,9 @@ from fastapi import FastAPI, status
 from fastapi.testclient import TestClient
 
 from flip_api.auth.dependencies import verify_token
-from flip.db.database import get_session
-from flip.db.models.main_models import Projects
-from flip.project_services.edit_project import router as edit_project_router
+from flip_api.db.database import get_session
+from flip_api.db.models.main_models import Projects
+from flip_api.project_services.edit_project import router as edit_project_router
 
 # Common test data
 TEST_PROJECT_ID = uuid.uuid4()
@@ -45,14 +45,14 @@ def mock_edit_payload():
 
 @pytest.fixture
 def mock_get_user_pool_id():
-    with patch("flip.project_services.edit_project.get_user_pool_id", return_value="mock_user_pool_id"):
+    with patch("flip_api.project_services.edit_project.get_user_pool_id", return_value="mock_user_pool_id"):
         yield
 
 
 @pytest.fixture
 def mock_filter_enabled_users():
     with patch(
-        "flip.project_services.edit_project.filter_enabled_users", return_value=[uuid.uuid4(), uuid.uuid4()]
+        "flip_api.project_services.edit_project.filter_enabled_users", return_value=[uuid.uuid4(), uuid.uuid4()]
     ):
         yield
 
@@ -68,7 +68,7 @@ def test_edit_project_success(
     app_fixture.dependency_overrides[get_session] = lambda: mock_db_session
     app_fixture.dependency_overrides[verify_token] = lambda: uuid.uuid4()
 
-    with patch("flip.project_services.edit_project.can_access_project", return_value=True) as mock_can_access:
+    with patch("flip_api.project_services.edit_project.can_access_project", return_value=True) as mock_can_access:
         response = client.put(
             f"/projects/{str(TEST_PROJECT_ID)}",
             json=mock_edit_payload,
@@ -93,7 +93,7 @@ def test_edit_project_no_permission(client: TestClient, app_fixture: FastAPI, mo
     app_fixture.dependency_overrides[get_session] = lambda: mock_db_session
     app_fixture.dependency_overrides[verify_token] = lambda: uuid.uuid4()
 
-    with patch("flip.project_services.edit_project.can_access_project", return_value=False) as mock_can_access:
+    with patch("flip_api.project_services.edit_project.can_access_project", return_value=False) as mock_can_access:
         response = client.put(
             f"/projects/{str(TEST_PROJECT_ID)}",
             json=mock_edit_payload,
@@ -115,7 +115,7 @@ def test_edit_project_not_found(client: TestClient, app_fixture: FastAPI, mock_e
     app_fixture.dependency_overrides[get_session] = lambda: mock_db_session
     app_fixture.dependency_overrides[verify_token] = lambda: uuid.uuid4()
 
-    with patch("flip.project_services.edit_project.can_access_project", return_value=True) as mock_can_access:
+    with patch("flip_api.project_services.edit_project.can_access_project", return_value=True) as mock_can_access:
         response = client.put(
             f"/projects/{project_id}",
             json=mock_edit_payload,
@@ -137,7 +137,7 @@ def test_edit_project_staged(client: TestClient, app_fixture: FastAPI, mock_edit
     app_fixture.dependency_overrides[get_session] = lambda: mock_db_session
     app_fixture.dependency_overrides[verify_token] = lambda: uuid.uuid4()
 
-    with patch("flip.project_services.edit_project.can_access_project", return_value=True) as mock_can_access:
+    with patch("flip_api.project_services.edit_project.can_access_project", return_value=True) as mock_can_access:
         response = client.put(
             f"/projects/{str(TEST_PROJECT_ID)}",
             json=mock_edit_payload,
@@ -164,7 +164,7 @@ def test_edit_project_db_commit_value_error(
     app_fixture.dependency_overrides[get_session] = lambda: mock_db_session
     app_fixture.dependency_overrides[verify_token] = lambda: uuid.uuid4()
 
-    with patch("flip.project_services.edit_project.can_access_project", return_value=True) as mock_can_access:
+    with patch("flip_api.project_services.edit_project.can_access_project", return_value=True) as mock_can_access:
         response = client.put(
             f"/projects/{str(TEST_PROJECT_ID)}",
             json=mock_edit_payload,
@@ -188,7 +188,7 @@ def test_edit_project_db_commit_generic_exception(
     app_fixture.dependency_overrides[get_session] = lambda: mock_db_session
     app_fixture.dependency_overrides[verify_token] = lambda: uuid.uuid4()
 
-    with patch("flip.project_services.edit_project.can_access_project", return_value=True) as mock_can_access:
+    with patch("flip_api.project_services.edit_project.can_access_project", return_value=True) as mock_can_access:
         response = client.put(
             f"/projects/{str(TEST_PROJECT_ID)}",
             json=mock_edit_payload,

--- a/flip-api/tests/unit/project_services/test_get_imaging_project_status.py
+++ b/flip-api/tests/unit/project_services/test_get_imaging_project_status.py
@@ -19,11 +19,11 @@ from fastapi import FastAPI, status
 from fastapi.testclient import TestClient
 
 from flip_api.auth.dependencies import verify_token
-from flip.db.database import get_session
-from flip.db.models.main_models import Queries as DbQueries
-from flip.domain.interfaces.project import IImagingStatus, IProjectQuery, IProjectResponse
-from flip.domain.schemas.status import ProjectStatus
-from flip.project_services.get_imaging_project_status import router as get_imaging_project_status_router
+from flip_api.db.database import get_session
+from flip_api.db.models.main_models import Queries as DbQueries
+from flip_api.domain.interfaces.project import IImagingStatus, IProjectQuery, IProjectResponse
+from flip_api.domain.schemas.status import ProjectStatus
+from flip_api.project_services.get_imaging_project_status import router as get_imaging_project_status_router
 
 # Assuming Queries is the model for project_response.query
 
@@ -77,22 +77,22 @@ def test_get_imaging_project_status_success(client: TestClient, app_fixture: Fas
 
     with (
         patch(
-            "flip.project_services.get_imaging_project_status.can_access_project", return_value=True
+            "flip_api.project_services.get_imaging_project_status.can_access_project", return_value=True
         ) as mock_can_access,
         patch(
-            "flip.project_services.get_imaging_project_status.get_project",
+            "flip_api.project_services.get_imaging_project_status.get_project",
             return_value=mock_project_response_obj,
         ) as mock_get_project,
         patch(
-            "flip.project_services.get_imaging_project_status.get_imaging_projects",
+            "flip_api.project_services.get_imaging_project_status.get_imaging_projects",
             return_value=mock_imaging_projects_list,
         ) as mock_get_imaging_projects,
         patch(
-            "flip.project_services.get_imaging_project_status.base64_url_encode",
+            "flip_api.project_services.get_imaging_project_status.base64_url_encode",
             return_value=MOCK_ENCODED_QUERY,
         ) as mock_base64_encode,
         patch(
-            "flip.project_services.get_imaging_project_status.get_imaging_project_statuses",
+            "flip_api.project_services.get_imaging_project_status.get_imaging_project_statuses",
             return_value=mock_imaging_statuses_list_data,
         ) as mock_get_statuses,
     ):
@@ -117,9 +117,9 @@ def test_get_imaging_project_status_forbidden(client: TestClient, app_fixture: F
 
     with (
         patch(
-            "flip.project_services.get_imaging_project_status.can_access_project", return_value=False
+            "flip_api.project_services.get_imaging_project_status.can_access_project", return_value=False
         ) as mock_can_access,
-        patch("flip.project_services.get_imaging_project_status.get_project") as mock_get_project,
+        patch("flip_api.project_services.get_imaging_project_status.get_project") as mock_get_project,
     ):
         response = client.get(f"/projects/{str(MOCK_PROJECT_ID)}/image/status")
 
@@ -143,10 +143,10 @@ def test_get_imaging_project_status_project_not_found(
 
     with (
         patch(
-            "flip.project_services.get_imaging_project_status.can_access_project", return_value=True
+            "flip_api.project_services.get_imaging_project_status.can_access_project", return_value=True
         ) as mock_can_access,
         patch(
-            "flip.project_services.get_imaging_project_status.get_project", return_value=None
+            "flip_api.project_services.get_imaging_project_status.get_project", return_value=None
         ) as mock_get_project,
     ):
         mock_get_project.return_value = IProjectResponse(
@@ -183,10 +183,10 @@ def test_get_imaging_project_status_project_query_not_found(client: TestClient, 
 
     with (
         patch(
-            "flip.project_services.get_imaging_project_status.can_access_project", return_value=True
+            "flip_api.project_services.get_imaging_project_status.can_access_project", return_value=True
         ) as mock_can_access,
         patch(
-            "flip.project_services.get_imaging_project_status.get_project",
+            "flip_api.project_services.get_imaging_project_status.get_project",
             return_value=project_response_no_query,
         ) as mock_get_project,
     ):
@@ -206,13 +206,13 @@ def test_get_imaging_project_status_imaging_projects_not_found(client: TestClien
     app_fixture.dependency_overrides[verify_token] = lambda: MOCK_USER_ID
 
     with (
-        patch("flip.project_services.get_imaging_project_status.can_access_project", return_value=True),
+        patch("flip_api.project_services.get_imaging_project_status.can_access_project", return_value=True),
         patch(
-            "flip.project_services.get_imaging_project_status.get_project",
+            "flip_api.project_services.get_imaging_project_status.get_project",
             return_value=mock_project_response_obj,
         ),
         patch(
-            "flip.project_services.get_imaging_project_status.get_imaging_projects", return_value=None
+            "flip_api.project_services.get_imaging_project_status.get_imaging_projects", return_value=None
         ) as mock_get_imaging_projects,
     ):
         response = client.get(f"/projects/{str(MOCK_PROJECT_ID)}/image/status")
@@ -230,21 +230,21 @@ def test_get_imaging_project_status_statuses_not_found(client: TestClient, app_f
     app_fixture.dependency_overrides[verify_token] = lambda: MOCK_USER_ID
 
     with (
-        patch("flip.project_services.get_imaging_project_status.can_access_project", return_value=True),
+        patch("flip_api.project_services.get_imaging_project_status.can_access_project", return_value=True),
         patch(
-            "flip.project_services.get_imaging_project_status.get_project",
+            "flip_api.project_services.get_imaging_project_status.get_project",
             return_value=mock_project_response_obj,
         ),
         patch(
-            "flip.project_services.get_imaging_project_status.get_imaging_projects",
+            "flip_api.project_services.get_imaging_project_status.get_imaging_projects",
             return_value=mock_imaging_projects_list,
         ),
         patch(
-            "flip.project_services.get_imaging_project_status.base64_url_encode",
+            "flip_api.project_services.get_imaging_project_status.base64_url_encode",
             return_value=MOCK_ENCODED_QUERY,
         ),
         patch(
-            "flip.project_services.get_imaging_project_status.get_imaging_project_statuses", return_value=None
+            "flip_api.project_services.get_imaging_project_status.get_imaging_project_statuses", return_value=None
         ) as mock_get_statuses,
     ):
         response = client.get(f"/projects/{str(MOCK_PROJECT_ID)}/image/status")

--- a/flip-api/tests/unit/project_services/test_get_models.py
+++ b/flip-api/tests/unit/project_services/test_get_models.py
@@ -19,13 +19,13 @@ from fastapi import FastAPI, status
 from fastapi.testclient import TestClient
 
 from flip_api.auth.dependencies import verify_token
-from flip.db.database import get_session
-from flip.domain.interfaces.project import (
+from flip_api.db.database import get_session
+from flip_api.domain.interfaces.project import (
     IModelsInfoResponse,
     ModelStatus,
 )
-from flip.project_services.get_models import router as get_models_router
-from flip.utils.paging_utils import IPagedResponse
+from flip_api.project_services.get_models import router as get_models_router
+from flip_api.utils.paging_utils import IPagedResponse
 
 
 @pytest.fixture
@@ -92,12 +92,12 @@ def test_get_models_success(client: TestClient, app_fixture: FastAPI):
     app_fixture.dependency_overrides[verify_token] = lambda: MOCK_USER_ID
 
     with (
-        patch("flip.project_services.get_models.can_access_project", return_value=True) as mock_can_access,
+        patch("flip_api.project_services.get_models.can_access_project", return_value=True) as mock_can_access,
         patch(
-            "flip.project_services.get_models.get_project", return_value=mock_project_instance
+            "flip_api.project_services.get_models.get_project", return_value=mock_project_instance
         ) as mock_get_project,
         patch(
-            "flip.project_services.get_models.get_project_models_service",
+            "flip_api.project_services.get_models.get_project_models_service",
             return_value=mock_get_models_service_response,
         ) as mock_get_project_models,
     ):
@@ -120,9 +120,9 @@ def test_get_models_access_denied(client: TestClient, app_fixture: FastAPI):
     app_fixture.dependency_overrides[verify_token] = lambda: MOCK_USER_ID
 
     with (
-        patch("flip.project_services.get_models.can_access_project", return_value=False) as mock_can_access,
-        patch("flip.project_services.get_models.get_project") as mock_get_project,
-        patch("flip.project_services.get_models.get_project_models_service") as mock_get_project_models,
+        patch("flip_api.project_services.get_models.can_access_project", return_value=False) as mock_can_access,
+        patch("flip_api.project_services.get_models.get_project") as mock_get_project,
+        patch("flip_api.project_services.get_models.get_project_models_service") as mock_get_project_models,
     ):
         response = client.get(f"/projects/{str(MOCK_PROJECT_ID)}/models")
 
@@ -141,9 +141,9 @@ def test_get_models_project_not_found(client: TestClient, app_fixture: FastAPI):
     app_fixture.dependency_overrides[verify_token] = lambda: MOCK_USER_ID
 
     with (
-        patch("flip.project_services.get_models.can_access_project", return_value=True) as mock_can_access,
-        patch("flip.project_services.get_models.get_project", return_value=None) as mock_get_project,
-        patch("flip.project_services.get_models.get_project_models_service") as mock_get_project_models,
+        patch("flip_api.project_services.get_models.can_access_project", return_value=True) as mock_can_access,
+        patch("flip_api.project_services.get_models.get_project", return_value=None) as mock_get_project,
+        patch("flip_api.project_services.get_models.get_project_models_service") as mock_get_project_models,
     ):
         response = client.get(f"/projects/{str(MOCK_PROJECT_ID)}/models")
 
@@ -163,12 +163,12 @@ def test_get_models_no_models_found_for_project(client: TestClient, app_fixture:
     app_fixture.dependency_overrides[verify_token] = lambda: MOCK_USER_ID
 
     with (
-        patch("flip.project_services.get_models.can_access_project", return_value=True) as mock_can_access,
+        patch("flip_api.project_services.get_models.can_access_project", return_value=True) as mock_can_access,
         patch(
-            "flip.project_services.get_models.get_project", return_value=mock_project_instance
+            "flip_api.project_services.get_models.get_project", return_value=mock_project_instance
         ) as mock_get_project,
         patch(
-            "flip.project_services.get_models.get_project_models_service",
+            "flip_api.project_services.get_models.get_project_models_service",
             return_value=mock_get_models_service_empty_response,
         ) as mock_get_project_models,
     ):

--- a/flip-api/tests/unit/project_services/test_get_project.py
+++ b/flip-api/tests/unit/project_services/test_get_project.py
@@ -18,11 +18,11 @@ from fastapi import status
 from fastapi.testclient import TestClient
 
 from flip_api.auth.dependencies import verify_token
-from flip.db.database import get_session
-from flip.domain.schemas.status import ProjectStatus
-from flip.main import app
+from flip_api.db.database import get_session
+from flip_api.domain.schemas.status import ProjectStatus
+from flip_api.main import app
 
-# from flip.project_services.services.project_services import (
+# from flip_api.project_services.services.project_services import (
 #     get_approved_trusts_for_project,
 # )
 
@@ -97,7 +97,7 @@ def mock_users_with_access():
 def test_get_project_details_no_access(client, mock_db):
     """Test project details access denied"""
     # Arrange
-    with patch("flip.project_services.get_project.can_access_project", return_value=False):
+    with patch("flip_api.project_services.get_project.can_access_project", return_value=False):
         # Act
         response = client.get(f"/projects/{TEST_PROJECT_ID}")
 
@@ -110,8 +110,8 @@ def test_get_project_details_not_found(client, mock_db):
     """Test project not found"""
     # Arrange
     with (
-        patch("flip.project_services.get_project.can_access_project", return_value=True),
-        patch("flip.project_services.get_project.get_project", return_value=None),
+        patch("flip_api.project_services.get_project.can_access_project", return_value=True),
+        patch("flip_api.project_services.get_project.get_project", return_value=None),
     ):
         # Act
         response = client.get(f"/projects/{TEST_PROJECT_ID}")

--- a/flip-api/tests/unit/project_services/test_get_project_approved_trusts.py
+++ b/flip-api/tests/unit/project_services/test_get_project_approved_trusts.py
@@ -18,11 +18,11 @@ from fastapi import FastAPI, status
 from fastapi.testclient import TestClient
 
 from flip_api.auth.dependencies import verify_token
-from flip.db.database import get_session
-from flip.db.models.main_models import Projects
-from flip.domain.interfaces.trust import ITrust
-from flip.domain.schemas.status import ProjectStatus
-from flip.project_services.get_project_approved_trusts import router as get_project_approved_trusts_router
+from flip_api.db.database import get_session
+from flip_api.db.models.main_models import Projects
+from flip_api.domain.interfaces.trust import ITrust
+from flip_api.domain.schemas.status import ProjectStatus
+from flip_api.project_services.get_project_approved_trusts import router as get_project_approved_trusts_router
 
 # Assuming the router and endpoint are in get_project_approved_trusts.py
 # Use absolute import based on the project structure
@@ -63,8 +63,8 @@ def test_get_project_approved_trusts_success(
     app_fixture.dependency_overrides[verify_token] = lambda: user_id
 
     with (
-        patch("flip.project_services.get_project_approved_trusts.can_access_project", return_value=True),
-        patch("flip.project_services.get_project_approved_trusts.get_project", return_value=mock_project),
+        patch("flip_api.project_services.get_project_approved_trusts.can_access_project", return_value=True),
+        patch("flip_api.project_services.get_project_approved_trusts.get_project", return_value=mock_project),
     ):
         response = client.get(f"projects/{TEST_PROJECT_ID}/trusts/approved")
 
@@ -83,7 +83,7 @@ def test_get_project_approved_trusts_forbidden(
     app_fixture.dependency_overrides[get_session] = lambda: mock_db_session
     app_fixture.dependency_overrides[verify_token] = lambda: TEST_USER_ID
 
-    with patch("flip.project_services.get_project_approved_trusts.can_access_project", return_value=False):
+    with patch("flip_api.project_services.get_project_approved_trusts.can_access_project", return_value=False):
         response = client.get(f"projects/{TEST_PROJECT_ID}/trusts/approved")
 
     # Assert
@@ -102,8 +102,8 @@ def test_get_project_approved_trusts_not_found(
     app_fixture.dependency_overrides[verify_token] = lambda: TEST_USER_ID
 
     with (
-        patch("flip.project_services.get_project_approved_trusts.can_access_project", return_value=True),
-        patch("flip.project_services.get_project_approved_trusts.get_project", return_value=None),
+        patch("flip_api.project_services.get_project_approved_trusts.can_access_project", return_value=True),
+        patch("flip_api.project_services.get_project_approved_trusts.get_project", return_value=None),
     ):
         response = client.get(f"projects/{TEST_PROJECT_ID}/trusts/approved")
 
@@ -128,10 +128,10 @@ def test_get_project_approved_trusts_project_not_approved(
     mock_project.status = ProjectStatus.UNSTAGED  # Or any status other than APPROVED
 
     with (
-        patch("flip.project_services.get_project_approved_trusts.can_access_project", return_value=True),
-        patch("flip.project_services.get_project_approved_trusts.get_project", return_value=mock_project),
+        patch("flip_api.project_services.get_project_approved_trusts.can_access_project", return_value=True),
+        patch("flip_api.project_services.get_project_approved_trusts.get_project", return_value=mock_project),
         patch(
-            "flip.project_services.get_project_approved_trusts.get_approved_trusts_for_project"
+            "flip_api.project_services.get_project_approved_trusts.get_approved_trusts_for_project"
         ) as mock_get_trusts,
     ):
         response = client.get(f"/projects/{TEST_PROJECT_ID}/trusts/approved")
@@ -155,10 +155,10 @@ def test_get_project_approved_trusts_value_error_fetching_trusts(
     mock_project.status = ProjectStatus.APPROVED
 
     with (
-        patch("flip.project_services.get_project_approved_trusts.can_access_project", return_value=True),
-        patch("flip.project_services.get_project_approved_trusts.get_project", return_value=mock_project),
+        patch("flip_api.project_services.get_project_approved_trusts.can_access_project", return_value=True),
+        patch("flip_api.project_services.get_project_approved_trusts.get_project", return_value=mock_project),
         patch(
-            "flip.project_services.get_project_approved_trusts.get_approved_trusts_for_project",
+            "flip_api.project_services.get_project_approved_trusts.get_approved_trusts_for_project",
             side_effect=ValueError("Test Value Error"),
         ) as mock_get_trusts,
     ):
@@ -183,10 +183,10 @@ def test_get_project_approved_trusts_generic_exception_fetching_trusts(
     mock_project.status = ProjectStatus.APPROVED
 
     with (
-        patch("flip.project_services.get_project_approved_trusts.can_access_project", return_value=True),
-        patch("flip.project_services.get_project_approved_trusts.get_project", return_value=mock_project),
+        patch("flip_api.project_services.get_project_approved_trusts.can_access_project", return_value=True),
+        patch("flip_api.project_services.get_project_approved_trusts.get_project", return_value=mock_project),
         patch(
-            "flip.project_services.get_project_approved_trusts.get_approved_trusts_for_project",
+            "flip_api.project_services.get_project_approved_trusts.get_approved_trusts_for_project",
             side_effect=Exception("Test Generic Error"),
         ) as mock_get_trusts,
     ):
@@ -217,10 +217,10 @@ def test_get_project_approved_trusts_success_with_data(
     expected_trusts_json = [trust.model_dump(mode="json") for trust in expected_trusts_data]
 
     with (
-        patch("flip.project_services.get_project_approved_trusts.can_access_project", return_value=True),
-        patch("flip.project_services.get_project_approved_trusts.get_project", return_value=mock_project),
+        patch("flip_api.project_services.get_project_approved_trusts.can_access_project", return_value=True),
+        patch("flip_api.project_services.get_project_approved_trusts.get_project", return_value=mock_project),
         patch(
-            "flip.project_services.get_project_approved_trusts.get_approved_trusts_for_project",
+            "flip_api.project_services.get_project_approved_trusts.get_approved_trusts_for_project",
             return_value=expected_trusts_data,
         ) as mock_get_trusts,
     ):

--- a/flip-api/tests/unit/project_services/test_get_projects.py
+++ b/flip-api/tests/unit/project_services/test_get_projects.py
@@ -17,9 +17,9 @@ from unittest.mock import MagicMock
 from sqlmodel import Session
 
 from flip_api.db.models.main_models import Projects
-from flip.domain.schemas.status import ProjectStatus
-from flip.project_services.get_projects import get_projects_paginated_orm
-from flip.utils.paging_utils import get_filter_details, get_paging_details
+from flip_api.domain.schemas.status import ProjectStatus
+from flip_api.project_services.get_projects import get_projects_paginated_orm
+from flip_api.utils.paging_utils import get_filter_details, get_paging_details
 
 paging_details = get_paging_details()
 

--- a/flip-api/tests/unit/project_services/test_reimport_imaging_project_studies.py
+++ b/flip-api/tests/unit/project_services/test_reimport_imaging_project_studies.py
@@ -23,9 +23,9 @@ def mock_session():
     return MagicMock()
 
 
-@patch("flip.project_services.reimport_imaging_project_studies.get_settings")
-@patch("flip.project_services.reimport_imaging_project_studies.get_reimport_queries_service")
-@patch("flip.project_services.reimport_imaging_project_studies.reimport_failed_studies")
+@patch("flip_api.project_services.reimport_imaging_project_studies.get_settings")
+@patch("flip_api.project_services.reimport_imaging_project_studies.get_reimport_queries_service")
+@patch("flip_api.project_services.reimport_imaging_project_studies.reimport_failed_studies")
 def test_reimport_success(mock_reimport, mock_queries_service, mock_get_settings, mock_session):
     # Mock settings
     mock_get_settings.return_value.PROJECT_REIMPORT_RATE = 2
@@ -43,9 +43,9 @@ def test_reimport_success(mock_reimport, mock_queries_service, mock_get_settings
     mock_reimport.assert_called_once()
 
 
-@patch("flip.project_services.reimport_imaging_project_studies.get_settings")
-@patch("flip.project_services.reimport_imaging_project_studies.get_reimport_queries_service")
-@patch("flip.project_services.reimport_imaging_project_studies.reimport_failed_studies")
+@patch("flip_api.project_services.reimport_imaging_project_studies.get_settings")
+@patch("flip_api.project_services.reimport_imaging_project_studies.get_reimport_queries_service")
+@patch("flip_api.project_services.reimport_imaging_project_studies.reimport_failed_studies")
 def test_failed_study_reimport_raises_500(mock_reimport, mock_queries_service, mock_get_settings, mock_session):
     mock_get_settings.return_value.PROJECT_REIMPORT_RATE = 2
     mock_get_settings.return_value.MAX_REIMPORT_COUNT = 100

--- a/flip-api/tests/unit/project_services/test_stage_project.py
+++ b/flip-api/tests/unit/project_services/test_stage_project.py
@@ -19,10 +19,10 @@ from fastapi import FastAPI, status
 from fastapi.testclient import TestClient
 
 from flip_api.auth.dependencies import verify_token
-from flip.db.database import get_session
-from flip.domain.interfaces.project import ProjectStatus
-from flip.domain.schemas.projects import StageProjectRequest
-from flip.project_services.stage_project import router as stage_project_router
+from flip_api.db.database import get_session
+from flip_api.domain.interfaces.project import ProjectStatus
+from flip_api.domain.schemas.projects import StageProjectRequest
+from flip_api.project_services.stage_project import router as stage_project_router
 
 # Global test data
 TEST_PROJECT_ID = uuid.uuid4()
@@ -81,9 +81,9 @@ def test_stage_project_success(
     app_fixture.dependency_overrides[verify_token] = lambda: test_user_id
 
     with (
-        patch("flip.project_services.stage_project.can_access_project", return_value=True),
-        patch("flip.project_services.stage_project.get_project", return_value=mock_project_data),
-        patch("flip.project_services.stage_project.stage_project_service"),
+        patch("flip_api.project_services.stage_project.can_access_project", return_value=True),
+        patch("flip_api.project_services.stage_project.get_project", return_value=mock_project_data),
+        patch("flip_api.project_services.stage_project.stage_project_service"),
     ):
         # Act
         response = client.post(f"/projects/{test_project_id}/stage", json=stage_request_payload)
@@ -99,8 +99,8 @@ def test_stage_project_access_denied(app_fixture, client, test_user_id, test_pro
     app_fixture.dependency_overrides[verify_token] = lambda: test_user_id
 
     with (
-        patch("flip.project_services.stage_project.can_access_project", return_value=False),
-        patch("flip.project_services.stage_project.get_project") as mock_get_project,
+        patch("flip_api.project_services.stage_project.can_access_project", return_value=False),
+        patch("flip_api.project_services.stage_project.get_project") as mock_get_project,
     ):
         # Act
         response = client.post(f"/projects/{test_project_id}/stage", json=stage_request_payload)
@@ -118,8 +118,8 @@ def test_stage_project_not_found(app_fixture, client, test_user_id, test_project
     app_fixture.dependency_overrides[verify_token] = lambda: test_user_id
 
     with (
-        patch("flip.project_services.stage_project.can_access_project", return_value=True),
-        patch("flip.project_services.stage_project.get_project", return_value=None),
+        patch("flip_api.project_services.stage_project.can_access_project", return_value=True),
+        patch("flip_api.project_services.stage_project.get_project", return_value=None),
     ):
         # Act
         response = client.post(f"/projects/{test_project_id}/stage", json=stage_request_payload)
@@ -139,8 +139,8 @@ def test_stage_project_not_unstaged_status(app_fixture, client, test_user_id, te
     mock_project_data.status = ProjectStatus.STAGED
 
     with (
-        patch("flip.project_services.stage_project.can_access_project", return_value=True),
-        patch("flip.project_services.stage_project.get_project", return_value=mock_project_data),
+        patch("flip_api.project_services.stage_project.can_access_project", return_value=True),
+        patch("flip_api.project_services.stage_project.get_project", return_value=mock_project_data),
     ):
         # Act
         response = client.post(f"/projects/{test_project_id}/stage", json=stage_request_payload)
@@ -164,8 +164,8 @@ def test_stage_project_no_query(app_fixture, client, test_user_id, test_project_
     mock_project_data.query = None
 
     with (
-        patch("flip.project_services.stage_project.can_access_project", return_value=True),
-        patch("flip.project_services.stage_project.get_project", return_value=mock_project_data),
+        patch("flip_api.project_services.stage_project.can_access_project", return_value=True),
+        patch("flip_api.project_services.stage_project.get_project", return_value=mock_project_data),
     ):
         # Act
         response = client.post(f"/projects/{test_project_id}/stage", json=stage_request_payload)
@@ -193,8 +193,8 @@ def test_stage_project_invalid_trusts_queried(
     mock_project_data.query.trusts_queried = 0
 
     with (
-        patch("flip.project_services.stage_project.can_access_project", return_value=True),
-        patch("flip.project_services.stage_project.get_project", return_value=mock_project_data),
+        patch("flip_api.project_services.stage_project.can_access_project", return_value=True),
+        patch("flip_api.project_services.stage_project.get_project", return_value=mock_project_data),
     ):
         # Act
         response = client.post(f"/projects/{test_project_id}/stage", json=stage_request_payload)
@@ -217,10 +217,10 @@ def test_stage_project_value_error_from_service(
     app_fixture.dependency_overrides[verify_token] = lambda: test_user_id
 
     with (
-        patch("flip.project_services.stage_project.can_access_project", return_value=True),
-        patch("flip.project_services.stage_project.get_project", return_value=mock_project_data),
+        patch("flip_api.project_services.stage_project.can_access_project", return_value=True),
+        patch("flip_api.project_services.stage_project.get_project", return_value=mock_project_data),
         patch(
-            "flip.project_services.stage_project.stage_project_service",
+            "flip_api.project_services.stage_project.stage_project_service",
             side_effect=ValueError("Invalid trust configuration"),
         ),
     ):
@@ -241,10 +241,10 @@ def test_stage_project_generic_exception(
     app_fixture.dependency_overrides[verify_token] = lambda: test_user_id
 
     with (
-        patch("flip.project_services.stage_project.can_access_project", return_value=True),
-        patch("flip.project_services.stage_project.get_project", return_value=mock_project_data),
+        patch("flip_api.project_services.stage_project.can_access_project", return_value=True),
+        patch("flip_api.project_services.stage_project.get_project", return_value=mock_project_data),
         patch(
-            "flip.project_services.stage_project.stage_project_service", side_effect=Exception("Database error")
+            "flip_api.project_services.stage_project.stage_project_service", side_effect=Exception("Database error")
         ),
     ):
         # Act

--- a/flip-api/tests/unit/project_services/test_unstage_project.py
+++ b/flip-api/tests/unit/project_services/test_unstage_project.py
@@ -18,10 +18,10 @@ from fastapi import FastAPI, status
 from fastapi.testclient import TestClient
 
 from flip_api.auth.dependencies import verify_token
-from flip.db.database import get_session
-from flip.db.models.user_models import PermissionRef
-from flip.domain.interfaces.project import ProjectStatus
-from flip.project_services.unstage_project import router as unstage_project_router
+from flip_api.db.database import get_session
+from flip_api.db.models.user_models import PermissionRef
+from flip_api.domain.interfaces.project import ProjectStatus
+from flip_api.project_services.unstage_project import router as unstage_project_router
 
 
 @pytest.fixture
@@ -60,9 +60,9 @@ def test_unstage_project_success(app_fixture, client, test_user_id, test_project
     app_fixture.dependency_overrides[verify_token] = lambda: test_user_id
 
     with (
-        patch("flip.project_services.unstage_project.has_permissions", return_value=True),
-        patch("flip.project_services.unstage_project.get_project", return_value=mock_project_data),
-        patch("flip.project_services.unstage_project.unstage_project_service") as mock_unstage_service,
+        patch("flip_api.project_services.unstage_project.has_permissions", return_value=True),
+        patch("flip_api.project_services.unstage_project.get_project", return_value=mock_project_data),
+        patch("flip_api.project_services.unstage_project.unstage_project_service") as mock_unstage_service,
     ):
         # Act
         response = client.post(f"/projects/{test_project_id}/unstage")
@@ -81,8 +81,8 @@ def test_unstage_project_permission_denied(app_fixture, client, test_user_id, te
     app_fixture.dependency_overrides[verify_token] = lambda: test_user_id
 
     with (
-        patch("flip.project_services.unstage_project.has_permissions", return_value=False),
-        patch("flip.project_services.unstage_project.get_project") as mock_get_project,
+        patch("flip_api.project_services.unstage_project.has_permissions", return_value=False),
+        patch("flip_api.project_services.unstage_project.get_project") as mock_get_project,
     ):
         # Act
         response = client.post(f"/projects/{test_project_id}/unstage")
@@ -100,8 +100,8 @@ def test_unstage_project_not_found(app_fixture, client, test_user_id, test_proje
     app_fixture.dependency_overrides[verify_token] = lambda: test_user_id
 
     with (
-        patch("flip.project_services.unstage_project.has_permissions", return_value=True),
-        patch("flip.project_services.unstage_project.get_project", return_value=None),
+        patch("flip_api.project_services.unstage_project.has_permissions", return_value=True),
+        patch("flip_api.project_services.unstage_project.get_project", return_value=None),
     ):
         # Act
         response = client.post(f"/projects/{test_project_id}/unstage")
@@ -121,8 +121,8 @@ def test_unstage_project_not_staged_status(app_fixture, client, test_user_id, te
     mock_project_data.status = ProjectStatus.UNSTAGED.value
 
     with (
-        patch("flip.project_services.unstage_project.has_permissions", return_value=True),
-        patch("flip.project_services.unstage_project.get_project", return_value=mock_project_data),
+        patch("flip_api.project_services.unstage_project.has_permissions", return_value=True),
+        patch("flip_api.project_services.unstage_project.get_project", return_value=mock_project_data),
     ):
         # Act
         response = client.post(f"/projects/{test_project_id}/unstage")
@@ -142,8 +142,8 @@ def test_unstage_project_approved_status(app_fixture, client, test_user_id, test
     mock_project_data.status = ProjectStatus.APPROVED.value
 
     with (
-        patch("flip.project_services.unstage_project.has_permissions", return_value=True),
-        patch("flip.project_services.unstage_project.get_project", return_value=mock_project_data),
+        patch("flip_api.project_services.unstage_project.has_permissions", return_value=True),
+        patch("flip_api.project_services.unstage_project.get_project", return_value=mock_project_data),
     ):
         # Act
         response = client.post(f"/projects/{test_project_id}/unstage")
@@ -162,10 +162,10 @@ def test_unstage_project_value_error_from_service(
     app_fixture.dependency_overrides[verify_token] = lambda: test_user_id
 
     with (
-        patch("flip.project_services.unstage_project.has_permissions", return_value=True),
-        patch("flip.project_services.unstage_project.get_project", return_value=mock_project_data),
+        patch("flip_api.project_services.unstage_project.has_permissions", return_value=True),
+        patch("flip_api.project_services.unstage_project.get_project", return_value=mock_project_data),
         patch(
-            "flip.project_services.unstage_project.unstage_project_service",
+            "flip_api.project_services.unstage_project.unstage_project_service",
             side_effect=ValueError("Invalid project state for unstaging"),
         ),
     ):
@@ -186,10 +186,10 @@ def test_unstage_project_generic_exception_from_service(
     app_fixture.dependency_overrides[verify_token] = lambda: test_user_id
 
     with (
-        patch("flip.project_services.unstage_project.has_permissions", return_value=True),
-        patch("flip.project_services.unstage_project.get_project", return_value=mock_project_data),
+        patch("flip_api.project_services.unstage_project.has_permissions", return_value=True),
+        patch("flip_api.project_services.unstage_project.get_project", return_value=mock_project_data),
         patch(
-            "flip.project_services.unstage_project.unstage_project_service",
+            "flip_api.project_services.unstage_project.unstage_project_service",
             side_effect=Exception("Database connection error"),
         ),
     ):
@@ -225,9 +225,9 @@ def test_unstage_project_permission_check_called_correctly(app_fixture, client, 
 
     with (
         patch(
-            "flip.project_services.unstage_project.has_permissions", return_value=True
+            "flip_api.project_services.unstage_project.has_permissions", return_value=True
         ) as mock_has_permissions,
-        patch("flip.project_services.unstage_project.get_project", return_value=None),
+        patch("flip_api.project_services.unstage_project.get_project", return_value=None),
     ):
         # Act
         client.post(f"/projects/{test_project_id}/unstage")
@@ -245,9 +245,9 @@ def test_unstage_project_session_transaction_management(
     app_fixture.dependency_overrides[verify_token] = lambda: test_user_id
 
     with (
-        patch("flip.project_services.unstage_project.has_permissions", return_value=True),
-        patch("flip.project_services.unstage_project.get_project", return_value=mock_project_data),
-        patch("flip.project_services.unstage_project.unstage_project_service") as mock_unstage_service,
+        patch("flip_api.project_services.unstage_project.has_permissions", return_value=True),
+        patch("flip_api.project_services.unstage_project.get_project", return_value=mock_project_data),
+        patch("flip_api.project_services.unstage_project.unstage_project_service") as mock_unstage_service,
     ):
         # Act
         response = client.post(f"/projects/{test_project_id}/unstage")
@@ -269,8 +269,8 @@ def test_unstage_project_edge_case_empty_uuid(app_fixture, client, test_user_id)
     zero_uuid = "00000000-0000-0000-0000-000000000000"
 
     with (
-        patch("flip.project_services.unstage_project.has_permissions", return_value=True),
-        patch("flip.project_services.unstage_project.get_project", return_value=None),
+        patch("flip_api.project_services.unstage_project.has_permissions", return_value=True),
+        patch("flip_api.project_services.unstage_project.get_project", return_value=None),
     ):
         # Act
         response = client.post(f"/projects/{zero_uuid}/unstage")

--- a/flip-api/tests/unit/role_services/test_get_roles.py
+++ b/flip-api/tests/unit/role_services/test_get_roles.py
@@ -18,8 +18,8 @@ import pytest
 from fastapi import HTTPException
 
 from flip_api.db.models.user_models import PermissionRef
-from flip.domain.interfaces.role import IRole, IRolesResponse
-from flip.role_services.get_roles import get_roles
+from flip_api.domain.interfaces.role import IRole, IRolesResponse
+from flip_api.role_services.get_roles import get_roles
 
 
 @pytest.fixture
@@ -45,8 +45,8 @@ def test_get_roles_success(mock_token_id):
     expected_response = IRolesResponse(roles=expected_roles)
 
     with (
-        patch("flip.role_services.get_roles.has_permissions", return_value=True) as mock_has_perms,
-        patch("flip.role_services.get_roles.logger") as mock_logger,
+        patch("flip_api.role_services.get_roles.has_permissions", return_value=True) as mock_has_perms,
+        patch("flip_api.role_services.get_roles.logger") as mock_logger,
     ):
         # Act
         response = get_roles(session=mock_session, token_id=mock_token_id)
@@ -71,8 +71,8 @@ def test_get_roles_no_permission(mock_token_id):
     mock_session = MagicMock()
 
     with (
-        patch("flip.role_services.get_roles.has_permissions", return_value=False) as mock_has_perms,
-        patch("flip.role_services.get_roles.logger") as mock_logger,
+        patch("flip_api.role_services.get_roles.has_permissions", return_value=False) as mock_has_perms,
+        patch("flip_api.role_services.get_roles.logger") as mock_logger,
     ):
         # Act & Assert
         with pytest.raises(HTTPException) as exc_info:
@@ -93,8 +93,8 @@ def test_get_roles_database_error(mock_token_id):
     mock_session.exec.side_effect = db_error
 
     with (
-        patch("flip.role_services.get_roles.has_permissions", return_value=True) as mock_has_perms,
-        patch("flip.role_services.get_roles.logger") as mock_logger,
+        patch("flip_api.role_services.get_roles.has_permissions", return_value=True) as mock_has_perms,
+        patch("flip_api.role_services.get_roles.logger") as mock_logger,
     ):
         # Act & Assert
         with pytest.raises(HTTPException) as exc_info:
@@ -117,8 +117,8 @@ def test_get_roles_no_roles_found(mock_token_id):
     expected_response = IRolesResponse(roles=[])
 
     with (
-        patch("flip.role_services.get_roles.has_permissions", return_value=True) as mock_has_perms,
-        patch("flip.role_services.get_roles.logger") as mock_logger,
+        patch("flip_api.role_services.get_roles.has_permissions", return_value=True) as mock_has_perms,
+        patch("flip_api.role_services.get_roles.logger") as mock_logger,
     ):
         # Act
         response = get_roles(session=mock_session, token_id=mock_token_id)

--- a/flip-api/tests/unit/site_services/services/test_details_service.py
+++ b/flip-api/tests/unit/site_services/services/test_details_service.py
@@ -17,8 +17,8 @@ from fastapi import HTTPException
 from sqlmodel import Session
 
 from flip_api.db.models.main_models import SiteBanner, SiteConfig
-from flip.domain.interfaces.site import ISiteBanner, ISiteDetails
-from flip.site_services.services.details_service import get_site_details, update_site_details
+from flip_api.domain.interfaces.site import ISiteBanner, ISiteDetails
+from flip_api.site_services.services.details_service import get_site_details, update_site_details
 
 
 @pytest.fixture

--- a/flip-api/tests/unit/site_services/test_details.py
+++ b/flip-api/tests/unit/site_services/test_details.py
@@ -17,9 +17,9 @@ from fastapi import status
 from fastapi.testclient import TestClient
 
 from flip_api.auth.dependencies import verify_token
-from flip.db.database import get_session
-from flip.db.models.main_models import SiteBanner, SiteConfig
-from flip.main import app
+from flip_api.db.database import get_session
+from flip_api.db.models.main_models import SiteBanner, SiteConfig
+from flip_api.main import app
 
 # ---- Test setup ----
 

--- a/flip-api/tests/unit/trusts_services/services/test_trust.py
+++ b/flip-api/tests/unit/trusts_services/services/test_trust.py
@@ -16,8 +16,8 @@ from uuid import uuid4
 import pytest
 
 from flip_api.db.models.main_models import Trust
-from flip.domain.interfaces.trust import ITrust
-from flip.trusts_services.services.trust import get_trusts
+from flip_api.domain.interfaces.trust import ITrust
+from flip_api.trusts_services.services.trust import get_trusts
 
 
 def create_mock_trust(id=None, name="Test Trust", endpoint="https://test.endpoint"):

--- a/flip-api/tests/unit/utils/test_cognito_helpers.py
+++ b/flip-api/tests/unit/utils/test_cognito_helpers.py
@@ -20,7 +20,7 @@ from fastapi.exceptions import HTTPException
 from starlette.status import HTTP_400_BAD_REQUEST, HTTP_500_INTERNAL_SERVER_ERROR
 
 from flip_api.domain.schemas.users import CognitoUser
-from flip.utils.cognito_helpers import create_cognito_user, filter_enabled_users, get_cognito_users, get_pool_id
+from flip_api.utils.cognito_helpers import create_cognito_user, filter_enabled_users, get_cognito_users, get_pool_id
 
 user1, user2, user3, user4, user5, user6 = [uuid4() for i in range(6)]
 USER_POOL_ID = "test-user-pool-id"
@@ -41,7 +41,7 @@ class CognitoUserFactory(factory.Factory):
 @pytest.fixture
 def mock_logger():
     """Mock logger for testing."""
-    with patch("flip.utils.cognito_helpers.logger") as mock_logger:
+    with patch("flip_api.utils.cognito_helpers.logger") as mock_logger:
         yield mock_logger
 
 
@@ -70,7 +70,7 @@ class TestFilterEnabledUsers:
 
     def test_empty_user_list(self):
         """Test that an empty user list returns an empty list."""
-        with patch("flip.utils.cognito_helpers.get_cognito_users") as mock_get_users:
+        with patch("flip_api.utils.cognito_helpers.get_cognito_users") as mock_get_users:
             result = filter_enabled_users(USER_POOL_ID, [])
 
             assert result == []
@@ -81,7 +81,7 @@ class TestFilterEnabledUsers:
         """Test when all users exist and are enabled."""
         valid_users = [user1, user3]
 
-        with patch("flip.utils.cognito_helpers.get_cognito_users") as mock_get_users:
+        with patch("flip_api.utils.cognito_helpers.get_cognito_users") as mock_get_users:
             mock_get_users.return_value = [
                 CognitoUserFactory(id=user1, is_disabled=False),
                 CognitoUserFactory(id=user3, is_disabled=False),
@@ -97,7 +97,7 @@ class TestFilterEnabledUsers:
         """Test filtering out disabled users."""
         input_users = [user1, user2, user3]
 
-        with patch("flip.utils.cognito_helpers.get_cognito_users") as mock_get_users:
+        with patch("flip_api.utils.cognito_helpers.get_cognito_users") as mock_get_users:
             mock_get_users.return_value = cognito_users
 
             result = filter_enabled_users(USER_POOL_ID, input_users)
@@ -112,7 +112,7 @@ class TestFilterEnabledUsers:
         """Test filtering out users that don't exist in Cognito."""
         input_users = [user1, user4, user5]
 
-        with patch("flip.utils.cognito_helpers.get_cognito_users") as mock_get_users:
+        with patch("flip_api.utils.cognito_helpers.get_cognito_users") as mock_get_users:
             mock_get_users.return_value = cognito_users
 
             result = filter_enabled_users(USER_POOL_ID, input_users)
@@ -127,7 +127,7 @@ class TestFilterEnabledUsers:
         """Test with mix of valid, disabled, and non-existent users."""
         input_users = [user1, user2, user3, user4, user5]
 
-        with patch("flip.utils.cognito_helpers.get_cognito_users") as mock_get_users:
+        with patch("flip_api.utils.cognito_helpers.get_cognito_users") as mock_get_users:
             mock_get_users.return_value = cognito_users
 
             result = filter_enabled_users(USER_POOL_ID, input_users)
@@ -144,7 +144,7 @@ class TestFilterEnabledUsers:
 
     def test_error_from_get_cognito_users(self):
         """Test handling of errors from get_cognito_users."""
-        with patch("flip.utils.cognito_helpers.get_cognito_users") as mock_get_users:
+        with patch("flip_api.utils.cognito_helpers.get_cognito_users") as mock_get_users:
             mock_get_users.side_effect = RuntimeError("Cognito service error")
 
             with pytest.raises(RuntimeError) as exc_info:
@@ -159,13 +159,13 @@ class TestCreateCognitoUser:
     @pytest.fixture
     def mock_boto3_client(self):
         """Mock boto3 client for Cognito operations."""
-        with patch("flip.utils.cognito_helpers.boto3.client") as mock_client:
+        with patch("flip_api.utils.cognito_helpers.boto3.client") as mock_client:
             yield mock_client
 
     @pytest.fixture
     def mock_settings(self):
         """Mock settings for AWS region."""
-        with patch("flip.utils.cognito_helpers.get_settings") as mock_get_settings:
+        with patch("flip_api.utils.cognito_helpers.get_settings") as mock_get_settings:
             mock_get_settings.return_value.AWS_REGION = "eu-west-2"
             yield mock_get_settings
 
@@ -446,7 +446,7 @@ class TestGetPoolId:
     @pytest.fixture
     def mock_get_settings(self):
         """Mock settings for testing."""
-        with patch("flip.utils.cognito_helpers.get_settings") as mock_settings:
+        with patch("flip_api.utils.cognito_helpers.get_settings") as mock_settings:
             yield mock_settings
 
     @pytest.fixture
@@ -684,13 +684,13 @@ class TestGetCognitoUsers:
     @pytest.fixture
     def mock_boto3_client(self):
         """Mock boto3 client for Cognito operations."""
-        with patch("flip.utils.cognito_helpers.boto3.client") as mock_client:
+        with patch("flip_api.utils.cognito_helpers.boto3.client") as mock_client:
             yield mock_client
 
     @pytest.fixture
     def mock_get_settings(self):
         """Mock settings for AWS region and user pool ID."""
-        with patch("flip.utils.cognito_helpers.get_settings") as mock_get_settings:
+        with patch("flip_api.utils.cognito_helpers.get_settings") as mock_get_settings:
             mock_get_settings.return_value.AWS_REGION = "test-west-1"
             mock_get_settings.return_value.AWS_COGNITO_USER_POOL_ID = "test-pool-id"
             yield mock_get_settings

--- a/flip-api/tests/unit/utils/test_encryption.py
+++ b/flip-api/tests/unit/utils/test_encryption.py
@@ -31,13 +31,13 @@ def test_encryption_decryption_roundtrip():
 
 
 def test_get_aes_key_returns_decoded_bytes():
-    with patch("flip.utils.encryption.get_secret", return_value=ENCODED_KEY):
+    with patch("flip_api.utils.encryption.get_secret", return_value=ENCODED_KEY):
         key = get_aes_key()
         assert key == RAW_KEY_BYTES
 
 
 def test_get_aes_key_raises_if_secret_invalid_base64():
-    with patch("flip.utils.encryption.get_secret", return_value="not-base64"):
+    with patch("flip_api.utils.encryption.get_secret", return_value="not-base64"):
         with pytest.raises(binascii.Error, match="Invalid base64-encoded string"):
             get_aes_key()
 

--- a/flip-api/tests/unit/utils/test_get_secrets.py
+++ b/flip-api/tests/unit/utils/test_get_secrets.py
@@ -23,7 +23,7 @@ from flip_api.utils.get_secrets import get_secrets
 @pytest.fixture
 def mock_settings():
     """Mock settings for AWS region."""
-    with patch("flip.utils.get_secrets.get_settings") as mock_get_settings:
+    with patch("flip_api.utils.get_secrets.get_settings") as mock_get_settings:
         mock_get_settings.return_value.AWS_SECRET_NAME = "MY_SECRET"
         mock_get_settings.return_value.AWS_REGION = "test-west-1"
         yield mock_get_settings

--- a/flip-api/tests/unit/utils/test_site_manager.py
+++ b/flip-api/tests/unit/utils/test_site_manager.py
@@ -15,7 +15,7 @@ from unittest.mock import MagicMock
 from sqlmodel import Session
 
 from flip_api.db.models.main_models import SiteConfig
-from flip.utils.site_manager import is_deployment_mode_enabled
+from flip_api.utils.site_manager import is_deployment_mode_enabled
 
 
 def test_deployment_mode_enabled():


### PR DESCRIPTION
…le structure

- Updated import paths in unit tests to reflect the new `flip_api` namespace.
- Adjusted patch targets in tests to ensure compatibility with the refactored module structure.
- Ensured all references to `flip` are replaced with `flip_api` in test files across various services including project, role, site, and utility services.