### PR TITLE
feat(flip-api): distribute Trust CA certificate and apply SSL verification to all httpx clients

### DIFF
--- a/.env.development.example
+++ b/.env.development.example
@@ -97,6 +97,10 @@ MIN_CLIENTS=1
 PRIVATE_API_KEY_HEADER=Authorization
 PRIVATE_API_KEY=<your-private-api-key-for-testing>
 AES_KEY_BASE64=<your-base64-encoded-32-byte-aes-key-for-testing>  # This should be a base64-encoded 32-byte key for AES-256 encryption (e.g., "c2VjdX...==")
+# Path to the Trust CA certificate PEM file used by flip-api to verify HTTPS connections to Trust services.
+# In development, this is mounted via compose.development.yml from trust/certs/trust-ca.crt.
+# Leave unset to rely on the system CA bundle only.
+TRUST_CA_BUNDLE=/etc/ssl/trust/trust-ca.crt
 #
 TRUST_DEBUG_PORT_TRUST_2=5685
 IMAGING_DEBUG_PORT_TRUST_2=5684

--- a/flip-api/src/flip_api/cohort_services/submit_cohort_query.py
+++ b/flip-api/src/flip_api/cohort_services/submit_cohort_query.py
@@ -32,6 +32,7 @@ from flip_api.domain.schemas.cohort import (
     TrustDetails,
 )
 from flip_api.utils.encryption import encrypt
+from flip_api.utils.http import _trust_ssl_context
 from flip_api.utils.logger import logger
 
 router = APIRouter(prefix="/cohort", tags=["cohort_services"])
@@ -159,7 +160,7 @@ def submit_cohort_query(
                 # Make request to trust
                 # headers = dict(request.headers)
 
-                with httpx.Client() as client:
+                with httpx.Client(verify=_trust_ssl_context()) as client:
                     response = client.post(
                         f"{trust.endpoint}/cohort",
                         json=request_body.model_dump(mode="json"),

--- a/flip-api/src/flip_api/config.py
+++ b/flip-api/src/flip_api/config.py
@@ -69,6 +69,9 @@ class Settings(BaseSettings):
     # Variables used during database seeding
     NET_ENDPOINTS: dict[str, str]
 
+    # SSL / TLS settings
+    TRUST_CA_BUNDLE: Optional[str] = None  # Path to the Trust CA certificate PEM file
+
     # FL settings
     FL_BACKEND: Literal["nvflare", "flower"] = "nvflare"
 

--- a/flip-api/src/flip_api/model_services/retrieve_model_status_from_logs.py
+++ b/flip-api/src/flip_api/model_services/retrieve_model_status_from_logs.py
@@ -22,6 +22,7 @@ from flip_api.auth.access_manager import can_access_model
 from flip_api.auth.dependencies import verify_token
 from flip_api.db.database import get_session
 from flip_api.model_services.services.model_service import get_model_status
+from flip_api.utils.http import _trust_ssl_context
 from flip_api.utils.logger import logger
 
 router = APIRouter(prefix="/model", tags=["model_services"])
@@ -81,7 +82,7 @@ def retrieve_model_status_from_logs(
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Elasticsearch URL not found.")
 
     try:
-        response = httpx.post(f"{elastic_url}/centralhub-eks/_search", json=query_body)
+        response = httpx.post(f"{elastic_url}/centralhub-eks/_search", json=query_body, verify=_trust_ssl_context())
         response.raise_for_status()
     except httpx.HTTPStatusError as exc:
         if exc.response.status_code == 404:

--- a/flip-api/src/flip_api/trusts_services/start_project_imaging_creation.py
+++ b/flip-api/src/flip_api/trusts_services/start_project_imaging_creation.py
@@ -37,6 +37,7 @@ from flip_api.project_services.services.project_services import get_project, get
 from flip_api.utils.cognito_helpers import get_cognito_users, get_user_pool_id
 from flip_api.utils.constants import IMAGING_CREDENTIALS_TEMPLATE_NAME
 from flip_api.utils.encryption import decrypt
+from flip_api.utils.http import _trust_ssl_context
 from flip_api.utils.logger import logger
 
 router = APIRouter(prefix="/trust", tags=["trusts_services"])
@@ -172,7 +173,7 @@ async def start_project_imaging_creation(
         # Make request to trust to create imaging project
         endpoint = f"{trust.endpoint}/imaging"
         try:
-            async with httpx.AsyncClient(timeout=30.0) as client:
+            async with httpx.AsyncClient(timeout=30.0, verify=_trust_ssl_context()) as client:
                 response = await client.post(
                     url=endpoint,
                     json=request_data.model_dump(mode="json"),

--- a/flip-api/tests/unit/cohort_services/test_submit_cohort_query.py
+++ b/flip-api/tests/unit/cohort_services/test_submit_cohort_query.py
@@ -146,8 +146,8 @@ def test_submit_cohort_query_trust_error(monkeypatch, mock_request, sample_query
         def post(self, *args, **kwargs):
             raise Exception("Connection failed")
 
-    # Monkeypatch `httpx.Client` to use the fake client
-    monkeypatch.setattr("httpx.Client", lambda: FakeClient())
+    # Monkeypatch `httpx.Client` to use the fake client (accept any kwargs such as verify=)
+    monkeypatch.setattr("httpx.Client", lambda **kwargs: FakeClient())
 
     # Call the function and capture the result
     response = submit_cohort_query(mock_request, sample_query, mock_db)

--- a/flip-api/tests/unit/utils/test_http.py
+++ b/flip-api/tests/unit/utils/test_http.py
@@ -1,0 +1,80 @@
+# Copyright (c) Guy's and St Thomas' NHS Foundation Trust & King's College London
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import os
+import ssl
+import subprocess
+from unittest.mock import patch
+
+import pytest
+
+from flip_api.utils.http import _trust_ssl_context
+
+
+@pytest.fixture
+def valid_ca_cert(tmp_path):
+    """Generate a self-signed CA certificate PEM file for use in tests."""
+    cert_path = tmp_path / "trust-ca.crt"
+    key_path = tmp_path / "trust-ca.key"
+    subprocess.run(
+        [
+            "openssl",
+            "req",
+            "-x509",
+            "-newkey",
+            "rsa:2048",
+            "-keyout",
+            str(key_path),
+            "-out",
+            str(cert_path),
+            "-days",
+            "1",
+            "-nodes",
+            "-subj",
+            "/C=GB/CN=Test Trust CA",
+        ],
+        check=True,
+        capture_output=True,
+    )
+    return cert_path
+
+
+def test_trust_ssl_context_returns_true_when_env_not_set():
+    """When TRUST_CA_BUNDLE is not set, _trust_ssl_context should return True (system CA store)."""
+    env_without_bundle = {k: v for k, v in os.environ.items() if k != "TRUST_CA_BUNDLE"}
+    with patch.dict("os.environ", env_without_bundle, clear=True):
+        result = _trust_ssl_context()
+        assert result is True
+
+
+def test_trust_ssl_context_returns_ssl_context_when_env_set(valid_ca_cert):
+    """When TRUST_CA_BUNDLE points to a valid PEM file, _trust_ssl_context returns an SSLContext."""
+    with patch.dict("os.environ", {"TRUST_CA_BUNDLE": str(valid_ca_cert)}):
+        result = _trust_ssl_context()
+        assert isinstance(result, ssl.SSLContext)
+
+
+def test_trust_ssl_context_falls_back_to_true_on_bad_pem(tmp_path):
+    """When TRUST_CA_BUNDLE points to an invalid/corrupt PEM, _trust_ssl_context falls back to True."""
+    bad_file = tmp_path / "bad-ca.crt"
+    bad_file.write_text("this is not a valid pem certificate")
+
+    with patch.dict("os.environ", {"TRUST_CA_BUNDLE": str(bad_file)}):
+        result = _trust_ssl_context()
+        assert result is True
+
+
+def test_trust_ssl_context_falls_back_to_true_when_file_missing():
+    """When TRUST_CA_BUNDLE is set to a non-existent path, _trust_ssl_context falls back to True."""
+    with patch.dict("os.environ", {"TRUST_CA_BUNDLE": "/nonexistent/path/cert.crt"}):
+        result = _trust_ssl_context()
+        assert result is True


### PR DESCRIPTION
# Description

Resolves the TLS verification gap introduced by #141 (HTTPS termination for Trust services).
The `flip-api` Central Hub now trusts the self-signed Trust CA certificate so all `httpx`
connections to Trust nodes can be verified rather than rejected with `CERTIFICATE_VERIFY_FAILED`.

Changes:
- Mount `trust/certs/trust-ca.crt` into the `flip-api` container in `compose.development.yml` and expose it via `TRUST_CA_BUNDLE`
- `entrypoint.sh` writes the CA cert from AWS Secrets Manager to disk before the server starts (production)
- `deploy/providers/AWS/main.tf` stores the Trust CA cert in the `flip_api_secret` Secrets Manager entry
- `utils/http.py` — `_trust_ssl_context()` helper reads `TRUST_CA_BUNDLE` and returns an `ssl.SSLContext` (or `True` to fall back to system CAs); all `http_get/post/delete` helpers use it
- All remaining `httpx` call sites updated: `image_service.py`, `trusts_health_check.py`, `start_project_imaging_creation.py`, `submit_cohort_query.py`, `retrieve_model_status_from_logs.py`
- `config.py` — `TRUST_CA_BUNDLE` added as an optional Pydantic settings field validated at startup
- `.env.development.example` / `.env.development` — `TRUST_CA_BUNDLE` documented and set

## Linked Issues

Fixes #142

## Checklist

- [x] Follows the project's coding conventions and style guide
- [x] Updates documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Type of Change

- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [x] In-line docstrings updated.
- [ ] Documentation updated, tested `make -C docs/ docs`.

## Testing

I did the following tests to verify my changes:

- [x] Quick tests passed locally by running `make unit-test`.
- [ ] Integration tests pass (if applicable) by running `make integration-test`.

**New tests added** (`flip-api/tests/unit/utils/test_http.py`):
- `test_trust_ssl_context_returns_true_when_env_not_set` — falls back to system CA when `TRUST_CA_BUNDLE` is unset
- `test_trust_ssl_context_returns_ssl_context_when_env_set` — returns an `ssl.SSLContext` for a valid PEM file
- `test_trust_ssl_context_falls_back_to_true_on_bad_pem` — gracefully falls back when PEM is corrupt
- `test_trust_ssl_context_falls_back_to_true_when_file_missing` — gracefully falls back when path does not exist

## Additional Notes

Branch 141 was merged into this branch before implementation. All 580 unit tests pass.


## Acceptance Criteria

*Imported from issue #142*

- [ ] Mount the Trust CA certificate into the flip-api container and set the TRUST_CA_BUNDLE environment variable.
- [ ] Update compose.development.yml and AWS Terraform (main.tf) to distribute the CA cert.
- [ ] Update entrypoint.sh to write the CA cert from secrets to disk.
- [ ] Refactor all httpx clients in flip-api (including utils/http.py, image_services/image_service.py, and trusts/trusts_health_check.py) to use a helper that loads the CA bundle for SSL verification.