### PR TITLE
Handle absence of model results more gracefully in UI and backend

### DIFF
--- a/flip-api/src/flip_api/file_services/retrieve_federated_results.py
+++ b/flip-api/src/flip_api/file_services/retrieve_federated_results.py
@@ -11,7 +11,6 @@
 #
 
 import json
-from enum import IntEnum
 from typing import List
 from uuid import UUID
 
@@ -27,12 +26,6 @@ from flip_api.utils.logger import logger
 from flip_api.utils.s3_client import S3Client
 
 router = APIRouter(prefix="/files", tags=["file_services"])
-
-
-# TODO move this definition
-class ObjectCount(IntEnum):
-    NOT_FOUND = 0
-    HAS_FILES = 1
 
 
 # [#114] ✅
@@ -54,8 +47,8 @@ def retrieve_federated_results(
         List[str]: A list of presigned URLs for the files associated with the model.
 
     Raises:
-        HTTPException: If the user does not have access to the model, if the S3 bucket is not defined, or if there are
-                       no objects found for the specified model ID.
+        HTTPException: If the user does not have access to the model, if the model ID does not exist, if S3 command
+                       gives an error while listing objects, or if there are any errors retrieving objects from S3.
     """
     try:
         # Check user access
@@ -102,13 +95,9 @@ def retrieve_federated_results(
         logger.debug(f"List of files returned: {json.dumps(list_objects, default=str)}")
 
         # Check if any files were found
-        key_count = len(list_objects)
-        if key_count < ObjectCount.HAS_FILES:
-            logger.error(f"No result data was found: {s3_path}")
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND,
-                detail="No result data was found",
-            )
+        if len(list_objects) == 0:
+            logger.info(f"No result data was found: {s3_path}")
+            return []
 
         # Get presigned URLs for each file
         try:

--- a/flip-api/tests/unit/file_services/test_retrieve_federated_results.py
+++ b/flip-api/tests/unit/file_services/test_retrieve_federated_results.py
@@ -215,11 +215,8 @@ class TestRetrieveFederatedResults:
     def test_no_files_found(self, mock_db_session, s3_mock_empty, mocked_settings, sample_model_id, user_id):
         """Test handling of no files found in S3."""
         with patch("flip_api.file_services.retrieve_federated_results.can_access_model", return_value=True):
-            with pytest.raises(HTTPException) as exc_info:
-                retrieve_federated_results(model_id=sample_model_id, db=mock_db_session, user_id=user_id)
-
-            assert exc_info.value.status_code == status.HTTP_404_NOT_FOUND
-            assert "No result data was found" in exc_info.value.detail
+            result = retrieve_federated_results(model_id=sample_model_id, db=mock_db_session, user_id=user_id)
+            assert result == []
 
     def test_presigned_url_error(
         self, mock_db_session, s3_mock_presigned_error, mocked_settings, sample_model_id, user_id

--- a/flip-ui/src/partials/models/TrainingActionsMenu.vue
+++ b/flip-ui/src/partials/models/TrainingActionsMenu.vue
@@ -145,22 +145,28 @@ const stopTrainingAction = async () => {
 };
 
 const downloadTrainingResults = async () => {
-    const urls = await getDownloadUrlForResults(
-        modelId
-    );
-    if (!urls.length) {
+    try {
+        const urls = await getDownloadUrlForResults(modelId);
+        if (!urls.length) {
+            Snackbar.error({
+                title: "No results available",
+                text: "No downloadable result files were found for this model."
+            });
+
+            return;
+        }
+        urls.forEach((url) => {
+            const element = document.createElement("a");
+            element.setAttribute("href", url);
+            element.click();
+            element.remove();
+        });
+    }
+    catch {
         Snackbar.error({
             title: "Unable to download results",
             text: "There was a problem when downloading the results for this model."
         });
-
-        return;
     }
-    urls.forEach((url) => {
-        const element = document.createElement("a");
-        element.setAttribute("href", url);
-        element.click();
-        element.remove();
-    });
 };
 </script>


### PR DESCRIPTION
This pull request updates the handling of cases where no result files are found for a model, both in the API and the UI. Instead of returning an error when no files are found, the API now returns an empty list, and the UI displays a user-friendly message. The changes also improve error handling and messaging for users.

**API behavior changes:**

* The `retrieve_federated_results` endpoint now returns an empty list when no files are found, instead of raising an HTTP 404 error.
* The error message documentation in the `retrieve_federated_results` function was updated to reflect the new behavior and clarify possible error cases.
* The unused `ObjectCount` enum was removed, simplifying the code. [[1]](diffhunk://#diff-3677a9b7458112323a705d7f6e543a5d3ce7cb838b15be6b87fc429ef369caf8L32-L37) [[2]](diffhunk://#diff-3677a9b7458112323a705d7f6e543a5d3ce7cb838b15be6b87fc429ef369caf8L14)

**Testing updates:**

* The unit test for "no files found" was updated to expect an empty list rather than an HTTP 404 error.

**UI improvements:**

* The UI now shows a specific "No results available" message when no files are found, and maintains a generic error message for other failures when downloading training results. [[1]](diffhunk://#diff-23893e33b0ca36cd0bcf6f78ab9db5de8afdd18f2da0e0c4cb7f40fec25775a1L148-R153) [[2]](diffhunk://#diff-23893e33b0ca36cd0bcf6f78ab9db5de8afdd18f2da0e0c4cb7f40fec25775a1R164-R170)

Before (HTTP 404 error):

<img width="1624" height="1062" alt="Screenshot 2026-03-12 at 12 06 48" src="https://github.com/user-attachments/assets/8d24c7c8-4f35-4a54-a9b9-7c126e22d645" />

Now (handled by the UI popup snackbar):

<img width="1624" height="1062" alt="Screenshot 2026-03-12 at 12 15 27" src="https://github.com/user-attachments/assets/c6d8f833-f312-41ed-b4db-7ceed8a70547" />