### PR TITLE
docs: add SECURITY.md and retire Security label in favour of private advisories

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,7 @@ FLIP is developed by the [London AI Centre](https://www.aicentre.co.uk/) in coll
 The project spans two repositories:
 
 | Repository | Description |
-|---|---|
+| --- | --- |
 | [FLIP](https://github.com/londonaicentre/FLIP) | Main mono-repo: Central Hub API, Trust APIs, UI, and Docker deployment |
 | [flip-fl-base](https://github.com/londonaicentre/flip-fl-base) | NVIDIA FLARE federated learning base application library, workflows, and tutorials |
 | [flip-fl-base-flower](https://github.com/londonaicentre/flip-fl-base-flower) | Flower federated learning base application library, workflows, and tutorials |

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ To start the services, you can use the Makefile provided in the root directory. 
 For example:
 
 | Command | Description |
-|---------|-------------|
+| --------- | ------------- |
 | `make up` | Run all services using Docker Swarm for XNAT (⚠️ This will not build the images, use `make build` first if needed)|
 | `make up-no-trust` | Run all services except the trust services related services |
 | `make up-trusts` | Run the trust services related services (uses Docker Swarm for XNAT) |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -3,7 +3,7 @@
 ## Supported versions
 
 | Version | Supported |
-|---------|-----------|
+| --------- | ----------- |
 | latest  | ✅        |
 
 ## Reporting a vulnerability

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,21 @@
+# Security Policy
+
+## Supported versions
+
+| Version | Supported |
+|---------|-----------|
+| latest  | ✅        |
+
+## Reporting a vulnerability
+
+Do **not** open a public GitHub issue for security bugs.
+
+Please use the private GitHub Security Advisory feature:
+
+1. Go to the [Security tab](https://github.com/londonaicentre/FLIP/security) of this repository.
+2. Click **"Report a vulnerability"**.
+3. Fill in the advisory form with as much detail as possible (description, reproduction steps, impact, suggested fix).
+
+The maintainers will acknowledge the report within **5 business days** and aim to release a fix within **90 days** under a coordinated-disclosure embargo.
+
+If you are unable to use GitHub, you can contact the maintainers by email: `gstt.ai-centre@nhs.net`.

--- a/deploy/providers/AWS/README.md
+++ b/deploy/providers/AWS/README.md
@@ -223,7 +223,7 @@ Two-Instance Setup
    - OMOP database
 
 | Application Component |
-|----------------------|
+| ---------------------- |
 | **Central Hub Services** |
 | FLIP API ✅ |
 | FLIP UI ✅ |
@@ -295,7 +295,7 @@ The Trust services are deployed on separate EC2 instance(s) using the `trust_ec2
 ### Port configuration
 
 | Port | Service | Status | Purpose |
-|------|---------|---------|---------|
+| ------ | --------- | --------- | --------- |
 | **22** | SSH | 🟢 **OPEN** | Remote administration |
 | **80** | HTTP | 🟢 **OPEN** | ALB traffic |
 | **3000** | FLIP UI | 🟢 **OPEN** | Frontend application |

--- a/trust/xnat/README.md
+++ b/trust/xnat/README.md
@@ -34,7 +34,7 @@ make xnat-plugins-download
 The following table lists the compatible versions of the plugins for the XNAT version `1.9.3` used in this environment.
 
 | Plugin                          | Version for XNAT 1.9.3  |
-|---------------------------------|-------------------------|
+| --------------------------------- | ------------------------- |
 | Container Service Plugin        | 3.7.3                   |
 | Batch Launch Plugin             | 0.9.0                   |
 | DICOM Query-Retrieve Plugin     | 2.2.0                   |


### PR DESCRIPTION
# Description

Adds a `SECURITY.md` file to the repository root so GitHub can surface the project's vulnerability-reporting policy on the Security tab. The file instructs reporters to use the private GitHub Security Advisory feature rather than opening public issues.

As part of the same change, existing open issues tagged `Security ⚠️` were reviewed:

- Security bug issues (#10, #12, #28) were converted to private draft Security Advisories (GHSA-768q-9xvr-89jm, GHSA-3v9j-9ch8-xg26, GHSA-2hrw-p6cg-jf93) and the corresponding public issues were closed with a pointer to the new process.
- Security enhancement/feature-request issues (#11, #52, #173) received a comment noting the new advisory process and remain open for normal tracking.
- The `Security ⚠️` label was deleted from the repository so future reporters are directed to advisories instead.

<img width="799" height="449" alt="image" src="https://github.com/user-attachments/assets/6f67325f-2b1c-4fe2-8bca-50cb0701e4ac" />

Markdown table separators across several documentation files were also standardised by an auto-formatter (no content changes).

## Linked Issues

Closes #174

## Checklist

- [x] Follows the project's coding conventions and style guide
- [x] Updates documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Type of Change

- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] In-line docstrings updated.
- [x] Documentation updated, tested `make -C docs/ docs`.

## Testing

I did the following tests to verify my changes:

- [ ] Quick tests passed locally by running `make unit-test`.
- [ ] Integration tests pass (if applicable) by running `make integration-test`.

## Additional Notes

- The `SECURITY.md` contact email has been set to `gstt.ai-centre@nhs.net`. Maintainers should verify this is the correct security contact before merging.
- Private vulnerability reporting must be confirmed as **enabled** in repository Settings → Code security and analysis (requires admin access — outside the scope of this PR).
- Three draft private Security Advisories have been created and are visible under the repository's Security tab for maintainers to triage.

## Acceptance Criteria

*Imported from issue #174*

- [x] Have a security guide for users to add security bugs.
- [x] Remove the security tag from issues and transform them into 'advisories

<img width="2356" height="861" alt="image" src="https://github.com/user-attachments/assets/f51d4ba3-19ac-4d8c-bfc8-a32b2f4e7c9b" />
