### PR TITLE
fix: preserve completed step indicators when training is stopped

### DIFF
--- a/flip-ui/src/pages/project/[projectId]/model/[modelId]/index.vue
+++ b/flip-ui/src/pages/project/[projectId]/model/[modelId]/index.vue
@@ -201,6 +201,14 @@ function getStatusEnumValue(status: string | undefined): number {
 
 const steps = computed((): IStep[] => {
     const statusValue = getStatusEnumValue(modelData.value?.status);
+    const isStopped = statusValue === ModelStatusEnum.STOPPED;
+    const isError = statusValue === ModelStatusEnum.ERROR;
+
+    // When training is stopped or errors, prior completed steps should
+    // remain marked as completed (✅) rather than showing 🚫.
+    // A stopped/errored model must have been at least PREPARED, so
+    // "Model Prepared" stays completed and only later steps show the
+    // stopped/error indicator.  See issue #29.
     return [
         {
             id: "01",
@@ -212,9 +220,7 @@ const steps = computed((): IStep[] => {
             name: "Model Prepared",
             description: statusValue === ModelStatusEnum.INITIATED ? "Model Queued" : undefined,
             inProgress: statusValue === ModelStatusEnum.INITIATED,
-            completed: statusValue >= ModelStatusEnum.PREPARED,
-            error: statusValue === ModelStatusEnum.ERROR,
-            stopped: statusValue === ModelStatusEnum.STOPPED
+            completed: statusValue >= ModelStatusEnum.PREPARED || isStopped || isError,
         },
         {
             id: "03",
@@ -222,17 +228,17 @@ const steps = computed((): IStep[] => {
             description:
                 (statusValue >= ModelStatusEnum.PREPARED && statusValue < ModelStatusEnum.RESULTS_UPLOADED)
                     ? "In Progress" : undefined,
-            inProgress: statusValue >= ModelStatusEnum.PREPARED,
+            inProgress: statusValue >= ModelStatusEnum.PREPARED && !isStopped && !isError,
             completed: statusValue > ModelStatusEnum.TRAINING_STARTED,
-            error: statusValue === ModelStatusEnum.ERROR,
-            stopped: statusValue === ModelStatusEnum.STOPPED
+            error: isError,
+            stopped: isStopped
         },
         {
             id: "04",
             name: "Results Uploaded",
             completed: statusValue === ModelStatusEnum.RESULTS_UPLOADED,
-            error: statusValue === ModelStatusEnum.ERROR,
-            stopped: statusValue === ModelStatusEnum.STOPPED
+            error: isError,
+            stopped: isStopped
         }
     ];
 });


### PR DESCRIPTION
## Summary

Fixes #29 — When clicking "Stop Training", the "Model Prepared" step incorrectly shows 🚫 instead of staying ✅.

## Problem

The `steps` computed property determines step states using ordinal comparisons against `ModelStatusEnum`. Since `STOPPED` (ordinal 1) is lower than `PREPARED` (ordinal 4):

```
statusValue >= ModelStatusEnum.PREPARED  →  1 >= 4  →  false
statusValue === ModelStatusEnum.STOPPED  →  1 === 1  →  true
```

So when training is stopped, "Model Prepared" gets `completed: false` and `stopped: true`, which renders the stop icon (🚫) instead of the check mark (✅).

## Solution

Terminal states (`STOPPED`, `ERROR`) should not regress prior completed steps:

- **"Model Prepared"** is now always marked `completed: true` when stopped or errored (training can only be stopped after preparation), and no longer sets `stopped` or `error` flags
- **"Training Started"** shows the stopped/error indicator (this is where the interruption actually occurred)
- **"Results Uploaded"** shows the stopped/error indicator (not reached)

### Before
| Step | STOPPED state |
|------|------|
| Model Created | ✅ |
| Model Prepared | 🚫 ← wrong |
| Training Started | 🚫 |
| Results Uploaded | 🚫 |

### After
| Step | STOPPED state |
|------|------|
| Model Created | ✅ |
| Model Prepared | ✅ ← correct |
| Training Started | 🚫 |
| Results Uploaded | 🚫 |