### PR TITLE
update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,8 @@ If you see errors like "fed_client.json does not exist" or "missing startup fold
 For production deployments on AWS, see the [AWS Deployment Guide](deploy/README.md). This covers provisioning
 infrastructure with OpenTofu (Terraform), configuring AWS services, and deploying the platform at scale.
 
+For hybrid on-premises trust deployments, see the [Local Trust Deployment Guide](deploy/providers/local/README.md).
+
 ## Project Structure
 
 The repository is organised as follows:

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ For example:
 | `make restart-no-trust` | Stop and start all services except the trust services related services |
 | `make clean` | Remove all stopped containers, networks, and images |
 | `make ci` | Run the CI pipeline locally using `act` |
+| `make up-local-trust-stag` | Run a local (on-premises) trust in staging mode (HTTPS via nginx-tls) |
 | `make unit_test` | Run the tests for all services |
 
 You can add new commands to the Makefile to create smaller deployments for testing and development.
@@ -221,7 +222,12 @@ The repository is organised as follows:
   - `omop-db`: Contains a mocked OMOP database
   - `orthanc`: Contains a mocked PACS service (uses [Orthanc](https://www.orthanc-server.com/))
   - `trust-api`: Contains the trust API service
+  - `nginx`: Contains the nginx TLS termination proxy for trust HTTPS endpoints
   - `xnat`: Contains a mocked [XNAT](https://www.xnat.org/) service
+
+### HTTPS / TLS
+
+Trust services are served over HTTPS via an nginx TLS termination proxy using self-signed CA certificates. The Central Hub verifies trust endpoints using a CA bundle containing all trust CAs. See [trust/README.md](trust/README.md) for certificate generation and setup, and [deploy/providers/local/README.md](deploy/providers/local/README.md) for hybrid on-premises deployment with HTTPS.
 
 ## Contributing
 

--- a/docs/source/components/component-fl-nodes.rst
+++ b/docs/source/components/component-fl-nodes.rst
@@ -1,3 +1,5 @@
+.. _flip-fl-nodes:
+
 #########################
 Federated Learning Nodes
 #########################
@@ -46,8 +48,8 @@ Then, the Central Hub API will take care of bundling together:
 - The files the user has uploaded
 - The static (non-modifiable) files that are required for the specific job type.
 
-For more information about currently supported apps, visit: <https://github.com/londonaicentre/flip-fl-base/tree/main/src>`_
-and <https://github.com/flwrlabs-partners/flip-flower/tree/main/src>`_ for NVFLARE and Flower respectively. 
+For more information about currently supported apps, visit `flip-fl-base <https://github.com/londonaicentre/flip-fl-base/tree/main/src>`_
+and `flip-fl-base-flower <https://github.com/londonaicentre/flip-fl-base-flower/tree/main/src>`_ for NVFLARE and Flower respectively.
 
 Examples of how the same job type (standard -> federated averaging) can run different user-uploaded applications are:
 

--- a/docs/source/sys-admin/admin-platform-support.rst
+++ b/docs/source/sys-admin/admin-platform-support.rst
@@ -80,9 +80,9 @@ FLIP jobs are distributed by the central hub FL scheduler to an available net.
 Security
 *********
 
-All traffic between the Central Hub and the Secure Enclaves are secured via the means of tunnelling through a VPN tunnel, linking both the Central Hub and the Secure Enclaves. 
+All traffic between the Central Hub and the Secure Enclaves is secured over HTTPS using TLS with self-signed CA certificates. Each Trust runs an nginx TLS termination proxy that serves the Trust API over HTTPS. The Central Hub verifies Trust endpoints using a CA bundle containing the certificates of all connected Trusts.
 
-This VPN tunnel means that all traffic is encrypted with at least AES-256 encryption, while traversing between the locations.
+Certificate generation, distribution, and verification are handled automatically during provisioning. See the `Trust README <../../../trust/README.md>`_ and `Local Deployment Guide <../../../deploy/providers/local/README.md>`_ for details on the certificate model.
 
 .. figure:: ../assets/support/flip_architecture-flip_network_architecture.png
    :align: center

--- a/docs/source/user-guides/user-common.rst
+++ b/docs/source/user-guides/user-common.rst
@@ -10,7 +10,7 @@ While users with ``admin`` roles may perform all the functions of those with ``r
 
 FLIP uses the concept of a *project*, in which multiple AI models can be managed. Projects can have multiple users associated with them, allowing individuals to view and contribute to the project. The typical project flow involves the creation of a project, running a cohort query, staging the project for approval, uploading the model plus any associated files and initiating the training. Once training is complete, the results of training can be downloaded.
 
-To facilitate federated learning and concurrent training of multiple models on the platform, :term:`NVIDIA FLARE` has been chosen as the SDK to enable collaborative workflow and so this page also covers concepts of NVIDIA FLARE *nets* and job scheduling.
+To facilitate federated learning and concurrent training of multiple models on the platform, FLIP supports both :term:`NVIDIA FLARE` and the :term:`Flower Framework` as federated learning backends. This page covers concepts such as FL *nets* and job scheduling. For details on framework-specific file requirements and job types, see :ref:`the FL nodes component page <flip-fl-nodes>`.
 
 .. _initial-login:
 
@@ -305,14 +305,16 @@ Model Files
 
    A model must be created before proceeding to upload model files and prepare the model for training.
 
-As a minimum, the following files are required:
+**For NVIDIA FLARE apps**, the minimum required files are:
 
 - ``validator.py``
 - ``trainer.py``
 
 Additional files may be uploaded, especially if these are referenced by the validator or trainer. A config file may also be uploaded (see :ref:`training-configuration` section for more information), in which optional variables can be defined.
 
-For more information on model training and model files, please see the `FLIP Sample Application <https://github.com/AI4VBH/flip-sample-application>`_.
+**For Flower apps**, the required files differ (e.g. ``client_app.py``, ``pyproject.toml``). See the :ref:`FL nodes documentation <flip-fl-nodes>` for Flower-specific file requirements and job types.
+
+For more information on model training and model files, please see the `FLIP Sample Application <https://github.com/londonaicentre/flip-sample-application>`_.
 
 .. warning::
 
@@ -344,6 +346,10 @@ If model files need to be managed further after uploading, the uploader function
 
 Training Configuration
 ----------------------
+
+.. note::
+
+   The following configuration applies to **NVIDIA FLARE** apps. For Flower apps, training configuration is managed via ``pyproject.toml``. See the :ref:`FL nodes documentation <flip-fl-nodes>` for details.
 
 Prior to commencing training you may also upload an optional ``config.json`` file (see example below). The config file defines variables which are used during FLIP training (e.g. ``GLOBAL_ROUNDS``, ``LOCAL_ROUNDS``, ``AGGREGATION_WEIGHTS``, ``AGGREGATOR``).
 
@@ -430,7 +436,7 @@ Delete Files
 Training
 ========
 
-FLIP allows for multiple models to be deployed to and trained at multiple Trust sites concurrently, and uses :term:`NVIDIA FLARE` to train, test and aggregate at each of the relevant nodes and report back to the user interface once the training is complete.
+FLIP allows for multiple models to be deployed to and trained at multiple Trust sites concurrently, using either :term:`NVIDIA FLARE` or the :term:`Flower Framework` to train, test and aggregate at each of the relevant nodes and report back to the user interface once the training is complete.
 
 FLIP uses the concept of *nets* that are deployed on the Central Hub and remote hardware at each Trust. Each *net* consists of a controller and worker (to manage the model training cycle) and FLIP uses a task scheduler to manage the resources available on the hardware at Trust sites. The scheduler maintains a queue of waiting *tasks*, when a *net* becomes free a *task* is assigned to it.
 

--- a/docs/source/user-guides/user-common.rst
+++ b/docs/source/user-guides/user-common.rst
@@ -314,11 +314,11 @@ Additional files may be uploaded, especially if these are referenced by the vali
 
 **For Flower apps**, the required files differ (e.g. ``client_app.py``, ``pyproject.toml``). See the :ref:`FL nodes documentation <flip-fl-nodes>` for Flower-specific file requirements and job types.
 
-For more information on model training and model files, please see the `FLIP Sample Application <https://github.com/londonaicentre/flip-sample-application>`_.
+For more information on model training and model files, please see the `FLIP tutorials <https://github.com/londonaicentre/flip-fl-base/tree/main/tutorials>`_.
 
 .. warning::
 
-   Please ensure that any model files uploaded to FLIP have been tested locally using the FLIP Sample Application, and have been validated to ensure they are free of syntax errors.
+   Please ensure that any model files uploaded to FLIP have been tested locally using the FLIP tutorials workflow, and have been validated to ensure they are free of syntax errors.
 
    Linting tools such as `Pylint <https://pypi.org/project/pylint/>`_ and `JSON Lint <https://www.npmjs.com/package/jsonlint>`_ can provide a simple way to validate any Python or JSON are free of errors before uploading.
 

--- a/flip-api/README.md
+++ b/flip-api/README.md
@@ -52,7 +52,7 @@ The API is served on the port defined by `FLIP_API_PORT` in [`.env.development.e
 (default: `8000`). Interactive API documentation (Swagger UI) is available at:
 
 ```
-http://localhost:<FLIP_API_PORT>/docs
+http://localhost:<FLIP_API_PORT>/api/docs
 ```
 
 ## Configuration

--- a/flip-api/README.md
+++ b/flip-api/README.md
@@ -48,11 +48,11 @@ or as part of the full platform:
 make up
 ```
 
-The API is served on the port defined by `FLIP_API_PORT` in [`.env.development.example`](../.env.development.example)
-(default: `8000`). Interactive API documentation (Swagger UI) is available at:
+The API is served on the port defined by `API_PORT` in [`.env.development.example`](../.env.development.example)
+(default: `8080`). Interactive API documentation (Swagger UI) is available at:
 
 ```
-http://localhost:<FLIP_API_PORT>/api/docs
+http://localhost:<API_PORT>/api/docs
 ```
 
 ## Configuration


### PR DESCRIPTION
This pull request updates the documentation to clarify the support for multiple federated learning frameworks (NVIDIA FLARE and Flower), details on HTTPS/TLS setup for Trust services, and provides improved instructions for local and hybrid deployments. It also improves references and documentation structure for easier navigation and understanding.

**Federated Learning Framework Support:**
- Updated user and component documentation to clarify that FLIP supports both NVIDIA FLARE and the Flower Framework as federated learning backends, including details on framework-specific file requirements and job types. [[1]](diffhunk://#diff-00a01998a815ee631d6eea90bb0913ae5d183a0446a18eee6dc83c0be7615ab1L13-R13) [[2]](diffhunk://#diff-00a01998a815ee631d6eea90bb0913ae5d183a0446a18eee6dc83c0be7615ab1L308-R317) [[3]](diffhunk://#diff-00a01998a815ee631d6eea90bb0913ae5d183a0446a18eee6dc83c0be7615ab1R350-R353) [[4]](diffhunk://#diff-00a01998a815ee631d6eea90bb0913ae5d183a0446a18eee6dc83c0be7615ab1L433-R439) [[5]](diffhunk://#diff-67f5b301a0401ed764f250147e86cdbb5348aff83d871952d5e8044c8b787401L49-R52)

**HTTPS/TLS and Security:**
- Added explanations on how Trust services are served over HTTPS using nginx TLS termination proxies with self-signed CA certificates, and how the Central Hub verifies endpoints, replacing previous VPN-based explanations. Linked to relevant setup guides. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R227-R233) [[2]](diffhunk://#diff-da80447eecc5c1f5b6e5103a006f143258a41dbd41b13069f544642407f5640eL83-R85)

**Deployment and Local Development:**
- Added a new `make up-local-trust-stag` command to the development Makefile and documented it for running a local Trust in staging mode with HTTPS.
- Added references and links to a new Local Trust Deployment Guide for hybrid on-premises deployments.

**Documentation Structure and Navigation:**
- Improved references to component documentation, including adding a new anchor for FL nodes and updating external links to point to the correct repositories and guides. [[1]](diffhunk://#diff-67f5b301a0401ed764f250147e86cdbb5348aff83d871952d5e8044c8b787401R1-R2) [[2]](diffhunk://#diff-67f5b301a0401ed764f250147e86cdbb5348aff83d871952d5e8044c8b787401L49-R52)

**API Documentation:**
- Updated the API documentation in `flip-api/README.md` to clarify environment variable names and default ports, and updated the Swagger UI URL.