### PR TITLE
cache cohort queries

### DIFF
--- a/flip-api/src/flip_api/model_services/retrieve_model_status_from_logs.py
+++ b/flip-api/src/flip_api/model_services/retrieve_model_status_from_logs.py
@@ -21,7 +21,6 @@ from flip_api.auth.access_manager import can_access_model
 from flip_api.auth.dependencies import verify_token
 from flip_api.db.database import get_session
 from flip_api.model_services.services.model_service import get_model_status
-from flip_api.utils.http import trust_ssl_context
 from flip_api.utils.get_secrets import get_secret
 from flip_api.utils.logger import logger
 

--- a/trust/data-access-api/data_access_api/config.py
+++ b/trust/data-access-api/data_access_api/config.py
@@ -13,7 +13,7 @@
 import os
 from pathlib import Path
 
-from pydantic import SecretStr
+from pydantic import PositiveInt, SecretStr
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -33,6 +33,8 @@ class Settings(BaseSettings):
     #
     COHORT_QUERY_THRESHOLD: int = 10  # Minimum number of records required to return statistics
     CACHE_TTL_DAYS: int = 60  # Number of days before cached query results expire
+    CACHE_MAX_RESULT_ROWS: PositiveInt = 50_000  # Max rows per cached result; larger results skip caching
+    CACHE_MAX_ENTRIES: PositiveInt = 64  # Max number of cached query results
 
     #
     OMOP_DB_SERVICE_NAME: str = "omop-db"  # The name of the OMOP database service in Docker Compose or Kubernetes

--- a/trust/data-access-api/data_access_api/config.py
+++ b/trust/data-access-api/data_access_api/config.py
@@ -32,6 +32,7 @@ class Settings(BaseSettings):
 
     #
     COHORT_QUERY_THRESHOLD: int = 10  # Minimum number of records required to return statistics
+    CACHE_TTL_DAYS: int = 60  # Number of days before cached query results expire
 
     #
     OMOP_DB_SERVICE_NAME: str = "omop-db"  # The name of the OMOP database service in Docker Compose or Kubernetes

--- a/trust/data-access-api/data_access_api/routers/cohort.py
+++ b/trust/data-access-api/data_access_api/routers/cohort.py
@@ -119,10 +119,4 @@ def get_dataframe(query_input: DataframeQuery) -> Dict[str, List[Any]]:
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 
-    # TODO Potentially store to cache - and at the beginning of the function, check if the query is already in the cache
-    # Set cache expiration time e.g. 60 days (if the OMOP database is not updated frequently)
-    # This avoids re-running the query if the same one is requested multiple times
-
-    # df.to_csv("data.csv", index=False) # debugging
-    return df.to_dict(orient="list")
     return df.to_dict(orient="list")

--- a/trust/data-access-api/data_access_api/services/cohort.py
+++ b/trust/data-access-api/data_access_api/services/cohort.py
@@ -273,10 +273,10 @@ def get_statistics(df: pd.DataFrame, query_input: CohortQueryInput, threshold: i
     if "person_id" in df.columns:
         logger.info("person_id column found in the query results; including age and sex distribution calculations.")
         age = get_age_distribution(df)
-        age["results"] = make_other_category(get_age_distribution(df)["results"], min_count=COHORT_QUERY_THRESHOLD)
+        age["results"] = make_other_category(age["results"], min_count=COHORT_QUERY_THRESHOLD)
 
         sex = get_sex_distribution(df)
-        sex["results"] = make_other_category(get_sex_distribution(df)["results"], min_count=COHORT_QUERY_THRESHOLD)
+        sex["results"] = make_other_category(sex["results"], min_count=COHORT_QUERY_THRESHOLD)
 
         stats.data += [age, sex]
     return stats

--- a/trust/data-access-api/data_access_api/services/cohort.py
+++ b/trust/data-access-api/data_access_api/services/cohort.py
@@ -20,6 +20,7 @@ from sqlalchemy.exc import DBAPIError, SQLAlchemyError
 from data_access_api.config import get_settings
 from data_access_api.db.database import engine
 from data_access_api.routers.schema import CohortQueryInput, StatisticsResponse
+from data_access_api.services.query_cache import get_cached_result, set_cached_result
 from data_access_api.utils.logger import logger
 from data_access_api.utils.sql_parsers import extract_missing_identifier
 
@@ -72,6 +73,10 @@ def get_records(query: str) -> pd.DataFrame:
     """
     logger.info(f"Executing SQL query: {query}")
 
+    cached = get_cached_result(query)
+    if cached is not None:
+        return cached
+
     try:
         # TODO: Trace the query filtering to understand what the final user can see.
         # Executing the query with pandas allows the user to query anything in the database.
@@ -80,6 +85,7 @@ def get_records(query: str) -> pd.DataFrame:
         # data.
         # TODO check if we can check column types -- could be used to exclude primary keys, foreign keys, etc.
         df = pd.read_sql(query, engine)
+        set_cached_result(query, df)
         return df
 
     except DBAPIError as e:

--- a/trust/data-access-api/data_access_api/services/query_cache.py
+++ b/trust/data-access-api/data_access_api/services/query_cache.py
@@ -19,8 +19,6 @@ import pandas as pd
 from data_access_api.config import get_settings
 from data_access_api.utils.logger import logger
 
-_MAX_CACHE_ENTRIES = 256
-
 
 @dataclass
 class CacheEntry:
@@ -53,9 +51,21 @@ def get_cached_result(query: str) -> pd.DataFrame | None:
 
 
 def set_cached_result(query: str, df: pd.DataFrame) -> None:
+    settings = get_settings()
+    max_rows = settings.CACHE_MAX_RESULT_ROWS
+    max_entries = settings.CACHE_MAX_ENTRIES
+
     key = _make_cache_key(query)
-    # Evict oldest entries when cache is full
-    if len(_cache) >= _MAX_CACHE_ENTRIES and key not in _cache:
+
+    # Skip caching results that are too large to keep memory usage bounded
+    if len(df) > max_rows:
+        logger.info(
+            f"Skipping cache for query hash {key[:12]}...: {len(df)} rows exceeds limit of {max_rows}"
+        )
+        return
+
+    # Evict oldest entry when cache is full to bound total memory usage
+    if len(_cache) >= max_entries and key not in _cache:
         oldest_key = min(_cache, key=lambda k: _cache[k].created_at)
         del _cache[oldest_key]
     _cache[key] = CacheEntry(df=df.copy(), created_at=datetime.now(UTC))

--- a/trust/data-access-api/data_access_api/services/query_cache.py
+++ b/trust/data-access-api/data_access_api/services/query_cache.py
@@ -51,17 +51,14 @@ def get_cached_result(query: str) -> pd.DataFrame | None:
 
 
 def set_cached_result(query: str, df: pd.DataFrame) -> None:
-    settings = get_settings()
-    max_rows = settings.CACHE_MAX_RESULT_ROWS
-    max_entries = settings.CACHE_MAX_ENTRIES
+    max_rows = get_settings().CACHE_MAX_RESULT_ROWS
+    max_entries = get_settings().CACHE_MAX_ENTRIES
 
     key = _make_cache_key(query)
 
     # Skip caching results that are too large to keep memory usage bounded
     if len(df) > max_rows:
-        logger.info(
-            f"Skipping cache for query hash {key[:12]}...: {len(df)} rows exceeds limit of {max_rows}"
-        )
+        logger.info(f"Skipping cache for query hash {key[:12]}...: {len(df)} rows exceeds limit of {max_rows}")
         return
 
     # Evict oldest entry when cache is full to bound total memory usage

--- a/trust/data-access-api/data_access_api/services/query_cache.py
+++ b/trust/data-access-api/data_access_api/services/query_cache.py
@@ -19,6 +19,8 @@ import pandas as pd
 from data_access_api.config import get_settings
 from data_access_api.utils.logger import logger
 
+_MAX_CACHE_ENTRIES = 256
+
 
 @dataclass
 class CacheEntry:
@@ -30,13 +32,11 @@ _cache: dict[str, CacheEntry] = {}
 
 
 def _make_cache_key(query: str) -> str:
-    """Create a cache key by hashing the normalized query string."""
     normalized = " ".join(query.strip().lower().split())
     return hashlib.sha256(normalized.encode()).hexdigest()
 
 
 def get_cached_result(query: str) -> pd.DataFrame | None:
-    """Return cached DataFrame if it exists and hasn't expired, otherwise None."""
     key = _make_cache_key(query)
     entry = _cache.get(key)
     if entry is None:
@@ -53,13 +53,15 @@ def get_cached_result(query: str) -> pd.DataFrame | None:
 
 
 def set_cached_result(query: str, df: pd.DataFrame) -> None:
-    """Store a query result in the cache."""
     key = _make_cache_key(query)
+    # Evict oldest entries when cache is full
+    if len(_cache) >= _MAX_CACHE_ENTRIES and key not in _cache:
+        oldest_key = min(_cache, key=lambda k: _cache[k].created_at)
+        del _cache[oldest_key]
     _cache[key] = CacheEntry(df=df.copy(), created_at=datetime.now(UTC))
     logger.info(f"Cached result for query hash {key[:12]}... ({len(_cache)} entries in cache)")
 
 
 def clear_cache() -> None:
-    """Clear all cached query results."""
     _cache.clear()
     logger.info("Query cache cleared")

--- a/trust/data-access-api/data_access_api/services/query_cache.py
+++ b/trust/data-access-api/data_access_api/services/query_cache.py
@@ -1,0 +1,65 @@
+# Copyright (c) Guy's and St Thomas' NHS Foundation Trust & King's College London
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import hashlib
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+
+import pandas as pd
+
+from data_access_api.config import get_settings
+from data_access_api.utils.logger import logger
+
+
+@dataclass
+class CacheEntry:
+    df: pd.DataFrame
+    created_at: datetime
+
+
+_cache: dict[str, CacheEntry] = {}
+
+
+def _make_cache_key(query: str) -> str:
+    """Create a cache key by hashing the normalized query string."""
+    normalized = " ".join(query.strip().lower().split())
+    return hashlib.sha256(normalized.encode()).hexdigest()
+
+
+def get_cached_result(query: str) -> pd.DataFrame | None:
+    """Return cached DataFrame if it exists and hasn't expired, otherwise None."""
+    key = _make_cache_key(query)
+    entry = _cache.get(key)
+    if entry is None:
+        return None
+
+    ttl_days = get_settings().CACHE_TTL_DAYS
+    if datetime.now(UTC) - entry.created_at > timedelta(days=ttl_days):
+        logger.info(f"Cache entry expired for query hash {key[:12]}...")
+        del _cache[key]
+        return None
+
+    logger.info(f"Cache hit for query hash {key[:12]}...")
+    return entry.df.copy()
+
+
+def set_cached_result(query: str, df: pd.DataFrame) -> None:
+    """Store a query result in the cache."""
+    key = _make_cache_key(query)
+    _cache[key] = CacheEntry(df=df.copy(), created_at=datetime.now(UTC))
+    logger.info(f"Cached result for query hash {key[:12]}... ({len(_cache)} entries in cache)")
+
+
+def clear_cache() -> None:
+    """Clear all cached query results."""
+    _cache.clear()
+    logger.info("Query cache cleared")

--- a/trust/data-access-api/tests/services/test_cohort.py
+++ b/trust/data-access-api/tests/services/test_cohort.py
@@ -19,6 +19,7 @@ from psycopg2 import errors as pg_errors
 from sqlalchemy.exc import DBAPIError, SQLAlchemyError
 
 from data_access_api.routers.schema import CohortQueryInput
+from data_access_api.services.query_cache import clear_cache
 from data_access_api.services.cohort import (
     get_age_distribution,
     get_counts,
@@ -30,6 +31,14 @@ from data_access_api.services.cohort import (
     validate_query,
     verify_cardinality,
 )
+
+
+@pytest.fixture(autouse=True)
+def _clear_query_cache():
+    """Clear the query cache before each test to prevent cross-test interference."""
+    clear_cache()
+    yield
+    clear_cache()
 
 
 @pytest.fixture
@@ -896,8 +905,9 @@ def test_get_statistics_with_person_id_column(mock_read_sql):
     assert {"value": "M", "count": 18} in sex_data["results"]
     assert {"value": "F", "count": 12} in sex_data["results"]
 
-    # Verify read_sql was called multiple times (main query + age + sex distributions)
-    assert mock_read_sql.call_count >= 3
+    # Verify read_sql was called for age and sex distribution queries
+    # (duplicate calls for the same query are served from the query cache)
+    assert mock_read_sql.call_count >= 2
 
 
 @patch("pandas.read_sql")

--- a/trust/data-access-api/tests/services/test_cohort.py
+++ b/trust/data-access-api/tests/services/test_cohort.py
@@ -19,7 +19,6 @@ from psycopg2 import errors as pg_errors
 from sqlalchemy.exc import DBAPIError, SQLAlchemyError
 
 from data_access_api.routers.schema import CohortQueryInput
-from data_access_api.services.query_cache import clear_cache
 from data_access_api.services.cohort import (
     get_age_distribution,
     get_counts,
@@ -31,6 +30,7 @@ from data_access_api.services.cohort import (
     validate_query,
     verify_cardinality,
 )
+from data_access_api.services.query_cache import clear_cache
 
 
 @pytest.fixture(autouse=True)

--- a/trust/data-access-api/tests/services/test_query_cache.py
+++ b/trust/data-access-api/tests/services/test_query_cache.py
@@ -1,0 +1,131 @@
+# Copyright (c) Guy's and St Thomas' NHS Foundation Trust & King's College London
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import patch
+
+import pandas as pd
+import pytest
+
+from data_access_api.services.query_cache import (
+    CacheEntry,
+    _cache,
+    _make_cache_key,
+    clear_cache,
+    get_cached_result,
+    set_cached_result,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    """Clear the cache before and after each test."""
+    _cache.clear()
+    yield
+    _cache.clear()
+
+
+class TestMakeCacheKey:
+    def test_deterministic(self):
+        key1 = _make_cache_key("SELECT * FROM table")
+        key2 = _make_cache_key("SELECT * FROM table")
+        assert key1 == key2
+
+    def test_normalizes_whitespace(self):
+        key1 = _make_cache_key("SELECT  *   FROM   table")
+        key2 = _make_cache_key("SELECT * FROM table")
+        assert key1 == key2
+
+    def test_case_insensitive(self):
+        key1 = _make_cache_key("SELECT * FROM table")
+        key2 = _make_cache_key("select * from table")
+        assert key1 == key2
+
+    def test_different_queries_different_keys(self):
+        key1 = _make_cache_key("SELECT * FROM table_a")
+        key2 = _make_cache_key("SELECT * FROM table_b")
+        assert key1 != key2
+
+
+class TestGetCachedResult:
+    @patch("data_access_api.services.query_cache.get_settings")
+    def test_returns_none_on_miss(self, mock_settings):
+        mock_settings.return_value.CACHE_TTL_DAYS = 60
+        result = get_cached_result("SELECT 1")
+        assert result is None
+
+    @patch("data_access_api.services.query_cache.get_settings")
+    def test_returns_cached_dataframe(self, mock_settings):
+        mock_settings.return_value.CACHE_TTL_DAYS = 60
+        df = pd.DataFrame({"col": [1, 2, 3]})
+        set_cached_result("SELECT 1", df)
+
+        result = get_cached_result("SELECT 1")
+        assert result is not None
+        pd.testing.assert_frame_equal(result, df)
+
+    @patch("data_access_api.services.query_cache.get_settings")
+    def test_returns_copy_not_reference(self, mock_settings):
+        mock_settings.return_value.CACHE_TTL_DAYS = 60
+        df = pd.DataFrame({"col": [1, 2, 3]})
+        set_cached_result("SELECT 1", df)
+
+        result = get_cached_result("SELECT 1")
+        result["col"] = [99, 99, 99]
+
+        # Original cached value should be unchanged
+        result2 = get_cached_result("SELECT 1")
+        pd.testing.assert_frame_equal(result2, df)
+
+    @patch("data_access_api.services.query_cache.get_settings")
+    def test_expired_entry_returns_none(self, mock_settings):
+        mock_settings.return_value.CACHE_TTL_DAYS = 60
+        query = "SELECT 1"
+        df = pd.DataFrame({"col": [1]})
+        key = _make_cache_key(query)
+
+        # Insert an entry that expired 1 day ago
+        _cache[key] = CacheEntry(df=df.copy(), created_at=datetime.now(UTC) - timedelta(days=61))
+
+        result = get_cached_result(query)
+        assert result is None
+        assert key not in _cache  # Expired entry should be removed
+
+
+class TestSetCachedResult:
+    @patch("data_access_api.services.query_cache.get_settings")
+    def test_stores_entry(self, mock_settings):
+        mock_settings.return_value.CACHE_TTL_DAYS = 60
+        df = pd.DataFrame({"col": [1, 2]})
+        set_cached_result("SELECT 1", df)
+        assert len(_cache) == 1
+
+    @patch("data_access_api.services.query_cache.get_settings")
+    def test_stores_copy(self, mock_settings):
+        mock_settings.return_value.CACHE_TTL_DAYS = 60
+        df = pd.DataFrame({"col": [1, 2]})
+        set_cached_result("SELECT 1", df)
+
+        # Mutating original should not affect cache
+        df["col"] = [99, 99]
+        result = get_cached_result("SELECT 1")
+        assert list(result["col"]) == [1, 2]
+
+
+class TestClearCache:
+    def test_clears_all_entries(self):
+        _cache["key1"] = CacheEntry(df=pd.DataFrame(), created_at=datetime.now(UTC))
+        _cache["key2"] = CacheEntry(df=pd.DataFrame(), created_at=datetime.now(UTC))
+        assert len(_cache) == 2
+
+        clear_cache()
+        assert len(_cache) == 0

--- a/trust/data-access-api/tests/services/test_query_cache.py
+++ b/trust/data-access-api/tests/services/test_query_cache.py
@@ -66,6 +66,8 @@ class TestGetCachedResult:
     @patch("data_access_api.services.query_cache.get_settings")
     def test_returns_cached_dataframe(self, mock_settings):
         mock_settings.return_value.CACHE_TTL_DAYS = 60
+        mock_settings.return_value.CACHE_MAX_RESULT_ROWS = 50_000
+        mock_settings.return_value.CACHE_MAX_ENTRIES = 64
         df = pd.DataFrame({"col": [1, 2, 3]})
         set_cached_result("SELECT 1", df)
 
@@ -76,6 +78,8 @@ class TestGetCachedResult:
     @patch("data_access_api.services.query_cache.get_settings")
     def test_returns_copy_not_reference(self, mock_settings):
         mock_settings.return_value.CACHE_TTL_DAYS = 60
+        mock_settings.return_value.CACHE_MAX_RESULT_ROWS = 50_000
+        mock_settings.return_value.CACHE_MAX_ENTRIES = 64
         df = pd.DataFrame({"col": [1, 2, 3]})
         set_cached_result("SELECT 1", df)
 
@@ -105,6 +109,8 @@ class TestSetCachedResult:
     @patch("data_access_api.services.query_cache.get_settings")
     def test_stores_entry(self, mock_settings):
         mock_settings.return_value.CACHE_TTL_DAYS = 60
+        mock_settings.return_value.CACHE_MAX_RESULT_ROWS = 50_000
+        mock_settings.return_value.CACHE_MAX_ENTRIES = 64
         df = pd.DataFrame({"col": [1, 2]})
         set_cached_result("SELECT 1", df)
         assert len(_cache) == 1
@@ -112,6 +118,8 @@ class TestSetCachedResult:
     @patch("data_access_api.services.query_cache.get_settings")
     def test_stores_copy(self, mock_settings):
         mock_settings.return_value.CACHE_TTL_DAYS = 60
+        mock_settings.return_value.CACHE_MAX_RESULT_ROWS = 50_000
+        mock_settings.return_value.CACHE_MAX_ENTRIES = 64
         df = pd.DataFrame({"col": [1, 2]})
         set_cached_result("SELECT 1", df)
 
@@ -119,6 +127,55 @@ class TestSetCachedResult:
         df["col"] = [99, 99]
         result = get_cached_result("SELECT 1")
         assert list(result["col"]) == [1, 2]
+
+    @patch("data_access_api.services.query_cache.get_settings")
+    def test_skips_caching_when_exceeding_max_rows(self, mock_settings):
+        mock_settings.return_value.CACHE_TTL_DAYS = 60
+        mock_settings.return_value.CACHE_MAX_RESULT_ROWS = 5
+        mock_settings.return_value.CACHE_MAX_ENTRIES = 64
+        df = pd.DataFrame({"col": range(10)})  # 10 rows > limit of 5
+        set_cached_result("SELECT big", df)
+        assert len(_cache) == 0
+
+    @patch("data_access_api.services.query_cache.get_settings")
+    def test_caches_dataframe_within_row_limit(self, mock_settings):
+        mock_settings.return_value.CACHE_TTL_DAYS = 60
+        mock_settings.return_value.CACHE_MAX_RESULT_ROWS = 10
+        mock_settings.return_value.CACHE_MAX_ENTRIES = 64
+        df = pd.DataFrame({"col": range(5)})  # 5 rows <= limit of 10
+        set_cached_result("SELECT small", df)
+        assert len(_cache) == 1
+
+    @patch("data_access_api.services.query_cache.get_settings")
+    def test_evicts_oldest_when_max_entries_reached(self, mock_settings):
+        mock_settings.return_value.CACHE_TTL_DAYS = 60
+        mock_settings.return_value.CACHE_MAX_RESULT_ROWS = 50_000
+        mock_settings.return_value.CACHE_MAX_ENTRIES = 2
+
+        set_cached_result("SELECT 1", pd.DataFrame({"col": [1]}))
+        set_cached_result("SELECT 2", pd.DataFrame({"col": [2]}))
+        assert len(_cache) == 2
+
+        # Adding a 3rd entry should evict the oldest (SELECT 1)
+        set_cached_result("SELECT 3", pd.DataFrame({"col": [3]}))
+        assert len(_cache) == 2
+
+        key1 = _make_cache_key("SELECT 1")
+        key3 = _make_cache_key("SELECT 3")
+        assert key1 not in _cache  # oldest evicted
+        assert key3 in _cache  # newest present
+
+    @patch("data_access_api.services.query_cache.get_settings")
+    def test_max_entries_config_value_read_from_settings(self, mock_settings):
+        mock_settings.return_value.CACHE_TTL_DAYS = 60
+        mock_settings.return_value.CACHE_MAX_RESULT_ROWS = 50_000
+        mock_settings.return_value.CACHE_MAX_ENTRIES = 3  # Not the old hardcoded 256
+
+        for i in range(5):
+            set_cached_result(f"SELECT {i}", pd.DataFrame({"col": [i]}))
+
+        # Cache should never exceed configured max of 3
+        assert len(_cache) == 3
 
 
 class TestClearCache:


### PR DESCRIPTION
This pull request introduces a query-level in-memory caching system for cohort queries, aimed at reducing redundant database queries and improving performance. It adds a configurable cache with time-to-live (TTL), integrates cache checks into the cohort data retrieval flow, and provides comprehensive tests to ensure cache correctness and isolation during testing.

**Query Caching Implementation and Integration:**

* Added a new `query_cache.py` service that implements an in-memory cache for query results, with normalization, SHA-256 hashing for cache keys, TTL expiry, and LRU eviction for up to 256 entries. The cache stores deep copies of Pandas DataFrames to avoid mutation side effects. (`trust/data-access-api/data_access_api/services/query_cache.py`)
* Integrated the cache into the cohort query flow: `get_records` now checks the cache before running queries and caches results after fetching from the database. (`trust/data-access-api/data_access_api/services/cohort.py`) [[1]](diffhunk://#diff-a2cdf71fe711bfa111ac3560de392cc1dcdff516d28c6370cae13ca16d12e2ceR23) [[2]](diffhunk://#diff-a2cdf71fe711bfa111ac3560de392cc1dcdff516d28c6370cae13ca16d12e2ceR76-R79) [[3]](diffhunk://#diff-a2cdf71fe711bfa111ac3560de392cc1dcdff516d28c6370cae13ca16d12e2ceR88)

New logs from data-access-api:

```
      INFO   Executing SQL query: SELECT * FROM OMOP.IMAGE_OCCURRENCE WHERE 
             modality_concept_id = 4300757
      INFO   Cache hit for query hash a0b4db089b27...
```

**Configuration and Settings:**

* Added a `CACHE_TTL_DAYS` setting to control cache expiration, defaulting to 60 days. (`trust/data-access-api/data_access_api/config.py`)

**Testing and Reliability:**

* Added a new test suite for the query cache, covering cache key normalization, cache hits/misses, expiry, and cache clearing. (`trust/data-access-api/tests/services/test_query_cache.py`)
* Updated cohort service tests to clear the cache before and after each test to avoid cross-test interference, ensuring test reliability. (`trust/data-access-api/tests/services/test_cohort.py`) [[1]](diffhunk://#diff-c707b1f8d4ec643e9711d8f026c8d1832e3707cee7ad54ab9f9ea40e39920579R22) [[2]](diffhunk://#diff-c707b1f8d4ec643e9711d8f026c8d1832e3707cee7ad54ab9f9ea40e39920579R36-R43)
* Updated test assertions to account for cache hits reducing the number of actual database calls. (`trust/data-access-api/tests/services/test_cohort.py`)

**Minor Bug Fixes:**

* Fixed redundant calls to distribution functions in age and sex statistics calculation. (`trust/data-access-api/data_access_api/services/cohort.py`)

These changes collectively improve the efficiency of repeated cohort queries, provide robust cache management, and ensure that the caching system is well-tested and reliable.