### PR TITLE
docs: fix outdated documentation, Makefile bug, and docstring mismatches

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ When creating issues, please use the appropriate issue template:
 
 FLIP is developed by the [London AI Centre](https://www.aicentre.co.uk/) in collaboration with Guy's and St Thomas' NHS Foundation Trust and King's College London. It is an open-source platform for federated training and evaluation of medical imaging AI models across healthcare institutions, while ensuring data privacy and security.
 
-The project spans two repositories:
+The project spans three repositories:
 
 | Repository | Description |
 | --- | --- |
@@ -59,6 +59,8 @@ FLIP/
 └── trust/              # Services deployed in individual trust environments
     ├── data-access-api/    # Data access API
     ├── imaging-api/        # Imaging API
+    ├── nginx/              # nginx TLS termination proxy
+    ├── observability/      # Observability stack (Grafana, Loki, Alloy)
     ├── omop-db/            # Mocked OMOP database
     ├── orthanc/            # Mocked PACS service (Orthanc)
     ├── trust-api/          # Trust API

--- a/Makefile
+++ b/Makefile
@@ -194,7 +194,7 @@ ui-off:
 	@echo "🛑 Stopping UI..."
 	$(DOCKER_COMMAND) down --remove-orphans flip-ui
 tests:
-	cd flip-ui && $(MAKE) tests && \
+	cd flip-ui && $(MAKE) unit_test && \
 	cd ../flip-api && $(MAKE) test
 
 debug-all:

--- a/README.md
+++ b/README.md
@@ -216,7 +216,6 @@ The repository is organised as follows:
   - `omop-db`: Contains a mocked OMOP database
   - `orthanc`: Contains a mocked PACS service (uses [Orthanc](https://www.orthanc-server.com/))
   - `trust-api`: Contains the trust API service
-  - `nginx`: Contains the nginx TLS termination proxy for trust HTTPS endpoints
   - `xnat`: Contains a mocked [XNAT](https://www.xnat.org/) service
 
 ### HTTPS / TLS

--- a/trust/data-access-api/data_access_api/routers/health.py
+++ b/trust/data-access-api/data_access_api/routers/health.py
@@ -16,11 +16,11 @@ router = APIRouter(prefix="/health", tags=["Health"])
 
 
 @router.get("")
-async def health_check():
+async def health_check() -> dict[str, str]:
     """
     Health check endpoint for the Data Access API
 
     Returns:
-        dict: A dictionary with the status of the service
+        dict[str, str]: A dictionary with the status of the service.
     """
     return {"status": "ok"}

--- a/trust/trust-api/trust_api/routers/cohort.py
+++ b/trust/trust-api/trust_api/routers/cohort.py
@@ -33,10 +33,6 @@ async def post_cohort_query(query_input: CohortQueryInput):
 
     Args:
         query_input (trust_api.routers.schemas.CohortQueryInput): The input data for the cohort query.
-
-    Returns:
-        None: This endpoint does not return a response body. Cohort results are forwarded
-        to the Central Hub via a separate HTTP call.
     """
     logger.debug(f"Received cohort query: {query_input.model_dump()}")
 

--- a/trust/trust-api/trust_api/routers/cohort.py
+++ b/trust/trust-api/trust_api/routers/cohort.py
@@ -35,7 +35,8 @@ async def post_cohort_query(query_input: CohortQueryInput):
         query_input (trust_api.routers.schemas.CohortQueryInput): The input data for the cohort query.
 
     Returns:
-        dict: The JSON response from the remote /cohort endpoint.
+        None: This endpoint does not return a response body. Cohort results are forwarded
+        to the Central Hub via a separate HTTP call.
     """
     logger.debug(f"Received cohort query: {query_input.model_dump()}")
 

--- a/trust/trust-api/trust_api/routers/health.py
+++ b/trust/trust-api/trust_api/routers/health.py
@@ -16,11 +16,11 @@ router = APIRouter(prefix="/health", tags=["Health"])
 
 
 @router.get("")
-async def health_check():
+async def health_check() -> dict[str, str]:
     """
     Health check endpoint for the Trust API
 
     Returns:
-        dict: A dictionary with the status of the service
+        dict[str, str]: A dictionary with the status of the service.
     """
     return {"status": "ok"}

--- a/trust/trust-api/trust_api/routers/imaging.py
+++ b/trust/trust-api/trust_api/routers/imaging.py
@@ -29,6 +29,9 @@ async def create_imaging_project(central_hub_project: CentralHubProject):
 
     Args:
         central_hub_project (trust_api.routers.schemas.CentralHubProject): The central hub project data.
+
+    Returns:
+        dict: The JSON response from the imaging API.
     """
     logger.info(f"Creating imaging project with input: {central_hub_project}")
     response = await make_request(
@@ -47,6 +50,9 @@ async def delete_imaging_project(imaging_project_id: str):
 
     Args:
         imaging_project_id (str): The ID of the imaging project to delete.
+
+    Returns:
+        dict: The JSON response from the imaging API.
     """
     logger.info(f"Deleting imaging project with ID: {imaging_project_id}")
     return await make_request(
@@ -64,6 +70,9 @@ async def get_imaging_project_status(imaging_project_id: str, encoded_query: str
     Args:
         imaging_project_id (str): The ID of the imaging project.
         encoded_query (str): Project cohort query base64 url encoded.
+
+    Returns:
+        dict: The JSON response from the imaging API containing import status.
     """
     logger.info(f"Retrieving imaging project with ID: {imaging_project_id}")
     response = await make_request(
@@ -83,6 +92,9 @@ async def reimport_studies(imaging_project_id: str, encoded_query: str):
     Args:
         imaging_project_id (str): The ID of the imaging project.
         encoded_query (str): Project cohort query base64 url encoded.
+
+    Returns:
+        dict: The JSON response from the imaging API.
     """
     logger.info(f"Reimporting studies for imaging project with ID: {imaging_project_id}")
     return await make_request(
@@ -99,6 +111,9 @@ async def update_profile(update_profile_request: UpdateProfileRequest):
 
     Args:
         update_profile_request (UpdateProfileRequest): The request data for updating the profile.
+
+    Returns:
+        dict: The JSON response from the imaging API.
     """
     logger.info(f"Updating profile with input: {update_profile_request}")
     return await make_request(


### PR DESCRIPTION
**Automated scheduled weekly task by Alex's Claude Code.**

## Summary

- **README.md**: Removed duplicate `nginx` entry in project structure listing (was listed twice under `trust/`)
- **CONTRIBUTING.md**: Fixed repository count ("two" → "three"); added missing `nginx/` and `observability/` directories to the project structure tree
- **Makefile**: Fixed `make tests` target — was calling nonexistent `tests` target in flip-ui (corrected to `unit_test`)
- **trust-api**: Added missing `Returns` sections to all imaging router docstrings; fixed cohort router docstring that incorrectly claimed a `dict` return when the function returns `None`; added `-> dict[str, str]` return type annotation to health check endpoint
- **data-access-api**: Added `-> dict[str, str]` return type annotation to health check endpoint

## Test plan

- [x] `ruff check` passes on trust-api and data-access-api
- [x] `mypy` passes on trust-api and data-access-api
- [x] Unit tests pass on trust-api (10 passed) and data-access-api (73 passed)
- [x] No functional changes — documentation, docstrings, and one Makefile target fix only

https://claude.ai/code/session_01X4yBe9j2yThG19GQVG77hw