### PR TITLE
CI: Add validation to ensure PRs to main originate from develop

### DIFF
--- a/.github/workflows/validate_branch_origin.yml
+++ b/.github/workflows/validate_branch_origin.yml
@@ -1,0 +1,49 @@
+# Copyright (c) 2026 Guy's and St Thomas' NHS Foundation Trust & King's College London
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: Validate PR Source Branch
+
+on:
+    pull_request:
+        types: [opened, reopened, synchronize]
+        branches:
+            - main
+
+permissions:
+    pull-requests: write
+
+jobs:
+    validate-source-branch:
+        name: Ensure PR to main originates from develop
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Check source branch
+              run: |
+                  SOURCE_BRANCH="${{ github.head_ref }}"
+                  TARGET_BRANCH="${{ github.base_ref }}"
+
+                  echo "PR Details:"
+                  echo "  Source branch: ${SOURCE_BRANCH}"
+                  echo "  Target branch: ${TARGET_BRANCH}"
+
+                  if [ "${TARGET_BRANCH}" = "main" ]; then
+                    if [ "${SOURCE_BRANCH}" != "develop" ]; then
+                      echo "❌ VALIDATION FAILED"
+                      echo "PRs to 'main' must originate from 'develop' branch."
+                      echo "Current source branch: ${SOURCE_BRANCH}"
+                      exit 1
+                    fi
+                    echo "✅ VALIDATION PASSED: PR to main originates from develop"
+                  else
+                    echo "ℹ️  Not a PR to main; skipping branch source validation"
+                  fi

--- a/.github/workflows/validate_branch_origin.yml
+++ b/.github/workflows/validate_branch_origin.yml
@@ -12,6 +12,9 @@
 
 name: Validate PR Source Branch
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     types: [opened, reopened, synchronize, edited]

--- a/.github/workflows/validate_branch_origin.yml
+++ b/.github/workflows/validate_branch_origin.yml
@@ -13,37 +13,30 @@
 name: Validate PR Source Branch
 
 on:
-    pull_request:
-        types: [opened, reopened, synchronize]
-        branches:
-            - main
-
-permissions:
-    pull-requests: write
+  pull_request:
+    types: [opened, reopened, synchronize, edited]
+    branches:
+      - main
 
 jobs:
-    validate-source-branch:
-        name: Ensure PR to main originates from develop
-        runs-on: ubuntu-latest
+  validate-source-branch:
+    name: Ensure PR to main originates from develop
+    runs-on: ubuntu-latest
 
-        steps:
-            - name: Check source branch
-              run: |
-                  SOURCE_BRANCH="${{ github.head_ref }}"
-                  TARGET_BRANCH="${{ github.base_ref }}"
+    steps:
+      - name: Check source branch
+        run: |
+          SOURCE_BRANCH="${{ github.head_ref }}"
+          TARGET_BRANCH="${{ github.base_ref }}"
 
-                  echo "PR Details:"
-                  echo "  Source branch: ${SOURCE_BRANCH}"
-                  echo "  Target branch: ${TARGET_BRANCH}"
+          echo "PR Details:"
+          echo "  Source branch: ${SOURCE_BRANCH}"
+          echo "  Target branch: ${TARGET_BRANCH}"
 
-                  if [ "${TARGET_BRANCH}" = "main" ]; then
-                    if [ "${SOURCE_BRANCH}" != "develop" ]; then
-                      echo "❌ VALIDATION FAILED"
-                      echo "PRs to 'main' must originate from 'develop' branch."
-                      echo "Current source branch: ${SOURCE_BRANCH}"
-                      exit 1
-                    fi
-                    echo "✅ VALIDATION PASSED: PR to main originates from develop"
-                  else
-                    echo "ℹ️  Not a PR to main; skipping branch source validation"
-                  fi
+          if [ "${SOURCE_BRANCH}" != "develop" ]; then
+            echo "❌ VALIDATION FAILED"
+            echo "PRs to 'main' must originate from 'develop' branch."
+            echo "Current source branch: ${SOURCE_BRANCH}"
+            exit 1
+          fi
+          echo "✅ VALIDATION PASSED: PR to main originates from develop"


### PR DESCRIPTION
## Description

This PR adds a new GitHub Actions workflow to enforce that all Pull Requests targeting the `main` branch must originate from the `develop` branch. This ensures a proper release workflow where code is thoroughly tested in `develop` before being promoted to `main`.

## Linked Issues

Relates to CI/CD pipeline improvements for release management.

## Checklist

- [x] Follows the project's coding conventions and style guide
- [x] Updates documentation (workflow is self-documenting)
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Type of Change

- [x] Non-breaking change (adds new CI validation without affecting existing functionality)
- [x] In-line docstrings updated

## Testing

The GitHub Actions workflow will be automatically available on all PRs to `main` and `develop`:

- [x] Workflow syntax validated in GitHub Actions UI
- [x] No unit tests required (this is a CI workflow configuration)

## Key Changes

### New File
- **`.github/workflows/validate_branch_origin.yml`** — New workflow that:
  - Triggers on all pull request events (opened, reopened, synchronize) targeting the `main` branch
  - Validates that the source branch is `develop`
  - Provides clear feedback to users if they attempt to PR directly to `main` from any other branch
  - Allows PRs to other branches (like `develop`) without restriction

## Additional Notes

This workflow is a guardrail to maintain release discipline. It prevents accidental PRs to `main` from feature branches while allowing the normal development flow where all PRs target `develop`.