### PR TITLE
Remove AWS secrets write access from EC2 IAM role (keep read)

### DIFF
--- a/deploy/providers/AWS/README.md
+++ b/deploy/providers/AWS/README.md
@@ -59,7 +59,7 @@ Managed policies that cover these requirements:
 - `ElasticLoadBalancingFullAccess`
 - `AmazonSESFullAccess` (optional)
 
-**Note**: The deployed EC2 instances use minimal IAM permissions (SSM and CloudWatch only) following the principle of least privilege.
+**Note**: The deployed EC2 instances use minimal IAM permissions (SSM, CloudWatch, and a scoped inline policy for `secretsmanager:GetSecretValue` on specific secrets) following the principle of least privilege.
 
 ## Deployment Workflow
 

--- a/deploy/providers/AWS/main.tf
+++ b/deploy/providers/AWS/main.tf
@@ -200,7 +200,6 @@ module "ec2_role" {
     "arn:aws:iam::aws:policy/AmazonCognitoPowerUser", # TODO Restrict this policy to only what we need in production
     "arn:aws:iam::aws:policy/AmazonS3FullAccess",     # TODO Restrict this policy to only what we need in production
     "arn:aws:iam::aws:policy/AmazonSESFullAccess",    # TODO Restrict this policy to only what we need in production
-    "arn:aws:iam::aws:policy/SecretsManagerReadWrite" # TODO could create a read-only policy instead
   ]
   role_requires_mfa = "false"
 }

--- a/deploy/providers/AWS/main.tf
+++ b/deploy/providers/AWS/main.tf
@@ -210,6 +210,7 @@ resource "aws_iam_instance_profile" "ec2_profile" {
 }
 
 # Add permissions to access secrets
+# TODO: Replace this inline policy with a reusable managed IAM policy for read-only Secrets Manager access
 resource "aws_iam_role_policy" "ec2_secret" {
   name = "secret-read"
   role = module.ec2_role.iam_role_name

--- a/deploy/providers/AWS/main.tf
+++ b/deploy/providers/AWS/main.tf
@@ -210,7 +210,6 @@ resource "aws_iam_instance_profile" "ec2_profile" {
 }
 
 # Add permissions to access secrets
-# TODO: Replace this inline policy with a reusable managed IAM policy for read-only Secrets Manager access
 resource "aws_iam_role_policy" "ec2_secret" {
   name = "secret-read"
   role = module.ec2_role.iam_role_name


### PR DESCRIPTION
## Summary

- Remove the broad `SecretsManagerReadWrite` AWS managed policy from the EC2 IAM role
- The existing scoped inline policy `ec2_secret` already grants `secretsmanager:GetSecretValue` on the two specific secrets needed (RDS DB + FLIP_API), making the managed policy redundant
- Update README note to accurately reflect EC2 instance permissions

## Test plan

- [ ] Run `terraform plan` and verify the only change is removal of the `SecretsManagerReadWrite` policy attachment from the EC2 role
- [ ] Confirm EC2 instances can still retrieve secrets via the scoped inline `ec2_secret` policy
- [ ] Verify `flip-api` starts correctly and reads secrets from Secrets Manager

https://claude.ai/code/session_01JxwkZQRLPvyv6MJeju2jTs