### PR TITLE
docs: fix README/docstring drift surfaced by weekly audit

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -130,13 +130,15 @@ To get started, copy the example file:
 cp .env.development.example .env.development
 ```
 
-Then generate per-trust API keys (must be done before `make up`):
+Then generate per-trust API keys and the internal service key (the trust keys must be done before `make up`; the
+internal service key is also generated automatically by `make up`):
 
 ```bash
-make generate-dev-keys
+make generate-trust-api-keys
+make generate-internal-service-key
 ```
 
-This generates all API keys and writes them directly into `.env.development`: trust plaintext keys
+These commands write all API keys directly into `.env.development`: trust plaintext keys
 in `TRUST_API_KEYS` (JSON dict) with their hashes in `TRUST_API_KEY_HASHES`, and `INTERNAL_SERVICE_KEY`
 with `INTERNAL_SERVICE_KEY_HASH` for fl-server-to-hub authentication. No separate key files are used.
 
@@ -251,11 +253,13 @@ uv run ruff check . --fix
 uv run mypy .
 ```
 
-Each service has a `Makefile` with a `test` target that runs linting, type checking, and tests in sequence. For example, from a service directory:
+Most services have a `Makefile` with a `test` target that runs linting, type checking, and tests in sequence. For example, from a Python service directory:
 
 ```bash
 make test
 ```
+
+The `flip-ui` service uses `make unit_test` (Vitest) instead of `make test`.
 
 Documentation follows the [Google style guide](https://google.github.io/styleguide/pyguide.html) for Python docstrings.
 
@@ -283,11 +287,14 @@ make test
 
 This will run ruff, mypy, and pytest in sequence. The coverage report is generated in HTML format in the `htmlcov` directory.
 
-To run all tests across the main repository from the root:
+To run unit tests across all services in the main repository from the root:
 
 ```bash
-make tests
+make unit_test
 ```
+
+`make tests` is a narrower target that runs `flip-ui` unit tests followed by the full `flip-api` test suite (ruff,
+mypy, and pytest).
 
 For the `flip-fl-base` repository, unit tests can be run with:
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ For example:
 | `make up` | Run all services using Docker Swarm for XNAT (⚠️ This will not build the images, use `make build` first if needed)|
 | `make up-no-trust` | Run all services except the trust services related services |
 | `make up-trusts` | Run the trust services related services (uses Docker Swarm for XNAT) |
-| `make central-hub` | Run the central API service, including the database and UI |
+| `make central-hub` | Run the central API service and the database (does not start the UI — use `make ui` for that) |
 | `make build` | Build all Docker images |
 | `make down` | Stop all services and remove the containers (including Swarm stacks) |
 | `make restart` | Stop and start all services |
@@ -136,13 +136,14 @@ make xnat-shell  # Get a shell in the XNAT container
 
 ### Trust API Key Setup
 
-Before starting the platform, generate per-trust API keys and write them into `.env.development` using:
+Before starting the platform, generate per-trust API keys and the internal service key, and write them into `.env.development` using:
 
 ```bash
-make generate-dev-keys
+make generate-trust-api-keys
+make generate-internal-service-key
 ```
 
-This generates a unique key for each trust found in `.env.development`, and writes both `TRUST_API_KEYS` and `TRUST_API_KEY_HASHES` (JSON dicts) directly into the env file.
+`generate-trust-api-keys` generates a unique key for each trust found in `.env.development`, and writes both `TRUST_API_KEYS` and `TRUST_API_KEY_HASHES` (JSON dicts) directly into the env file. `generate-internal-service-key` writes `INTERNAL_SERVICE_KEY` and `INTERNAL_SERVICE_KEY_HASH` for fl-server-to-hub authentication. `make up` invokes `generate-internal-service-key` automatically.
 
 To generate a key for a single trust (e.g. when adding a new trust):
 
@@ -227,7 +228,6 @@ The repository is organised as follows:
 - `trust`: Contains the services that would be deployed in individual trust environments.
   - `data-access-api`: Contains the data access API service
   - `imaging-api`: Contains the imaging API service
-  - `nginx`: Contains the nginx/TLS reverse proxy configuration
   - `observability`: Contains the observability stack (Grafana, Loki, Alloy)
   - `omop-db`: Contains a mocked OMOP database
   - `orthanc`: Contains a mocked PACS service (uses [Orthanc](https://www.orthanc-server.com/))

--- a/docs/source/components/component-fl-nodes.rst
+++ b/docs/source/components/component-fl-nodes.rst
@@ -53,8 +53,8 @@ and `flip-fl-base-flower <https://github.com/londonaicentre/flip-fl-base-flower/
 
 Examples of how the same job type (standard -> federated averaging) can run different user-uploaded applications are:
 
-- <https://github.com/londonaicentre/flip-fl-base/tree/main/tutorials/image_classification/xray_classification>`_
-- <https://github.com/londonaicentre/flip-fl-base/tree/main/tutorials/image_segmentation/3d_spleen_segmentation>`_
+- `xray_classification <https://github.com/londonaicentre/flip-fl-base/tree/main/tutorials/image_classification/xray_classification>`_
+- `3d_spleen_segmentation <https://github.com/londonaicentre/flip-fl-base/tree/main/tutorials/image_segmentation/3d_spleen_segmentation>`_
 
 Both cases perform a supervised federated averaging training, but the data, architecture and training configuration are different.
 

--- a/flip-api/CONTRIBUTING.md
+++ b/flip-api/CONTRIBUTING.md
@@ -22,11 +22,11 @@ For general contribution guidelines (coding style, testing, pull requests), see 
 
 ```bash
 uv sync
-make dev
+make up
 ```
 
-This starts the API with live-reload enabled. The service expects the PostgreSQL database to be running (start it
-first with `make central-hub` or `docker compose up flip-db -d`).
+This starts the API (and the PostgreSQL database) via Docker Compose. To start only the database first, use
+`make central-hub` from the repo root or `docker compose -f deploy/compose.development.yml up flip-db -d`.
 
 ### Running tests
 

--- a/flip-api/README.md
+++ b/flip-api/README.md
@@ -14,7 +14,7 @@
 # flip-api
 
 [![Python 3.12+](https://img.shields.io/badge/python-3.12%2B-blue.svg)](https://www.python.org/downloads/)
-[![FLIP Central Hub API CI](https://github.com/londonaicentre/FLIP/actions/workflows/central_hub_api.yml/badge.svg)](https://github.com/londonaicentre/FLIP/actions/workflows/central_hub_api.yml)
+[![FLIP Central Hub API CI](https://github.com/londonaicentre/FLIP/actions/workflows/test_flip_api.yml/badge.svg)](https://github.com/londonaicentre/FLIP/actions/workflows/test_flip_api.yml)
 [![flip-api](https://ghcr-badge.egpl.dev/londonaicentre/flip-api/latest_tag?trim=major&label=flip-api)](https://github.com/londonaicentre/FLIP/pkgs/container/flip-api)
 [![Coverage](https://codecov.io/gh/londonaicentre/FLIP/branch/main/graph/badge.svg?flag=flip-api)](https://codecov.io/gh/londonaicentre/FLIP)
 
@@ -39,7 +39,7 @@ It communicates with each Trust's [trust-api](../trust/trust-api/) and stores al
 The flip-api is deployed as a Docker container. In the full local stack, it is started via:
 
 ```bash
-make central-hub   # starts flip-api, the database, and flip-ui
+make central-hub   # starts flip-api and the database
 ```
 
 or as part of the full platform:
@@ -48,13 +48,14 @@ or as part of the full platform:
 make up
 ```
 
-Before starting the platform, generate per-trust API keys:
+Before starting the platform, generate per-trust API keys and the internal service key:
 
 ```bash
-make generate-dev-keys   # from repo root
+make generate-trust-api-keys        # from repo root
+make generate-internal-service-key  # from repo root (also invoked automatically by `make up`)
 ```
 
-This updates `TRUST_API_KEYS` and `TRUST_API_KEY_HASHES` in `.env.development` automatically.
+`generate-trust-api-keys` updates `TRUST_API_KEYS` and `TRUST_API_KEY_HASHES` in `.env.development`. `generate-internal-service-key` writes `INTERNAL_SERVICE_KEY` and `INTERNAL_SERVICE_KEY_HASH` (used for fl-server-to-hub authentication).
 See [`.env.development.example`](../.env.development.example) for the expected format.
 
 The API is served on the port defined by `API_PORT` in [`.env.development.example`](../.env.development.example)

--- a/flip-api/src/flip_api/model_services/retrieve_logs_for_model.py
+++ b/flip-api/src/flip_api/model_services/retrieve_logs_for_model.py
@@ -43,7 +43,7 @@ def retrieve_logs_for_model_endpoint(
         user_id (UUID): User ID from authentication.
 
     Returns:
-        list[FLLogs]: A list of logs associated with the specified model.
+        list[ILog]: A list of log objects associated with the specified model.
 
     Raises:
         HTTPException: If the user does not have access to the model, if the model does not exist, or if there is a

--- a/flip-api/src/flip_api/model_services/services/model_service.py
+++ b/flip-api/src/flip_api/model_services/services/model_service.py
@@ -65,11 +65,11 @@ def update_model_status(model_id: UUID, status: ModelStatus | None, session: Ses
 
     Args:
         model_id (UUID): The ID of the model
-        status (flip.domain.schemas.status.ModelStatus): The new status to be set
+        status (ModelStatus | None): The new status to be set
         session (Session): The database session
 
     Returns:
-        flip.domain.schemas.status.ModelStatus | None: The updated status of the model
+        ModelStatus | None: The updated status of the model, or None if the model does not exist.
     """
     logger.info(f"Attempting to set the model's status... ID: {model_id}, Status: {status}")
 
@@ -208,7 +208,7 @@ def get_model_status(model_id: UUID, session: Session) -> IDetailedModelStatus |
         session (Session): The database session.
 
     Returns:
-        dict | None: A dictionary containing the model's status and deleted status.
+        IDetailedModelStatus | None: The model's status and deleted flag, or None if the model does not exist.
     """
     logger.debug("Attempting to get the model's status...")
 

--- a/flip-ui/README.md
+++ b/flip-ui/README.md
@@ -25,10 +25,10 @@ a portal to manage projects, monitor federated learning jobs, inspect cohort que
 The flip-ui is served as a containerised static web application. In the full local stack it starts automatically with:
 
 ```bash
-make central-hub   # starts flip-api, flip-db, and flip-ui
+make ui            # starts the UI only
 ```
 
-or as part of the full platform:
+or as part of the full platform (which also starts the UI):
 
 ```bash
 make up


### PR DESCRIPTION
> _This PR was opened by **Alex's Claude Code** as part of an automated scheduled weekly task that reconciles documentation and docstrings against the current code._

## Summary

The weekly audit walked the root and service READMEs, `CONTRIBUTING.md` files, the ReadTheDocs sources under `docs/source/`, and Python docstrings in `flip-api/`. It surfaced a small set of confirmed drift items (stale `make` targets, a stale workflow path, a non-existent directory in the project structure, two broken RST links, and a couple of incorrect docstring return types). All fixes are documentation- or docstring-only — no runtime behaviour changes.

## Changes

### Docs / READMEs

- **`README.md`, `flip-api/README.md`, `flip-ui/README.md`, `CONTRIBUTING.md`, `flip-api/CONTRIBUTING.md`** — replace references to the non-existent `make generate-dev-keys` / `make dev` targets with the real `make generate-trust-api-keys`, `make generate-internal-service-key`, and `make up` commands.
- **`README.md`, `flip-api/README.md`, `flip-ui/README.md`** — correct the description of `make central-hub` (it does not start the UI; only `flip-api` and `flip-db`).
- **`README.md`** — drop the non-existent `trust/nginx` directory from the Project Structure listing.
- **`flip-api/README.md`** — point the CI badge at the actual workflow file (`test_flip_api.yml`, not the non-existent `central_hub_api.yml`).
- **`CONTRIBUTING.md`** — clarify that `flip-ui` uses `make unit_test` (not `make test`) and that `make unit_test` (not `make tests`) is the root-level all-services target.
- **`docs/source/components/component-fl-nodes.rst`** — fix two malformed external link directives in the "Job types" section (missing leading backtick + label).

### Docstrings

- **`flip-api/src/flip_api/model_services/retrieve_logs_for_model.py`** — `Returns` docstring updated from `list[FLLogs]` to `list[ILog]` to match the endpoint's `response_model` and the actual return value.
- **`flip-api/src/flip_api/model_services/services/model_service.py`** —
  - `get_model_status`: `Returns` docstring updated from `dict | None` to `IDetailedModelStatus | None` to match the signature.
  - `update_model_status`: docstring type references updated from the stale `flip.domain.schemas.status.ModelStatus` path to the correct local `ModelStatus` symbol; `Returns` clarified for the `None` case.

## Test plan

- [x] `uv run ruff check` — passes for the two modified Python files.
- [x] `uv run mypy` — passes for the two modified Python files.
- [ ] CI on this PR (test_flip_api.yml, docs.yml, etc.) is green.
- [ ] Sphinx docs build succeeds with the corrected RST links.

---

_Generated as part of the weekly automated documentation reconciliation task._
