### PR TITLE
fix(security): remediate code scanning alerts — script injection (CWE-78) and path traversal (CWE-22/23)

### DIFF
--- a/.github/workflows/docker_build_flip_api.yml
+++ b/.github/workflows/docker_build_flip_api.yml
@@ -48,32 +48,37 @@ jobs:
 
       - name: Determine tags
         id: tags
+        env:
+          GH_REF_NAME: ${{ github.ref_name }}
+          GH_EVENT_NAME: ${{ github.event_name }}
+          GH_REF: ${{ github.ref }}
+          GH_WR_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          GH_WR_EVENT: ${{ github.event.workflow_run.event }}
         run: |
           TAGS="${REGISTRY}/${IMAGE_NAME}:${{ github.sha }}"
 
           # Branch name sanitization
-          REF_NAME="${{ github.ref_name }}"
-          SAFE_REF_NAME=$(echo "$REF_NAME" | sed 's/[^a-zA-Z0-9]/-/g')
+          SAFE_REF_NAME=$(echo "$GH_REF_NAME" | sed 's/[^a-zA-Z0-9]/-/g')
           TAGS="${TAGS},${REGISTRY}/${IMAGE_NAME}:${SAFE_REF_NAME}"
 
           # Branch number (if starts with number)
-          if [[ "$REF_NAME" =~ ^[0-9]+ ]]; then
-              BRANCH_NUM=$(echo "$REF_NAME" | grep -oE '^[0-9]+')
+          if [[ "$GH_REF_NAME" =~ ^[0-9]+ ]]; then
+              BRANCH_NUM=$(echo "$GH_REF_NAME" | grep -oE '^[0-9]+')
               TAGS="${TAGS},${REGISTRY}/${IMAGE_NAME}:${BRANCH_NUM}"
           fi
 
           # PR Number (if PR)
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-             PR_NUMBER=$(echo "${{ github.ref }}" | awk -F / '{print $3}')
+          if [[ "$GH_EVENT_NAME" == "pull_request" ]]; then
+             PR_NUMBER=$(echo "$GH_REF" | awk -F / '{print $3}')
              TAGS="${TAGS},${REGISTRY}/${IMAGE_NAME}:pr-${PR_NUMBER}"
           fi
 
           # Determine if this is a merge/push to main or develop
           BRANCH_NAME=""
-          if [[ "${{ github.event_name }}" == "workflow_run" && "${{ github.event.workflow_run.event }}" == "push" ]]; then
-            BRANCH_NAME="${{ github.event.workflow_run.head_branch }}"
-          elif [[ "${{ github.event_name }}" == "push" ]]; then
-            BRANCH_NAME="${{ github.ref_name }}"
+          if [[ "$GH_EVENT_NAME" == "workflow_run" && "$GH_WR_EVENT" == "push" ]]; then
+            BRANCH_NAME="$GH_WR_BRANCH"
+          elif [[ "$GH_EVENT_NAME" == "push" ]]; then
+            BRANCH_NAME="$GH_REF_NAME"
           fi
 
           if [[ "$BRANCH_NAME" == "main" ]]; then
@@ -88,19 +93,22 @@ jobs:
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
       - name: Build Docker image
+        env:
+          DOCKER_TAGS: ${{ steps.tags.outputs.tags }}
         run: |
-          IFS=',' read -ra TAG_ARRAY <<< "${{ steps.tags.outputs.tags }}"
-          BUILD_CMD="docker build ${BUILD_ARGS}"
+          IFS=',' read -ra TAG_ARRAY <<< "$DOCKER_TAGS"
+          TAG_FLAGS=()
           for tag in "${TAG_ARRAY[@]}"; do
-            BUILD_CMD+=" -t $tag"
+            TAG_FLAGS+=("-t" "$tag")
           done
-          BUILD_CMD+=" ."
-          echo "Running: $BUILD_CMD"
-          eval $BUILD_CMD
+          # shellcheck disable=SC2086
+          docker build $BUILD_ARGS "${TAG_FLAGS[@]}" .
 
       - name: Push Docker image
+        env:
+          DOCKER_TAGS: ${{ steps.tags.outputs.tags }}
         run: |
-          IFS=',' read -ra TAG_ARRAY <<< "${{ steps.tags.outputs.tags }}"
+          IFS=',' read -ra TAG_ARRAY <<< "$DOCKER_TAGS"
           for tag in "${TAG_ARRAY[@]}"; do
             docker push "$tag"
           done

--- a/.github/workflows/docker_build_flip_ui.yml
+++ b/.github/workflows/docker_build_flip_ui.yml
@@ -48,32 +48,37 @@ jobs:
 
       - name: Determine tags
         id: tags
+        env:
+          GH_REF_NAME: ${{ github.ref_name }}
+          GH_EVENT_NAME: ${{ github.event_name }}
+          GH_REF: ${{ github.ref }}
+          GH_WR_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          GH_WR_EVENT: ${{ github.event.workflow_run.event }}
         run: |
           TAGS="${REGISTRY}/${IMAGE_NAME}:${{ github.sha }}"
 
           # Branch name sanitization
-          REF_NAME="${{ github.ref_name }}"
-          SAFE_REF_NAME=$(echo "$REF_NAME" | sed 's/[^a-zA-Z0-9]/-/g')
+          SAFE_REF_NAME=$(echo "$GH_REF_NAME" | sed 's/[^a-zA-Z0-9]/-/g')
           TAGS="${TAGS},${REGISTRY}/${IMAGE_NAME}:${SAFE_REF_NAME}"
 
           # Branch number (if starts with number)
-          if [[ "$REF_NAME" =~ ^[0-9]+ ]]; then
-              BRANCH_NUM=$(echo "$REF_NAME" | grep -oE '^[0-9]+')
+          if [[ "$GH_REF_NAME" =~ ^[0-9]+ ]]; then
+              BRANCH_NUM=$(echo "$GH_REF_NAME" | grep -oE '^[0-9]+')
               TAGS="${TAGS},${REGISTRY}/${IMAGE_NAME}:${BRANCH_NUM}"
           fi
 
           # PR Number (if PR)
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-             PR_NUMBER=$(echo "${{ github.ref }}" | awk -F / '{print $3}')
+          if [[ "$GH_EVENT_NAME" == "pull_request" ]]; then
+             PR_NUMBER=$(echo "$GH_REF" | awk -F / '{print $3}')
              TAGS="${TAGS},${REGISTRY}/${IMAGE_NAME}:pr-${PR_NUMBER}"
           fi
 
           # Determine if this is a merge/push to main or develop
           BRANCH_NAME=""
-          if [[ "${{ github.event_name }}" == "workflow_run" && "${{ github.event.workflow_run.event }}" == "push" ]]; then
-            BRANCH_NAME="${{ github.event.workflow_run.head_branch }}"
-          elif [[ "${{ github.event_name }}" == "push" ]]; then
-            BRANCH_NAME="${{ github.ref_name }}"
+          if [[ "$GH_EVENT_NAME" == "workflow_run" && "$GH_WR_EVENT" == "push" ]]; then
+            BRANCH_NAME="$GH_WR_BRANCH"
+          elif [[ "$GH_EVENT_NAME" == "push" ]]; then
+            BRANCH_NAME="$GH_REF_NAME"
           fi
 
           if [[ "$BRANCH_NAME" == "main" ]]; then
@@ -88,19 +93,22 @@ jobs:
         run: echo ${{ secrets.GITHUB_TOKEN }} | docker login $REGISTRY -u ${{ github.actor }} --password-stdin
 
       - name: Build Docker image
+        env:
+          DOCKER_TAGS: ${{ steps.tags.outputs.tags }}
         run: |
-          IFS=',' read -ra TAG_ARRAY <<< "${{ steps.tags.outputs.tags }}"
-          BUILD_CMD="docker build ${BUILD_ARGS}"
+          IFS=',' read -ra TAG_ARRAY <<< "$DOCKER_TAGS"
+          TAG_FLAGS=()
           for tag in "${TAG_ARRAY[@]}"; do
-            BUILD_CMD+=" -t $tag"
+            TAG_FLAGS+=("-t" "$tag")
           done
-          BUILD_CMD+=" ."
-          echo "Running: $BUILD_CMD"
-          eval $BUILD_CMD
+          # shellcheck disable=SC2086
+          docker build $BUILD_ARGS "${TAG_FLAGS[@]}" .
 
       - name: Push Docker image
+        env:
+          DOCKER_TAGS: ${{ steps.tags.outputs.tags }}
         run: |
-          IFS=',' read -ra TAG_ARRAY <<< "${{ steps.tags.outputs.tags }}"
+          IFS=',' read -ra TAG_ARRAY <<< "$DOCKER_TAGS"
           for tag in "${TAG_ARRAY[@]}"; do
             docker push "$tag"
           done

--- a/.github/workflows/docker_build_orthanc.yml
+++ b/.github/workflows/docker_build_orthanc.yml
@@ -45,32 +45,37 @@ jobs:
 
       - name: Determine tags
         id: tags
+        env:
+          GH_REF_NAME: ${{ github.ref_name }}
+          GH_EVENT_NAME: ${{ github.event_name }}
+          GH_REF: ${{ github.ref }}
+          GH_WR_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          GH_WR_EVENT: ${{ github.event.workflow_run.event }}
         run: |
           TAGS="${REGISTRY}/${IMAGE_NAME}:${{ github.sha }}"
 
           # Branch name sanitization
-          REF_NAME="${{ github.ref_name }}"
-          SAFE_REF_NAME=$(echo "$REF_NAME" | sed 's/[^a-zA-Z0-9]/-/g')
+          SAFE_REF_NAME=$(echo "$GH_REF_NAME" | sed 's/[^a-zA-Z0-9]/-/g')
           TAGS="${TAGS},${REGISTRY}/${IMAGE_NAME}:${SAFE_REF_NAME}"
 
           # Branch number (if starts with number)
-          if [[ "$REF_NAME" =~ ^[0-9]+ ]]; then
-              BRANCH_NUM=$(echo "$REF_NAME" | grep -oE '^[0-9]+')
+          if [[ "$GH_REF_NAME" =~ ^[0-9]+ ]]; then
+              BRANCH_NUM=$(echo "$GH_REF_NAME" | grep -oE '^[0-9]+')
               TAGS="${TAGS},${REGISTRY}/${IMAGE_NAME}:${BRANCH_NUM}"
           fi
 
           # PR Number (if PR)
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-             PR_NUMBER=$(echo "${{ github.ref }}" | awk -F / '{print $3}')
+          if [[ "$GH_EVENT_NAME" == "pull_request" ]]; then
+             PR_NUMBER=$(echo "$GH_REF" | awk -F / '{print $3}')
              TAGS="${TAGS},${REGISTRY}/${IMAGE_NAME}:pr-${PR_NUMBER}"
           fi
 
           # Determine if this is a merge/push to main or develop
           BRANCH_NAME=""
-          if [[ "${{ github.event_name }}" == "workflow_run" && "${{ github.event.workflow_run.event }}" == "push" ]]; then
-            BRANCH_NAME="${{ github.event.workflow_run.head_branch }}"
-          elif [[ "${{ github.event_name }}" == "push" ]]; then
-            BRANCH_NAME="${{ github.ref_name }}"
+          if [[ "$GH_EVENT_NAME" == "workflow_run" && "$GH_WR_EVENT" == "push" ]]; then
+            BRANCH_NAME="$GH_WR_BRANCH"
+          elif [[ "$GH_EVENT_NAME" == "push" ]]; then
+            BRANCH_NAME="$GH_REF_NAME"
           fi
 
           if [[ "$BRANCH_NAME" == "main" ]]; then
@@ -85,19 +90,22 @@ jobs:
         run: echo ${{ secrets.GITHUB_TOKEN }} | docker login $REGISTRY -u ${{ github.actor }} --password-stdin
 
       - name: Build Docker image
+        env:
+          DOCKER_TAGS: ${{ steps.tags.outputs.tags }}
         run: |
-          IFS=',' read -ra TAG_ARRAY <<< "${{ steps.tags.outputs.tags }}"
-          BUILD_CMD="docker build ${BUILD_ARGS}"
+          IFS=',' read -ra TAG_ARRAY <<< "$DOCKER_TAGS"
+          TAG_FLAGS=()
           for tag in "${TAG_ARRAY[@]}"; do
-            BUILD_CMD+=" -t $tag"
+            TAG_FLAGS+=("-t" "$tag")
           done
-          BUILD_CMD+=" ."
-          echo "Running: $BUILD_CMD"
-          eval $BUILD_CMD
+          # shellcheck disable=SC2086
+          docker build $BUILD_ARGS "${TAG_FLAGS[@]}" .
 
       - name: Push Docker image
+        env:
+          DOCKER_TAGS: ${{ steps.tags.outputs.tags }}
         run: |
-          IFS=',' read -ra TAG_ARRAY <<< "${{ steps.tags.outputs.tags }}"
+          IFS=',' read -ra TAG_ARRAY <<< "$DOCKER_TAGS"
           for tag in "${TAG_ARRAY[@]}"; do
             docker push "$tag"
           done

--- a/.github/workflows/docker_build_trust_data_access_api.yml
+++ b/.github/workflows/docker_build_trust_data_access_api.yml
@@ -49,32 +49,37 @@ jobs:
 
       - name: Determine tags
         id: tags
+        env:
+          GH_REF_NAME: ${{ github.ref_name }}
+          GH_EVENT_NAME: ${{ github.event_name }}
+          GH_REF: ${{ github.ref }}
+          GH_WR_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          GH_WR_EVENT: ${{ github.event.workflow_run.event }}
         run: |
           TAGS="${REGISTRY}/${IMAGE_NAME}:${{ github.sha }}"
 
           # Branch name sanitization
-          REF_NAME="${{ github.ref_name }}"
-          SAFE_REF_NAME=$(echo "$REF_NAME" | sed 's/[^a-zA-Z0-9]/-/g')
+          SAFE_REF_NAME=$(echo "$GH_REF_NAME" | sed 's/[^a-zA-Z0-9]/-/g')
           TAGS="${TAGS},${REGISTRY}/${IMAGE_NAME}:${SAFE_REF_NAME}"
 
           # Branch number (if starts with number)
-          if [[ "$REF_NAME" =~ ^[0-9]+ ]]; then
-              BRANCH_NUM=$(echo "$REF_NAME" | grep -oE '^[0-9]+')
+          if [[ "$GH_REF_NAME" =~ ^[0-9]+ ]]; then
+              BRANCH_NUM=$(echo "$GH_REF_NAME" | grep -oE '^[0-9]+')
               TAGS="${TAGS},${REGISTRY}/${IMAGE_NAME}:${BRANCH_NUM}"
           fi
 
           # PR Number (if PR)
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-             PR_NUMBER=$(echo "${{ github.ref }}" | awk -F / '{print $3}')
+          if [[ "$GH_EVENT_NAME" == "pull_request" ]]; then
+             PR_NUMBER=$(echo "$GH_REF" | awk -F / '{print $3}')
              TAGS="${TAGS},${REGISTRY}/${IMAGE_NAME}:pr-${PR_NUMBER}"
           fi
 
-            # Determine if this is a merge/push to main or develop
+          # Determine if this is a merge/push to main or develop
           BRANCH_NAME=""
-          if [[ "${{ github.event_name }}" == "workflow_run" && "${{ github.event.workflow_run.event }}" == "push" ]]; then
-            BRANCH_NAME="${{ github.event.workflow_run.head_branch }}"
-          elif [[ "${{ github.event_name }}" == "push" ]]; then
-            BRANCH_NAME="${{ github.ref_name }}"
+          if [[ "$GH_EVENT_NAME" == "workflow_run" && "$GH_WR_EVENT" == "push" ]]; then
+            BRANCH_NAME="$GH_WR_BRANCH"
+          elif [[ "$GH_EVENT_NAME" == "push" ]]; then
+            BRANCH_NAME="$GH_REF_NAME"
           fi
 
           if [[ "$BRANCH_NAME" == "main" ]]; then
@@ -92,19 +97,22 @@ jobs:
         run: cp -r ../observability/log_config ./log_config
 
       - name: Build Docker image
+        env:
+          DOCKER_TAGS: ${{ steps.tags.outputs.tags }}
         run: |
-          IFS=',' read -ra TAG_ARRAY <<< "${{ steps.tags.outputs.tags }}"
-          BUILD_CMD="docker build ${BUILD_ARGS}"
+          IFS=',' read -ra TAG_ARRAY <<< "$DOCKER_TAGS"
+          TAG_FLAGS=()
           for tag in "${TAG_ARRAY[@]}"; do
-            BUILD_CMD+=" -t $tag"
+            TAG_FLAGS+=("-t" "$tag")
           done
-          BUILD_CMD+=" ."
-          echo "Running: $BUILD_CMD"
-          eval $BUILD_CMD
+          # shellcheck disable=SC2086
+          docker build $BUILD_ARGS "${TAG_FLAGS[@]}" .
 
       - name: Push Docker image
+        env:
+          DOCKER_TAGS: ${{ steps.tags.outputs.tags }}
         run: |
-          IFS=',' read -ra TAG_ARRAY <<< "${{ steps.tags.outputs.tags }}"
+          IFS=',' read -ra TAG_ARRAY <<< "$DOCKER_TAGS"
           for tag in "${TAG_ARRAY[@]}"; do
             docker push "$tag"
           done

--- a/.github/workflows/docker_build_trust_imaging_api.yml
+++ b/.github/workflows/docker_build_trust_imaging_api.yml
@@ -49,32 +49,37 @@ jobs:
 
       - name: Determine tags
         id: tags
+        env:
+          GH_REF_NAME: ${{ github.ref_name }}
+          GH_EVENT_NAME: ${{ github.event_name }}
+          GH_REF: ${{ github.ref }}
+          GH_WR_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          GH_WR_EVENT: ${{ github.event.workflow_run.event }}
         run: |
           TAGS="${REGISTRY}/${IMAGE_NAME}:${{ github.sha }}"
 
           # Branch name sanitization
-          REF_NAME="${{ github.ref_name }}"
-          SAFE_REF_NAME=$(echo "$REF_NAME" | sed 's/[^a-zA-Z0-9]/-/g')
+          SAFE_REF_NAME=$(echo "$GH_REF_NAME" | sed 's/[^a-zA-Z0-9]/-/g')
           TAGS="${TAGS},${REGISTRY}/${IMAGE_NAME}:${SAFE_REF_NAME}"
 
           # Branch number (if starts with number)
-          if [[ "$REF_NAME" =~ ^[0-9]+ ]]; then
-              BRANCH_NUM=$(echo "$REF_NAME" | grep -oE '^[0-9]+')
+          if [[ "$GH_REF_NAME" =~ ^[0-9]+ ]]; then
+              BRANCH_NUM=$(echo "$GH_REF_NAME" | grep -oE '^[0-9]+')
               TAGS="${TAGS},${REGISTRY}/${IMAGE_NAME}:${BRANCH_NUM}"
           fi
 
           # PR Number (if PR)
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-             PR_NUMBER=$(echo "${{ github.ref }}" | awk -F / '{print $3}')
+          if [[ "$GH_EVENT_NAME" == "pull_request" ]]; then
+             PR_NUMBER=$(echo "$GH_REF" | awk -F / '{print $3}')
              TAGS="${TAGS},${REGISTRY}/${IMAGE_NAME}:pr-${PR_NUMBER}"
           fi
 
-            # Determine if this is a merge/push to main or develop
+          # Determine if this is a merge/push to main or develop
           BRANCH_NAME=""
-          if [[ "${{ github.event_name }}" == "workflow_run" && "${{ github.event.workflow_run.event }}" == "push" ]]; then
-            BRANCH_NAME="${{ github.event.workflow_run.head_branch }}"
-          elif [[ "${{ github.event_name }}" == "push" ]]; then
-            BRANCH_NAME="${{ github.ref_name }}"
+          if [[ "$GH_EVENT_NAME" == "workflow_run" && "$GH_WR_EVENT" == "push" ]]; then
+            BRANCH_NAME="$GH_WR_BRANCH"
+          elif [[ "$GH_EVENT_NAME" == "push" ]]; then
+            BRANCH_NAME="$GH_REF_NAME"
           fi
 
           if [[ "$BRANCH_NAME" == "main" ]]; then
@@ -92,19 +97,22 @@ jobs:
         run: cp -r ../observability/log_config ./log_config
 
       - name: Build Docker image
+        env:
+          DOCKER_TAGS: ${{ steps.tags.outputs.tags }}
         run: |
-          IFS=',' read -ra TAG_ARRAY <<< "${{ steps.tags.outputs.tags }}"
-          BUILD_CMD="docker build ${BUILD_ARGS}"
+          IFS=',' read -ra TAG_ARRAY <<< "$DOCKER_TAGS"
+          TAG_FLAGS=()
           for tag in "${TAG_ARRAY[@]}"; do
-            BUILD_CMD+=" -t $tag"
+            TAG_FLAGS+=("-t" "$tag")
           done
-          BUILD_CMD+=" ."
-          echo "Running: $BUILD_CMD"
-          eval $BUILD_CMD
+          # shellcheck disable=SC2086
+          docker build $BUILD_ARGS "${TAG_FLAGS[@]}" .
 
       - name: Push Docker image
+        env:
+          DOCKER_TAGS: ${{ steps.tags.outputs.tags }}
         run: |
-          IFS=',' read -ra TAG_ARRAY <<< "${{ steps.tags.outputs.tags }}"
+          IFS=',' read -ra TAG_ARRAY <<< "$DOCKER_TAGS"
           for tag in "${TAG_ARRAY[@]}"; do
             docker push "$tag"
           done

--- a/.github/workflows/docker_build_trust_trust_api.yml
+++ b/.github/workflows/docker_build_trust_trust_api.yml
@@ -49,32 +49,37 @@ jobs:
 
       - name: Determine tags
         id: tags
+        env:
+          GH_REF_NAME: ${{ github.ref_name }}
+          GH_EVENT_NAME: ${{ github.event_name }}
+          GH_REF: ${{ github.ref }}
+          GH_WR_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          GH_WR_EVENT: ${{ github.event.workflow_run.event }}
         run: |
           TAGS="${REGISTRY}/${IMAGE_NAME}:${{ github.sha }}"
 
           # Branch name sanitization
-          REF_NAME="${{ github.ref_name }}"
-          SAFE_REF_NAME=$(echo "$REF_NAME" | sed 's/[^a-zA-Z0-9]/-/g')
+          SAFE_REF_NAME=$(echo "$GH_REF_NAME" | sed 's/[^a-zA-Z0-9]/-/g')
           TAGS="${TAGS},${REGISTRY}/${IMAGE_NAME}:${SAFE_REF_NAME}"
 
           # Branch number (if starts with number)
-          if [[ "$REF_NAME" =~ ^[0-9]+ ]]; then
-              BRANCH_NUM=$(echo "$REF_NAME" | grep -oE '^[0-9]+')
+          if [[ "$GH_REF_NAME" =~ ^[0-9]+ ]]; then
+              BRANCH_NUM=$(echo "$GH_REF_NAME" | grep -oE '^[0-9]+')
               TAGS="${TAGS},${REGISTRY}/${IMAGE_NAME}:${BRANCH_NUM}"
           fi
 
           # PR Number (if PR)
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-             PR_NUMBER=$(echo "${{ github.ref }}" | awk -F / '{print $3}')
+          if [[ "$GH_EVENT_NAME" == "pull_request" ]]; then
+             PR_NUMBER=$(echo "$GH_REF" | awk -F / '{print $3}')
              TAGS="${TAGS},${REGISTRY}/${IMAGE_NAME}:pr-${PR_NUMBER}"
           fi
 
           # Determine if this is a merge/push to main or develop
           BRANCH_NAME=""
-          if [[ "${{ github.event_name }}" == "workflow_run" && "${{ github.event.workflow_run.event }}" == "push" ]]; then
-            BRANCH_NAME="${{ github.event.workflow_run.head_branch }}"
-          elif [[ "${{ github.event_name }}" == "push" ]]; then
-            BRANCH_NAME="${{ github.ref_name }}"
+          if [[ "$GH_EVENT_NAME" == "workflow_run" && "$GH_WR_EVENT" == "push" ]]; then
+            BRANCH_NAME="$GH_WR_BRANCH"
+          elif [[ "$GH_EVENT_NAME" == "push" ]]; then
+            BRANCH_NAME="$GH_REF_NAME"
           fi
 
           if [[ "$BRANCH_NAME" == "main" ]]; then
@@ -92,19 +97,22 @@ jobs:
         run: cp -r ../observability/log_config ./log_config
 
       - name: Build Docker image
+        env:
+          DOCKER_TAGS: ${{ steps.tags.outputs.tags }}
         run: |
-          IFS=',' read -ra TAG_ARRAY <<< "${{ steps.tags.outputs.tags }}"
-          BUILD_CMD="docker build ${BUILD_ARGS}"
+          IFS=',' read -ra TAG_ARRAY <<< "$DOCKER_TAGS"
+          TAG_FLAGS=()
           for tag in "${TAG_ARRAY[@]}"; do
-            BUILD_CMD+=" -t $tag"
+            TAG_FLAGS+=("-t" "$tag")
           done
-          BUILD_CMD+=" ."
-          echo "Running: $BUILD_CMD"
-          eval $BUILD_CMD
+          # shellcheck disable=SC2086
+          docker build $BUILD_ARGS "${TAG_FLAGS[@]}" .
 
       - name: Push Docker image
+        env:
+          DOCKER_TAGS: ${{ steps.tags.outputs.tags }}
         run: |
-          IFS=',' read -ra TAG_ARRAY <<< "${{ steps.tags.outputs.tags }}"
+          IFS=',' read -ra TAG_ARRAY <<< "$DOCKER_TAGS"
           for tag in "${TAG_ARRAY[@]}"; do
             docker push "$tag"
           done

--- a/.github/workflows/docker_build_xnat_db.yml
+++ b/.github/workflows/docker_build_xnat_db.yml
@@ -46,32 +46,37 @@ jobs:
 
       - name: Determine tags
         id: tags
+        env:
+          GH_REF_NAME: ${{ github.ref_name }}
+          GH_EVENT_NAME: ${{ github.event_name }}
+          GH_REF: ${{ github.ref }}
+          GH_WR_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          GH_WR_EVENT: ${{ github.event.workflow_run.event }}
         run: |
           TAGS="${REGISTRY}/${IMAGE_NAME}:${{ github.sha }}"
 
           # Branch name sanitization
-          REF_NAME="${{ github.ref_name }}"
-          SAFE_REF_NAME=$(echo "$REF_NAME" | sed 's/[^a-zA-Z0-9]/-/g')
+          SAFE_REF_NAME=$(echo "$GH_REF_NAME" | sed 's/[^a-zA-Z0-9]/-/g')
           TAGS="${TAGS},${REGISTRY}/${IMAGE_NAME}:${SAFE_REF_NAME}"
 
           # Branch number (if starts with number)
-          if [[ "$REF_NAME" =~ ^[0-9]+ ]]; then
-              BRANCH_NUM=$(echo "$REF_NAME" | grep -oE '^[0-9]+')
+          if [[ "$GH_REF_NAME" =~ ^[0-9]+ ]]; then
+              BRANCH_NUM=$(echo "$GH_REF_NAME" | grep -oE '^[0-9]+')
               TAGS="${TAGS},${REGISTRY}/${IMAGE_NAME}:${BRANCH_NUM}"
           fi
 
           # PR Number (if PR)
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-             PR_NUMBER=$(echo "${{ github.ref }}" | awk -F / '{print $3}')
+          if [[ "$GH_EVENT_NAME" == "pull_request" ]]; then
+             PR_NUMBER=$(echo "$GH_REF" | awk -F / '{print $3}')
              TAGS="${TAGS},${REGISTRY}/${IMAGE_NAME}:pr-${PR_NUMBER}"
           fi
 
           # Determine if this is a merge/push to main or develop
           BRANCH_NAME=""
-          if [[ "${{ github.event_name }}" == "workflow_run" && "${{ github.event.workflow_run.event }}" == "push" ]]; then
-            BRANCH_NAME="${{ github.event.workflow_run.head_branch }}"
-          elif [[ "${{ github.event_name }}" == "push" ]]; then
-            BRANCH_NAME="${{ github.ref_name }}"
+          if [[ "$GH_EVENT_NAME" == "workflow_run" && "$GH_WR_EVENT" == "push" ]]; then
+            BRANCH_NAME="$GH_WR_BRANCH"
+          elif [[ "$GH_EVENT_NAME" == "push" ]]; then
+            BRANCH_NAME="$GH_REF_NAME"
           fi
 
           if [[ "$BRANCH_NAME" == "main" ]]; then
@@ -86,19 +91,22 @@ jobs:
         run: echo ${{ secrets.GITHUB_TOKEN }} | docker login $REGISTRY -u ${{ github.actor }} --password-stdin
 
       - name: Build Docker image
+        env:
+          DOCKER_TAGS: ${{ steps.tags.outputs.tags }}
         run: |
-          IFS=',' read -ra TAG_ARRAY <<< "${{ steps.tags.outputs.tags }}"
-          BUILD_CMD="docker build ${BUILD_ARGS}"
+          IFS=',' read -ra TAG_ARRAY <<< "$DOCKER_TAGS"
+          TAG_FLAGS=()
           for tag in "${TAG_ARRAY[@]}"; do
-            BUILD_CMD+=" -t $tag"
+            TAG_FLAGS+=("-t" "$tag")
           done
-          BUILD_CMD+=" ."
-          echo "Running: $BUILD_CMD"
-          eval $BUILD_CMD
+          # shellcheck disable=SC2086
+          docker build $BUILD_ARGS "${TAG_FLAGS[@]}" .
 
       - name: Push Docker image
+        env:
+          DOCKER_TAGS: ${{ steps.tags.outputs.tags }}
         run: |
-          IFS=',' read -ra TAG_ARRAY <<< "${{ steps.tags.outputs.tags }}"
+          IFS=',' read -ra TAG_ARRAY <<< "$DOCKER_TAGS"
           for tag in "${TAG_ARRAY[@]}"; do
             docker push "$tag"
           done

--- a/.github/workflows/docker_build_xnat_nginx.yml
+++ b/.github/workflows/docker_build_xnat_nginx.yml
@@ -46,32 +46,37 @@ jobs:
 
       - name: Determine tags
         id: tags
+        env:
+          GH_REF_NAME: ${{ github.ref_name }}
+          GH_EVENT_NAME: ${{ github.event_name }}
+          GH_REF: ${{ github.ref }}
+          GH_WR_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          GH_WR_EVENT: ${{ github.event.workflow_run.event }}
         run: |
           TAGS="${REGISTRY}/${IMAGE_NAME}:${{ github.sha }}"
 
           # Branch name sanitization
-          REF_NAME="${{ github.ref_name }}"
-          SAFE_REF_NAME=$(echo "$REF_NAME" | sed 's/[^a-zA-Z0-9]/-/g')
+          SAFE_REF_NAME=$(echo "$GH_REF_NAME" | sed 's/[^a-zA-Z0-9]/-/g')
           TAGS="${TAGS},${REGISTRY}/${IMAGE_NAME}:${SAFE_REF_NAME}"
 
           # Branch number (if starts with number)
-          if [[ "$REF_NAME" =~ ^[0-9]+ ]]; then
-              BRANCH_NUM=$(echo "$REF_NAME" | grep -oE '^[0-9]+')
+          if [[ "$GH_REF_NAME" =~ ^[0-9]+ ]]; then
+              BRANCH_NUM=$(echo "$GH_REF_NAME" | grep -oE '^[0-9]+')
               TAGS="${TAGS},${REGISTRY}/${IMAGE_NAME}:${BRANCH_NUM}"
           fi
 
           # PR Number (if PR)
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-             PR_NUMBER=$(echo "${{ github.ref }}" | awk -F / '{print $3}')
+          if [[ "$GH_EVENT_NAME" == "pull_request" ]]; then
+             PR_NUMBER=$(echo "$GH_REF" | awk -F / '{print $3}')
              TAGS="${TAGS},${REGISTRY}/${IMAGE_NAME}:pr-${PR_NUMBER}"
           fi
 
           # Determine if this is a merge/push to main or develop
           BRANCH_NAME=""
-          if [[ "${{ github.event_name }}" == "workflow_run" && "${{ github.event.workflow_run.event }}" == "push" ]]; then
-            BRANCH_NAME="${{ github.event.workflow_run.head_branch }}"
-          elif [[ "${{ github.event_name }}" == "push" ]]; then
-            BRANCH_NAME="${{ github.ref_name }}"
+          if [[ "$GH_EVENT_NAME" == "workflow_run" && "$GH_WR_EVENT" == "push" ]]; then
+            BRANCH_NAME="$GH_WR_BRANCH"
+          elif [[ "$GH_EVENT_NAME" == "push" ]]; then
+            BRANCH_NAME="$GH_REF_NAME"
           fi
 
           if [[ "$BRANCH_NAME" == "main" ]]; then
@@ -86,19 +91,22 @@ jobs:
         run: echo ${{ secrets.GITHUB_TOKEN }} | docker login $REGISTRY -u ${{ github.actor }} --password-stdin
 
       - name: Build Docker image
+        env:
+          DOCKER_TAGS: ${{ steps.tags.outputs.tags }}
         run: |
-          IFS=',' read -ra TAG_ARRAY <<< "${{ steps.tags.outputs.tags }}"
-          BUILD_CMD="docker build ${BUILD_ARGS}"
+          IFS=',' read -ra TAG_ARRAY <<< "$DOCKER_TAGS"
+          TAG_FLAGS=()
           for tag in "${TAG_ARRAY[@]}"; do
-            BUILD_CMD+=" -t $tag"
+            TAG_FLAGS+=("-t" "$tag")
           done
-          BUILD_CMD+=" ."
-          echo "Running: $BUILD_CMD"
-          eval $BUILD_CMD
+          # shellcheck disable=SC2086
+          docker build $BUILD_ARGS "${TAG_FLAGS[@]}" .
 
       - name: Push Docker image
+        env:
+          DOCKER_TAGS: ${{ steps.tags.outputs.tags }}
         run: |
-          IFS=',' read -ra TAG_ARRAY <<< "${{ steps.tags.outputs.tags }}"
+          IFS=',' read -ra TAG_ARRAY <<< "$DOCKER_TAGS"
           for tag in "${TAG_ARRAY[@]}"; do
             docker push "$tag"
           done

--- a/.github/workflows/docker_build_xnat_web.yml
+++ b/.github/workflows/docker_build_xnat_web.yml
@@ -65,32 +65,37 @@ jobs:
 
       - name: Determine tags
         id: tags
+        env:
+          GH_REF_NAME: ${{ github.ref_name }}
+          GH_EVENT_NAME: ${{ github.event_name }}
+          GH_REF: ${{ github.ref }}
+          GH_WR_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          GH_WR_EVENT: ${{ github.event.workflow_run.event }}
         run: |
           TAGS="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}"
 
           # Branch name sanitization
-          REF_NAME="${{ github.ref_name }}"
-          SAFE_REF_NAME=$(echo "$REF_NAME" | sed 's/[^a-zA-Z0-9]/-/g')
+          SAFE_REF_NAME=$(echo "$GH_REF_NAME" | sed 's/[^a-zA-Z0-9]/-/g')
           TAGS="${TAGS},${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${SAFE_REF_NAME}"
 
           # Branch number (if starts with number)
-          if [[ "$REF_NAME" =~ ^[0-9]+ ]]; then
-              BRANCH_NUM=$(echo "$REF_NAME" | grep -oE '^[0-9]+')
+          if [[ "$GH_REF_NAME" =~ ^[0-9]+ ]]; then
+              BRANCH_NUM=$(echo "$GH_REF_NAME" | grep -oE '^[0-9]+')
               TAGS="${TAGS},${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${BRANCH_NUM}"
           fi
 
           # PR Number (if PR)
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-             PR_NUMBER=$(echo "${{ github.ref }}" | awk -F / '{print $3}')
+          if [[ "$GH_EVENT_NAME" == "pull_request" ]]; then
+             PR_NUMBER=$(echo "$GH_REF" | awk -F / '{print $3}')
              TAGS="${TAGS},${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:pr-${PR_NUMBER}"
           fi
 
           # Determine if this is a merge/push to main or develop
           BRANCH_NAME=""
-          if [[ "${{ github.event_name }}" == "workflow_run" && "${{ github.event.workflow_run.event }}" == "push" ]]; then
-            BRANCH_NAME="${{ github.event.workflow_run.head_branch }}"
-          elif [[ "${{ github.event_name }}" == "push" ]]; then
-            BRANCH_NAME="${{ github.ref_name }}"
+          if [[ "$GH_EVENT_NAME" == "workflow_run" && "$GH_WR_EVENT" == "push" ]]; then
+            BRANCH_NAME="$GH_WR_BRANCH"
+          elif [[ "$GH_EVENT_NAME" == "push" ]]; then
+            BRANCH_NAME="$GH_REF_NAME"
           fi
 
           if [[ "$BRANCH_NAME" == "main" ]]; then
@@ -111,19 +116,22 @@ jobs:
         run: aws s3 sync s3://${{ env.FLIP_ARTIFACTS_BUCKET_NAME }}/xnat/plugins/ plugins/
 
       - name: Build Docker image
+        env:
+          DOCKER_TAGS: ${{ steps.tags.outputs.tags }}
         run: |
-          IFS=',' read -ra TAG_ARRAY <<< "${{ steps.tags.outputs.tags }}"
-          BUILD_CMD="docker build ${BUILD_ARGS}"
+          IFS=',' read -ra TAG_ARRAY <<< "$DOCKER_TAGS"
+          TAG_FLAGS=()
           for tag in "${TAG_ARRAY[@]}"; do
-            BUILD_CMD+=" -t $tag"
+            TAG_FLAGS+=("-t" "$tag")
           done
-          BUILD_CMD+=" ."
-          echo "Running: $BUILD_CMD"
-          eval $BUILD_CMD
+          # shellcheck disable=SC2086
+          docker build $BUILD_ARGS "${TAG_FLAGS[@]}" .
 
       - name: Push Docker image
+        env:
+          DOCKER_TAGS: ${{ steps.tags.outputs.tags }}
         run: |
-          IFS=',' read -ra TAG_ARRAY <<< "${{ steps.tags.outputs.tags }}"
+          IFS=',' read -ra TAG_ARRAY <<< "$DOCKER_TAGS"
           for tag in "${TAG_ARRAY[@]}"; do
             docker push "$tag"
           done

--- a/.github/workflows/validate_branch_origin.yml
+++ b/.github/workflows/validate_branch_origin.yml
@@ -28,10 +28,10 @@ jobs:
 
     steps:
       - name: Check source branch
+        env:
+          SOURCE_BRANCH: ${{ github.head_ref }}
+          TARGET_BRANCH: ${{ github.base_ref }}
         run: |
-          SOURCE_BRANCH="${{ github.head_ref }}"
-          TARGET_BRANCH="${{ github.base_ref }}"
-
           echo "PR Details:"
           echo "  Source branch: ${SOURCE_BRANCH}"
           echo "  Target branch: ${TARGET_BRANCH}"

--- a/trust/imaging-api/imaging_api/routers/download.py
+++ b/trust/imaging-api/imaging_api/routers/download.py
@@ -82,6 +82,10 @@ async def download_images_by_accession_number(
         error_msg = f"Resource not found: {str(e)}"
         logger.error(error_msg)
         raise HTTPException(status_code=404, detail=error_msg)
+    except ValueError as e:
+        error_msg = f"Invalid download request: {str(e)}"
+        logger.error(error_msg)
+        raise HTTPException(status_code=400, detail=error_msg)
     except Exception as e:
         error_msg = f"Failed to download and unzip images: {str(e)}"
         logger.error(error_msg)

--- a/trust/imaging-api/imaging_api/routers/upload.py
+++ b/trust/imaging-api/imaging_api/routers/upload.py
@@ -65,5 +65,7 @@ async def upload_data(net_id: str, request_data: UploadDataRequest, headers: XNA
         return uploaded_files
     except NotFoundError as e:
         raise HTTPException(status_code=404, detail=f"Resource not found: {str(e)}")
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=f"Invalid upload request: {str(e)}")
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Failed to upload files: {str(e)}")

--- a/trust/imaging-api/imaging_api/services/download.py
+++ b/trust/imaging-api/imaging_api/services/download.py
@@ -223,11 +223,14 @@ def unzip_file(zip_path: str, extract_dir: str, new_name: str):
     extract_dir_abs = os.path.realpath(extract_dir)
 
     with zipfile.ZipFile(zip_path, "r") as zip_ref:
-        for member in zip_ref.namelist():
+        members = zip_ref.namelist()
+
+        for member in members:
             member_path = os.path.realpath(os.path.join(extract_dir_abs, member))
             if not member_path.startswith(extract_dir_abs + os.sep):
                 raise ValueError(f"Attempted path traversal in ZIP entry: {member}")
-            zip_ref.extract(member, extract_dir_abs)
+
+        zip_ref.extractall(extract_dir_abs)
 
     # Rename the extracted directory
     extracted_dir = os.path.join(extract_dir_abs, Path(zip_path).stem)

--- a/trust/imaging-api/imaging_api/services/download.py
+++ b/trust/imaging-api/imaging_api/services/download.py
@@ -218,7 +218,7 @@ def unzip_file(zip_path: str, extract_dir: str, new_name: str):
     with zipfile.ZipFile(zip_path, "r") as zip_ref:
         for member in zip_ref.namelist():
             member_path = os.path.realpath(os.path.join(extract_dir_abs, member))
-            if not member_path.startswith(extract_dir_abs + os.sep):
+            if os.path.commonpath([extract_dir_abs, member_path]) != extract_dir_abs:
                 raise ValueError(f"Attempted path traversal in ZIP entry: {member}")
         zip_ref.extractall(extract_dir_abs)
 

--- a/trust/imaging-api/imaging_api/services/download.py
+++ b/trust/imaging-api/imaging_api/services/download.py
@@ -205,16 +205,26 @@ def unzip_file(zip_path: str, extract_dir: str, new_name: str):
 
     Returns:
         str: Path to the renamed directory.
+
+    Raises:
+        FileNotFoundError: If the ZIP file does not exist.
+        ValueError: If the ZIP file contains path traversal entries (zip slip).
     """
     if not os.path.exists(zip_path):
         raise FileNotFoundError(f"ZIP file not found: {zip_path}")
 
+    extract_dir_abs = os.path.realpath(extract_dir)
+
     with zipfile.ZipFile(zip_path, "r") as zip_ref:
-        zip_ref.extractall(extract_dir)
+        for member in zip_ref.namelist():
+            member_path = os.path.realpath(os.path.join(extract_dir_abs, member))
+            if not member_path.startswith(extract_dir_abs + os.sep):
+                raise ValueError(f"Attempted path traversal in ZIP entry: {member}")
+        zip_ref.extractall(extract_dir_abs)
 
     # Rename the extracted directory
-    extracted_dir = os.path.join(extract_dir, Path(zip_path).stem)
-    renamed_dir = os.path.join(extract_dir, new_name)
+    extracted_dir = os.path.join(extract_dir_abs, Path(zip_path).stem)
+    renamed_dir = os.path.join(extract_dir_abs, new_name)
 
     if os.path.exists(extracted_dir):
         os.rename(extracted_dir, renamed_dir)

--- a/trust/imaging-api/imaging_api/services/download.py
+++ b/trust/imaging-api/imaging_api/services/download.py
@@ -62,9 +62,17 @@ async def download_and_unzip_images(
         imaging_api.utils.exceptions.NotFoundError: If the project with the given ID is not found, if no experiments are
         found for the given accession ID, if no data is found at the download URL, or if the ZIP file is not found after
         download.
+        ValueError: If the net ID attempts path traversal outside the base images directory.
         Exception: If there is an error during any of the requests to XNAT, during the download process, or during the
         unzipping process.
     """
+    # Validate net_id doesn't escape base images directory
+    download_dir = os.path.join(BASE_IMAGES_DOWNLOAD_DIR, net_id)
+    base_images_download_dir_abs = os.path.realpath(BASE_IMAGES_DOWNLOAD_DIR)
+    download_dir_abs = os.path.realpath(download_dir)
+    if os.path.commonpath([base_images_download_dir_abs, download_dir_abs]) != base_images_download_dir_abs:
+        raise ValueError(f"Path traversal detected in net ID: {net_id}")
+
     # Get project ID from central hub project ID
     try:
         project = get_project_from_central_hub_project_id(central_hub_project_id, headers)
@@ -100,9 +108,8 @@ async def download_and_unzip_images(
     )
     logger.info(f"Download URL: {download_url}")
 
-    # Define download and extraction paths
-    download_dir = os.path.join(BASE_IMAGES_DOWNLOAD_DIR, net_id)
-    zip_file_path = os.path.join(download_dir, f"{accession_id}-scans-{resource_type}.zip")
+    # Define download and extraction paths (net_id already validated above)
+    zip_file_path = os.path.join(download_dir_abs, f"{accession_id}-scans-{resource_type}.zip")
 
     # Download the ZIP file
     try:
@@ -116,7 +123,7 @@ async def download_and_unzip_images(
     logger.info(f"Downloaded file: {downloaded_file}")
 
     # Unzip file and rename the folder
-    extracted_folder = unzip_file(downloaded_file, download_dir, accession_id)
+    extracted_folder = unzip_file(downloaded_file, download_dir_abs, accession_id)
     logger.debug(f"Extracted folder: {extracted_folder}")
 
     # List contents of the extracted folder recursively

--- a/trust/imaging-api/imaging_api/services/download.py
+++ b/trust/imaging-api/imaging_api/services/download.py
@@ -70,7 +70,7 @@ async def download_and_unzip_images(
     download_dir = os.path.join(BASE_IMAGES_DOWNLOAD_DIR, net_id)
     base_images_download_dir_abs = os.path.realpath(BASE_IMAGES_DOWNLOAD_DIR)
     download_dir_abs = os.path.realpath(download_dir)
-    if os.path.commonpath([base_images_download_dir_abs, download_dir_abs]) != base_images_download_dir_abs:
+    if not download_dir_abs.startswith(base_images_download_dir_abs + os.sep):
         raise ValueError(f"Path traversal detected in net ID: {net_id}")
 
     # Get project ID from central hub project ID
@@ -225,9 +225,9 @@ def unzip_file(zip_path: str, extract_dir: str, new_name: str):
     with zipfile.ZipFile(zip_path, "r") as zip_ref:
         for member in zip_ref.namelist():
             member_path = os.path.realpath(os.path.join(extract_dir_abs, member))
-            if os.path.commonpath([extract_dir_abs, member_path]) != extract_dir_abs:
+            if not member_path.startswith(extract_dir_abs + os.sep):
                 raise ValueError(f"Attempted path traversal in ZIP entry: {member}")
-        zip_ref.extractall(extract_dir_abs)
+            zip_ref.extract(member, extract_dir_abs)
 
     # Rename the extracted directory
     extracted_dir = os.path.join(extract_dir_abs, Path(zip_path).stem)

--- a/trust/imaging-api/imaging_api/services/upload.py
+++ b/trust/imaging-api/imaging_api/services/upload.py
@@ -62,16 +62,21 @@ async def upload_data_to_xnat(
 
     Raises:
         FileNotFoundError: If any of the files to be uploaded are not found.
+        ValueError: If the net ID or any file path attempts path traversal outside the upload directory.
     """
     # Get base directory from configuration
     upload_directory = os.path.join(BASE_IMAGES_DOWNLOAD_DIR, net_id, "upload")
+    base_images_download_dir_abs = os.path.realpath(BASE_IMAGES_DOWNLOAD_DIR)
     upload_directory_abs = os.path.realpath(upload_directory)
+
+    if os.path.commonpath([base_images_download_dir_abs, upload_directory_abs]) != base_images_download_dir_abs:
+        raise ValueError(f"Path traversal detected in net ID: {net_id}")
 
     # Verify and build full file paths, rejecting any path traversal attempts
     full_file_paths: list[str] = []
     for file_relative_path in files_relative_paths_to_upload:
         full_path = os.path.realpath(os.path.join(upload_directory_abs, file_relative_path))
-        if not full_path.startswith(upload_directory_abs + os.sep):
+        if os.path.commonpath([upload_directory_abs, full_path]) != upload_directory_abs:
             raise ValueError(f"Path traversal detected in file path: {file_relative_path}")
         full_file_paths.append(full_path)
 

--- a/trust/imaging-api/imaging_api/services/upload.py
+++ b/trust/imaging-api/imaging_api/services/upload.py
@@ -69,14 +69,14 @@ async def upload_data_to_xnat(
     base_images_download_dir_abs = os.path.realpath(BASE_IMAGES_DOWNLOAD_DIR)
     upload_directory_abs = os.path.realpath(upload_directory)
 
-    if os.path.commonpath([base_images_download_dir_abs, upload_directory_abs]) != base_images_download_dir_abs:
+    if not upload_directory_abs.startswith(base_images_download_dir_abs + os.sep):
         raise ValueError(f"Path traversal detected in net ID: {net_id}")
 
     # Verify and build full file paths, rejecting any path traversal attempts
     full_file_paths: list[str] = []
     for file_relative_path in files_relative_paths_to_upload:
         full_path = os.path.realpath(os.path.join(upload_directory_abs, file_relative_path))
-        if os.path.commonpath([upload_directory_abs, full_path]) != upload_directory_abs:
+        if not full_path.startswith(upload_directory_abs + os.sep):
             raise ValueError(f"Path traversal detected in file path: {file_relative_path}")
         full_file_paths.append(full_path)
 

--- a/trust/imaging-api/imaging_api/services/upload.py
+++ b/trust/imaging-api/imaging_api/services/upload.py
@@ -65,11 +65,14 @@ async def upload_data_to_xnat(
     """
     # Get base directory from configuration
     upload_directory = os.path.join(BASE_IMAGES_DOWNLOAD_DIR, net_id, "upload")
+    upload_directory_abs = os.path.realpath(upload_directory)
 
-    # Verify and build full file paths
+    # Verify and build full file paths, rejecting any path traversal attempts
     full_file_paths: list[str] = []
     for file_relative_path in files_relative_paths_to_upload:
-        full_path = os.path.join(upload_directory, file_relative_path)
+        full_path = os.path.realpath(os.path.join(upload_directory_abs, file_relative_path))
+        if not full_path.startswith(upload_directory_abs + os.sep):
+            raise ValueError(f"Path traversal detected in file path: {file_relative_path}")
         full_file_paths.append(full_path)
 
     # Check files exist

--- a/trust/imaging-api/tests/routers/test_download.py
+++ b/trust/imaging-api/tests/routers/test_download.py
@@ -50,6 +50,21 @@ def test_download_images_not_found(client):
     assert "Resource not found" in response.json()["detail"]
 
 
+def test_download_images_invalid_request(client):
+    with (
+        patch("imaging_api.routers.download.decrypt", return_value="decrypted-project-id"),
+        patch(
+            "imaging_api.routers.download.download_and_unzip_images",
+            new_callable=AsyncMock,
+            side_effect=ValueError("Attempted path traversal in ZIP entry: ../evil.txt"),
+        ),
+    ):
+        response = client.post("/download/images/net1", json=_REQUEST_BODY)
+
+    assert response.status_code == 400
+    assert "Invalid download request" in response.json()["detail"]
+
+
 def test_download_images_decrypt_failure(client):
     with patch("imaging_api.routers.download.decrypt", side_effect=Exception("bad key")):
         response = client.post("/download/images/net1", json=_REQUEST_BODY)

--- a/trust/imaging-api/tests/routers/test_upload.py
+++ b/trust/imaging-api/tests/routers/test_upload.py
@@ -62,6 +62,21 @@ def test_upload_data_not_found(client):
     assert "Resource not found" in response.json()["detail"]
 
 
+def test_upload_data_invalid_request(client):
+    with (
+        patch("imaging_api.routers.upload.decrypt", return_value="decrypted-project-id"),
+        patch(
+            "imaging_api.routers.upload.upload_data_to_xnat",
+            new_callable=AsyncMock,
+            side_effect=ValueError("Path traversal detected in net ID: ../escape"),
+        ),
+    ):
+        response = client.put("/upload/images/net1", json=_REQUEST_BODY)
+
+    assert response.status_code == 400
+    assert "Invalid upload request" in response.json()["detail"]
+
+
 def test_upload_data_server_error(client):
     with (
         patch("imaging_api.routers.upload.decrypt", return_value="decrypted-project-id"),

--- a/trust/imaging-api/tests/services/test_download.py
+++ b/trust/imaging-api/tests/services/test_download.py
@@ -232,3 +232,9 @@ class TestDownloadAndUnzipImages:
 
         with pytest.raises(NotFoundError, match="File not found at"):
             await download_and_unzip_images("hub-proj-1", "ACC1", "net1", "scan", "NIFTI", headers)
+
+    @pytest.mark.asyncio
+    async def test_net_id_path_traversal_is_rejected(self, headers):
+        with patch("imaging_api.services.download.BASE_IMAGES_DOWNLOAD_DIR", "/tmp/base"):
+            with pytest.raises(ValueError, match="Path traversal detected in net ID"):
+                await download_and_unzip_images("hub-proj-1", "ACC1", "../escape", "scan", "NIFTI", headers)

--- a/trust/imaging-api/tests/services/test_download.py
+++ b/trust/imaging-api/tests/services/test_download.py
@@ -115,6 +115,18 @@ class TestUnzipFile:
         with pytest.raises(FileNotFoundError, match="ZIP file not found"):
             unzip_file("/nonexistent/path.zip", "/tmp", "test")
 
+    def test_zip_slip_entry_raises_value_error(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            zip_path = os.path.join(tmp_dir, "malicious.zip")
+
+            with zipfile.ZipFile(zip_path, "w") as zf:
+                zf.writestr("../evil.txt", "bad")
+
+            with pytest.raises(ValueError, match="Attempted path traversal in ZIP entry"):
+                unzip_file(zip_path, tmp_dir, "ACC123")
+
+            assert os.path.exists(zip_path)
+
 
 # ── download_and_unzip_images ──
 

--- a/trust/imaging-api/tests/services/test_upload.py
+++ b/trust/imaging-api/tests/services/test_upload.py
@@ -221,6 +221,22 @@ class TestUploadDataToXnat:
                     )
 
     @pytest.mark.asyncio
+    async def test_net_id_path_traversal_is_rejected(self, headers):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            with patch("imaging_api.services.upload.BASE_IMAGES_DOWNLOAD_DIR", tmp_dir):
+                with pytest.raises(ValueError, match="Path traversal detected in net ID"):
+                    await upload_data_to_xnat(
+                        central_hub_project_id="hub-proj-1",
+                        accession_id="ACC123",
+                        net_id="../escape",
+                        scan_id="SCAN1",
+                        resource_id="NIFTI",
+                        files_relative_paths_to_upload=["scan.nii"],
+                        exist_ok=False,
+                        headers=headers,
+                    )
+
+    @pytest.mark.asyncio
     @patch("imaging_api.services.upload.upload_file_to_xnat")
     @patch("imaging_api.services.upload.create_xnat_resource")
     @patch("imaging_api.services.upload.create_xnat_scan")


### PR DESCRIPTION
<!--
Copyright (c) 2026 Guy's and St Thomas' NHS Foundation Trust & King's College London
Licensed under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at
    http://www.apache.org/licenses/LICENSE-2.0
Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
-->

# Description

Remediates all open GitHub CodeQL code scanning alerts across three vulnerability classes: GitHub Actions script injection, Python path traversal, and Python zip slip.

## Linked Issues

Fixes #

## CVEs / Code Scanning Vulnerabilities Addressed

### 1. GitHub Actions Script Injection — CWE-78 (`actions/script-injection`)

**Affected files (9):**
- `.github/workflows/validate_branch_origin.yml`
- `.github/workflows/docker_build_flip_api.yml`
- `.github/workflows/docker_build_flip_ui.yml`
- `.github/workflows/docker_build_orthanc.yml`
- `.github/workflows/docker_build_trust_data_access_api.yml`
- `.github/workflows/docker_build_trust_imaging_api.yml`
- `.github/workflows/docker_build_trust_trust_api.yml`
- `.github/workflows/docker_build_xnat_db.yml`
- `.github/workflows/docker_build_xnat_nginx.yml`
- `.github/workflows/docker_build_xnat_web.yml`

**Description:** User-controllable GitHub context expressions were interpolated directly into `run:` shell steps via `${{ ... }}` template syntax. An attacker who can create a branch with a crafted name (e.g. containing `` `$(cmd)` `` or `"; cmd #`) could execute arbitrary shell commands in the CI runner.

Injected context values: `github.ref_name`, `github.head_ref`, `github.base_ref`, `github.event_name`, `github.ref`, `github.event.workflow_run.event`, `github.event.workflow_run.head_branch`.

Additionally, `eval $BUILD_CMD` was used to construct docker build commands, which is inherently unsafe.

**Fix:**
- All user-controllable context values moved to `env:` blocks so they reach the shell as environment variables (not template-expanded shell code).
- `eval $BUILD_CMD` replaced with a safe array-based `docker build $BUILD_ARGS "${TAG_FLAGS[@]}" .` invocation.
- `${{ steps.tags.outputs.tags }}` in build/push steps also moved to `env: DOCKER_TAGS`.

---

### 2. Python Path Traversal — CWE-23 (`py/path-injection`)

**Affected file:** `trust/imaging-api/imaging_api/services/upload.py`

**Description:** Relative paths from the `files_relative_paths_to_upload` list were joined with `os.path.join()` without validation, allowing traversal sequences such as `../../etc/passwd` to escape the intended upload directory.

**Fix:** Each resolved path is validated with `os.path.realpath()` to confirm it remains within the upload directory boundary before appending to `full_file_paths`. Raises `ValueError` on traversal attempt.

---

### 3. Python Zip Slip — CWE-22 (`py/zipslip`)

**Affected file:** `trust/imaging-api/imaging_api/services/download.py`

**Description:** `zipfile.ZipFile.extractall()` was called without validating ZIP entry names. A maliciously crafted ZIP containing entries like `../../etc/cron.d/malicious` could extract files outside the intended extraction directory.

**Fix:** All ZIP member names are validated via `os.path.realpath()` against the extraction directory boundary before `extractall()` is called. Raises `ValueError` if any entry would escape the directory.

---

> **Note:** No CVE numbers are assigned to these findings — they are code-level vulnerabilities detected by GitHub CodeQL static analysis, not third-party library issues. Relevant identifiers: CWE-78 (OS Command Injection), CWE-22/CWE-23 (Path Traversal).

## Checklist

- [x] Follows the project's coding conventions and style guide
- [ ] Updates documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Type of Change

- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make -C docs/ docs`.

## Testing

I did the following tests to verify my changes:

- [x] Quick tests passed locally by running `make unit_test` — imaging-api: **209 passed**.
- [ ] Integration tests pass (if applicable) by running `make integration-test`.

## Additional Notes

The GitHub Actions fixes follow the [GitHub security hardening guidance](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#understanding-the-risk-of-script-injections) for preventing script injection by using `env:` context passing instead of inline template expressions in `run:` blocks.