### PR TITLE
279 bug no email title in light mode

### DIFF
--- a/deploy/providers/AWS/templates/cognito/invite.html
+++ b/deploy/providers/AWS/templates/cognito/invite.html
@@ -23,7 +23,7 @@
       <td style="padding: 40px 20px;">
         <!-- Main container -->
         <table cellpadding="0" cellspacing="0" width="100%" style="max-width: 600px; margin: 0 auto; background-color: #ffffff; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); overflow: hidden;">
-          <!-- Header with gradient background -->
+          <!-- Header with gradient background and solid purple fallback -->
           <tr>
             <td bgcolor="#61366e" style="background-color: #61366e; background-image: linear-gradient(135deg, #61366e 0%, #9452A8 100%); padding: 30px;">
               <table cellpadding="0" cellspacing="0" width="100%">

--- a/deploy/providers/AWS/templates/cognito/invite.html
+++ b/deploy/providers/AWS/templates/cognito/invite.html
@@ -25,7 +25,7 @@
         <table cellpadding="0" cellspacing="0" width="100%" style="max-width: 600px; margin: 0 auto; background-color: #ffffff; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); overflow: hidden;">
           <!-- Header with gradient background -->
           <tr>
-            <td style="background: linear-gradient(135deg, #61366e 0%, #9452A8 100%); padding: 30px;">
+            <td bgcolor="#61366e" style="background-color: #61366e; background-image: linear-gradient(135deg, #61366e 0%, #9452A8 100%); padding: 30px;">
               <table cellpadding="0" cellspacing="0" width="100%">
                 <tr>
                   <td style="width: 80px; vertical-align: middle;">

--- a/deploy/providers/AWS/templates/cognito/password_reset_code.html
+++ b/deploy/providers/AWS/templates/cognito/password_reset_code.html
@@ -23,7 +23,7 @@
       <td style="padding: 40px 20px;">
         <!-- Main container -->
         <table cellpadding="0" cellspacing="0" width="100%" style="max-width: 600px; margin: 0 auto; background-color: #ffffff; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); overflow: hidden;">
-          <!-- Header with gradient background -->
+          <!-- Header with gradient background and solid purple fallback -->
           <tr>
             <td bgcolor="#61366e" style="background-color: #61366e; background-image: linear-gradient(135deg, #61366e 0%, #9452A8 100%); padding: 30px;">
               <table cellpadding="0" cellspacing="0" width="100%">

--- a/deploy/providers/AWS/templates/cognito/password_reset_code.html
+++ b/deploy/providers/AWS/templates/cognito/password_reset_code.html
@@ -25,7 +25,7 @@
         <table cellpadding="0" cellspacing="0" width="100%" style="max-width: 600px; margin: 0 auto; background-color: #ffffff; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); overflow: hidden;">
           <!-- Header with gradient background -->
           <tr>
-            <td style="background: linear-gradient(135deg, #61366e 0%, #9452A8 100%); padding: 30px;">
+            <td bgcolor="#61366e" style="background-color: #61366e; background-image: linear-gradient(135deg, #61366e 0%, #9452A8 100%); padding: 30px;">
               <table cellpadding="0" cellspacing="0" width="100%">
                 <tr>
                   <td style="width: 80px; vertical-align: middle;">

--- a/deploy/providers/AWS/templates/cognito/password_reset_link.html
+++ b/deploy/providers/AWS/templates/cognito/password_reset_link.html
@@ -23,7 +23,7 @@
       <td style="padding: 40px 20px;">
         <!-- Main container -->
         <table cellpadding="0" cellspacing="0" width="100%" style="max-width: 600px; margin: 0 auto; background-color: #ffffff; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); overflow: hidden;">
-          <!-- Header with gradient background -->
+          <!-- Header with gradient background and solid purple fallback -->
           <tr>
             <td bgcolor="#61366e" style="background-color: #61366e; background-image: linear-gradient(135deg, #61366e 0%, #9452A8 100%); padding: 30px;">
               <table cellpadding="0" cellspacing="0" width="100%">

--- a/deploy/providers/AWS/templates/cognito/password_reset_link.html
+++ b/deploy/providers/AWS/templates/cognito/password_reset_link.html
@@ -25,7 +25,7 @@
         <table cellpadding="0" cellspacing="0" width="100%" style="max-width: 600px; margin: 0 auto; background-color: #ffffff; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); overflow: hidden;">
           <!-- Header with gradient background -->
           <tr>
-            <td style="background: linear-gradient(135deg, #61366e 0%, #9452A8 100%); padding: 30px;">
+            <td bgcolor="#61366e" style="background-color: #61366e; background-image: linear-gradient(135deg, #61366e 0%, #9452A8 100%); padding: 30px;">
               <table cellpadding="0" cellspacing="0" width="100%">
                 <tr>
                   <td style="width: 80px; vertical-align: middle;">

--- a/deploy/providers/AWS/templates/ses/flip-access-request.html
+++ b/deploy/providers/AWS/templates/ses/flip-access-request.html
@@ -23,7 +23,7 @@
       <td style="padding: 40px 20px;">
         <!-- Main container -->
         <table cellpadding="0" cellspacing="0" width="100%" style="max-width: 600px; margin: 0 auto; background-color: #ffffff; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); overflow: hidden;">
-          <!-- Header with gradient background -->
+          <!-- Header with gradient background and solid purple fallback -->
           <tr>
             <td bgcolor="#61366e" style="background-color: #61366e; background-image: linear-gradient(135deg, #61366e 0%, #9452A8 100%); padding: 30px;">
               <table cellpadding="0" cellspacing="0" width="100%">

--- a/deploy/providers/AWS/templates/ses/flip-access-request.html
+++ b/deploy/providers/AWS/templates/ses/flip-access-request.html
@@ -25,7 +25,7 @@
         <table cellpadding="0" cellspacing="0" width="100%" style="max-width: 600px; margin: 0 auto; background-color: #ffffff; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); overflow: hidden;">
           <!-- Header with gradient background -->
           <tr>
-            <td style="background: linear-gradient(135deg, #61366e 0%, #9452A8 100%); padding: 30px;">
+            <td bgcolor="#61366e" style="background-color: #61366e; background-image: linear-gradient(135deg, #61366e 0%, #9452A8 100%); padding: 30px;">
               <table cellpadding="0" cellspacing="0" width="100%">
                 <tr>
                   <td style="width: 80px; vertical-align: middle;">

--- a/deploy/providers/AWS/templates/ses/flip-xnat-added-to-project.html
+++ b/deploy/providers/AWS/templates/ses/flip-xnat-added-to-project.html
@@ -23,7 +23,7 @@
       <td style="padding: 40px 20px;">
         <!-- Main container -->
         <table cellpadding="0" cellspacing="0" width="100%" style="max-width: 600px; margin: 0 auto; background-color: #ffffff; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); overflow: hidden;">
-          <!-- Header with gradient background -->
+          <!-- Header with gradient background and solid purple fallback -->
           <tr>
             <td bgcolor="#61366e" style="background-color: #61366e; background-image: linear-gradient(135deg, #61366e 0%, #9452A8 100%); padding: 30px;">
               <table cellpadding="0" cellspacing="0" width="100%">

--- a/deploy/providers/AWS/templates/ses/flip-xnat-added-to-project.html
+++ b/deploy/providers/AWS/templates/ses/flip-xnat-added-to-project.html
@@ -25,7 +25,7 @@
         <table cellpadding="0" cellspacing="0" width="100%" style="max-width: 600px; margin: 0 auto; background-color: #ffffff; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); overflow: hidden;">
           <!-- Header with gradient background -->
           <tr>
-            <td style="background: linear-gradient(135deg, #61366e 0%, #9452A8 100%); padding: 30px;">
+            <td bgcolor="#61366e" style="background-color: #61366e; background-image: linear-gradient(135deg, #61366e 0%, #9452A8 100%); padding: 30px;">
               <table cellpadding="0" cellspacing="0" width="100%">
                 <tr>
                   <td style="width: 80px; vertical-align: middle;">

--- a/deploy/providers/AWS/templates/ses/flip-xnat-credentials.html
+++ b/deploy/providers/AWS/templates/ses/flip-xnat-credentials.html
@@ -23,7 +23,7 @@
       <td style="padding: 40px 20px;">
         <!-- Main container -->
         <table cellpadding="0" cellspacing="0" width="100%" style="max-width: 600px; margin: 0 auto; background-color: #ffffff; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); overflow: hidden;">
-          <!-- Header with gradient background -->
+          <!-- Header with gradient background and solid purple fallback -->
           <tr>
             <td bgcolor="#61366e" style="background-color: #61366e; background-image: linear-gradient(135deg, #61366e 0%, #9452A8 100%); padding: 30px;">
               <table cellpadding="0" cellspacing="0" width="100%">

--- a/deploy/providers/AWS/templates/ses/flip-xnat-credentials.html
+++ b/deploy/providers/AWS/templates/ses/flip-xnat-credentials.html
@@ -25,7 +25,7 @@
         <table cellpadding="0" cellspacing="0" width="100%" style="max-width: 600px; margin: 0 auto; background-color: #ffffff; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); overflow: hidden;">
           <!-- Header with gradient background -->
           <tr>
-            <td style="background: linear-gradient(135deg, #61366e 0%, #9452A8 100%); padding: 30px;">
+            <td bgcolor="#61366e" style="background-color: #61366e; background-image: linear-gradient(135deg, #61366e 0%, #9452A8 100%); padding: 30px;">
               <table cellpadding="0" cellspacing="0" width="100%">
                 <tr>
                   <td style="width: 80px; vertical-align: middle;">


### PR DESCRIPTION
Outlook couldn't render the CSS linear gradient and used the background color by default (white or black  depending on light/dark mode) -- now we set a background color to default to a similar color to the gradient, for a similar experience across email provider.

Before

| Outlook Dark mode 🤨 | Outlook Light mode 🤨 | Gmail Light mode ✅ |
|-------------|------------------------|---------------------|
| <img src="https://github.com/user-attachments/assets/0ebb4d7a-f368-459a-8be4-7ce57cf4d4dd" width="250"/> | <img src="https://github.com/user-attachments/assets/0bd6b623-e134-4d90-82d2-8fdafc68cc0e" width="250"/> | <img src="https://github.com/user-attachments/assets/e5ef478e-fb81-4667-9266-0e760d51fedd" width="250"/> |

After

| Outlook Dark mode ✅ | Outlook Light mode ✅ | Gmail Light mode ✅ |
|-------------|------------------------|---------------------|
| <img src="https://github.com/user-attachments/assets/cffc6241-370b-463c-a2a3-74ff85575c3f" width="250" /> | <img  src="https://github.com/user-attachments/assets/545afcad-c4b3-4e6d-a6b3-641fffa739f3" width="250" /> | <img  src="https://github.com/user-attachments/assets/c0a56ff8-7eeb-4295-9b25-c92918e8df9c" width="250" /> |




