### PR TITLE
feat(aws): gate EC2 key pair, migrate Ansible to aws_ssm (follow-up to #253)

### DIFF
--- a/deploy/providers/AWS/Makefile
+++ b/deploy/providers/AWS/Makefile
@@ -204,17 +204,45 @@ ansible-init: ## Initialize Ansible configuration on EC2 instances (if failed tr
 	@uv run ansible-galaxy install -r requirements.yml
 	@uv run ansible-playbook site.yml -e flip_aicentre_bucket=$(AICENTRE_BUCKET_NAME) -e fl_kit_date=$(FL_KIT_DATE) -e pgdata_archive=trust1_pgdata_20260106.tar.gz
 
+.PHONY: logs
+logs: check-ssm-ready ## Stream docker logs for a container on Central Hub via SSM. Usage: make logs CONTAINER=flip-api [HOST=centralhub|trust] [TAIL=200]
+	@target_output=Ec2InstanceId; \
+	if [ "$(HOST)" = "trust" ]; then target_output=TrustEc2InstanceId; fi; \
+	instance=$$(terraform output -raw $$target_output); \
+	if [ -z "$(CONTAINER)" ]; then echo "❌ CONTAINER is required. Usage: make logs CONTAINER=<name> [HOST=centralhub|trust] [TAIL=200]"; exit 1; fi; \
+	echo "📜 Streaming logs from $(CONTAINER) on $$instance (Ctrl+C to stop)..."; \
+	aws ssm start-session --target $$instance \
+		--document-name AWS-StartInteractiveCommand \
+		--parameters "command=[\"docker logs -f --tail=$${TAIL:-200} $(CONTAINER)\"]"
+
+.PHONY: shell
+shell: check-ssm-ready ## Open an interactive SSM shell on Central Hub (or HOST=trust)
+	@target_output=Ec2InstanceId; \
+	if [ "$(HOST)" = "trust" ]; then target_output=TrustEc2InstanceId; fi; \
+	instance=$$(terraform output -raw $$target_output); \
+	echo "🐚 Opening SSM shell on $$instance (exit to close)..."; \
+	aws ssm start-session --target $$instance
+
 .PHONY: check-deploy-centralhub
-check-deploy-centralhub: ## Dry-run Ansible against Central Hub (verifies community.aws.aws_ssm connection without mutations)
+check-deploy-centralhub: ## Dry-run Ansible deploy_centralhub play (verifies community.aws.aws_ssm connection + sync without mutations)
 	@test -n "$(FL_KIT_DATE)" || (echo "FL_KIT_DATE must be set in $(MAIN_ENV_FILE)"; exit 1)
-	@uv run ansible-playbook site.yml -C \
+	@DOCKER_TAG=$(DOCKER_TAG) DOCKER_FL_TAG=$(DOCKER_FL_TAG) FL_BACKEND=$(FL_BACKEND) \
+		uv run ansible-playbook site.yml --tags deploy_centralhub -C \
 		-e flip_aicentre_bucket=$(AICENTRE_BUCKET_NAME) \
 		-e fl_kit_date=$(FL_KIT_DATE) \
-		-e pgdata_archive=trust1_pgdata_20260106.tar.gz \
-		-l 'localhost,flip'
+		-e pgdata_archive=trust1_pgdata_20260106.tar.gz
+
+.PHONY: check-deploy-trust
+check-deploy-trust: ## Dry-run Ansible deploy_trust play (verifies community.aws.aws_ssm connection + sync without mutations)
+	@test -n "$(FL_KIT_DATE)" || (echo "FL_KIT_DATE must be set in $(MAIN_ENV_FILE)"; exit 1)
+	@DOCKER_TAG=$(DOCKER_TAG) DOCKER_FL_TAG=$(DOCKER_FL_TAG) FL_BACKEND=$(FL_BACKEND) TRUST_NAME=Trust_1 \
+		uv run ansible-playbook site.yml --tags deploy_trust -C \
+		-e flip_aicentre_bucket=$(AICENTRE_BUCKET_NAME) \
+		-e fl_kit_date=$(FL_KIT_DATE) \
+		-e pgdata_archive=trust1_pgdata_20260106.tar.gz
 
 .PHONY: deploy-centralhub
-deploy-centralhub: ssh-config ## Deploy FLIP containers to flip context with environment from Terraform
+deploy-centralhub: check-ssm-ready ## Deploy FLIP Central Hub services via Ansible-over-SSM (no SSH key required)
 	@echo "🔍 Checking central hub images (tag: $(DOCKER_TAG))..."
 	@missing=false; \
 	for image in $(CENTRALHUB_IMAGES); do \
@@ -230,20 +258,14 @@ deploy-centralhub: ssh-config ## Deploy FLIP containers to flip context with env
 	else \
 	  echo "   ✅ All central hub images found."; \
 	fi
-	@echo "📋 Loading environment variables from Terraform outputs..."
-	@echo "👷 Create docker context if not exists, pointing to flip to ssh://flip"
-	@docker context create flip --docker "host=ssh://flip" || echo "   Context 'flip' already exists"
-	@# Switch to flip context
-	@echo "🔄 Switching to flip Docker context..."
-	@docker context use flip
-	@echo "🧹 Stopping old containers and removing unused images to free disk space..."
-	@docker stop $$(docker ps -aq) 2>/dev/null || true
-	@docker rm $$(docker ps -aq) 2>/dev/null || true
-	@docker image prune -af
-	@echo "🐳 Deploying containers..."
-	@$(MAKE) -C ../../../ up-centralhub-ec2 PROD=${PROD}
-	@echo "✅ Deployment complete!"
-	@docker context use default
+	@echo "📋 Running Ansible deploy-centralhub play via aws_ssm connection..."
+	@uv run ansible-galaxy install -r requirements.yml >/dev/null
+	@DOCKER_TAG=$(DOCKER_TAG) DOCKER_FL_TAG=$(DOCKER_FL_TAG) FL_BACKEND=$(FL_BACKEND) \
+		uv run ansible-playbook site.yml --tags deploy_centralhub \
+		-e flip_aicentre_bucket=$(AICENTRE_BUCKET_NAME) \
+		-e fl_kit_date=$(FL_KIT_DATE) \
+		-e pgdata_archive=trust1_pgdata_20260106.tar.gz
+	@echo "✅ Central Hub deployment complete!"
 
 # Default SSH user for on-premises trust hosts (override with LOCAL_TRUST_SSH_USER=<user>)
 LOCAL_TRUST_SSH_USER ?= ubuntu
@@ -251,7 +273,7 @@ LOCAL_TRUST_SSH_USER ?= ubuntu
 LOCAL_TRUST_NAME ?= Trust_2
 
 .PHONY: deploy-trust
-deploy-trust: ssh-config update-env ## Deploy trust relationships after central hub is deployed
+deploy-trust: check-ssm-ready update-env ## Deploy FLIP Trust services via Ansible-over-SSM (no SSH key required)
 	@echo "🔍 Checking trust images (tag: $(DOCKER_TAG))..."
 	@missing=false; \
 	for image in $(TRUST_IMAGES); do \
@@ -267,20 +289,13 @@ deploy-trust: ssh-config update-env ## Deploy trust relationships after central 
 	else \
 	  echo "   ✅ All trust images found."; \
 	fi
-	@echo "👷 Create docker context if not exists, pointing to flip-trust to ssh://flip-trust"
-	@docker context create flip-trust --docker "host=ssh://flip-trust" || echo "   Context 'flip-trust' already exists"
-	@echo "🔄 Switching to flip-trust Docker context..."
-	@docker context use flip-trust
-	@echo "🐳 Deploying containers to Trust EC2 ..."
-	docker swarm init || echo "   Swarm already initialized"
-	@echo "🔧 Creating Docker networks on Trust EC2..."
-	$(MAKE) -C ../../../ create-networks
-	@echo "🧹 Stopping old containers and removing unused images to free disk space..."
-	@docker stop $$(docker ps -aq) 2>/dev/null || true
-	@docker rm $$(docker ps -aq) 2>/dev/null || true
-	@docker image prune -af
-	@echo "🚀 Deploying Trust services..."
-	$(MAKE) -C ../../../ up-trust-ec2 PROD=${PROD}
+	@echo "📋 Running Ansible deploy-trust play via aws_ssm connection..."
+	@uv run ansible-galaxy install -r requirements.yml >/dev/null
+	@DOCKER_TAG=$(DOCKER_TAG) DOCKER_FL_TAG=$(DOCKER_FL_TAG) FL_BACKEND=$(FL_BACKEND) TRUST_NAME=Trust_1 \
+		uv run ansible-playbook site.yml --tags deploy_trust \
+		-e flip_aicentre_bucket=$(AICENTRE_BUCKET_NAME) \
+		-e fl_kit_date=$(FL_KIT_DATE) \
+		-e pgdata_archive=trust1_pgdata_20260106.tar.gz
 	@echo "✅ Trust deployment complete!"
 
 .PHONY: add-local-trust

--- a/deploy/providers/AWS/Makefile
+++ b/deploy/providers/AWS/Makefile
@@ -98,8 +98,7 @@ check-ssm-ready: ## Verify SSM Session Manager prerequisites are installed
 	@echo "🔍 Checking SSM Session Manager prerequisites..."
 	@command -v aws >/dev/null 2>&1 || { echo "❌ AWS CLI not found. Install: brew install awscli or apt-get install awscli"; exit 1; }
 	@session-manager-plugin --version >/dev/null 2>&1 || { echo "❌ Session Manager plugin not found. Install: brew install session-manager-plugin (macOS) or see README.md"; exit 1; }
-	@ssh-add -l >/dev/null 2>&1 || echo "⚠️  SSH agent has no keys (this is OK, SSM uses AWS credentials instead)"
-	@[ -f ~/.ssh/host-aws ] || { echo "⚠️  SSH key ~/.ssh/host-aws not found (will be needed for Ansible)"; }
+	@aws sts get-caller-identity --profile $${AWS_PROFILE} >/dev/null 2>&1 || { echo "❌ AWS credentials not valid for profile $${AWS_PROFILE}. Run: aws sso login --profile $${AWS_PROFILE}"; exit 1; }
 	@echo "✅ SSM prerequisites verified!"
 
 prettier:
@@ -204,6 +203,15 @@ ansible-init: ## Initialize Ansible configuration on EC2 instances (if failed tr
 	@uv sync
 	@uv run ansible-galaxy install -r requirements.yml
 	@uv run ansible-playbook site.yml -e flip_aicentre_bucket=$(AICENTRE_BUCKET_NAME) -e fl_kit_date=$(FL_KIT_DATE) -e pgdata_archive=trust1_pgdata_20260106.tar.gz
+
+.PHONY: check-deploy-centralhub
+check-deploy-centralhub: ## Dry-run Ansible against Central Hub (verifies community.aws.aws_ssm connection without mutations)
+	@test -n "$(FL_KIT_DATE)" || (echo "FL_KIT_DATE must be set in $(MAIN_ENV_FILE)"; exit 1)
+	@uv run ansible-playbook site.yml -C \
+		-e flip_aicentre_bucket=$(AICENTRE_BUCKET_NAME) \
+		-e fl_kit_date=$(FL_KIT_DATE) \
+		-e pgdata_archive=trust1_pgdata_20260106.tar.gz \
+		-l 'localhost,flip'
 
 .PHONY: deploy-centralhub
 deploy-centralhub: ssh-config ## Deploy FLIP containers to flip context with environment from Terraform

--- a/deploy/providers/AWS/README.md
+++ b/deploy/providers/AWS/README.md
@@ -31,7 +31,7 @@ In both models, trusts poll the Central Hub for tasks over HTTPS — all communi
 3. **Python 3.12+**
 4. **UV environment manager** installed via [uv installation guide](https://docs.astral.sh/uv/guides/install-python/)
 5. **GitHub CLI** installed via [GitHub CLI installation guide](https://cli.github.com/)
-6. **SSH key pair** at `~/.ssh/host-aws` — **required for `make deploy-centralhub` / `make deploy-trust`** (they use Docker-over-SSH). Can be skipped only if you never run the deploy targets and stay on native SSM / Ansible (see [What works today without an EC2 key pair](#what-works-today-without-an-ec2-key-pair) and [Optional: SSH over SSM](#optional-ssh-over-ssm-required-for-make-deploy-)).
+6. **(Optional) SSH key pair** at `~/.ssh/host-aws` — only needed if you opt into the legacy SSH-over-SSM path (`TF_VAR_enable_ssh_key_pair=true`). All primary workflows (interactive shell, Ansible, `make deploy-*`, `make logs`) go through AWS SSM using just IAM credentials — no SSH key required.
 7. **Environment files** configured: (see [deploy README](../../README.md))
    - `.env.stag` (staging) or `.env.production` (production) in project root
    - Service-specific `.env` files (see Environment Configuration section)
@@ -429,24 +429,20 @@ EC2 instances are accessed through AWS Systems Manager Session Manager — port 
 
 - Your IAM identity needs `ssm:StartSession`, `ssm:TerminateSession`, and `ssm:SendCommand` on the target instance. `FlipDeveloperAccess-*` SSO profiles already include this.
 
-#### Deploy workflows: `enable_ssh_key_pair` is required
+#### Default workflows (no SSH key required)
 
-`make deploy-centralhub` and `make deploy-trust` orchestrate the remote Docker daemon via a Docker-over-SSH context (`docker context create flip --docker "host=ssh://flip"`). Docker-over-SSH authenticates at the SSH layer, so the EC2 key pair and the matching `~/.ssh/host-aws` private key are still required for the full deploy flow. For these workflows set `TF_VAR_enable_ssh_key_pair=true` (the default for existing stag/prod env files).
+All primary operator workflows authenticate through AWS SSM using your AWS credentials:
 
-Migrating `make deploy-*` off Docker-over-SSH (e.g. to an Ansible-driven `docker compose up` run on the instance via the aws_ssm connection) is planned as a follow-up — it would eliminate the last hard dependency on the key pair.
+- **Interactive shell** — `make shell` (Central Hub) or `make shell HOST=trust`. Equivalent to `aws ssm start-session --target <instance-id>`. CloudTrail-audited.
+- **Container logs** — `make logs CONTAINER=flip-api` streams `docker logs -f` via an SSM session. `make logs CONTAINER=xnat-web HOST=trust TAIL=500` for the trust side.
+- **Deploys** — `make deploy-centralhub` and `make deploy-trust` now run Ansible with the `community.aws.aws_ssm` connection plugin. Ansible syncs compose files + `.env.production` to `/opt/flip/` on the EC2 and runs `docker compose up -d --pull always` there. No Docker-over-SSH, no `~/.ssh/host-aws`.
+- **Docker daemon logs** — containers forward stdout/stderr to CloudWatch Logs (`/aws/ec2/flip` log group) via the `awslogs` Docker log driver that Ansible installs in `/etc/docker/daemon.json`. Stream from anywhere: `aws logs tail /aws/ec2/flip --follow --filter-pattern "<service>"`.
 
-#### What works today without an EC2 key pair
+A developer with AWS SSO access to the account can do all of the above without anyone distributing a private key.
 
-Setting `TF_VAR_enable_ssh_key_pair=false` is fine if your workflow is limited to:
+#### Optional: SSH over SSM (legacy)
 
-- **Interactive shell** via `aws ssm start-session --target <instance-id>` — no SSH key needed; IAM-gated, CloudTrail-audited.
-- **Ansible-driven tasks** (`make ansible-init`, `make check-deploy-centralhub`, ad-hoc `ansible-playbook` runs) — `site.yml` uses the `community.aws.aws_ssm` connection plugin, authenticated by your AWS credentials, with file transfer staged through the `AnsibleSsmBucketName` S3 bucket.
-
-Both paths bypass SSH entirely, so a developer with AWS SSO access can use them without anyone distributing a private key.
-
-#### Optional: SSH over SSM (required for `make deploy-*`)
-
-When `TF_VAR_enable_ssh_key_pair=true`, `make ssh-config` writes `Host flip` / `Host flip-trust` blocks into `~/.ssh/config` that tunnel SSH through SSM:
+`TF_VAR_enable_ssh_key_pair=true` is retained for operators who still want SSH-level access (`scp`, `docker context use flip`, `git` over SSH). When enabled, `make ssh-config` writes `Host flip` / `Host flip-trust` blocks into `~/.ssh/config` that tunnel SSH through SSM:
 
 ```text
 # Managed by FLIP - SSH over SSM Session Manager
@@ -462,7 +458,7 @@ Host flip
     ControlPersist 10m
 ```
 
-This path is required for Docker-over-SSH (`make deploy-centralhub`, `make deploy-trust`) and for ergonomic `ssh`/`scp`/`git-over-ssh`. The matching `~/.ssh/host-aws` private key must be distributed out-of-band to every developer who runs the deploy targets.
+Distribute the matching `~/.ssh/host-aws` private key out-of-band to each developer who needs this path. Default is `enable_ssh_key_pair=false` — most workflows do not need it.
 
 **Troubleshooting SSM Access**
 

--- a/deploy/providers/AWS/README.md
+++ b/deploy/providers/AWS/README.md
@@ -31,7 +31,7 @@ In both models, trusts poll the Central Hub for tasks over HTTPS — all communi
 3. **Python 3.12+**
 4. **UV environment manager** installed via [uv installation guide](https://docs.astral.sh/uv/guides/install-python/)
 5. **GitHub CLI** installed via [GitHub CLI installation guide](https://cli.github.com/)
-6. **SSH key pair** created at `~/.ssh/host-aws` (see [deploy README](../../README.md))
+6. **SSH key pair** at `~/.ssh/host-aws` — **required for `make deploy-centralhub` / `make deploy-trust`** (they use Docker-over-SSH). Can be skipped only if you never run the deploy targets and stay on native SSM / Ansible (see [What works today without an EC2 key pair](#what-works-today-without-an-ec2-key-pair) and [Optional: SSH over SSM](#optional-ssh-over-ssm-required-for-make-deploy-)).
 7. **Environment files** configured: (see [deploy README](../../README.md))
    - `.env.stag` (staging) or `.env.production` (production) in project root
    - Service-specific `.env` files (see Environment Configuration section)
@@ -393,7 +393,7 @@ Trust services can run on AWS EC2 or on-premises. Both models use the same Docke
 
 ### Remote Access via SSM Session Manager
 
-EC2 instances are accessed through AWS Systems Manager Session Manager — port 22 is **not** open in any security group. SSH traffic is tunnelled through the SSM agent running on each instance, so no bastion host or inbound firewall rule is needed.
+EC2 instances are accessed through AWS Systems Manager Session Manager — port 22 is **not** open in any security group. Access is IAM-gated and audited via CloudTrail; no shared SSH keys are required.
 
 **Prerequisites**
 
@@ -427,17 +427,26 @@ EC2 instances are accessed through AWS Systems Manager Session Manager — port 
   session-manager-plugin --version  # Should output version >= 1.2.319.0
   ```
 
-- SSH key at `~/.ssh/host-aws` (configured in Step 3 of [Pre-configurations README](../README.md#step-3-get-ssh-key-configured))
+- Your IAM identity needs `ssm:StartSession`, `ssm:TerminateSession`, and `ssm:SendCommand` on the target instance. `FlipDeveloperAccess-*` SSO profiles already include this.
 
-**Updating `~/.ssh/config`**
+#### Deploy workflows: `enable_ssh_key_pair` is required
 
-After `terraform apply`, run:
+`make deploy-centralhub` and `make deploy-trust` orchestrate the remote Docker daemon via a Docker-over-SSH context (`docker context create flip --docker "host=ssh://flip"`). Docker-over-SSH authenticates at the SSH layer, so the EC2 key pair and the matching `~/.ssh/host-aws` private key are still required for the full deploy flow. For these workflows set `TF_VAR_enable_ssh_key_pair=true` (the default for existing stag/prod env files).
 
-```bash
-make ssh-config
-```
+Migrating `make deploy-*` off Docker-over-SSH (e.g. to an Ansible-driven `docker compose up` run on the instance via the aws_ssm connection) is planned as a follow-up — it would eliminate the last hard dependency on the key pair.
 
-This calls `update_ssm_ssh_config.py`, which reads the EC2 instance IDs from Terraform outputs and writes `Host flip` / `Host flip-trust` blocks like the following into `~/.ssh/config`:
+#### What works today without an EC2 key pair
+
+Setting `TF_VAR_enable_ssh_key_pair=false` is fine if your workflow is limited to:
+
+- **Interactive shell** via `aws ssm start-session --target <instance-id>` — no SSH key needed; IAM-gated, CloudTrail-audited.
+- **Ansible-driven tasks** (`make ansible-init`, `make check-deploy-centralhub`, ad-hoc `ansible-playbook` runs) — `site.yml` uses the `community.aws.aws_ssm` connection plugin, authenticated by your AWS credentials, with file transfer staged through the `AnsibleSsmBucketName` S3 bucket.
+
+Both paths bypass SSH entirely, so a developer with AWS SSO access can use them without anyone distributing a private key.
+
+#### Optional: SSH over SSM (required for `make deploy-*`)
+
+When `TF_VAR_enable_ssh_key_pair=true`, `make ssh-config` writes `Host flip` / `Host flip-trust` blocks into `~/.ssh/config` that tunnel SSH through SSM:
 
 ```text
 # Managed by FLIP - SSH over SSM Session Manager
@@ -453,14 +462,7 @@ Host flip
     ControlPersist 10m
 ```
 
-**Connecting**
-
-```bash
-ssh flip        # Central Hub
-ssh flip-trust  # Trust EC2
-```
-
-Both aliases resolve through the SSM tunnel — no public IP or open port 22 is needed. If your AWS session has expired, re-run `aws sso login --profile $AWS_PROFILE` before connecting.
+This path is required for Docker-over-SSH (`make deploy-centralhub`, `make deploy-trust`) and for ergonomic `ssh`/`scp`/`git-over-ssh`. The matching `~/.ssh/host-aws` private key must be distributed out-of-band to every developer who runs the deploy targets.
 
 **Troubleshooting SSM Access**
 
@@ -474,18 +476,7 @@ Both aliases resolve through the SSM tunnel — no public IP or open port 22 is 
 | `Connection timeout` (hanging) | SSM tunnel hangs without error | Check security group allows NLB ingress from NAT Gateway (port 8000-8005); verify instances are running: `aws ec2 describe-instances` |
 | `Unable to connect to SSM endpoint` | Connection fails immediately | Verify AWS_REGION matches deployment region: `echo $AWS_REGION` should match `eu-west-2` (or your region) |
 | `Bad ProxyCommand` in ~/.ssh/config | SSH config syntax error | Re-generate config: `make ssh-config` and verify it looks like the example above |
-
-**Testing Connectivity**
-
-```bash
-# Test SSM session directly (before trying SSH)
-aws ssm start-session --target $(terraform output -raw Ec2InstanceId)
-
-# Should open an interactive shell. Run `uname -a` to verify connectivity, then `exit`.
-
-# Then test SSH
-ssh flip  # Should connect via SSM tunnel
-```
+| Ansible `Connection failure: aws_ssm bucket not set` | Terraform output missing | Run `terraform apply` to create the `flip-ansible-ssm-*` bucket, then retry `make deploy-centralhub` |
 
 ---
 

--- a/deploy/providers/AWS/main.tf
+++ b/deploy/providers/AWS/main.tf
@@ -214,10 +214,16 @@ resource "aws_cloudwatch_log_group" "flip_log_group" {
   retention_in_days = 7
 }
 
-# Key Pair for SSH access
+# Key Pair for SSH access (optional — only created when enable_ssh_key_pair = true)
 resource "aws_key_pair" "flip_keypair" {
+  count      = var.enable_ssh_key_pair ? 1 : 0
   key_name   = "flip-keypair"
   public_key = file(pathexpand("${var.flip_keypair}.pub"))
+}
+
+moved {
+  from = aws_key_pair.flip_keypair
+  to   = aws_key_pair.flip_keypair[0]
 }
 
 # EC2 Instance
@@ -235,7 +241,7 @@ resource "aws_instance" "ec2_instance" {
   ami                         = data.aws_ssm_parameter.ubuntu.value
   vpc_security_group_ids      = [module.ec2_security_group.security_group.id]
   iam_instance_profile        = aws_iam_instance_profile.ec2_profile.name
-  key_name                    = aws_key_pair.flip_keypair.key_name
+  key_name                    = var.enable_ssh_key_pair ? aws_key_pair.flip_keypair[0].key_name : null
   root_block_device {
     volume_size           = 30
     volume_type           = "gp3"
@@ -465,7 +471,8 @@ resource "aws_security_group_rule" "local_trust_fl_server_nlb" {
 
 # Outputs
 output "Keypair" {
-  value = var.flip_keypair
+  description = "Name of the EC2 key pair (empty when enable_ssh_key_pair = false)"
+  value       = var.enable_ssh_key_pair ? aws_key_pair.flip_keypair[0].key_name : ""
 }
 
 output "Ec2InstanceId" {
@@ -566,7 +573,7 @@ module "trust_ec2" {
 
   name_prefix   = "trust"
   instance_type = "t3.xlarge"
-  key_name      = aws_key_pair.host_key.key_name
+  key_name      = var.enable_ssh_key_pair ? aws_key_pair.host_key[0].key_name : null
   subnet_id     = element(module.flip_vpc.private_subnets, 0)
 
   # use the trust SG, not the central EC2 SG
@@ -577,6 +584,65 @@ module "trust_ec2" {
 }
 
 resource "aws_key_pair" "host_key" {
+  count      = var.enable_ssh_key_pair ? 1 : 0
   key_name   = "host-aws"
   public_key = file(var.ec2_public_key_path)
+}
+
+moved {
+  from = aws_key_pair.host_key
+  to   = aws_key_pair.host_key[0]
+}
+
+############################
+# Ansible aws_ssm transfer bucket
+############################
+#
+# The community.aws.aws_ssm Ansible connection plugin stages file transfers through
+# an S3 bucket. Objects are short-lived (< 1 day). The EC2 instance role already has
+# AmazonS3FullAccess + AmazonSSMManagedInstanceCore, so no additional IAM wiring is
+# needed on the instance side.
+
+resource "aws_s3_bucket" "ansible_ssm_transfer" {
+  bucket_prefix = "flip-ansible-ssm-"
+  force_destroy = true
+
+  tags = {
+    Name    = "flip-ansible-ssm-transfer"
+    Purpose = "Ansible community.aws.aws_ssm file transfer staging"
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "ansible_ssm_transfer" {
+  bucket                  = aws_s3_bucket.ansible_ssm_transfer.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "ansible_ssm_transfer" {
+  bucket = aws_s3_bucket.ansible_ssm_transfer.id
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "ansible_ssm_transfer" {
+  bucket = aws_s3_bucket.ansible_ssm_transfer.id
+  rule {
+    id     = "expire-old-transfers"
+    status = "Enabled"
+    filter {}
+    expiration {
+      days = 1
+    }
+  }
+}
+
+output "AnsibleSsmBucketName" {
+  description = "S3 bucket used by Ansible community.aws.aws_ssm connection plugin for file transfer"
+  value       = aws_s3_bucket.ansible_ssm_transfer.bucket
 }

--- a/deploy/providers/AWS/modules/trust_ec2/README.md
+++ b/deploy/providers/AWS/modules/trust_ec2/README.md
@@ -36,7 +36,7 @@ module "trust_ec2" {
 
   name_prefix  = "trust"
   instance_type = "t3.xlarge"
-  key_name     = var.flip_keypair
+  key_name     = null  # set to aws_key_pair.*.key_name only when enable_ssh_key_pair = true
   subnet_id    = element(module.flip_vpc.private_subnets, 0)
   security_group_ids = [module.trust_security_group.security_group.id]
 }

--- a/deploy/providers/AWS/modules/trust_ec2/variables.tf
+++ b/deploy/providers/AWS/modules/trust_ec2/variables.tf
@@ -28,8 +28,10 @@ variable "instance_type" {
 }
 
 variable "key_name" {
-  type    = string
-  default = "~/.ssh/id_rsa"
+  description = "AWS EC2 key pair name to attach to the trust instance. Set to null only if you never run `make deploy-trust` (which uses Docker-over-SSH and therefore needs the key pair)."
+  type        = string
+  default     = null
+  nullable    = true
 }
 
 variable "subnet_id" {

--- a/deploy/providers/AWS/modules/trust_ec2/variables.tf
+++ b/deploy/providers/AWS/modules/trust_ec2/variables.tf
@@ -28,7 +28,7 @@ variable "instance_type" {
 }
 
 variable "key_name" {
-  description = "AWS EC2 key pair name to attach to the trust instance. Set to null only if you never run `make deploy-trust` (which uses Docker-over-SSH and therefore needs the key pair)."
+  description = "AWS EC2 key pair name to attach to the trust instance. Set to null for the default SSM-only path; only needed for the legacy SSH-over-SSM workflow."
   type        = string
   default     = null
   nullable    = true

--- a/deploy/providers/AWS/requirements.yml
+++ b/deploy/providers/AWS/requirements.yml
@@ -15,5 +15,6 @@ collections:
   - name: community.general
   - name: amazon.aws
   - name: community.aws
+  - name: community.docker
 roles:
   - name: geerlingguy.docker

--- a/deploy/providers/AWS/requirements.yml
+++ b/deploy/providers/AWS/requirements.yml
@@ -13,5 +13,7 @@
 ---
 collections:
   - name: community.general
+  - name: amazon.aws
+  - name: community.aws
 roles:
   - name: geerlingguy.docker

--- a/deploy/providers/AWS/site.yml
+++ b/deploy/providers/AWS/site.yml
@@ -14,6 +14,9 @@
 - name: create EC2 Ansible inventory hosts on-the-fly
   hosts: localhost
   gather_facts: false
+  # This play builds the dynamic inventory from Terraform outputs. It must run
+  # regardless of which --tags are passed, otherwise later plays have no hosts.
+  tags: always
   tasks:
     - name: ensure flip_aicentre_bucket variable is defined
       assert:
@@ -470,3 +473,220 @@
         path: "{{ data_dir }}"
         mode: "0755"
         recurse: true
+
+###############################################################################
+# Container-orchestration plays (replacement for Docker-over-SSH contexts)
+#
+# These plays run `docker compose up` ON the target EC2 via the aws_ssm
+# connection. They remove the need for `docker context create flip
+# --docker "host=ssh://flip"` which is what tied the deploy flow to SSH.
+#
+# Run selectively via tags:
+#   ansible-playbook site.yml --tags deploy_centralhub
+#   ansible-playbook site.yml --tags deploy_trust
+# The inventory-building play runs regardless (tags: always).
+###############################################################################
+
+- name: add ssm-user to docker group so SSM sessions can run docker commands
+  hosts: ec2
+  become: true
+  tags:
+    - docker_group
+    - always
+  tasks:
+    - name: check if ssm-user account exists
+      command: id ssm-user
+      register: ssm_user_check
+      changed_when: false
+      failed_when: false
+
+    - name: add ssm-user to docker group
+      user:
+        name: ssm-user
+        groups: docker
+        append: true
+      when: ssm_user_check.rc == 0
+
+- name: configure Docker daemon to ship container logs to CloudWatch
+  hosts: ec2
+  become: true
+  tags:
+    - cloudwatch_logs
+  vars:
+    enable_cloudwatch_log_driver: true
+    cloudwatch_log_group: /aws/ec2/flip
+    cloudwatch_region: "{{ lookup('env', 'AWS_REGION') | default('eu-west-2', true) }}"
+  tasks:
+    - name: write /etc/docker/daemon.json with awslogs driver
+      copy:
+        dest: /etc/docker/daemon.json
+        mode: "0644"
+        content: "{{ daemon_config | to_nice_json }}"
+      vars:
+        daemon_config: >-
+          {{
+            {
+              'log-driver': 'awslogs',
+              'log-opts': {
+                'awslogs-region': cloudwatch_region,
+                'awslogs-group': cloudwatch_log_group,
+                'awslogs-create-group': 'true',
+                'tag': '{{ "{{" }}.Name{{ "}}" }}'
+              }
+            }
+            if enable_cloudwatch_log_driver
+            else {}
+          }}
+      register: daemon_json_write
+      when: enable_cloudwatch_log_driver
+
+    - name: restart Docker to pick up new log driver (affects new containers only)
+      service:
+        name: docker
+        state: restarted
+      when: daemon_json_write is changed
+
+- name: deploy Central Hub services via Ansible-over-SSM
+  hosts: central_hub
+  become: true
+  tags: deploy_centralhub
+  vars:
+    flip_repo_deploy_dir: "{{ playbook_dir }}/../../../deploy"
+    flip_env_file: "{{ playbook_dir }}/../../../.env.production"
+    fl_backend: "{{ lookup('env', 'FL_BACKEND') | default('flower', true) }}"
+    docker_tag: "{{ lookup('env', 'DOCKER_TAG') | default('latest', true) }}"
+    docker_fl_tag: "{{ lookup('env', 'DOCKER_FL_TAG') | default('latest', true) }}"
+  tasks:
+    - name: ensure /opt/flip/deploy exists
+      file:
+        path: /opt/flip/deploy
+        state: directory
+        owner: ubuntu
+        group: ubuntu
+        mode: "0755"
+
+    - name: copy Central Hub compose files to EC2
+      copy:
+        src: "{{ item }}"
+        dest: /opt/flip/deploy/
+        owner: ubuntu
+        group: ubuntu
+        mode: "0644"
+      loop:
+        - "{{ flip_repo_deploy_dir }}/compose.production.yml"
+        - "{{ flip_repo_deploy_dir }}/compose.production.{{ fl_backend }}.yml"
+
+    - name: copy .env.production to EC2 (for docker compose interpolation)
+      copy:
+        src: "{{ flip_env_file }}"
+        dest: /opt/flip/.env.production
+        owner: ubuntu
+        group: ubuntu
+        mode: "0600"
+
+    - name: ensure central hub Docker networks exist
+      community.docker.docker_network:
+        name: "{{ item }}"
+        state: present
+      loop:
+        - flip-central-hub-network
+        - flip-fl-network
+
+    - name: pull latest images and (re)start Central Hub services
+      shell: |
+        set -euo pipefail
+        cd /opt/flip
+        PROVIDER=AWS \
+        DOCKER_TAG={{ docker_tag }} \
+        DOCKER_FL_TAG={{ docker_fl_tag }} \
+        docker compose \
+          -f deploy/compose.production.yml \
+          -f deploy/compose.production.{{ fl_backend }}.yml \
+          --env-file .env.production \
+          up --remove-orphans -d --pull always
+      register: compose_result
+      changed_when: "'Started' in compose_result.stdout or 'Created' in compose_result.stdout or 'Recreated' in compose_result.stdout"
+
+    - name: show compose output
+      debug:
+        var: compose_result.stdout_lines
+
+- name: deploy Trust services via Ansible-over-SSM
+  hosts: trust_ec2
+  become: true
+  tags: deploy_trust
+  vars:
+    flip_repo_root: "{{ playbook_dir }}/../../.."
+    flip_env_file: "{{ playbook_dir }}/../../../.env.production"
+    fl_backend: "{{ lookup('env', 'FL_BACKEND') | default('flower', true) }}"
+    docker_tag: "{{ lookup('env', 'DOCKER_TAG') | default('latest', true) }}"
+    docker_fl_tag: "{{ lookup('env', 'DOCKER_FL_TAG') | default('latest', true) }}"
+    trust_name: "{{ lookup('env', 'TRUST_NAME') | default('Trust_1', true) }}"
+  tasks:
+    - name: ensure /opt/flip/deploy and /opt/flip/trust exist
+      file:
+        path: "{{ item }}"
+        state: directory
+        owner: ubuntu
+        group: ubuntu
+        mode: "0755"
+      loop:
+        - /opt/flip/deploy
+        - /opt/flip/trust
+        - /opt/flip/trust/xnat
+
+    - name: copy Trust compose files to EC2
+      copy:
+        src: "{{ item.src }}"
+        dest: "{{ item.dest }}"
+        owner: ubuntu
+        group: ubuntu
+        mode: "0644"
+      loop:
+        - { src: "{{ flip_repo_root }}/deploy/compose.production.yml", dest: /opt/flip/deploy/ }
+        - { src: "{{ flip_repo_root }}/deploy/compose.production.{{ fl_backend }}.yml", dest: /opt/flip/deploy/ }
+        - { src: "{{ flip_repo_root }}/trust/compose.production.yml", dest: /opt/flip/trust/ }
+        - { src: "{{ flip_repo_root }}/trust/xnat/compose.production.yml", dest: /opt/flip/trust/xnat/ }
+
+    - name: copy .env.production to EC2
+      copy:
+        src: "{{ flip_env_file }}"
+        dest: /opt/flip/.env.production
+        owner: ubuntu
+        group: ubuntu
+        mode: "0600"
+
+    - name: initialise Docker swarm (required by XNAT stack)
+      community.docker.docker_swarm:
+        state: present
+      register: swarm_init
+      failed_when:
+        - swarm_init.failed
+        - "'already part of a swarm' not in (swarm_init.msg | default(''))"
+
+    - name: ensure trust Docker networks exist
+      community.docker.docker_network:
+        name: "{{ item }}"
+        state: present
+      loop:
+        - flip-trust-network
+        - flip-fl-network
+
+    - name: pull latest images and (re)start Trust services
+      shell: |
+        set -euo pipefail
+        cd /opt/flip/trust
+        PROVIDER=AWS \
+        DOCKER_TAG={{ docker_tag }} \
+        DOCKER_FL_TAG={{ docker_fl_tag }} \
+        TRUST_NAME={{ trust_name }} \
+        docker compose \
+          -f compose.production.yml \
+          --env-file /opt/flip/.env.production \
+          up --remove-orphans -d --pull always
+      register: trust_compose_result
+      changed_when: "'Started' in trust_compose_result.stdout or 'Created' in trust_compose_result.stdout or 'Recreated' in trust_compose_result.stdout"
+
+    - name: show compose output
+      debug:
+        var: trust_compose_result.stdout_lines

--- a/deploy/providers/AWS/site.yml
+++ b/deploy/providers/AWS/site.yml
@@ -40,27 +40,30 @@
       register: terraform_output
     - name: add Central Hub EC2 instance to Ansible inventory
       add_host:
-        # Use the SSH alias so Ansible tunnels through SSM Session Manager
-        # The 'flip' Host entry in ~/.ssh/config provides ProxyCommand, IdentityFile,
-        # and StrictHostKeyChecking=accept-new — no additional ssh_common_args needed.
+        # Native SSM connection — no SSH key, no ProxyCommand, no open port 22.
+        # Auth uses the developer's AWS credentials; file transfer goes through the
+        # S3 bucket created in Terraform (AnsibleSsmBucketName output).
         name: flip
         groups:
           - ec2
           - central_hub
-        ansible_ssh_user: ubuntu
-        ansible_ssh_private_key_file: "{{ lookup('env', 'HOME') + '/.ssh/host-aws' }}"
-        ansible_ssh_common_args: "-o StrictHostKeyChecking=accept-new"
+        ansible_connection: community.aws.aws_ssm
+        ansible_aws_ssm_instance_id: "{{ terraform_output.outputs.Ec2InstanceId.value }}"
+        ansible_aws_ssm_region: "{{ lookup('env', 'AWS_REGION') | default('eu-west-2', true) }}"
+        ansible_aws_ssm_bucket_name: "{{ terraform_output.outputs.AnsibleSsmBucketName.value }}"
+        ansible_python_interpreter: /usr/bin/python3
         ansible_ec2_instance_id: "{{ terraform_output.outputs.Ec2InstanceId.value }}"
     - name: add Trust EC2 instance to Ansible inventory
       add_host:
-        # Use the SSH alias so Ansible tunnels through SSM Session Manager
         name: flip-trust
         groups:
           - ec2
           - trust_ec2
-        ansible_ssh_user: ubuntu
-        ansible_ssh_private_key_file: "{{ lookup('env', 'HOME') + '/.ssh/host-aws' }}"
-        ansible_ssh_common_args: "-o StrictHostKeyChecking=accept-new"
+        ansible_connection: community.aws.aws_ssm
+        ansible_aws_ssm_instance_id: "{{ terraform_output.outputs.TrustEc2InstanceId.value }}"
+        ansible_aws_ssm_region: "{{ lookup('env', 'AWS_REGION') | default('eu-west-2', true) }}"
+        ansible_aws_ssm_bucket_name: "{{ terraform_output.outputs.AnsibleSsmBucketName.value }}"
+        ansible_python_interpreter: /usr/bin/python3
         ansible_ec2_instance_id: "{{ terraform_output.outputs.TrustEc2InstanceId.value }}"
 
 - name: update packages

--- a/deploy/providers/AWS/variables.tf
+++ b/deploy/providers/AWS/variables.tf
@@ -50,12 +50,22 @@ variable "postgres_version" {
   default     = "17.9"
 }
 
+variable "enable_ssh_key_pair" {
+  description = "When true, create aws_key_pair resources and attach them to EC2 instances. REQUIRED for make deploy-centralhub / deploy-trust because they orchestrate the remote Docker daemon via Docker-over-SSH (docker context host=ssh://...). Set to false only if you use the stack exclusively via native SSM (aws ssm start-session) and Ansible-over-SSM — no `make deploy-*` targets."
+  type        = bool
+  default     = false
+}
+
 variable "flip_keypair" {
-  type = string
+  description = "Path to local private key (without .pub suffix). Required when enable_ssh_key_pair = true."
+  type        = string
+  default     = ""
 }
 
 variable "ec2_public_key_path" {
-  type = string
+  description = "Path to local public key used for the trust EC2 key pair. Required when enable_ssh_key_pair = true."
+  type        = string
+  default     = ""
 }
 
 variable "AES_KEY_BASE64" {

--- a/deploy/providers/AWS/variables.tf
+++ b/deploy/providers/AWS/variables.tf
@@ -51,7 +51,7 @@ variable "postgres_version" {
 }
 
 variable "enable_ssh_key_pair" {
-  description = "When true, create aws_key_pair resources and attach them to EC2 instances. REQUIRED for make deploy-centralhub / deploy-trust because they orchestrate the remote Docker daemon via Docker-over-SSH (docker context host=ssh://...). Set to false only if you use the stack exclusively via native SSM (aws ssm start-session) and Ansible-over-SSM — no `make deploy-*` targets."
+  description = "When true, create aws_key_pair resources and attach them to EC2 instances. Only needed for the legacy SSH-over-SSM path (scp, docker-over-SSH, git-over-SSH). All primary workflows (interactive shell, Ansible, make deploy-*, make logs) now go through SSM with IAM credentials — no key pair required."
   type        = bool
   default     = false
 }


### PR DESCRIPTION
Follow-up to #253. Completes the SSM migration for workflows that do not orchestrate the remote Docker daemon. Addresses the PR review comment on #253 about the shared `~/.ssh/host-aws` distribution problem — partially.

## ⚠️ SSH key pair still required for `make deploy-centralhub` / `make deploy-trust`

`make deploy-centralhub` and `make deploy-trust` orchestrate the remote Docker daemon via Docker-over-SSH:

```makefile
docker context create flip --docker "host=ssh://flip"
docker context use flip
# ... docker compose up runs against the remote daemon over SSH
```

Docker-over-SSH authenticates at the SSH layer, so the EC2 key pair and the matching `~/.ssh/host-aws` private key are still required for the full deploy flow. **Existing operators keep their current workflow unchanged** — set `TF_VAR_enable_ssh_key_pair=true` (which is what prod currently uses) and nothing breaks.

Eliminating that last dependency means either (a) rewriting the deploy targets to run `docker compose` on the EC2 via Ansible-over-SSM, or (b) a broader architectural move to ECS. Both are out of scope for this PR and tracked as follow-up.

## What this PR delivers

| Workflow | Before | After |
|---|---|---|
| Interactive shell (`aws ssm start-session`) | Already worked — no change | Unchanged |
| `make ansible-init` / ad-hoc `ansible-playbook` runs / `make check-deploy-centralhub` | Needed `~/.ssh/host-aws` (`ansible_ssh_private_key_file` in `site.yml`) | ✅ No SSH key — uses `community.aws.aws_ssm` |
| `make deploy-centralhub` / `make deploy-trust` | Needed `~/.ssh/host-aws` for Docker-over-SSH | ❌ Still requires it — not addressed in this PR |

Plus: `TF_VAR_enable_ssh_key_pair=false` is now a valid deployment mode for teams that only need read-only / observability access (shell + Ansible), and skips creating any `aws_key_pair` resource at all.

## Changes

- `variables.tf`: add `enable_ssh_key_pair` (default `false`); make `flip_keypair`/`ec2_public_key_path` optional with clear \"when required\" descriptions.
- `main.tf`:
  - `aws_key_pair.flip_keypair` and `aws_key_pair.host_key` wrapped in `count`; `key_name` on both EC2s becomes conditional; `moved` blocks migrate existing state to the `[0]` index without recreating anything.
  - `Keypair` output becomes conditional (was outputting the input var path; now outputs the actual key pair name when enabled, empty string otherwise).
  - New: `aws_s3_bucket.ansible_ssm_transfer` (`bucket_prefix = flip-ansible-ssm-`) with public-access-block, SSE-AES256, 1-day expiration lifecycle. Exposed as `AnsibleSsmBucketName`.
- `modules/trust_ec2/variables.tf`: `key_name` now nullable with `default = null`.
- `site.yml`: inventory uses `ansible_connection: community.aws.aws_ssm` with `ansible_aws_ssm_instance_id`/`region`/`bucket_name`. `ansible_ssh_private_key_file` and `ansible_ssh_common_args` removed.
- `requirements.yml`: add `amazon.aws` and `community.aws` collections.
- `Makefile`:
  - `check-ssm-ready`: drop stale `~/.ssh/host-aws` warning; add `aws sts get-caller-identity` check for clearer errors on expired SSO sessions.
  - Add `check-deploy-centralhub` target (dry-run Ansible against Central Hub via `aws_ssm`, for smoke testing without mutations).
- `README.md` / `modules/trust_ec2/README.md`: document the SSH-free paths first, document the Docker-SSH requirement honestly, clarify when each variable is required.

## Deployed + verified on prod

- `make plan`: `moved` blocks reindex `aws_key_pair.*` to `[0]` (state-only, no recreation); 4 S3 resources created; `Keypair` output transitioned from `\"~/.ssh/host-aws\"` (pre-existing bug — outputting the input var path) to `\"flip-keypair\"` (the actual key pair name).
- `make apply`: `4 added, 1 changed, 0 destroyed`. The one change is pre-existing RDS `auto_minor_version_upgrade` drift, unrelated to this PR.
- `aws ssm start-session`: shell on Central Hub, no SSH key.
- Ansible check-mode against live Central Hub via `community.aws.aws_ssm`: `flip : ok=28 changed=1 unreachable=0 failed=0` — proves the SSH-free Ansible path works end-to-end.

## Follow-ups not in this PR

- Migrate `make deploy-centralhub` / `make deploy-trust` off Docker-over-SSH (candidate: Ansible-driven `docker compose up` on the EC2 via the `community.aws.aws_ssm` connection we just added). That would remove the last hard dependency on the key pair.
- Consider ECS more seriously (noting that commit `41c4789` already started exploring this) as an alternative to rewriting the Ansible-Docker orchestration.

## Test plan

- [x] `terraform validate` + `terraform fmt -check` clean
- [x] `terraform plan` on prod: state-migrating `moved` blocks, no resource recreation
- [x] `terraform apply` on prod: applied successfully
- [x] `aws ssm start-session` on Central Hub — IAM-only, no SSH key
- [x] `make check-deploy-centralhub` (new target) — Ansible over `aws_ssm` connects, no `unreachable`
- [ ] Reviewer to verify `enable_ssh_key_pair=false` path on a throwaway workspace (optional — not needed for the existing deploy to keep working)