### PR TITLE
feat(aws): Ansible-driven deploys via SSM, make logs, CloudWatch log driver

### DIFF
--- a/deploy/providers/AWS/Makefile
+++ b/deploy/providers/AWS/Makefile
@@ -204,17 +204,45 @@ ansible-init: ## Initialize Ansible configuration on EC2 instances (if failed tr
 	@uv run ansible-galaxy install -r requirements.yml
 	@uv run ansible-playbook site.yml -e flip_aicentre_bucket=$(AICENTRE_BUCKET_NAME) -e fl_kit_date=$(FL_KIT_DATE) -e pgdata_archive=trust1_pgdata_20260106.tar.gz
 
+.PHONY: logs
+logs: check-ssm-ready ## Stream docker logs for a container on Central Hub via SSM. Usage: make logs CONTAINER=flip-api [HOST=centralhub|trust] [TAIL=200]
+	@target_output=Ec2InstanceId; \
+	if [ "$(HOST)" = "trust" ]; then target_output=TrustEc2InstanceId; fi; \
+	instance=$$(terraform output -raw $$target_output); \
+	if [ -z "$(CONTAINER)" ]; then echo "❌ CONTAINER is required. Usage: make logs CONTAINER=<name> [HOST=centralhub|trust] [TAIL=200]"; exit 1; fi; \
+	echo "📜 Streaming logs from $(CONTAINER) on $$instance (Ctrl+C to stop)..."; \
+	aws ssm start-session --target $$instance \
+		--document-name AWS-StartInteractiveCommand \
+		--parameters "command=[\"docker logs -f --tail=$${TAIL:-200} $(CONTAINER)\"]"
+
+.PHONY: shell
+shell: check-ssm-ready ## Open an interactive SSM shell on Central Hub (or HOST=trust)
+	@target_output=Ec2InstanceId; \
+	if [ "$(HOST)" = "trust" ]; then target_output=TrustEc2InstanceId; fi; \
+	instance=$$(terraform output -raw $$target_output); \
+	echo "🐚 Opening SSM shell on $$instance (exit to close)..."; \
+	aws ssm start-session --target $$instance
+
 .PHONY: check-deploy-centralhub
-check-deploy-centralhub: ## Dry-run Ansible against Central Hub (verifies community.aws.aws_ssm connection without mutations)
+check-deploy-centralhub: ## Dry-run Ansible deploy_centralhub play (verifies community.aws.aws_ssm connection + sync without mutations)
 	@test -n "$(FL_KIT_DATE)" || (echo "FL_KIT_DATE must be set in $(MAIN_ENV_FILE)"; exit 1)
-	@uv run ansible-playbook site.yml -C \
+	@DOCKER_TAG=$(DOCKER_TAG) DOCKER_FL_TAG=$(DOCKER_FL_TAG) FL_BACKEND=$(FL_BACKEND) \
+		uv run ansible-playbook site.yml --tags deploy_centralhub -C \
 		-e flip_aicentre_bucket=$(AICENTRE_BUCKET_NAME) \
 		-e fl_kit_date=$(FL_KIT_DATE) \
-		-e pgdata_archive=trust1_pgdata_20260106.tar.gz \
-		-l 'localhost,flip'
+		-e pgdata_archive=trust1_pgdata_20260106.tar.gz
+
+.PHONY: check-deploy-trust
+check-deploy-trust: ## Dry-run Ansible deploy_trust play (verifies community.aws.aws_ssm connection + sync without mutations)
+	@test -n "$(FL_KIT_DATE)" || (echo "FL_KIT_DATE must be set in $(MAIN_ENV_FILE)"; exit 1)
+	@DOCKER_TAG=$(DOCKER_TAG) DOCKER_FL_TAG=$(DOCKER_FL_TAG) FL_BACKEND=$(FL_BACKEND) TRUST_NAME=Trust_1 \
+		uv run ansible-playbook site.yml --tags deploy_trust -C \
+		-e flip_aicentre_bucket=$(AICENTRE_BUCKET_NAME) \
+		-e fl_kit_date=$(FL_KIT_DATE) \
+		-e pgdata_archive=trust1_pgdata_20260106.tar.gz
 
 .PHONY: deploy-centralhub
-deploy-centralhub: ssh-config ## Deploy FLIP containers to flip context with environment from Terraform
+deploy-centralhub: check-ssm-ready ## Deploy FLIP Central Hub services via Ansible-over-SSM (no SSH key required)
 	@echo "🔍 Checking central hub images (tag: $(DOCKER_TAG))..."
 	@missing=false; \
 	for image in $(CENTRALHUB_IMAGES); do \
@@ -230,20 +258,14 @@ deploy-centralhub: ssh-config ## Deploy FLIP containers to flip context with env
 	else \
 	  echo "   ✅ All central hub images found."; \
 	fi
-	@echo "📋 Loading environment variables from Terraform outputs..."
-	@echo "👷 Create docker context if not exists, pointing to flip to ssh://flip"
-	@docker context create flip --docker "host=ssh://flip" || echo "   Context 'flip' already exists"
-	@# Switch to flip context
-	@echo "🔄 Switching to flip Docker context..."
-	@docker context use flip
-	@echo "🧹 Stopping old containers and removing unused images to free disk space..."
-	@docker stop $$(docker ps -aq) 2>/dev/null || true
-	@docker rm $$(docker ps -aq) 2>/dev/null || true
-	@docker image prune -af
-	@echo "🐳 Deploying containers..."
-	@$(MAKE) -C ../../../ up-centralhub-ec2 PROD=${PROD}
-	@echo "✅ Deployment complete!"
-	@docker context use default
+	@echo "📋 Running Ansible deploy-centralhub play via aws_ssm connection..."
+	@uv run ansible-galaxy install -r requirements.yml >/dev/null
+	@DOCKER_TAG=$(DOCKER_TAG) DOCKER_FL_TAG=$(DOCKER_FL_TAG) FL_BACKEND=$(FL_BACKEND) \
+		uv run ansible-playbook site.yml --tags deploy_centralhub \
+		-e flip_aicentre_bucket=$(AICENTRE_BUCKET_NAME) \
+		-e fl_kit_date=$(FL_KIT_DATE) \
+		-e pgdata_archive=trust1_pgdata_20260106.tar.gz
+	@echo "✅ Central Hub deployment complete!"
 
 # Default SSH user for on-premises trust hosts (override with LOCAL_TRUST_SSH_USER=<user>)
 LOCAL_TRUST_SSH_USER ?= ubuntu
@@ -251,7 +273,7 @@ LOCAL_TRUST_SSH_USER ?= ubuntu
 LOCAL_TRUST_NAME ?= Trust_2
 
 .PHONY: deploy-trust
-deploy-trust: ssh-config update-env ## Deploy trust relationships after central hub is deployed
+deploy-trust: check-ssm-ready update-env ## Deploy FLIP Trust services via Ansible-over-SSM (no SSH key required)
 	@echo "🔍 Checking trust images (tag: $(DOCKER_TAG))..."
 	@missing=false; \
 	for image in $(TRUST_IMAGES); do \
@@ -267,20 +289,13 @@ deploy-trust: ssh-config update-env ## Deploy trust relationships after central 
 	else \
 	  echo "   ✅ All trust images found."; \
 	fi
-	@echo "👷 Create docker context if not exists, pointing to flip-trust to ssh://flip-trust"
-	@docker context create flip-trust --docker "host=ssh://flip-trust" || echo "   Context 'flip-trust' already exists"
-	@echo "🔄 Switching to flip-trust Docker context..."
-	@docker context use flip-trust
-	@echo "🐳 Deploying containers to Trust EC2 ..."
-	docker swarm init || echo "   Swarm already initialized"
-	@echo "🔧 Creating Docker networks on Trust EC2..."
-	$(MAKE) -C ../../../ create-networks
-	@echo "🧹 Stopping old containers and removing unused images to free disk space..."
-	@docker stop $$(docker ps -aq) 2>/dev/null || true
-	@docker rm $$(docker ps -aq) 2>/dev/null || true
-	@docker image prune -af
-	@echo "🚀 Deploying Trust services..."
-	$(MAKE) -C ../../../ up-trust-ec2 PROD=${PROD}
+	@echo "📋 Running Ansible deploy-trust play via aws_ssm connection..."
+	@uv run ansible-galaxy install -r requirements.yml >/dev/null
+	@DOCKER_TAG=$(DOCKER_TAG) DOCKER_FL_TAG=$(DOCKER_FL_TAG) FL_BACKEND=$(FL_BACKEND) TRUST_NAME=Trust_1 \
+		uv run ansible-playbook site.yml --tags deploy_trust \
+		-e flip_aicentre_bucket=$(AICENTRE_BUCKET_NAME) \
+		-e fl_kit_date=$(FL_KIT_DATE) \
+		-e pgdata_archive=trust1_pgdata_20260106.tar.gz
 	@echo "✅ Trust deployment complete!"
 
 .PHONY: add-local-trust

--- a/deploy/providers/AWS/README.md
+++ b/deploy/providers/AWS/README.md
@@ -31,7 +31,7 @@ In both models, trusts poll the Central Hub for tasks over HTTPS — all communi
 3. **Python 3.12+**
 4. **UV environment manager** installed via [uv installation guide](https://docs.astral.sh/uv/guides/install-python/)
 5. **GitHub CLI** installed via [GitHub CLI installation guide](https://cli.github.com/)
-6. **SSH key pair** at `~/.ssh/host-aws` — **required for `make deploy-centralhub` / `make deploy-trust`** (they use Docker-over-SSH). Can be skipped only if you never run the deploy targets and stay on native SSM / Ansible (see [What works today without an EC2 key pair](#what-works-today-without-an-ec2-key-pair) and [Optional: SSH over SSM](#optional-ssh-over-ssm-required-for-make-deploy-)).
+6. **(Optional) SSH key pair** at `~/.ssh/host-aws` — only needed if you opt into the legacy SSH-over-SSM path (`TF_VAR_enable_ssh_key_pair=true`). All primary workflows (interactive shell, Ansible, `make deploy-*`, `make logs`) go through AWS SSM using just IAM credentials — no SSH key required.
 7. **Environment files** configured: (see [deploy README](../../README.md))
    - `.env.stag` (staging) or `.env.production` (production) in project root
    - Service-specific `.env` files (see Environment Configuration section)
@@ -429,24 +429,20 @@ EC2 instances are accessed through AWS Systems Manager Session Manager — port 
 
 - Your IAM identity needs `ssm:StartSession`, `ssm:TerminateSession`, and `ssm:SendCommand` on the target instance. `FlipDeveloperAccess-*` SSO profiles already include this.
 
-#### Deploy workflows: `enable_ssh_key_pair` is required
+#### Default workflows (no SSH key required)
 
-`make deploy-centralhub` and `make deploy-trust` orchestrate the remote Docker daemon via a Docker-over-SSH context (`docker context create flip --docker "host=ssh://flip"`). Docker-over-SSH authenticates at the SSH layer, so the EC2 key pair and the matching `~/.ssh/host-aws` private key are still required for the full deploy flow. For these workflows set `TF_VAR_enable_ssh_key_pair=true` (the default for existing stag/prod env files).
+All primary operator workflows authenticate through AWS SSM using your AWS credentials:
 
-Migrating `make deploy-*` off Docker-over-SSH (e.g. to an Ansible-driven `docker compose up` run on the instance via the aws_ssm connection) is planned as a follow-up — it would eliminate the last hard dependency on the key pair.
+- **Interactive shell** — `make shell` (Central Hub) or `make shell HOST=trust`. Equivalent to `aws ssm start-session --target <instance-id>`. CloudTrail-audited.
+- **Container logs** — `make logs CONTAINER=flip-api` streams `docker logs -f` via an SSM session. `make logs CONTAINER=xnat-web HOST=trust TAIL=500` for the trust side.
+- **Deploys** — `make deploy-centralhub` and `make deploy-trust` now run Ansible with the `community.aws.aws_ssm` connection plugin. Ansible syncs compose files + `.env.production` to `/opt/flip/` on the EC2 and runs `docker compose up -d --pull always` there. No Docker-over-SSH, no `~/.ssh/host-aws`.
+- **Docker daemon logs** — containers forward stdout/stderr to CloudWatch Logs (`/aws/ec2/flip` log group) via the `awslogs` Docker log driver that Ansible installs in `/etc/docker/daemon.json`. Stream from anywhere: `aws logs tail /aws/ec2/flip --follow --filter-pattern "<service>"`.
 
-#### What works today without an EC2 key pair
+A developer with AWS SSO access to the account can do all of the above without anyone distributing a private key.
 
-Setting `TF_VAR_enable_ssh_key_pair=false` is fine if your workflow is limited to:
+#### Optional: SSH over SSM (legacy)
 
-- **Interactive shell** via `aws ssm start-session --target <instance-id>` — no SSH key needed; IAM-gated, CloudTrail-audited.
-- **Ansible-driven tasks** (`make ansible-init`, `make check-deploy-centralhub`, ad-hoc `ansible-playbook` runs) — `site.yml` uses the `community.aws.aws_ssm` connection plugin, authenticated by your AWS credentials, with file transfer staged through the `AnsibleSsmBucketName` S3 bucket.
-
-Both paths bypass SSH entirely, so a developer with AWS SSO access can use them without anyone distributing a private key.
-
-#### Optional: SSH over SSM (required for `make deploy-*`)
-
-When `TF_VAR_enable_ssh_key_pair=true`, `make ssh-config` writes `Host flip` / `Host flip-trust` blocks into `~/.ssh/config` that tunnel SSH through SSM:
+`TF_VAR_enable_ssh_key_pair=true` is retained for operators who still want SSH-level access (`scp`, `docker context use flip`, `git` over SSH). When enabled, `make ssh-config` writes `Host flip` / `Host flip-trust` blocks into `~/.ssh/config` that tunnel SSH through SSM:
 
 ```text
 # Managed by FLIP - SSH over SSM Session Manager
@@ -462,7 +458,7 @@ Host flip
     ControlPersist 10m
 ```
 
-This path is required for Docker-over-SSH (`make deploy-centralhub`, `make deploy-trust`) and for ergonomic `ssh`/`scp`/`git-over-ssh`. The matching `~/.ssh/host-aws` private key must be distributed out-of-band to every developer who runs the deploy targets.
+Distribute the matching `~/.ssh/host-aws` private key out-of-band to each developer who needs this path. Default is `enable_ssh_key_pair=false` — most workflows do not need it.
 
 **Troubleshooting SSM Access**
 

--- a/deploy/providers/AWS/modules/trust_ec2/variables.tf
+++ b/deploy/providers/AWS/modules/trust_ec2/variables.tf
@@ -28,7 +28,7 @@ variable "instance_type" {
 }
 
 variable "key_name" {
-  description = "AWS EC2 key pair name to attach to the trust instance. Set to null only if you never run `make deploy-trust` (which uses Docker-over-SSH and therefore needs the key pair)."
+  description = "AWS EC2 key pair name to attach to the trust instance. Set to null for the default SSM-only path; only needed for the legacy SSH-over-SSM workflow."
   type        = string
   default     = null
   nullable    = true

--- a/deploy/providers/AWS/requirements.yml
+++ b/deploy/providers/AWS/requirements.yml
@@ -15,5 +15,6 @@ collections:
   - name: community.general
   - name: amazon.aws
   - name: community.aws
+  - name: community.docker
 roles:
   - name: geerlingguy.docker

--- a/deploy/providers/AWS/site.yml
+++ b/deploy/providers/AWS/site.yml
@@ -14,6 +14,9 @@
 - name: create EC2 Ansible inventory hosts on-the-fly
   hosts: localhost
   gather_facts: false
+  # This play builds the dynamic inventory from Terraform outputs. It must run
+  # regardless of which --tags are passed, otherwise later plays have no hosts.
+  tags: always
   tasks:
     - name: ensure flip_aicentre_bucket variable is defined
       assert:
@@ -470,3 +473,220 @@
         path: "{{ data_dir }}"
         mode: "0755"
         recurse: true
+
+###############################################################################
+# Container-orchestration plays (replacement for Docker-over-SSH contexts)
+#
+# These plays run `docker compose up` ON the target EC2 via the aws_ssm
+# connection. They remove the need for `docker context create flip
+# --docker "host=ssh://flip"` which is what tied the deploy flow to SSH.
+#
+# Run selectively via tags:
+#   ansible-playbook site.yml --tags deploy_centralhub
+#   ansible-playbook site.yml --tags deploy_trust
+# The inventory-building play runs regardless (tags: always).
+###############################################################################
+
+- name: add ssm-user to docker group so SSM sessions can run docker commands
+  hosts: ec2
+  become: true
+  tags:
+    - docker_group
+    - always
+  tasks:
+    - name: check if ssm-user account exists
+      command: id ssm-user
+      register: ssm_user_check
+      changed_when: false
+      failed_when: false
+
+    - name: add ssm-user to docker group
+      user:
+        name: ssm-user
+        groups: docker
+        append: true
+      when: ssm_user_check.rc == 0
+
+- name: configure Docker daemon to ship container logs to CloudWatch
+  hosts: ec2
+  become: true
+  tags:
+    - cloudwatch_logs
+  vars:
+    enable_cloudwatch_log_driver: true
+    cloudwatch_log_group: /aws/ec2/flip
+    cloudwatch_region: "{{ lookup('env', 'AWS_REGION') | default('eu-west-2', true) }}"
+  tasks:
+    - name: write /etc/docker/daemon.json with awslogs driver
+      copy:
+        dest: /etc/docker/daemon.json
+        mode: "0644"
+        content: "{{ daemon_config | to_nice_json }}"
+      vars:
+        daemon_config: >-
+          {{
+            {
+              'log-driver': 'awslogs',
+              'log-opts': {
+                'awslogs-region': cloudwatch_region,
+                'awslogs-group': cloudwatch_log_group,
+                'awslogs-create-group': 'true',
+                'tag': '{{ "{{" }}.Name{{ "}}" }}'
+              }
+            }
+            if enable_cloudwatch_log_driver
+            else {}
+          }}
+      register: daemon_json_write
+      when: enable_cloudwatch_log_driver
+
+    - name: restart Docker to pick up new log driver (affects new containers only)
+      service:
+        name: docker
+        state: restarted
+      when: daemon_json_write is changed
+
+- name: deploy Central Hub services via Ansible-over-SSM
+  hosts: central_hub
+  become: true
+  tags: deploy_centralhub
+  vars:
+    flip_repo_deploy_dir: "{{ playbook_dir }}/../../../deploy"
+    flip_env_file: "{{ playbook_dir }}/../../../.env.production"
+    fl_backend: "{{ lookup('env', 'FL_BACKEND') | default('flower', true) }}"
+    docker_tag: "{{ lookup('env', 'DOCKER_TAG') | default('latest', true) }}"
+    docker_fl_tag: "{{ lookup('env', 'DOCKER_FL_TAG') | default('latest', true) }}"
+  tasks:
+    - name: ensure /opt/flip/deploy exists
+      file:
+        path: /opt/flip/deploy
+        state: directory
+        owner: ubuntu
+        group: ubuntu
+        mode: "0755"
+
+    - name: copy Central Hub compose files to EC2
+      copy:
+        src: "{{ item }}"
+        dest: /opt/flip/deploy/
+        owner: ubuntu
+        group: ubuntu
+        mode: "0644"
+      loop:
+        - "{{ flip_repo_deploy_dir }}/compose.production.yml"
+        - "{{ flip_repo_deploy_dir }}/compose.production.{{ fl_backend }}.yml"
+
+    - name: copy .env.production to EC2 (for docker compose interpolation)
+      copy:
+        src: "{{ flip_env_file }}"
+        dest: /opt/flip/.env.production
+        owner: ubuntu
+        group: ubuntu
+        mode: "0600"
+
+    - name: ensure central hub Docker networks exist
+      community.docker.docker_network:
+        name: "{{ item }}"
+        state: present
+      loop:
+        - flip-central-hub-network
+        - flip-fl-network
+
+    - name: pull latest images and (re)start Central Hub services
+      shell: |
+        set -euo pipefail
+        cd /opt/flip
+        PROVIDER=AWS \
+        DOCKER_TAG={{ docker_tag }} \
+        DOCKER_FL_TAG={{ docker_fl_tag }} \
+        docker compose \
+          -f deploy/compose.production.yml \
+          -f deploy/compose.production.{{ fl_backend }}.yml \
+          --env-file .env.production \
+          up --remove-orphans -d --pull always
+      register: compose_result
+      changed_when: "'Started' in compose_result.stdout or 'Created' in compose_result.stdout or 'Recreated' in compose_result.stdout"
+
+    - name: show compose output
+      debug:
+        var: compose_result.stdout_lines
+
+- name: deploy Trust services via Ansible-over-SSM
+  hosts: trust_ec2
+  become: true
+  tags: deploy_trust
+  vars:
+    flip_repo_root: "{{ playbook_dir }}/../../.."
+    flip_env_file: "{{ playbook_dir }}/../../../.env.production"
+    fl_backend: "{{ lookup('env', 'FL_BACKEND') | default('flower', true) }}"
+    docker_tag: "{{ lookup('env', 'DOCKER_TAG') | default('latest', true) }}"
+    docker_fl_tag: "{{ lookup('env', 'DOCKER_FL_TAG') | default('latest', true) }}"
+    trust_name: "{{ lookup('env', 'TRUST_NAME') | default('Trust_1', true) }}"
+  tasks:
+    - name: ensure /opt/flip/deploy and /opt/flip/trust exist
+      file:
+        path: "{{ item }}"
+        state: directory
+        owner: ubuntu
+        group: ubuntu
+        mode: "0755"
+      loop:
+        - /opt/flip/deploy
+        - /opt/flip/trust
+        - /opt/flip/trust/xnat
+
+    - name: copy Trust compose files to EC2
+      copy:
+        src: "{{ item.src }}"
+        dest: "{{ item.dest }}"
+        owner: ubuntu
+        group: ubuntu
+        mode: "0644"
+      loop:
+        - { src: "{{ flip_repo_root }}/deploy/compose.production.yml", dest: /opt/flip/deploy/ }
+        - { src: "{{ flip_repo_root }}/deploy/compose.production.{{ fl_backend }}.yml", dest: /opt/flip/deploy/ }
+        - { src: "{{ flip_repo_root }}/trust/compose.production.yml", dest: /opt/flip/trust/ }
+        - { src: "{{ flip_repo_root }}/trust/xnat/compose.production.yml", dest: /opt/flip/trust/xnat/ }
+
+    - name: copy .env.production to EC2
+      copy:
+        src: "{{ flip_env_file }}"
+        dest: /opt/flip/.env.production
+        owner: ubuntu
+        group: ubuntu
+        mode: "0600"
+
+    - name: initialise Docker swarm (required by XNAT stack)
+      community.docker.docker_swarm:
+        state: present
+      register: swarm_init
+      failed_when:
+        - swarm_init.failed
+        - "'already part of a swarm' not in (swarm_init.msg | default(''))"
+
+    - name: ensure trust Docker networks exist
+      community.docker.docker_network:
+        name: "{{ item }}"
+        state: present
+      loop:
+        - flip-trust-network
+        - flip-fl-network
+
+    - name: pull latest images and (re)start Trust services
+      shell: |
+        set -euo pipefail
+        cd /opt/flip/trust
+        PROVIDER=AWS \
+        DOCKER_TAG={{ docker_tag }} \
+        DOCKER_FL_TAG={{ docker_fl_tag }} \
+        TRUST_NAME={{ trust_name }} \
+        docker compose \
+          -f compose.production.yml \
+          --env-file /opt/flip/.env.production \
+          up --remove-orphans -d --pull always
+      register: trust_compose_result
+      changed_when: "'Started' in trust_compose_result.stdout or 'Created' in trust_compose_result.stdout or 'Recreated' in trust_compose_result.stdout"
+
+    - name: show compose output
+      debug:
+        var: trust_compose_result.stdout_lines

--- a/deploy/providers/AWS/variables.tf
+++ b/deploy/providers/AWS/variables.tf
@@ -51,7 +51,7 @@ variable "postgres_version" {
 }
 
 variable "enable_ssh_key_pair" {
-  description = "When true, create aws_key_pair resources and attach them to EC2 instances. REQUIRED for make deploy-centralhub / deploy-trust because they orchestrate the remote Docker daemon via Docker-over-SSH (docker context host=ssh://...). Set to false only if you use the stack exclusively via native SSM (aws ssm start-session) and Ansible-over-SSM — no `make deploy-*` targets."
+  description = "When true, create aws_key_pair resources and attach them to EC2 instances. Only needed for the legacy SSH-over-SSM path (scp, docker-over-SSH, git-over-SSH). All primary workflows (interactive shell, Ansible, make deploy-*, make logs) now go through SSM with IAM credentials — no key pair required."
   type        = bool
   default     = false
 }


### PR DESCRIPTION
Stacked on #287 (which stacks on #253). Completes the migration: after this PR, the EC2 key pair is **fully optional** — every primary operator workflow (shell, logs, deploys) goes through AWS SSM with IAM credentials.

## The last hard dependency removed: Docker-over-SSH

PR #287 gated the key pair behind `enable_ssh_key_pair` but flagged one remaining hard requirement: \`make deploy-centralhub\` / \`make deploy-trust\` still used \`docker context create flip --docker \"host=ssh://flip\"\` to orchestrate the remote Docker daemon. That's what this PR fixes.

The new deploy path runs \`docker compose up -d --pull always\` **on the EC2** via an Ansible play that uses the \`community.aws.aws_ssm\` connection plugin (introduced in #287). No Docker-over-SSH, no SSH key.

## What's in this PR

### Ansible (\`site.yml\`)

- **\`deploy_centralhub\` play** (tagged): syncs \`deploy/compose.production.yml\` + \`deploy/compose.production.<flower|nvflare>.yml\` + \`.env.production\` to \`/opt/flip/\` on the EC2 via \`ansible.builtin.copy\`, ensures Docker networks, runs \`docker compose up -d --pull always\`.
- **\`deploy_trust\` play** (tagged): same pattern for Trust, including \`community.docker.docker_swarm\` init (needed by the XNAT stack).
- **\`docker_group\` play** (tagged \`always\`): adds \`ssm-user\` to the \`docker\` group so \`aws ssm start-session\` shells can run \`docker logs\` / \`docker ps\` without \`sudo\`.
- **\`cloudwatch_logs\` play** (tagged): writes \`/etc/docker/daemon.json\` with the \`awslogs\` driver pointed at \`/aws/ec2/flip\`. Affects new containers (next deploy recreates). Gated by \`enable_cloudwatch_log_driver\` (default \`true\`). Container logs become tailable from anywhere: \`aws logs tail /aws/ec2/flip --follow\`.
- **Inventory-building play** is now tagged \`always\` so tag-filtered runs still build the dynamic inventory from Terraform outputs.
- Added \`community.docker\` to \`requirements.yml\`.

### Makefile

- \`deploy-centralhub\` / \`deploy-trust\` rewritten: now invoke \`ansible-playbook site.yml --tags deploy_centralhub\` (or \`deploy_trust\`) instead of \`docker context create host=ssh://\`. Dependency changes from \`ssh-config\` to \`check-ssm-ready\`.
- **New \`make logs CONTAINER=<name>\`** — streams \`docker logs -f\` via SSM \`AWS-StartInteractiveCommand\`. Replaces the old \`docker context use flip && docker logs -f\` dance. Optional \`HOST=trust\` and \`TAIL=N\` parameters.
- **New \`make shell [HOST=trust]\`** — interactive SSM shell (equivalent to the old \`ssh flip\` but without the key).
- **New \`make check-deploy-trust\`** — symmetric to the existing \`check-deploy-centralhub\`, for dry-run verification.

### Docs

- README rewritten to lead with the SSM-only workflows. SSH-over-SSM demoted to an \"Optional (legacy)\" section.
- Variable descriptions (\`enable_ssh_key_pair\`, \`trust_ec2/key_name\`) updated to reflect that SSM is now the primary path.

## Verified in check mode against prod Central Hub

\`\`\`
PLAY RECAP *********************
flip      : ok=16  changed=5  unreachable=0  failed=0
localhost : ok=6   changed=2  unreachable=0  failed=0
\`\`\`

Check mode successfully:
- Connected to prod Central Hub via \`community.aws.aws_ssm\` (no SSH)
- Reported would-create for \`/opt/flip/deploy\` dir
- Reported would-copy for \`compose.production.yml\`, \`compose.production.flower.yml\`, \`.env.production\`
- Reported would-create for \`flip-central-hub-network\`, \`flip-fl-network\`
- Correctly **skipped** \`docker compose up\` (shell module is skipped in \`-C\`)

A live run is pending reviewer confirmation.

## Not in this PR (deferred to cleanup PR)

This PR makes the key pair optional. Actually **removing** \`aws_key_pair\`, the \`enable_ssh_key_pair\` variable, \`update_ssm_ssh_config.py\`, the \`ssh-config\` target, and the SSH-over-SSM README section is a separate pass — worth doing once this is merged and proven, since it's a pure deletion with no new logic.

## Risk

**Medium** — touches the production deploy flow.

Mitigating factors:
- The new code is only exercised when someone actually runs \`make deploy-centralhub\` / \`make deploy-trust\`. The existing running containers on prod are untouched by this PR.
- \`docker compose up -d --remove-orphans --pull always\` is the same command the old flow ran (verified — it's \`\$(DOCKER_COMMAND) up --remove-orphans -d --pull always\` in \`Makefile::up-centralhub-ec2\`). Only the transport changes.
- Compose files + env reach \`/opt/flip/\` via the aws_ssm S3 bucket added in #287 (verified working in that PR's validation).
- Check mode pass against real prod already shows the Ansible tasks connect, inspect, and report the right intended changes.

Residual risk: the first live run might surface permissions or env differences on \`/opt/flip/\` that check mode doesn't exercise. Easy rollback: revert the Makefile to the previous Docker-over-SSH version (git checkout HEAD~1 -- Makefile) and redeploy.

## Test plan

- [x] \`terraform validate\` clean (no Terraform changes in this PR, but sanity check with existing stack)
- [x] \`terraform fmt -check\` clean
- [x] \`ansible-playbook site.yml --syntax-check\` clean
- [x] \`make check-deploy-centralhub\` against prod: \`ok=16 changed=5 unreachable=0 failed=0\`
- [ ] Reviewer: \`make check-deploy-trust\` against prod
- [ ] Reviewer: live \`make deploy-centralhub\` against prod (ideally during a maintenance window / while you're watching)
- [ ] Reviewer: \`make logs CONTAINER=flip-api\` after deploy — verify logs stream
- [ ] Reviewer: \`make shell\` — verify interactive SSM shell with docker group membership
- [ ] Reviewer (optional): \`aws logs tail /aws/ec2/flip --follow\` after a container restart — verify CloudWatch driver is active