### PR TITLE
docs: update outdated PostgreSQL versions and fix missing type annotations

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -17,7 +17,7 @@
 
 FLIP uses AWS RDS PostgreSQL with the following version support policy:
 
-- **Current Version**: PostgreSQL 15 (EOL: October 2027) ✓
+- **Current Version**: PostgreSQL 17 (EOL: November 2029) ✓
 - **Minimum Version**: PostgreSQL 15
 - **Deprecated**: PostgreSQL 13 (EOL: November 2025) ❌ EXPIRED
 
@@ -26,9 +26,10 @@ FLIP uses AWS RDS PostgreSQL with the following version support policy:
 | Version | EOL | Status |
 | ------- | --- | ------ |
 | PostgreSQL 13 | November 2025 | ❌ EXPIRED — do not use |
-| PostgreSQL 14 | October 2026 | ⚠️ Deprecating soon |
-| PostgreSQL 15 | October 2027 | ✓ Current |
-| PostgreSQL 16 | October 2028 | Available for next upgrade |
+| PostgreSQL 14 | October 2026 | ❌ EXPIRED — do not use |
+| PostgreSQL 15 | October 2027 | ⚠️ Deprecating soon |
+| PostgreSQL 16 | October 2028 | ✓ Supported |
+| PostgreSQL 17 | November 2029 | ✓ Current (Terraform default) |
 
 **Upgrade Policy**: Plan PostgreSQL major version upgrades with a 6-month lead time before EOL. AWS charges premium rates for EOL versions. To change the version, update the `postgres_version` variable in `deploy/providers/AWS/variables.tf`.
 

--- a/deploy/compose.development.yml
+++ b/deploy/compose.development.yml
@@ -103,7 +103,7 @@ services:
     container_name: flip-api
 
   flip-db:
-    image: postgres:13
+    image: postgres:17
     ports:
       - ${DB_PORT}:${DB_PORT}
     environment:

--- a/flip-api/src/flip_api/fl_services/services/fl_service.py
+++ b/flip-api/src/flip_api/fl_services/services/fl_service.py
@@ -87,7 +87,7 @@ def get_fl_backend_job_id_by_model_id(model_id: UUID, session: Session) -> str:
     return fl_backend_job_id
 
 
-def add_fl_backend_job_id(fl_job_id: UUID, fl_backend_job_id: str, session: Session):
+def add_fl_backend_job_id(fl_job_id: UUID, fl_backend_job_id: str, session: Session) -> None:
     """
     Add the FL backend job ID to the FLJob entry in the database
 
@@ -108,7 +108,7 @@ def add_fl_backend_job_id(fl_job_id: UUID, fl_backend_job_id: str, session: Sess
     session.commit()
 
 
-def submit_job(fl_job_id: UUID, endpoint: str, model_id: UUID, session: Session):
+def submit_job(fl_job_id: UUID, endpoint: str, model_id: UUID, session: Session) -> None:
     """
     Submits a job to the FL API that is going to kick off training
 
@@ -278,7 +278,7 @@ def start_training(
     endpoint: str,
     bundle_urls: list[str],
     session: Session,
-):
+) -> None:
     """
     Start the training process for a given model by uploading the application and submitting the job.
     It first checks if the clients are available, then it bundles the application files,

--- a/flip-api/src/flip_api/fl_services/services/pull_required_files.py
+++ b/flip-api/src/flip_api/fl_services/services/pull_required_files.py
@@ -23,7 +23,7 @@ REQUIRED_JOB_TYPES_FILE = Path(__file__).parent.parent.parent / "assets" / JOB_T
 
 
 # TODO Review: This is disruptive for development if the file on the s3 bucket is not in sync with the current codebase.
-def pull_required_files_json_to_assets():
+def pull_required_files_json_to_assets() -> None:
     """
     Pulls required_files.json from S3 and saves it to the local assets folder.
     """

--- a/flip-api/src/flip_api/model_services/retrieve_model.py
+++ b/flip-api/src/flip_api/model_services/retrieve_model.py
@@ -71,7 +71,7 @@ def retrieve_model(
     model_id: UUID = Path(..., title="Model ID"),
     db: Session = Depends(get_session),
     user_id: UUID = Depends(verify_token),
-):
+) -> IModelResponse:
     """
     Retrieve a model by its ID. Returns the model details, including its status, associated files, and query.
 

--- a/flip-api/src/flip_api/project_services/services/project_services.py
+++ b/flip-api/src/flip_api/project_services/services/project_services.py
@@ -97,7 +97,7 @@ def create_project(
     Creates a new project and assigns user access.
 
     Args:
-        payload (IProjectDetails): The project details including name, description, and user IDs.
+        payload (ProjectDetails): The project details including name, description, and user IDs.
         current_user_id (UUID): The ID of the user creating the project.
         session (Session): The SQLModel session to use for database operations.
 
@@ -147,7 +147,7 @@ def create_project(
         )
 
 
-def delete_project(project_id: UUID, current_user_id: UUID, session: Session):
+def delete_project(project_id: UUID, current_user_id: UUID, session: Session) -> None:
     """
     Marks a project as deleted and handles related cleanup.
     This is a soft delete, meaning the project is marked as deleted but not removed from the database.

--- a/flip-api/src/flip_api/utils/formatters.py
+++ b/flip-api/src/flip_api/utils/formatters.py
@@ -11,7 +11,7 @@
 #
 
 
-def to_pascal_case(snake_str):
+def to_pascal_case(snake_str: str) -> str:
     """
     Convert a snake_case string to PascalCase.
     This is needed for the UI to understand the permissions format.


### PR DESCRIPTION
**This is an automated scheduled weekly task by Alex's Claude Code.**

## Summary

Audited all READMEs, ReadTheDocs documentation, and Python docstrings/type annotations against the current codebase. Found and fixed the following discrepancies:

### Documentation fixes
- **`deploy/README.md`**: PostgreSQL version table was outdated — listed v15 as current but Terraform default (`variables.tf`) is v17.9. Updated table to reflect v17 as current, v14 as expired, and added v17 row.
- **`deploy/compose.development.yml`**: Local dev database used `postgres:13` (marked as expired in README). Updated to `postgres:17` to align with production.

### Docstring fixes
- **`flip-api/.../project_services.py`**: `create_project()` docstring referenced `IProjectDetails` but actual parameter type is `ProjectDetails`. Fixed the mismatch.

### Missing type annotations added
- `to_pascal_case()` in `formatters.py` — added `str` param and return type
- `delete_project()` in `project_services.py` — added `-> None`
- `add_fl_backend_job_id()` in `fl_service.py` — added `-> None`
- `submit_job()` in `fl_service.py` — added `-> None`
- `start_training()` in `fl_service.py` — added `-> None`
- `retrieve_model()` in `retrieve_model.py` — added `-> IModelResponse`
- `pull_required_files_json_to_assets()` in `pull_required_files.py` — added `-> None`

## Verification

- `ruff check`: All checks passed
- `mypy`: No issues found (292 source files in flip-api, 27 in data-access-api)

## Test plan

- [x] Ruff linting passes on flip-api
- [x] MyPy type checking passes on flip-api (292 files)
- [x] Ruff + MyPy passes on data-access-api (27 files)
- [ ] Verify local dev `flip-db` starts correctly with `postgres:17` image

https://claude.ai/code/session_01PSUo44nk4vWsqJ1v7JgFXr