### PR TITLE
fix(data-access-api): parameterize cohort SQL queries (P1-02)

### DIFF
--- a/trust/data-access-api/data_access_api/services/cohort.py
+++ b/trust/data-access-api/data_access_api/services/cohort.py
@@ -11,11 +11,15 @@
 #
 
 import datetime
+from collections.abc import Mapping
+from typing import Any
 
 import pandas as pd
 from fastapi import HTTPException
 from psycopg2 import errors as pg_errors
+from sqlalchemy import bindparam, text
 from sqlalchemy.exc import DBAPIError, SQLAlchemyError
+from sqlalchemy.sql.elements import TextClause
 
 from data_access_api.config import get_settings
 from data_access_api.db.database import engine
@@ -58,12 +62,18 @@ def validate_query(query: str) -> bool:
     return True
 
 
-def get_records(query: str) -> pd.DataFrame:
+def get_records(
+    query: str | TextClause,
+    params: Mapping[str, Any] | None = None,
+) -> pd.DataFrame:
     """
-    Executes a raw SQL query and returns results.
+    Executes a SQL query and returns results.
 
     Args:
-        query (str): The SQL query to execute.
+        query (str | TextClause): The SQL query to execute. Pass a ``TextClause`` with bind
+            parameters when the query is parameterized.
+        params (Mapping[str, Any] | None): Optional mapping of bind parameter names to values
+            for parameterized queries.
 
     Returns:
         pd.DataFrame: The results of the query as a DataFrame.
@@ -73,7 +83,7 @@ def get_records(query: str) -> pd.DataFrame:
     """
     logger.info("Executing SQL query")
 
-    cached = get_cached_result(query)
+    cached = get_cached_result(query, params)
     if cached is not None:
         return cached
 
@@ -84,8 +94,8 @@ def get_records(query: str) -> pd.DataFrame:
         # Therefore, we need to validate the query is safe, e.g. only SELECT queries, and does not contain sensitive
         # data.
         # TODO check if we can check column types -- could be used to exclude primary keys, foreign keys, etc.
-        df = pd.read_sql(query, engine)
-        set_cached_result(query, df)
+        df = pd.read_sql(query, engine, params=params)
+        set_cached_result(query, df, params)
         return df
 
     except DBAPIError as e:
@@ -142,16 +152,19 @@ def get_sex_distribution(df: pd.DataFrame) -> dict:
     if "person_id" not in df.columns:
         return {"name": "Sex Distribution", "results": []}
 
-    sex_counts_database_query = f"""
+    person_ids = [int(pid) for pid in df["person_id"].unique()]
+
+    sex_counts_database_query = text("""
     SELECT
     p.gender_source_value,
     COUNT(*) AS count
     FROM omop.person p
-    WHERE p.person_id IN ({", ".join(df["person_id"].unique().astype(str).tolist())})
+    WHERE p.person_id IN :person_ids
     GROUP BY p.gender_source_value
-    """
+    """).bindparams(bindparam("person_ids", expanding=True))
     sex_counts = get_records(
         query=sex_counts_database_query,
+        params={"person_ids": person_ids},
     )
     return {
         "name": "Sex Distribution",
@@ -169,17 +182,20 @@ def get_age_distribution(df: pd.DataFrame) -> dict:
     if "person_id" not in df.columns:
         return {"name": "Age Distribution", "results": []}
 
-    age_distribution_database_query = f"""
+    person_ids = [int(pid) for pid in df["person_id"].unique()]
+
+    age_distribution_database_query = text("""
     SELECT
     FLOOR(DATE_PART('year', AGE(CURRENT_DATE, p.birth_datetime)) / 10) * 10 AS age_group,
     COUNT(*) AS count
     FROM omop.person p
-    WHERE p.person_id IN ({", ".join(df["person_id"].unique().astype(str).tolist())})
+    WHERE p.person_id IN :person_ids
     GROUP BY age_group
     ORDER BY age_group
-    """
+    """).bindparams(bindparam("person_ids", expanding=True))
     age_distribution = get_records(
         query=age_distribution_database_query,
+        params={"person_ids": person_ids},
     )
     return {
         "name": "Age Distribution",

--- a/trust/data-access-api/data_access_api/services/query_cache.py
+++ b/trust/data-access-api/data_access_api/services/query_cache.py
@@ -11,8 +11,10 @@
 #
 
 import hashlib
+from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
+from typing import Any
 
 import pandas as pd
 
@@ -29,13 +31,20 @@ class CacheEntry:
 _cache: dict[str, CacheEntry] = {}
 
 
-def _make_cache_key(query: str) -> str:
-    normalized = " ".join(query.strip().lower().split())
+def _make_cache_key(query: Any, params: Mapping[str, Any] | None = None) -> str:
+    query_str = query if isinstance(query, str) else str(query)
+    normalized = " ".join(query_str.strip().lower().split())
+    if params:
+        normalized_params = {
+            k: sorted(v) if isinstance(v, (list, tuple)) else v
+            for k, v in sorted(params.items())
+        }
+        normalized += "|" + repr(normalized_params)
     return hashlib.sha256(normalized.encode()).hexdigest()
 
 
-def get_cached_result(query: str) -> pd.DataFrame | None:
-    key = _make_cache_key(query)
+def get_cached_result(query: Any, params: Mapping[str, Any] | None = None) -> pd.DataFrame | None:
+    key = _make_cache_key(query, params)
     entry = _cache.get(key)
     if entry is None:
         return None
@@ -50,11 +59,11 @@ def get_cached_result(query: str) -> pd.DataFrame | None:
     return entry.df.copy()
 
 
-def set_cached_result(query: str, df: pd.DataFrame) -> None:
+def set_cached_result(query: Any, df: pd.DataFrame, params: Mapping[str, Any] | None = None) -> None:
     max_rows = get_settings().CACHE_MAX_RESULT_ROWS
     max_entries = get_settings().CACHE_MAX_ENTRIES
 
-    key = _make_cache_key(query)
+    key = _make_cache_key(query, params)
 
     # Skip caching results that are too large to keep memory usage bounded
     if len(df) > max_rows:

--- a/trust/data-access-api/tests/services/test_cohort.py
+++ b/trust/data-access-api/tests/services/test_cohort.py
@@ -515,11 +515,15 @@ def test_get_sex_distribution_with_person_id(mock_get_records):
     }
 
     assert result == expected
-    # Verify the SQL query was called with correct person IDs
+    # Verify the SQL query was called with a parameterized IN clause and the correct unique person IDs
     mock_get_records.assert_called_once()
-    call_args = mock_get_records.call_args[1]["query"]
-    assert "1, 2, 3" in call_args  # Unique person IDs
-    assert "omop.person" in call_args
+    call_kwargs = mock_get_records.call_args[1]
+    query_sql = str(call_kwargs["query"])
+    assert "person_ids" in query_sql
+    assert "omop.person" in query_sql
+    assert call_kwargs["params"] == {"person_ids": [1, 2, 3]}
+    # Ensure raw interpolation of IDs into the SQL text is not used
+    assert "1, 2, 3" not in query_sql
 
 
 # Tests for get_age_distribution
@@ -571,12 +575,16 @@ def test_get_age_distribution_with_person_id(mock_get_records):
     }
 
     assert result == expected
-    # Verify the SQL query was called
+    # Verify the SQL query was called with a parameterized IN clause and the correct unique person IDs
     mock_get_records.assert_called_once()
-    call_args = mock_get_records.call_args[1]["query"]
-    assert "1, 2, 3" in call_args
-    assert "omop.person" in call_args
-    assert "birth_datetime" in call_args
+    call_kwargs = mock_get_records.call_args[1]
+    query_sql = str(call_kwargs["query"])
+    assert "person_ids" in query_sql
+    assert "omop.person" in query_sql
+    assert "birth_datetime" in query_sql
+    assert call_kwargs["params"] == {"person_ids": [1, 2, 3]}
+    # Ensure raw interpolation of IDs into the SQL text is not used
+    assert "1, 2, 3" not in query_sql
 
 
 # Tests for verify_cardinality
@@ -858,9 +866,10 @@ def test_get_statistics_with_person_id_column(mock_read_sql):
 
     # Configure mocks to return different data based on query
     def read_sql_side_effect(query, *args, **kwargs):
-        if "birth_datetime" in query:
+        query_str = str(query)
+        if "birth_datetime" in query_str:
             return mock_age_data
-        elif "gender_source_value" in query:
+        elif "gender_source_value" in query_str:
             return mock_sex_data
         else:
             # Main query
@@ -936,9 +945,10 @@ def test_get_statistics_with_person_id_and_low_count_categories(mock_read_sql):
     })
 
     def read_sql_side_effect(query, *args, **kwargs):
-        if "birth_datetime" in query:
+        query_str = str(query)
+        if "birth_datetime" in query_str:
             return mock_age_data
-        elif "gender_source_value" in query:
+        elif "gender_source_value" in query_str:
             return mock_sex_data
         else:
             return mock_df


### PR DESCRIPTION
Replaces f-string SQL interpolation with parameterised queries in
`trust/data-access-api/data_access_api/services/cohort.py`.

The `get_sex_distribution` and `get_age_distribution` helpers previously
inlined `person_id` values into the SQL text via an f-string. They now
build a `sqlalchemy.text()` statement with an expanding bind parameter
(`bindparam("person_ids", expanding=True)`) and pass the IDs as
parameters, so the database driver — not Python string formatting —
substitutes the values.

## Changes

- `services/cohort.py`
  - `get_sex_distribution` / `get_age_distribution`: switch from f-string
    `IN (...)` construction to `text(...).bindparams(bindparam("person_ids", expanding=True))`,
    passing `params={"person_ids": [...]}`.
  - `get_records`: accept optional `params: Mapping[str, Any]` and
    forward to `pd.read_sql` and the cache helpers. The public
    behaviour for plain-string callers (e.g. the cohort router) is
    unchanged.
- `services/query_cache.py`
  - `_make_cache_key`, `get_cached_result`, `set_cached_result` now
    include bind parameters in the cache key. Params are sorted by
    name and list values are sorted so semantically equivalent parameter
    sets hash to the same key.
- `tests/services/test_cohort.py`
  - Updated `get_sex_distribution` / `get_age_distribution` tests to
    assert a parameterised IN clause is used and to verify the `params`
    mapping, and to assert that raw ID interpolation (`"1, 2, 3"`) is
    absent from the SQL text.
  - Updated `read_sql_side_effect` helpers to stringify the query
    (since it can now be a `TextClause`).

## Why

Even though `person_id` values originate from a DataFrame and not
directly from the user request, inlining them into SQL via f-strings
is an avoidable SQL-injection risk and fails linters/security scans.
Parameterisation is the standard fix and aligns with OWASP guidance.

## Scope

Bounded to the data-access-api `cohort` service and its query cache.
No API/contract changes and no deployment changes.

## Test plan

- [x] `uv run ruff check .` — clean
- [x] `uv run mypy . --ignore-missing-imports` — clean
- [x] `uv run pytest` — 73 passed, 99% coverage
- [x] Cohort unit tests verify parameterised IN clause and absence of raw-ID interpolation
- [ ] Integration smoke: run a cohort query end-to-end against the mocked OMOP DB

Refs P1-02.

https://claude.ai/code/session_01Pt9X2XJAUBv1aFXvU5zAWy