### PR TITLE
Add comprehensive docstrings to functions across codebase

### DIFF
--- a/flip-api/src/flip_api/db/seed/banner.py
+++ b/flip-api/src/flip_api/db/seed/banner.py
@@ -16,7 +16,11 @@ from flip_api.db.models.main_models import SiteBanner
 
 
 def seed_banner(session: Session) -> None:
-    """Seed site banner."""
+    """Seed site banner.
+
+    Args:
+        session (Session): The SQLModel session used to read and insert the seed row.
+    """
     existing_banner = session.get(SiteBanner, 1)
 
     if not existing_banner:

--- a/flip-api/src/flip_api/db/seed/fl_nets.py
+++ b/flip-api/src/flip_api/db/seed/fl_nets.py
@@ -20,7 +20,15 @@ from flip_api.utils.logger import logger
 
 
 def seed_fl_nets(session: Session) -> list[FLNets]:
-    """Seed FL nets into the database."""
+    """Seed FL nets into the database.
+
+    Args:
+        session (Session): The SQLModel session used to read existing FL nets and insert missing
+            ones from ``NET_ENDPOINTS``.
+
+    Returns:
+        list[FLNets]: All FL net rows present after seeding.
+    """
     nets = get_settings().NET_ENDPOINTS
 
     fl_nets = session.exec(select(FLNets)).all()

--- a/flip-api/src/flip_api/db/seed/fl_scheduler.py
+++ b/flip-api/src/flip_api/db/seed/fl_scheduler.py
@@ -20,7 +20,15 @@ from flip_api.utils.logger import logger
 
 
 def seed_fl_scheduler(session: Session, nets: list[FLNets]) -> list[FLScheduler]:
-    """Seed FL scheduler entries."""
+    """Seed FL scheduler entries.
+
+    Args:
+        session (Session): The SQLModel session used for reads and inserts.
+        nets (list[FLNets]): FL nets to create scheduler entries for if they don't already exist.
+
+    Returns:
+        list[FLScheduler]: All FL scheduler rows present after seeding.
+    """
     logger.debug("Seeding Federated Learning Scheduler")
     for net in nets:
         # Check if scheduler entry exists

--- a/flip-api/src/flip_api/db/seed/main_users.py
+++ b/flip-api/src/flip_api/db/seed/main_users.py
@@ -22,7 +22,13 @@ from flip_api.utils.logger import logger
 
 
 def ensure_user_and_role(email: str, role_ref: RoleRef, session: Session) -> None:
-    """Fetch or create a Cognito + DB user and assign a role."""
+    """Fetch or create a Cognito + DB user and assign a role.
+
+    Args:
+        email (str): The user's email, used to look up the corresponding Cognito user.
+        role_ref (RoleRef): The role to assign to the user if they don't already have it.
+        session (Session): The SQLModel session used for DB reads and writes.
+    """
     user_pool_id = get_settings().AWS_COGNITO_USER_POOL_ID
 
     # 1️⃣ Try to get the user from Cognito
@@ -54,9 +60,13 @@ def ensure_user_and_role(email: str, role_ref: RoleRef, session: Session) -> Non
 def seed_main_users(session: Session) -> None:
     """
     Seed the admin and researcher users into the database.
+
     - Get the user from Cognito by email.
     - If the user does not exist in DB, create them with the correct Cognito sub.
     - Assign appropriate roles.
+
+    Args:
+        session (Session): The SQLModel session used for DB reads and writes.
     """
     logger.debug("Seeding main users...")
 

--- a/flip-api/src/flip_api/db/seed/permissions.py
+++ b/flip-api/src/flip_api/db/seed/permissions.py
@@ -18,7 +18,14 @@ from flip_api.db.models.user_models import Permission, PermissionRef
 
 
 def seed_permissions(session: Session) -> list[str]:
-    """Seed permissions into the database."""
+    """Seed permissions into the database.
+
+    Args:
+        session (Session): The SQLModel session used for reads and inserts.
+
+    Returns:
+        list[str]: All permission names present after seeding.
+    """
     for perm_data in PermissionRef:
         # Check if permission exists
         statement = select(Permission).where(Permission.permission_name == perm_data.name)

--- a/flip-api/src/flip_api/db/seed/role_permissions.py
+++ b/flip-api/src/flip_api/db/seed/role_permissions.py
@@ -21,7 +21,11 @@ from flip_api.utils.logger import logger
 
 
 def seed_role_permissions(session: Session) -> None:
-    """Seed role permissions intersections."""
+    """Seed role permissions intersections.
+
+    Args:
+        session (Session): The SQLModel session used for reads and inserts.
+    """
     # Delete existing role permissions
     delete(RolePermission)
     session.commit()

--- a/flip-api/src/flip_api/db/seed/roles.py
+++ b/flip-api/src/flip_api/db/seed/roles.py
@@ -35,7 +35,14 @@ CURRENT_ROLES = [
 
 
 def seed_roles(session: Session) -> list[str]:
-    """Seed roles into the database."""
+    """Seed roles into the database.
+
+    Args:
+        session (Session): The SQLModel session used for reads and inserts.
+
+    Returns:
+        list[str]: All role names present after seeding.
+    """
     for role_data in CURRENT_ROLES:
         # Check if role exists
         statement = select(Role).where(Role.name == role_data["name"])

--- a/flip-api/src/flip_api/db/seed/seed_essential_data.py
+++ b/flip-api/src/flip_api/db/seed/seed_essential_data.py
@@ -26,7 +26,12 @@ from flip_api.utils.logger import logger
 
 
 def main() -> None:
-    """Main seeding function."""
+    """Main seeding function.
+
+    Raises:
+        Exception: Any error encountered during seeding is re-raised after rolling back the
+            session.
+    """
     logger.debug("Creating database tables...")
     SQLModel.metadata.create_all(engine)
     logger.debug("About to seed the database...")

--- a/flip-api/src/flip_api/db/seed/site_config.py
+++ b/flip-api/src/flip_api/db/seed/site_config.py
@@ -16,7 +16,11 @@ from flip_api.db.models.main_models import SiteConfig
 
 
 def seed_config(session: Session) -> None:
-    """Seed site configuration."""
+    """Seed site configuration.
+
+    Args:
+        session (Session): The SQLModel session used for reads and inserts.
+    """
     deployment_mode = {"key": "DeploymentMode", "value": False}
 
     # Check if config exists

--- a/flip-api/src/flip_api/db/seed/trusts.py
+++ b/flip-api/src/flip_api/db/seed/trusts.py
@@ -20,7 +20,15 @@ from flip_api.utils.logger import logger
 
 
 def seed_trusts(session: Session) -> list[dict[str, str]]:
-    """Seed trusts into the database."""
+    """Seed trusts into the database.
+
+    Args:
+        session (Session): The SQLModel session used for reads and inserts.
+
+    Returns:
+        list[dict[str, str]]: List of ``{"name": <trust_name>}`` dicts for every trust present
+        after seeding.
+    """
 
     # Get settings
     stt = get_settings()

--- a/flip-api/src/flip_api/domain/interfaces/fl.py
+++ b/flip-api/src/flip_api/domain/interfaces/fl.py
@@ -167,13 +167,26 @@ class JobRequiredFiles(BaseModel):
 
     @classmethod
     def get_required_files(cls, job_type: JobTypes) -> list[str]:
-        """Returns the list of required files for a specific job type (always reloads from disk)."""
+        """Returns the list of required files for a specific job type (always reloads from disk).
+
+        Args:
+            job_type (JobTypes): The job type to look up.
+
+        Returns:
+            list[str]: Required file names for ``job_type``, or an empty list if the job type is
+            not present in the on-disk configuration.
+        """
         config = _load_job_types_config()
         return config.get(job_type.value, [])
 
     @classmethod
     def get_all_job_types_with_files(cls) -> dict[str, list[str]]:
-        """Returns all job types with their required files (always reloads from disk)."""
+        """Returns all job types with their required files (always reloads from disk).
+
+        Returns:
+            dict[str, list[str]]: A copy of the on-disk mapping of job type names to their
+            required files.
+        """
         return _load_job_types_config().copy()
 
     @classmethod

--- a/flip-api/src/flip_api/fl_services/services/fl_scheduler_service.py
+++ b/flip-api/src/flip_api/fl_services/services/fl_scheduler_service.py
@@ -59,6 +59,10 @@ def remove_job(job_id: UUID, session: Session):
 
     Returns:
         None
+
+    Raises:
+        NotFoundError: If no ``FLJob`` exists with the given ID.
+        DatabaseError: If the update fails at the DB layer.
     """
     logger.info(f"Reverting job pickup: {job_id}")
     try:
@@ -90,6 +94,9 @@ def remove_job_from_queue(model_id: UUID, session: Session):
 
     Returns:
         None
+
+    Raises:
+        DatabaseError: If the update fails at the DB layer.
     """
     logger.info(f"Setting job status for model ({model_id}) to {JobStatus.DELETED}")
     try:
@@ -123,6 +130,10 @@ def revert_scheduler_pickup(scheduler_id: UUID, session: Session):
 
     Returns:
         None
+
+    Raises:
+        NotFoundError: If no ``FLScheduler`` exists with the given ID.
+        DatabaseError: If the update fails at the DB layer.
     """
     logger.info("Reverting scheduler pickup")
     try:
@@ -154,6 +165,10 @@ def get_net_by_model_id(model_id: UUID, session: Session) -> INetDetails:
 
     Returns:
         INetDetails: Details of the net.
+
+    Raises:
+        NotFoundError: If no net is associated with the given ``model_id``.
+        DatabaseError: If the query fails at the DB layer.
     """
     logger.info("Getting the net endpoint via its model ID...")
     try:
@@ -188,6 +203,9 @@ def get_net_by_name(name: str, session: Session) -> INetDetails | None:
 
     Returns:
         INetDetails | None: Details of the net or None if not found
+
+    Raises:
+        DatabaseError: If the query fails at the DB layer.
     """
     logger.info(f"Getting {name} info from db...")
 
@@ -218,6 +236,10 @@ def get_nets(session: Session) -> list[INetDetails]:
 
     Returns:
         list[INetDetails]: A list of all nets.
+
+    Raises:
+        NotFoundError: If no nets are registered in the database.
+        DatabaseError: If the query fails at the DB layer.
     """
     logger.info("Getting net info from db...")
     try:
@@ -245,6 +267,9 @@ def check_for_available_net(session: Session) -> ISchedulerResponse | None:
 
     Returns:
         ISchedulerResponse | None: The scheduler response if an available net is found, otherwise None.
+
+    Raises:
+        DatabaseError: If the update fails at the DB layer.
     """
     logger.info("Checking for any available nets...")
 
@@ -283,6 +308,11 @@ def check_for_queued_jobs(scheduler_id: UUID, session: Session) -> IJobResponse 
 
     Returns:
         IJobResponse | None: The job response if a queued job is found, otherwise None.
+
+    Raises:
+        NotFoundError: If the scheduler referenced by ``scheduler_id`` cannot be found.
+        DatabaseError: If the query or update fails at the DB layer.
+        Exception: If the job references invalid trusts.
     """
     logger.info("Checking for any queued jobs...")
 
@@ -342,6 +372,11 @@ def prepare_and_start_training(model_id: UUID, fl_job_id: UUID, clients: list[st
 
     Returns:
         None
+
+    Raises:
+        Exception: If the FL backend is unsupported, the net endpoint cannot be resolved, client
+            availability validation fails, or training fails to start. On failure the job is
+            removed, the model is marked as errored, and the original exception is re-raised.
     """
     try:
         logger.debug("Attempting to prepare and start training...")
@@ -407,6 +442,10 @@ def get_required_training_details(model_id: UUID, session: Session) -> IRequired
 
     Returns:
         IRequiredTrainingInformation: The required training information.
+
+    Raises:
+        NotFoundError: If the model or its associated cohort query cannot be found.
+        DatabaseError: If the query fails at the DB layer.
     """
     logger.info(f"Getting required details for training for model: {model_id}")
 
@@ -446,6 +485,9 @@ def update_fl_scheduler(model_id: UUID, session: Session):
 
     Returns:
         None
+
+    Raises:
+        DatabaseError: If the update fails at the DB layer.
     """
     try:
         logger.debug(f"Attempting to update the FL job to {JobStatus.COMPLETED} for model: {model_id}")

--- a/flip-api/src/flip_api/fl_services/services/fl_service.py
+++ b/flip-api/src/flip_api/fl_services/services/fl_service.py
@@ -675,6 +675,18 @@ def verify_bundle_paths(
 ) -> None:
     """
     Verifies that all expected destination keys exist after bundling.
+
+    Args:
+        s3 (S3Client): S3 client used to list destination objects.
+        base_files (list[str]): Keys of the base application files in the source bucket.
+        model_files (list[str]): Keys of the user-uploaded model files in the source bucket.
+        app_folders (set[str]): Application subfolder names that model files get mirrored into.
+        base_bucket_s3_path (str): Root S3 path of the base application bucket.
+        model_bucket_s3_path (str): Root S3 path of the user model bucket.
+        dest_bucket_s3_path (str): Root S3 path of the destination bundle bucket.
+
+    Raises:
+        RuntimeError: If any expected destination key is missing from the bundle bucket.
     """
 
     # Relative paths of model files
@@ -758,6 +770,10 @@ def extract_current_job_data(net_endpoint: str, fl_backend_job_id: str) -> IJobM
 
     Returns:
         IJobMetaData: The current job data if found.
+
+    Raises:
+        ValueError: If the FL server response is not a list, no running job matches
+            ``fl_backend_job_id``, or more than one running job shares the same ID.
     """
     url = f"{net_endpoint}/list_jobs"
     current_job_data = http_get(url)
@@ -802,6 +818,10 @@ def abort_model_training(request: Request, model_id: UUID, session: Session) -> 
         request (Request): The FastAPI request object
         model_id (UUID): The ID of the model to abort
         session (Session): SQLModel session object
+
+    Raises:
+        ValueError: If the FL server is not running, or if the job currently running on the
+            server does not correspond to ``model_id``, or if ``target`` is invalid.
     """
     logger.debug(f"Checking if model {model_id} is currently running...")
 

--- a/flip-api/src/flip_api/main.py
+++ b/flip-api/src/flip_api/main.py
@@ -100,7 +100,11 @@ from flip_api.utils.rate_limiter import limiter
 
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
-    """Start scheduler."""
+    """Start scheduler.
+
+    Args:
+        app (FastAPI): The FastAPI application instance being started.
+    """
     start_scheduler()
     print("Starting up the app...")
     yield
@@ -213,7 +217,11 @@ ROUTERS: tuple[APIRouter, ...] = (
 
 
 def include_api_routers(fastapi_app: FastAPI) -> None:
-    """Mount all API routes under the shared /api namespace."""
+    """Mount all API routes under the shared /api namespace.
+
+    Args:
+        fastapi_app (FastAPI): The FastAPI application to attach the routers to.
+    """
     for router in ROUTERS:
         fastapi_app.include_router(router, prefix=API_PREFIX)
 
@@ -224,13 +232,21 @@ include_api_routers(app)
 # Root endpoint
 @app.get(API_PREFIX, response_model=dict[str, str])
 def root():
-    """Root endpoint to verify the API is running."""
+    """Root endpoint to verify the API is running.
+
+    Returns:
+        dict[str, str]: A welcome message.
+    """
     return {"message": "Welcome to flip"}
 
 
 @app.get(f"{API_PREFIX}/health", response_model=dict[str, str])
 def health_check():
-    """Health check endpoint to verify the API is running"""
+    """Health check endpoint to verify the API is running.
+
+    Returns:
+        dict[str, str]: ``{"status": "ok", "message": "flip is running"}``.
+    """
     return {"status": "ok", "message": "flip is running"}
 
 

--- a/flip-api/src/flip_api/model_services/retrieve_model.py
+++ b/flip-api/src/flip_api/model_services/retrieve_model.py
@@ -31,13 +31,28 @@ RETRIEVE_MODEL_QUERY_FILE = f"{os.path.dirname(os.path.abspath(__file__))}/retri
 
 
 def load_sql(file_path: str) -> str:
-    """Load an SQL query from a file."""
+    """Load an SQL query from a file.
+
+    Args:
+        file_path (str): Absolute or relative path to the ``.sql`` file.
+
+    Returns:
+        str: The file contents.
+    """
     with open(file_path, "r") as f:
         return f.read()
 
 
 def parse_query_from_result(query: Any) -> IQuery:
-    """Parse a query from the SQL result into an IQuery object."""
+    """Parse a query from the SQL result into an IQuery object.
+
+    Args:
+        query (Any): Mapping-like row from the raw SQL result with ``id``, ``name``, and ``query``
+            keys.
+
+    Returns:
+        IQuery: The parsed query domain object.
+    """
     # TODO review whether to add 'results' field to IQuery
     # It seems to make assumptions that the query returns 'Gender' and 'Age' columns, which may not always be true.
     return IQuery(
@@ -48,7 +63,17 @@ def parse_query_from_result(query: Any) -> IQuery:
 
 
 def parse_files_from_result(files: Any, model_id: UUID) -> list[UploadedFiles]:
-    """Parse files from the SQL result into a list of UploadedFiles objects."""
+    """Parse files from the SQL result into a list of UploadedFiles objects.
+
+    Args:
+        files (Any): Iterable of mapping-like rows with ``id``, ``name``, ``status``, ``size``,
+            ``type``, and ``tag`` keys.
+        model_id (UUID): The model ID that each parsed file should be attributed to.
+
+    Returns:
+        list[UploadedFiles]: Parsed uploaded-file records. Rows with an unknown ``status`` are
+        mapped to :attr:`FileUploadStatus.ERROR`.
+    """
     parsed_files = [
         UploadedFiles(
             id=f["id"],

--- a/flip-api/src/flip_api/model_services/services/model_service.py
+++ b/flip-api/src/flip_api/model_services/services/model_service.py
@@ -40,6 +40,9 @@ def edit_model(model_id: UUID, model_details: IModelDetails, user_id: UUID, sess
         model_details (IModelDetails): The new details for the model
         user_id (UUID): The ID of the user making the changes
         session (Session): The database session
+
+    Raises:
+        ValueError: If no model exists with the given ``model_id``.
     """
     logger.debug("Attempting to update model details...")
 
@@ -107,6 +110,10 @@ def add_log(
 
     Returns:
         None
+
+    Raises:
+        Exception: Re-raises any error encountered when persisting the log entry, after rolling
+            back the session.
     """
     logger.info({"message": "Attempting to add a log line for model...", "modelId": model_id, "log": log})
 
@@ -169,6 +176,10 @@ def delete_models(project_id: UUID, user_id: str, session: Session, ensure_delet
 
     Returns:
         int: The number of models deleted.
+
+    Raises:
+        ValueError: If ``ensure_deletion`` is True and no non-deleted models exist for the given
+            project.
     """
     logger.debug("Attempting to delete models...")
 

--- a/flip-api/src/flip_api/model_services/utils/audit_helper.py
+++ b/flip-api/src/flip_api/model_services/utils/audit_helper.py
@@ -57,6 +57,9 @@ def audit_model_actions(actions: list[IModelAuditAction], session: Session) -> l
 
     Returns:
         list[ModelsAudit]: List of created ModelsAudit entries.
+
+    Raises:
+        RuntimeError: If ``actions`` is non-empty but no audit rows ended up being created.
     """
     logger.debug("Attempting to audit multiple actions...")
 

--- a/flip-api/src/flip_api/private_services/services/private_service.py
+++ b/flip-api/src/flip_api/private_services/services/private_service.py
@@ -22,6 +22,14 @@ from flip_api.utils.logger import logger
 def save_training_metrics(model_id: UUID, training_metrics: TrainingMetrics, db: Session) -> None:
     """
     Saves the provided training metrics to the database.
+
+    Args:
+        model_id (UUID): The ID of the model these metrics belong to.
+        training_metrics (TrainingMetrics): The metrics payload reported by a trust.
+        db (Session): The SQLModel session used for the insert.
+
+    Raises:
+        Exception: Re-raises any database error after rolling back the session.
     """
     logger.info(f"Attempting to save training metrics for model_id: {model_id}, trust: {training_metrics.trust}")
 

--- a/flip-api/src/flip_api/private_services/trust_tasks.py
+++ b/flip-api/src/flip_api/private_services/trust_tasks.py
@@ -71,6 +71,21 @@ def get_pending_tasks(
     Returns pending tasks for the specified trust and marks them as in_progress.
 
     This endpoint is polled by trusts to pick up work dispatched by the central hub.
+
+    Args:
+        request (Request): The FastAPI request, used by the rate limiter.
+        trust_name (str): The trust polling for tasks, taken from the URL path.
+        db (Session): Database session, provided by dependency injection.
+        authenticated_trust (str): The trust name resolved from the API key, provided by
+            dependency injection.
+
+    Returns:
+        list[TrustTaskResponse]: Pending tasks (up to ``PENDING_TASKS_LIMIT``), now marked
+        ``IN_PROGRESS``, with payloads encrypted for transport.
+
+    Raises:
+        HTTPException: 403 if the authenticated trust doesn't match ``trust_name``, 404 if the
+            trust is not registered, 500 on any other error.
     """
     verify_trust_identity(trust_name, authenticated_trust)
     logger.debug(f"Trust '{trust_name}' polling for pending tasks")
@@ -143,6 +158,23 @@ def submit_task_result(
 
     The trust_name path parameter is verified against the authenticated trust identity
     to prevent one trust from submitting results for another trust's tasks.
+
+    Args:
+        request (Request): The FastAPI request, used by the rate limiter.
+        trust_name (str): The trust submitting the result, taken from the URL path.
+        task_id (UUID): The ID of the task whose result is being submitted.
+        task_result (TaskResultInput): The task outcome reported by the trust.
+        db (Session): Database session, provided by dependency injection.
+        authenticated_trust (str): The trust name resolved from the API key, provided by
+            dependency injection.
+
+    Returns:
+        dict[str, str]: ``{"message": "Task <id> result recorded"}`` on success.
+
+    Raises:
+        HTTPException: 403 if the authenticated trust doesn't match ``trust_name`` or the task
+            belongs to a different trust; 404 if the trust or task is not found; 409 if the task
+            is not currently ``IN_PROGRESS``; 500 on any other error.
     """
     verify_trust_identity(trust_name, authenticated_trust)
     logger.info(f"Received result for task {task_id} from trust '{trust_name}'")
@@ -221,7 +253,22 @@ def trust_heartbeat(
 ) -> dict[str, str]:
     """
     Receives a heartbeat from a trust, updating its last_heartbeat timestamp.
+
     This replaces the hub-initiated health check with a trust-initiated heartbeat.
+
+    Args:
+        request (Request): The FastAPI request, used by the rate limiter.
+        trust_name (str): The trust sending the heartbeat, taken from the URL path.
+        db (Session): Database session, provided by dependency injection.
+        authenticated_trust (str): The trust name resolved from the API key, provided by
+            dependency injection.
+
+    Returns:
+        dict[str, str]: ``{"message": "Heartbeat recorded"}`` on success.
+
+    Raises:
+        HTTPException: 403 if the authenticated trust doesn't match ``trust_name``, 404 if the
+            trust is not registered, 500 on any other error.
     """
     verify_trust_identity(trust_name, authenticated_trust)
     logger.debug(f"Heartbeat received from trust '{trust_name}'")

--- a/flip-api/src/flip_api/project_services/get_projects.py
+++ b/flip-api/src/flip_api/project_services/get_projects.py
@@ -43,6 +43,16 @@ def get_projects_paginated_orm(
 ) -> IPagedResponse[IProject]:
     """
     Fetches paginated project data from the database using SQLModel ORM.
+
+    Args:
+        session (Session): The SQLModel session used for the database queries.
+        user_id (UUID | None): The requesting user's ID. When provided, results are restricted to
+            projects the user owns or has explicit access to.
+        paging_details (PagingInfo): Page size, offset, and optional search string.
+        filter_details (FilterInfo): Additional filter criteria (e.g. owner ID).
+
+    Returns:
+        IPagedResponse[IProject]: Paginated list of projects and total row count.
     """
     # Extract paging and filter details
     page_size = paging_details.page_size

--- a/flip-api/src/flip_api/project_services/services/image_service.py
+++ b/flip-api/src/flip_api/project_services/services/image_service.py
@@ -61,7 +61,15 @@ def has_pending_imaging_tasks(project_id: UUID, db: Session) -> bool:
 
 
 def to_utc_aware(dt: datetime | None) -> datetime:
-    """Convert a datetime to a timezone-aware UTC datetime. If the input is None, returns the minimum datetime."""
+    """Convert a datetime to a timezone-aware UTC datetime. If the input is None, returns the minimum datetime.
+
+    Args:
+        dt (datetime | None): The datetime to normalise. Naive datetimes are assumed to be in UTC.
+
+    Returns:
+        datetime: A timezone-aware UTC datetime. Returns ``datetime.min`` with UTC tzinfo when
+        ``dt`` is None.
+    """
     if dt is None:
         return datetime.min.replace(tzinfo=timezone.utc)
     return dt if dt.tzinfo is not None else dt.replace(tzinfo=timezone.utc)
@@ -69,7 +77,14 @@ def to_utc_aware(dt: datetime | None) -> datetime:
 
 # Helper for Base64 URL encoding
 def base64_url_encode(data: str) -> str:
-    """Encode a string using Base64 URL encoding without padding."""
+    """Encode a string using Base64 URL encoding without padding.
+
+    Args:
+        data (str): The string to encode.
+
+    Returns:
+        str: The Base64 URL-encoded string with trailing ``=`` padding stripped.
+    """
     return base64.urlsafe_b64encode(data.encode("utf-8")).decode("utf-8").rstrip("=")
 
 

--- a/flip-api/src/flip_api/trusts_services/get_trusts.py
+++ b/flip-api/src/flip_api/trusts_services/get_trusts.py
@@ -32,6 +32,13 @@ def get_trusts(
     """
     Retrieve all trusts with their ID and name.
 
+    Args:
+        db (Session): Database session, provided by dependency injection.
+        user_id (UUID): ID of the authenticated user making the request.
+
+    Returns:
+        list[IBasicTrust]: Every trust in the database, reduced to its ID and name.
+
     Raises:
         HTTPException: If an error occurs while fetching trusts from the database.
     """

--- a/flip-api/src/flip_api/utils/api_response.py
+++ b/flip-api/src/flip_api/utils/api_response.py
@@ -27,6 +27,13 @@ HEADERS = {
 def success(status_code=status.HTTP_200_OK, data=None):
     """
     Construct a successful API response with default CORS headers.
+
+    Args:
+        status_code (int): HTTP status code for the response. Defaults to 200 OK.
+        data (dict | None): Response body payload. Defaults to an empty dict when None.
+
+    Returns:
+        dict: Response envelope with ``statusCode``, ``headers``, and JSON-encoded ``body``.
     """
     if data is None:
         data = {}
@@ -39,6 +46,15 @@ def success(status_code=status.HTTP_200_OK, data=None):
 def error(status_code, error):
     """
     Construct an error response with logging and error message.
+
+    Args:
+        status_code (int): HTTP status code for the response.
+        error (Exception | Any): The error to log. If it has a ``message`` attribute, that is returned
+            to the client; otherwise a generic message is used.
+
+    Returns:
+        dict: Response envelope with ``statusCode``, ``headers``, and JSON-encoded ``body``
+        containing the error message.
     """
     logging.error(str(error))
 
@@ -54,6 +70,15 @@ def error(status_code, error):
 def unhandled_error(status_code, error):
     """
     Construct an unhandled error response with logging and generic error message.
+
+    Args:
+        status_code (int): HTTP status code for the response.
+        error (Exception | Any): The error to log. Logged at error level when it exposes a
+            ``message`` attribute.
+
+    Returns:
+        dict: Response envelope with ``statusCode``, ``headers``, and JSON-encoded ``body``
+        containing a generic error message.
     """
     logging.debug("UNHANDLED ERROR")
 
@@ -68,6 +93,13 @@ def unhandled_error(status_code, error):
 def api_response(status_code, body=None):
     """
     Construct a generic API response with default CORS headers.
+
+    Args:
+        status_code (int): HTTP status code for the response.
+        body (dict | None): Response body payload. Defaults to an empty dict when None.
+
+    Returns:
+        dict: Response envelope with ``statusCode``, ``headers``, and JSON-encoded ``body``.
     """
     if body is None:
         body = {}

--- a/flip-api/src/flip_api/utils/encryption.py
+++ b/flip-api/src/flip_api/utils/encryption.py
@@ -28,6 +28,9 @@ def get_aes_key() -> bytes:
 
     In production, fetches from AWS Secrets Manager. In dev, uses the environment variable directly.
     Cached after first call — the key does not change during the lifetime of a process.
+
+    Returns:
+        bytes: The decoded AES key.
     """
     global _aes_key_cache  # noqa: PLW0603
     if _aes_key_cache is not None:
@@ -40,7 +43,17 @@ def get_aes_key() -> bytes:
 
 
 def encrypt(plaintext: str, key: bytes | None = None) -> str:
-    """Encrypt plaintext using AES-CBC with PKCS7 padding. Returns Base64-encoded ciphertext."""
+    """Encrypt plaintext using AES-CBC with PKCS7 padding. Returns Base64-encoded ciphertext.
+
+    Args:
+        plaintext (str): The plaintext string to encrypt.
+        key (bytes | None): The AES key to use. If None, the shared AES key is retrieved via
+            :func:`get_aes_key`.
+
+    Returns:
+        str: Base64-encoded ciphertext, with the random IV prepended to the ciphertext bytes
+        before encoding.
+    """
     if key is None:
         key = get_aes_key()
 
@@ -57,7 +70,17 @@ def encrypt(plaintext: str, key: bytes | None = None) -> str:
 
 
 def decrypt(encoded_payload: str, key: bytes | None = None) -> str:
-    """Decrypt Base64-encoded ciphertext using AES-CBC with PKCS7 padding. Returns the original plaintext."""
+    """Decrypt Base64-encoded ciphertext using AES-CBC with PKCS7 padding. Returns the original plaintext.
+
+    Args:
+        encoded_payload (str): Base64-encoded payload where the first 16 bytes are the IV and the
+            remaining bytes are the ciphertext.
+        key (bytes | None): The AES key to use. If None, the shared AES key is retrieved via
+            :func:`get_aes_key`.
+
+    Returns:
+        str: The decrypted plaintext.
+    """
     if key is None:
         key = get_aes_key()
 

--- a/flip-api/src/flip_api/utils/formatters.py
+++ b/flip-api/src/flip_api/utils/formatters.py
@@ -14,7 +14,14 @@
 def to_pascal_case(snake_str: str) -> str:
     """
     Convert a snake_case string to PascalCase.
+
     This is needed for the UI to understand the permissions format.
     Example: CAN_ACCESS_ADMIN_PANEL -> CanAccessAdminPanel
+
+    Args:
+        snake_str (str): The snake_case (or UPPER_SNAKE_CASE) string to convert.
+
+    Returns:
+        str: The input string converted to PascalCase.
     """
     return "".join(word.capitalize() for word in snake_str.lower().split("_"))

--- a/flip-api/src/flip_api/utils/get_secrets.py
+++ b/flip-api/src/flip_api/utils/get_secrets.py
@@ -28,6 +28,11 @@ def get_secrets(secret_name: str = "", region_name: str = "") -> dict:
 
     Returns:
         dict: The retrieved secret as a dictionary.
+
+    Raises:
+        ClientError: If the AWS Secrets Manager API call fails.
+        ValueError: If the secret does not contain a ``SecretString``, is not valid JSON, or is
+            not a JSON object.
     """
     secret_name = get_settings().AWS_SECRET_NAME if not secret_name else secret_name
     region_name = get_settings().AWS_REGION if not region_name else region_name
@@ -78,6 +83,11 @@ def get_secret(secret_key: str, secret_name: str = "", region_name: str = "") ->
 
     Returns:
         str: The value of the requested secret.
+
+    Raises:
+        KeyError: If ``secret_key`` is not present in the retrieved secret.
+        ClientError: If the AWS Secrets Manager API call fails.
+        ValueError: If the secret payload is malformed (see :func:`get_secrets`).
     """
     secret_name = get_settings().AWS_SECRET_NAME if not secret_name else secret_name
     region_name = get_settings().AWS_REGION if not region_name else region_name

--- a/flip-api/src/flip_api/utils/http.py
+++ b/flip-api/src/flip_api/utils/http.py
@@ -28,7 +28,20 @@ from flip_api.utils.logger import logger
 
 
 def http_get(url: str, request_id: str | None = None) -> Any:
-    """Perform an HTTP GET request to the specified URL with optional request ID for tracing."""
+    """Perform an HTTP GET request to the specified URL with optional request ID for tracing.
+
+    Args:
+        url (str): The URL to GET.
+        request_id (str | None): Optional value for the ``x-request-id`` header used for
+            distributed tracing.
+
+    Returns:
+        Any: Parsed JSON body when the response is JSON; otherwise the raw response text.
+
+    Raises:
+        httpx.RequestError: If the request cannot be sent (connection, timeout, etc.).
+        httpx.HTTPStatusError: If the response status is 4xx/5xx (via ``raise_for_status``).
+    """
     headers = {"x-request-id": request_id} if request_id else {}
     with httpx.Client() as client:
         try:
@@ -46,7 +59,23 @@ def http_get(url: str, request_id: str | None = None) -> Any:
 def http_post(
     url: str, request_id: str | None = None, data: dict | None = None, timeout: float | None = None
 ) -> Any:
-    """Perform an HTTP POST request to the specified URL with optional request ID for tracing."""
+    """Perform an HTTP POST request to the specified URL with optional request ID for tracing.
+
+    Args:
+        url (str): The URL to POST to.
+        request_id (str | None): Optional value for the ``x-request-id`` header used for
+            distributed tracing.
+        data (dict | None): JSON-serialisable body to send.
+        timeout (float | None): Optional request timeout in seconds. When None, httpx defaults
+            are used.
+
+    Returns:
+        Any: Parsed JSON body when the response is JSON; otherwise the raw response text.
+
+    Raises:
+        httpx.RequestError: If the request cannot be sent (connection, timeout, etc.).
+        httpx.HTTPStatusError: If the response status is 4xx/5xx (via ``raise_for_status``).
+    """
     headers = (
         {"Content-Type": "application/json", "x-request-id": request_id}
         if request_id
@@ -70,7 +99,20 @@ def http_post(
 
 
 def http_delete(url: str, request_id: str | None = None) -> Any:
-    """Perform an HTTP DELETE request to the specified URL with optional request ID for tracing."""
+    """Perform an HTTP DELETE request to the specified URL with optional request ID for tracing.
+
+    Args:
+        url (str): The URL to DELETE.
+        request_id (str | None): Optional value for the ``x-request-id`` header used for
+            distributed tracing.
+
+    Returns:
+        Any: Parsed JSON body when the response is JSON; otherwise the raw response text.
+
+    Raises:
+        httpx.RequestError: If the request cannot be sent (connection, timeout, etc.).
+        httpx.HTTPStatusError: If the response status is 4xx/5xx (via ``raise_for_status``).
+    """
     headers = {"x-request-id": request_id} if request_id else {}
     with httpx.Client() as client:
         try:

--- a/flip-api/src/flip_api/utils/rate_limiter.py
+++ b/flip-api/src/flip_api/utils/rate_limiter.py
@@ -17,7 +17,15 @@ from slowapi import Limiter
 
 
 def _trust_name_key(request: Request) -> str:
-    """Extract trust_name from path params for per-trust rate limiting."""
+    """Extract trust_name from path params for per-trust rate limiting.
+
+    Args:
+        request (Request): The incoming FastAPI request.
+
+    Returns:
+        str: The ``trust_name`` path parameter when present; otherwise the client's host; otherwise
+        the literal ``"unknown"``.
+    """
     return request.path_params.get("trust_name", request.client.host if request.client else "unknown")
 
 

--- a/flip-api/src/flip_api/utils/s3_client.py
+++ b/flip-api/src/flip_api/utils/s3_client.py
@@ -220,6 +220,10 @@ class S3Client:
 
         Returns:
             bool: True if the object exists, False otherwise.
+
+        Raises:
+            ClientError: If ``head_object`` fails with any error other than HTTP 404 (e.g.,
+                permissions issues).
         """
         bucket, key = parse_s3_path(s3_path)
         try:

--- a/trust/data-access-api/data_access_api/config.py
+++ b/trust/data-access-api/data_access_api/config.py
@@ -55,7 +55,12 @@ class Settings(BaseSettings):
     # Define the database URL for the OMOP database
     @property
     def OMOP_DATABASE_URL(self) -> SecretStr:
-        """Construct the database URL for the OMOP database."""
+        """Construct the database URL for the OMOP database.
+
+        Returns:
+            SecretStr: A ``postgresql://`` URL wrapped as a SecretStr to avoid leaking the password
+            in logs or error messages.
+        """
         return SecretStr(
             f"postgresql://{self.DATA_ACCESS_POSTGRES_USER}:{self.DATA_ACCESS_POSTGRES_PASSWORD.get_secret_value()}@{self.OMOP_DB_SERVICE_NAME}:{self.OMOP_DB_PORT}/{self.OMOP_POSTGRES_DB}"
         )

--- a/trust/data-access-api/data_access_api/services/cohort.py
+++ b/trust/data-access-api/data_access_api/services/cohort.py
@@ -117,6 +117,12 @@ def get_records(query: str) -> pd.DataFrame:
 def get_counts(df: pd.DataFrame) -> dict:
     """
     Returns counts of non-null values for each column in the DataFrame.
+
+    Args:
+        df (pd.DataFrame): The cohort DataFrame.
+
+    Returns:
+        dict: ``{"name": "Counts", "results": [{"value": <column>, "count": <int>}, ...]}``.
     """
     return {
         "name": "Counts",
@@ -127,6 +133,12 @@ def get_counts(df: pd.DataFrame) -> dict:
 def get_null_counts(df: pd.DataFrame) -> dict:
     """
     Returns counts of null values for each column in the DataFrame.
+
+    Args:
+        df (pd.DataFrame): The cohort DataFrame.
+
+    Returns:
+        dict: ``{"name": "Nulls", "results": [{"value": <column>, "count": <int>}, ...]}``.
     """
     return {
         "name": "Nulls",
@@ -137,7 +149,15 @@ def get_null_counts(df: pd.DataFrame) -> dict:
 def get_sex_distribution(df: pd.DataFrame) -> dict:
     """
     Returns the distribution of sexes in the DataFrame.
+
     Assumes the DataFrame has accesion_id, query the table to get the sex distribution.
+
+    Args:
+        df (pd.DataFrame): The cohort DataFrame. Must include a ``person_id`` column; otherwise an
+            empty result set is returned.
+
+    Returns:
+        dict: ``{"name": "Sex Distribution", "results": [{"value": <sex>, "count": <int>}, ...]}``.
     """
     if "person_id" not in df.columns:
         return {"name": "Sex Distribution", "results": []}
@@ -164,7 +184,16 @@ def get_sex_distribution(df: pd.DataFrame) -> dict:
 def get_age_distribution(df: pd.DataFrame) -> dict:
     """
     Returns the distribution of ages in the DataFrame.
+
     Assumes the DataFrame has accesion_id, query the table to get the age distribution.
+
+    Args:
+        df (pd.DataFrame): The cohort DataFrame. Must include a ``person_id`` column; otherwise an
+            empty result set is returned.
+
+    Returns:
+        dict: ``{"name": "Age Distribution", "results": [{"value": "<decade>", "count": <int>},
+        ...]}`` where each value is a ten-year age bucket.
     """
     if "person_id" not in df.columns:
         return {"name": "Age Distribution", "results": []}
@@ -193,7 +222,18 @@ def get_age_distribution(df: pd.DataFrame) -> dict:
 def verify_cardinality(df: pd.DataFrame, threshold: float = 0.05) -> bool:
     """
     Verifies that the number of unique values in each column of the DataFrame is not smaller than the threshold.
+
     This is to prevent leaking information about individuals in the cohort.
+
+    Args:
+        df (pd.DataFrame): The cohort DataFrame to check.
+        threshold (float): Minimum acceptable proportion of unique values per column. Defaults to
+            ``0.05``.
+
+    Returns:
+        bool: ``True`` if every column has enough unique values (either above
+        ``COHORT_QUERY_THRESHOLD`` in absolute terms, or above ``threshold`` in relative terms).
+        ``False`` if any column falls below both thresholds.
     """
     for col in df.columns:
         unique_count = df[col].nunique()

--- a/trust/data-access-api/data_access_api/utils/encryption.py
+++ b/trust/data-access-api/data_access_api/utils/encryption.py
@@ -22,7 +22,14 @@ from data_access_api.config import get_settings
 
 # --- Step 1: Load AES key from environment file ---
 def get_aes_key() -> bytes:
-    """Retrieve the AES key from the environment file and return it as bytes."""
+    """Retrieve the AES key from the environment file and return it as bytes.
+
+    Returns:
+        bytes: The decoded AES key (16, 24, or 32 bytes).
+
+    Raises:
+        ValueError: If the AES key is missing from configuration or has an invalid length.
+    """
     key_b64 = get_settings().AES_KEY_BASE64
     if not key_b64:
         raise ValueError("AES key not found in environment file")
@@ -35,7 +42,17 @@ def get_aes_key() -> bytes:
 
 # --- Step 2: AES-CBC encryption ---
 def encrypt(plaintext: str, key: bytes | None = None) -> str:
-    """Encrypt plaintext using AES-CBC with PKCS7 padding. Returns Base64-encoded ciphertext."""
+    """Encrypt plaintext using AES-CBC with PKCS7 padding. Returns Base64-encoded ciphertext.
+
+    Args:
+        plaintext (str): The plaintext string to encrypt.
+        key (bytes | None): The AES key to use. If None, the shared AES key is retrieved via
+            :func:`get_aes_key`.
+
+    Returns:
+        str: Base64-encoded ciphertext with the random 16-byte IV prepended to the ciphertext
+        bytes before encoding.
+    """
     if key is None:
         key = get_aes_key()
 
@@ -56,7 +73,17 @@ def encrypt(plaintext: str, key: bytes | None = None) -> str:
 
 # --- Step 3: AES-CBC decryption ---
 def decrypt(encoded_payload: str, key: bytes | None = None) -> str:
-    """Decrypt Base64-encoded ciphertext using AES-CBC with PKCS7 padding. Returns the original plaintext."""
+    """Decrypt Base64-encoded ciphertext using AES-CBC with PKCS7 padding. Returns the original plaintext.
+
+    Args:
+        encoded_payload (str): Base64-encoded payload where the first 16 bytes are the IV and the
+            remaining bytes are the ciphertext.
+        key (bytes | None): The AES key to use. If None, the shared AES key is retrieved via
+            :func:`get_aes_key`.
+
+    Returns:
+        str: The decrypted plaintext.
+    """
     if key is None:
         key = get_aes_key()
 

--- a/trust/imaging-api/imaging_api/routers/retrieval.py
+++ b/trust/imaging-api/imaging_api/routers/retrieval.py
@@ -33,7 +33,14 @@ XNATAuthHeaders = Annotated[dict[str, str], Depends(get_xnat_auth_headers)]
 
 
 def base64_url_decode(data: str) -> str:
-    """Decode a Base64 URL-encoded string, adding padding if necessary."""
+    """Decode a Base64 URL-encoded string, adding padding if necessary.
+
+    Args:
+        data (str): The Base64 URL-encoded string to decode. Padding is added if missing.
+
+    Returns:
+        str: The decoded UTF-8 string.
+    """
     # Add padding if necessary
     padding = "=" * (-len(data) % 4)
     return base64.urlsafe_b64decode(data + padding).decode("utf-8")

--- a/trust/imaging-api/imaging_api/routers/schemas.py
+++ b/trust/imaging-api/imaging_api/routers/schemas.py
@@ -224,7 +224,16 @@ class ImportStudyRequest(BaseModel):
     @model_validator(mode="before")
     @classmethod
     def deduplicate_and_parse_studies(cls, data):
-        """Deduplicates and parses studies before validation."""
+        """Deduplicates and parses studies before validation.
+
+        Args:
+            data (dict): The raw input payload being validated. ``data["studies"]`` may contain
+                ``dict`` entries or already-parsed ``ImportStudy`` instances.
+
+        Returns:
+            dict: The same payload with ``studies`` replaced by a de-duplicated list of
+            ``ImportStudy`` instances keyed by ``study_instance_uid``.
+        """
         # Make sure studies exist in raw input
         studies = data.get("studies", [])
         if studies:

--- a/trust/imaging-api/imaging_api/routers/users.py
+++ b/trust/imaging-api/imaging_api/routers/users.py
@@ -36,7 +36,14 @@ XNATAuthHeaders = Annotated[dict[str, str], Depends(get_xnat_auth_headers)]
 
 @router.get("", summary="Get XNAT Users")
 def get_users(headers: XNATAuthHeaders) -> list[User]:
-    """Get a list of all users on XNAT."""
+    """Get a list of all users on XNAT.
+
+    Args:
+        headers (XNATAuthHeaders): XNAT authentication headers injected via FastAPI dependency.
+
+    Returns:
+        list[User]: All users currently registered on the XNAT instance.
+    """
     return get_xnat_users(headers)
 
 

--- a/trust/imaging-api/imaging_api/services/projects.py
+++ b/trust/imaging-api/imaging_api/services/projects.py
@@ -47,6 +47,10 @@ def get_project_from_central_hub_project_id(central_hub_project_id: str, headers
 
     Returns:
         Project: XNAT project object
+
+    Raises:
+        NotFoundError: If no XNAT project has a matching ``secondary_ID``.
+        Exception: If the upstream ``get_all_projects`` call fails.
     """
     try:
         projects = get_all_projects(headers)
@@ -70,6 +74,10 @@ def get_project(project_id: str, headers: dict[str, str]) -> Project:
 
     Returns:
         Project: XNAT project object
+
+    Raises:
+        NotFoundError: If no XNAT project matches ``project_id``.
+        Exception: If the upstream ``get_all_projects`` call fails.
     """
     try:
         projects = get_all_projects(headers)
@@ -92,6 +100,9 @@ def get_all_projects(headers: dict[str, str]) -> list[Project]:
 
     Returns:
         list[Project]: List of XNAT project objects
+
+    Raises:
+        Exception: If the HTTP request to XNAT fails, or if XNAT returns a non-200 response.
     """
     try:
         response = requests.get(f"{XNAT_URL}/data/projects", headers=headers)
@@ -444,6 +455,10 @@ async def delete_project(project_id: str, headers: dict[str, str]) -> Project:
 
     Returns:
         Project: XNAT project object
+
+    Raises:
+        NotFoundError: If the project does not exist on XNAT.
+        Exception: If XNAT returns a non-200 response for the delete call.
     """
     # Check if project exists
     project = get_project(project_id, headers)

--- a/trust/imaging-api/imaging_api/services/users.py
+++ b/trust/imaging-api/imaging_api/services/users.py
@@ -33,6 +33,9 @@ def get_xnat_users(headers: dict[str, str]) -> list[User]:
 
     Returns:
         list[imaging_api.routers.schemas.User]: List of XNAT users.
+
+    Raises:
+        Exception: If XNAT returns a non-200 response.
     """
     response = requests.get(f"{XNAT_URL}/xapi/users/profiles", headers=headers)
     users = [User(**user) for user in response.json()]
@@ -57,6 +60,9 @@ def to_create_imaging_user(user: CentralHubUser, headers: dict[str, str]) -> Cre
 
     Returns:
         imaging_api.routers.schemas.CreateUser: XNAT user creation request object.
+
+    Raises:
+        Exception: If fetching existing XNAT users fails.
     """
     # Extract username from email (part before @)
     base_username = user.email.split("@")[0]
@@ -100,6 +106,11 @@ def get_user_profile_by(key: str, value: str, headers: dict[str, str]) -> User:
 
     Returns:
         imaging_api.routers.schemas.User: The user profile.
+
+    Raises:
+        AssertionError: If ``key`` is not ``"username"`` or ``"email"``.
+        NotFoundError: If no XNAT user matches ``value`` for the given ``key``.
+        Exception: If fetching XNAT users fails.
     """
     assert key in [
         "username",
@@ -173,6 +184,10 @@ def create_user(user: CreateUser, headers: dict[str, str]) -> User:
 
     Returns:
         imaging_api.routers.schemas.User: The created user profile.
+
+    Raises:
+        AlreadyExistsError: If a user with the same username already exists on XNAT (HTTP 409).
+        Exception: If XNAT returns any other non-201 response.
     """
     logger.info(f"Creating user '{user.username}' on XNAT")
 

--- a/trust/imaging-api/imaging_api/services_external/data_access.py
+++ b/trust/imaging-api/imaging_api/services_external/data_access.py
@@ -40,6 +40,10 @@ async def get_dataframe(encrypted_project_id: str, query: str) -> pd.DataFrame:
 
     Returns:
         pd.DataFrame: The DataFrame containing the results of the query.
+
+    Raises:
+        RuntimeError: If the HTTP call to the Data Access API fails (network error or non-2xx
+            response).
     """
     dataframe_request = DataframeRequest(encrypted_project_id=encrypted_project_id, query=query)
 

--- a/trust/imaging-api/imaging_api/utils/encryption.py
+++ b/trust/imaging-api/imaging_api/utils/encryption.py
@@ -22,7 +22,14 @@ from imaging_api.config import get_settings
 
 # --- Step 1: Load AES key from environment file ---
 def get_aes_key() -> bytes:
-    """Retrieve the AES key from the environment file and return it as bytes."""
+    """Retrieve the AES key from the environment file and return it as bytes.
+
+    Returns:
+        bytes: The decoded AES key (16, 24, or 32 bytes).
+
+    Raises:
+        ValueError: If the AES key is missing from configuration or has an invalid length.
+    """
     key_b64 = get_settings().AES_KEY_BASE64
     if not key_b64:
         raise ValueError("AES key not found in environment file")
@@ -35,7 +42,17 @@ def get_aes_key() -> bytes:
 
 # --- Step 2: AES-CBC encryption ---
 def encrypt(plaintext: str, key: bytes | None = None) -> str:
-    """Encrypt plaintext using AES-CBC with PKCS7 padding. Returns Base64-encoded ciphertext."""
+    """Encrypt plaintext using AES-CBC with PKCS7 padding. Returns Base64-encoded ciphertext.
+
+    Args:
+        plaintext (str): The plaintext string to encrypt.
+        key (bytes | None): The AES key to use. If None, the shared AES key is retrieved via
+            :func:`get_aes_key`.
+
+    Returns:
+        str: Base64-encoded ciphertext with the random 16-byte IV prepended to the ciphertext
+        bytes before encoding.
+    """
     if key is None:
         key = get_aes_key()
 
@@ -56,7 +73,17 @@ def encrypt(plaintext: str, key: bytes | None = None) -> str:
 
 # --- Step 3: AES-CBC decryption ---
 def decrypt(encoded_payload: str, key: bytes | None = None) -> str:
-    """Decrypt Base64-encoded ciphertext using AES-CBC with PKCS7 padding. Returns the original plaintext."""
+    """Decrypt Base64-encoded ciphertext using AES-CBC with PKCS7 padding. Returns the original plaintext.
+
+    Args:
+        encoded_payload (str): Base64-encoded payload where the first 16 bytes are the IV and the
+            remaining bytes are the ciphertext.
+        key (bytes | None): The AES key to use. If None, the shared AES key is retrieved via
+            :func:`get_aes_key`.
+
+    Returns:
+        str: The decrypted plaintext.
+    """
     if key is None:
         key = get_aes_key()
 

--- a/trust/imaging-api/imaging_api/utils/passwords.py
+++ b/trust/imaging-api/imaging_api/utils/passwords.py
@@ -20,6 +20,10 @@ def generate_complex_password(length: int = 15) -> str:
 
     Args:
         length (int): Length of the password to generate. Default is 15.
+
+    Returns:
+        str: A complex password of the requested length containing at least one lowercase letter,
+        one uppercase letter, one digit, and one special character.
     """
     # Define character sets
     lowercase = string.ascii_lowercase

--- a/trust/trust-api/trust_api/main.py
+++ b/trust/trust-api/trust_api/main.py
@@ -24,7 +24,11 @@ from trust_api.utils.logger import logger
 
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
-    """Start the task poller background service."""
+    """Start the task poller background service.
+
+    Args:
+        app (FastAPI): The FastAPI application instance being started.
+    """
     poller_task = asyncio.create_task(run_poller())
     logger.info("Trust API started with task poller")
     yield

--- a/trust/trust-api/trust_api/services/task_poller.py
+++ b/trust/trust-api/trust_api/services/task_poller.py
@@ -36,7 +36,11 @@ POLL_INTERVAL_SECONDS = get_settings().POLL_INTERVAL_SECONDS
 
 
 def _auth_headers() -> dict[str, str]:
-    """Return authentication headers for hub API calls."""
+    """Return authentication headers for hub API calls.
+
+    Returns:
+        dict[str, str]: Single-entry mapping of the trust API key header to the configured key.
+    """
     return {TRUST_API_KEY_HEADER: TRUST_API_KEY}
 
 

--- a/trust/trust-api/trust_api/utils/encryption.py
+++ b/trust/trust-api/trust_api/utils/encryption.py
@@ -27,6 +27,9 @@ def get_aes_key() -> bytes:
     """Retrieve the AES key from the environment and return it as bytes.
 
     Cached after first call — the key does not change during the lifetime of a process.
+
+    Returns:
+        bytes: The decoded AES key.
     """
     global _aes_key_cache  # noqa: PLW0603
     if _aes_key_cache is not None:
@@ -37,7 +40,17 @@ def get_aes_key() -> bytes:
 
 
 def decrypt(encoded_payload: str, key: bytes | None = None) -> str:
-    """Decrypt Base64-encoded ciphertext using AES-CBC with PKCS7 padding."""
+    """Decrypt Base64-encoded ciphertext using AES-CBC with PKCS7 padding.
+
+    Args:
+        encoded_payload (str): Base64-encoded payload where the first 16 bytes are the IV and the
+            remaining bytes are the ciphertext.
+        key (bytes | None): The AES key to use. If None, the shared AES key is retrieved via
+            :func:`get_aes_key`.
+
+    Returns:
+        str: The decrypted plaintext.
+    """
     if key is None:
         key = get_aes_key()
 


### PR DESCRIPTION
# Description

This PR adds detailed docstrings to functions across the codebase following Google-style documentation format. The changes enhance code documentation by adding:

- **Args sections**: Document all function parameters with types and descriptions
- **Returns sections**: Describe return values and their types
- **Raises sections**: Document exceptions that functions may raise
- **Additional context**: Clarify behavior, assumptions, and edge cases

The changes span multiple modules including:
- HTTP utilities (`flip-api/src/flip_api/utils/http.py`)
- Trust services (`flip-api/src/flip_api/private_services/trust_tasks.py`)
- FL scheduler service (`flip-api/src/flip_api/fl_services/services/fl_scheduler_service.py`)
- Data access API (`trust/data-access-api/data_access_api/services/cohort.py`)
- Encryption utilities (multiple modules)
- API response helpers, model services, and database seeding functions
- Various utility functions across the codebase

## Linked Issues

Fixes #

## Checklist

- [x] Follows the project's coding conventions and style guide
- [x] Updates documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Type of Change

- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [x] In-line docstrings updated.
- [x] Documentation updated, tested `make -C docs/ docs`.

## Testing

No testing needed. This is a documentation-only change that adds docstrings without modifying any function logic or behavior.

## Additional Notes

All docstrings follow Google-style format for consistency with the project's documentation standards. No functional changes were made to any code paths.

https://claude.ai/code/session_01JP2KA4kAnvqwVmazatGgkG