### PR TITLE
Route Cognito emails through verified SES identity

### DIFF
--- a/deploy/providers/AWS/dev/main.tf
+++ b/deploy/providers/AWS/dev/main.tf
@@ -49,6 +49,10 @@ module "cognito" {
   templates_dir      = "${path.module}/../templates/cognito"
   callback_urls      = var.cognito_callback_urls
   logout_urls        = var.cognito_logout_urls
+  # Route Cognito account emails through our verified SES identity. The dev
+  # account's SES identity must be verified out-of-band before apply.
+  ses_sender_identity_arn = module.ses.sender_identity_arn
+  ses_sender_email        = var.SES_VERIFIED_EMAIL
 }
 
 module "ses" {

--- a/deploy/providers/AWS/modules/cognito/main.tf
+++ b/deploy/providers/AWS/modules/cognito/main.tf
@@ -55,6 +55,16 @@ resource "aws_cognito_user_pool" "flip_user_pool" {
     email_message_by_link = file("${var.templates_dir}/password_reset_link.html")
   }
 
+  # Route account emails (invite, password reset) through our verified SES
+  # identity instead of Cognito's shared COGNITO_DEFAULT sender. The default
+  # path is hard-capped at 50 sends/day and uses no-reply@verificationemail.com,
+  # which Gmail and most enterprise mail filters classify as spam.
+  email_configuration {
+    email_sending_account = "DEVELOPER"
+    source_arn            = var.ses_sender_identity_arn
+    from_email_address    = "FLIP <${var.ses_sender_email}>"
+  }
+
   deletion_protection = "ACTIVE"
   lifecycle {
     prevent_destroy = true

--- a/deploy/providers/AWS/modules/cognito/variables.tf
+++ b/deploy/providers/AWS/modules/cognito/variables.tf
@@ -60,3 +60,13 @@ variable "templates_dir" {
   type        = string
   description = "Path to the directory containing invite.html, password_reset_code.html and password_reset_link.html. Callers typically pass $${path.module}/templates/cognito."
 }
+
+variable "ses_sender_identity_arn" {
+  type        = string
+  description = "ARN of the verified SES identity that Cognito will send account emails from. Typically module.ses.sender_identity_arn."
+}
+
+variable "ses_sender_email" {
+  type        = string
+  description = "Bare email address embedded in the from_email_address header (\"FLIP <email>\"). Must match the SES identity referenced by ses_sender_identity_arn."
+}

--- a/deploy/providers/AWS/services.tf
+++ b/deploy/providers/AWS/services.tf
@@ -104,6 +104,9 @@ module "cognito" {
   # hygiene only — keep the canonical subdomain + localhost for dev.
   callback_urls = ["https://${var.flip_alb_subdomain}", "https://localhost:443"]
   logout_urls   = ["https://${var.flip_alb_subdomain}", "https://localhost:443"]
+  # Route Cognito account emails through our verified SES identity.
+  ses_sender_identity_arn = module.ses.sender_identity_arn
+  ses_sender_email        = var.SES_VERIFIED_EMAIL
 }
 
 # State migration: Cognito resources used to live at the root of this stack and


### PR DESCRIPTION
# Description

Configure AWS Cognito to send account emails (invitations, password resets) through a verified SES identity instead of Cognito's default shared sender. This resolves deliverability issues where emails from the default `no-reply@verificationemail.com` sender are frequently flagged as spam by Gmail and enterprise mail filters, and are subject to a hard 50 sends/day rate limit.

## Changes

- Added `email_configuration` block to the Cognito user pool to use `DEVELOPER` email sending mode with a custom verified SES identity
- Added two new variables to the Cognito module:
  - `ses_sender_identity_arn`: ARN of the verified SES identity
  - `ses_sender_email`: Email address for the "From" header
- Updated both dev and production Cognito module instantiations to pass the SES identity configuration

## Linked Issues

Fixes #

## Type of Change

- [x] Non-breaking change (new feature that does not break existing functionality)
- [ ] Breaking change
- [ ] New tests added to cover the changes
- [ ] In-line docstrings updated
- [ ] Documentation updated

## Testing

No testing needed. This is a configuration change that routes emails through an existing SES module. The SES identity must be verified out-of-band before applying these changes (as noted in the dev environment comments).

## Additional Notes

The SES identity verification is a prerequisite and must be completed before running `terraform apply`. This is a one-time setup requirement per environment.

https://claude.ai/code/session_01H5mz7aSH7cyfixwfPp46aE