### PR TITLE
refactor(deploy): derive FL_PROVISIONED_DIR from FL_BACKEND

### DIFF
--- a/.env.development.example
+++ b/.env.development.example
@@ -96,13 +96,10 @@ BASE_IMAGES_DOWNLOAD_DIR_TRUST2=./data/Trust_2
 FL_ADMIN_DIRECTORY=/app/admin
 FL_API_PORT=8000
 FL_SERVER_PORT=8002
-# Path to NVFLARE / Flower provisioned workspace (from flip-fl-base / flip-fl-base-flower)
-# Contains certificates, keys, fed_client.json, and other provisioned files per network
-# NOTE: The Makefile resolves this to an absolute path relative to the repo root
-# It is normally 
-#   - ../flip-fl-base/workspace for the NVFLARE implementation
-#   - ../flip-fl-base-flower/certs for the Flower implementation
-FL_PROVISIONED_DIR=../flip-fl-base/workspace
+# FL_PROVISIONED_DIR is derived from FL_BACKEND in deploy/fl_backend.mk
+# (../flip-fl-base/workspace for nvflare, ../flip-fl-base-flower/certs for
+# flower). It is only read by the development compose overlays. Override
+# on the command line for a one-off: `make up FL_PROVISIONED_DIR=/tmp/ws`.
 # FL kit date is used in production to download the provisioned workspace from S3 path
 FLARE_KIT_DATE=20260318
 FLOWER_KIT_DATE=20260401

--- a/deploy/fl_backend.mk
+++ b/deploy/fl_backend.mk
@@ -9,12 +9,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Single source of truth for FL backend selection and derived Docker image names.
+# Single source of truth for FL backend selection, derived Docker image names,
+# and the provisioned-workspace path used by the dev compose overlays.
 # Included from the root Makefile and trust/Makefile after the .env* include block.
-# Any .env* file value for DOCKER_FL_API_NAME / DOCKER_FL_SERVER_NAME / DOCKER_FL_CLIENT_NAME
-# is overridden here on purpose — these names must match FL_BACKEND. To test a one-off
-# image, override on the command line (CLI args outrank Makefile assignments):
+# Any .env* file value for DOCKER_FL_API_NAME / DOCKER_FL_SERVER_NAME /
+# DOCKER_FL_CLIENT_NAME / FL_PROVISIONED_DIR is overridden here on purpose —
+# these must match FL_BACKEND. To test a one-off image or a custom workspace,
+# override on the command line (CLI args outrank Makefile assignments):
 #   make up DOCKER_FL_SERVER_NAME=ghcr.io/foo/custom:test
+#   make up FL_PROVISIONED_DIR=/tmp/my-workspace
+#
+# FL_PROVISIONED_DIR is only read by deploy/compose.development.{flower,nvflare}.yml
+# (volume mounts of the provisioned certs / workspace from the sibling repo).
+# In stag/prod the FL services pull their kit from S3 and this path is unused —
+# the root Makefile still absolutises it for consistency but no prod compose
+# references ${FL_PROVISIONED_DIR}.
 
 FL_BACKEND ?= flower
 VALID_FL_BACKENDS := flower nvflare
@@ -27,10 +36,12 @@ ifeq ($(FL_BACKEND),nvflare)
 DOCKER_FL_API_NAME    := flare-fl-api
 DOCKER_FL_SERVER_NAME := flare-fl-server
 DOCKER_FL_CLIENT_NAME := flare-fl-client
+FL_PROVISIONED_DIR    := ../flip-fl-base/workspace
 else
 DOCKER_FL_API_NAME    := flower-fl-api
 DOCKER_FL_SERVER_NAME := flower-superlink
 DOCKER_FL_CLIENT_NAME := flower-supernode
+FL_PROVISIONED_DIR    := ../flip-fl-base-flower/certs
 endif
 
-export DOCKER_FL_API_NAME DOCKER_FL_SERVER_NAME DOCKER_FL_CLIENT_NAME
+export DOCKER_FL_API_NAME DOCKER_FL_SERVER_NAME DOCKER_FL_CLIENT_NAME FL_PROVISIONED_DIR


### PR DESCRIPTION
## Summary

Move `FL_PROVISIONED_DIR` out of the env files and into `deploy/fl_backend.mk`, where it's derived from `FL_BACKEND` alongside the existing `DOCKER_FL_*_NAME` derivations. One FL backend toggle now flips the image names AND the provisioned-workspace path in a single place.

## Why

`FL_PROVISIONED_DIR` is only referenced by `deploy/compose.development.{flower,nvflare}.yml` (the dev compose overlays that bind-mount the provisioned certs / workspace from the sibling `flip-fl-base*` repo). Its correct value is fully determined by `FL_BACKEND`:

- `../flip-fl-base-flower/certs` for `FL_BACKEND=flower`
- `../flip-fl-base/workspace` for `FL_BACKEND=nvflare`

Until now this was one-more-thing-to-remember when switching backends — flip `FL_BACKEND` in the env file, then remember to also flip `FL_PROVISIONED_DIR` separately. The env file even carried commented-out alternatives next to each other:

```
# FL_PROVISIONED_DIR=../flip-fl-base/workspace     # nvflare
FL_PROVISIONED_DIR=../flip-fl-base-flower/certs   # flower (active)
```

which is exactly the kind of sibling-of-a-single-source-of-truth that `fl_backend.mk` was introduced to eliminate for image names — so extend the pattern here.

## Changes

- **`deploy/fl_backend.mk`** — `FL_PROVISIONED_DIR` now set inside the `ifeq ($(FL_BACKEND),nvflare)` / `else` branches alongside `DOCKER_FL_{API,SERVER,CLIENT}_NAME`. Added to the `export` line and to the file header comment that documents the override contract.
- **`.env.development.example`** — dropped the `FL_PROVISIONED_DIR=...` line and the multi-line comment block describing its two possible values. Replaced with a one-paragraph note pointing at `fl_backend.mk`.

No compose-file changes: they continue to read `${FL_PROVISIONED_DIR}` from the Make-exported env; the value just comes from `fl_backend.mk` now instead of `.env`.

Any `.env*` file value is overridden by `fl_backend.mk` on purpose — same pattern and rationale as the image names. CLI-level overrides still work for one-off tests:

```bash
make up FL_PROVISIONED_DIR=/tmp/my-workspace
```

## Test plan

- [x] `make -f <(...) FL_BACKEND=flower` resolves to `FL_PROVISIONED_DIR=../flip-fl-base-flower/certs`
- [x] `make -f <(...) FL_BACKEND=nvflare` resolves to `FL_PROVISIONED_DIR=../flip-fl-base/workspace`
- [x] `make -f <(...) FL_BACKEND=xxx` still errors with the existing validation
- [x] `make -n up` with the root Makefile prints the expected absolutised path (via the existing `override FL_PROVISIONED_DIR := $(abspath ...)` in `Makefile`)
- [ ] `make up FL_BACKEND=flower` on a clean checkout launches the flower dev stack (reviewer to confirm)
- [ ] `make up FL_BACKEND=nvflare` on a clean checkout launches the nvflare dev stack (reviewer to confirm)

## Stag/prod impact

None. No prod compose file references `${FL_PROVISIONED_DIR}` — FL services on stag/prod pull their kit from S3 on the EC2 host. The variable being set in all environments is harmless; the root Makefile's `override FL_PROVISIONED_DIR := $(abspath ...)` step still runs but the resulting absolute path is never consumed.