### PR TITLE
Remove development target from flip-ui Docker build

### DIFF
--- a/deploy/compose.development.yml
+++ b/deploy/compose.development.yml
@@ -22,7 +22,6 @@ services:
         UI_PORT: ${UI_PORT}
       context: ../flip-ui
       dockerfile: Dockerfile
-      target: development
     ports:
       - "${UI_PORT}:443"
     volumes:


### PR DESCRIPTION
# Description

Removes the `target: development` build argument from the flip-ui service Docker build configuration in the development compose file. This allows the Docker build to use the default target (typically the final production stage) instead of explicitly targeting the development stage.

## Linked Issues

Fixes #

## Checklist

- [x] Follows the project's coding conventions and style guide
- [ ] Updates documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Type of Change

- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make -C docs/ docs`.

## Testing

This is a configuration change to the Docker Compose file. No additional testing is needed beyond verifying that the development environment still builds and runs correctly with `docker-compose -f deploy/compose.development.yml up`.

## Additional Notes

This change simplifies the Docker build configuration by removing an explicit target specification, allowing the Dockerfile's default behavior to take precedence.

https://claude.ai/code/session_01PYqKThozHEwFCg9TVZE9K3