### PR TITLE
fix(deploy): pin omop-db production image to :latest

### DIFF
--- a/trust/compose_trust.development.yml
+++ b/trust/compose_trust.development.yml
@@ -17,6 +17,7 @@ services:
 
   # --- Application services ---
 
+  # Image built from https://github.com/londonaicentre/flip-omop-db
   omop-db:
     image: ghcr.io/londonaicentre/omop-db:latest
     restart: always

--- a/trust/compose_trust.production.yml
+++ b/trust/compose_trust.production.yml
@@ -18,7 +18,7 @@ services:
   # --- Application services ---
 
   omop-db:
-    image: ghcr.io/londonaicentre/omop-db:stag
+    image: ghcr.io/londonaicentre/omop-db:latest
     restart: always
     ports:
       - "${OMOP_DB_PORT}:5432"

--- a/trust/compose_trust.production.yml
+++ b/trust/compose_trust.production.yml
@@ -17,6 +17,7 @@ services:
 
   # --- Application services ---
 
+  # Image built from https://github.com/londonaicentre/flip-omop-db
   omop-db:
     image: ghcr.io/londonaicentre/omop-db:latest
     restart: always


### PR DESCRIPTION
## Summary

Hotfix: replace `ghcr.io/londonaicentre/omop-db:stag` with `ghcr.io/londonaicentre/omop-db:latest` in `trust/compose_trust.production.yml`.

The `:stag` tag is no longer published, so production trust deployments fail to pull the `omop-db` image. Switching to `:latest` aligns with `trust/compose_trust.development.yml` (which already uses `:latest`) and restores working deployments.

## Change

```diff
   omop-db:
-    image: ghcr.io/londonaicentre/omop-db:stag
+    image: ghcr.io/londonaicentre/omop-db:latest
```

## History context

The `:stag` line has never been modified since it was first written — it was introduced with the initial production compose file and was simply stale. `grep -rn "omop-db:stag"` confirms no other references remain.

## Test plan

- [ ] `grep -rn "omop-db:stag"` returns no matches
- [ ] On the trust EC2: `docker compose -f compose_trust.production.yml pull omop-db` resolves without `manifest unknown`
- [ ] `docker compose up -d omop-db` starts the container cleanly