### PR TITLE
fix(cohort): return 202 while cohort query is pending, 404 only when unknown

### DIFF
--- a/flip-api/src/flip_api/cohort_services/get_cohort_query_results.py
+++ b/flip-api/src/flip_api/cohort_services/get_cohort_query_results.py
@@ -14,12 +14,13 @@ import json
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Path
+from fastapi.responses import JSONResponse
 from sqlmodel import Session, select
 
 from flip_api.auth.access_manager import can_access_cohort_query
 from flip_api.auth.dependencies import verify_token
 from flip_api.db.database import get_session
-from flip_api.db.models.main_models import QueryStats
+from flip_api.db.models.main_models import Queries, QueryStats
 from flip_api.domain.schemas.cohort import OmopCohortResultsResponse
 from flip_api.utils.logger import logger
 
@@ -31,15 +32,31 @@ router = APIRouter(prefix="/cohort", tags=["cohort_services"])
     "/{query_id}",
     response_model=OmopCohortResultsResponse,
     summary="Get cohort query results",
-    description="Retrieve the results of a previously executed cohort query.",
+    description=(
+        "Retrieve the aggregated results of a cohort query. Returns 202 while the query is "
+        "still pending trust responses, 200 once results are available, and 404 only when the "
+        "query id is unknown."
+    ),
+    responses={
+        202: {"description": "Query exists but no results have been posted by trusts yet."},
+        404: {"description": "No cohort query exists with the supplied id."},
+    },
 )
 def get_cohort_query_results(
     query_id: UUID = Path(..., description="Unique identifier of the cohort query"),
     db: Session = Depends(get_session),
     user_id: UUID = Depends(verify_token),
-) -> OmopCohortResultsResponse:
+) -> OmopCohortResultsResponse | JSONResponse:
     """
-    Retrieve the results of a previously executed cohort query.
+    Retrieve the aggregated results of a cohort query.
+
+    Cohort queries are async: the hub queues tasks for all trusts, each trust runs the query
+    against its OMOP database and posts results back. Until the first trust responds, the
+    query exists but has no stats. This endpoint distinguishes three states:
+
+    * **200** — stats are populated, return them.
+    * **202** — query is known but still pending trust responses.
+    * **404** — query id is unknown (or access-layer denies it).
 
     Args:
         query_id (UUID): Unique identifier of the cohort query.
@@ -47,13 +64,9 @@ def get_cohort_query_results(
         user_id (UUID): ID of the user making the request, obtained from authentication.
 
     Returns:
-        OmopCohortResultsResponse: The results of the cohort query
-
-    Raises:
-        HTTPException: If the user does not have access to the cohort query or if there are errors retrieving results.
+        OmopCohortResultsResponse | JSONResponse: Results (200) or a pending marker (202).
     """
     try:
-        # Check access permissions
         logger.info(f"Checking access for user: {user_id} to cohort query: {query_id}")
 
         if not can_access_cohort_query(user_id, query_id, db):
@@ -62,33 +75,31 @@ def get_cohort_query_results(
                 status_code=403, detail=f"User with ID: {user_id} is denied access to this cohort query"
             )
 
-        # Validation is handled by FastAPI's path parameter validation
-        # No need for explicit validation as in the original
+        # Step 1: does the query exist at all? Needed so we can distinguish "unknown id"
+        # (404) from "known but pending" (202). Without this, a freshly-submitted query
+        # spuriously returns 404 during the window between POST /step/cohort and the first
+        # trust's POST /cohort/results — which surfaces as a noisy error in the browser
+        # console while the UI polls.
+        query_exists = db.exec(select(Queries.id).where(Queries.id == query_id)).first()
+        if not query_exists:
+            logger.info(f"Cohort query not found for id: {query_id}")
+            raise HTTPException(status_code=404, detail=f"Cohort query not found for id: {query_id}")
 
-        logger.debug("Gathering aggregated cohort results...")
-
-        # Execute database query
-        # Note we only expect one entry for a given query_id, so we can use first()
+        # Step 2: results lookup. A single QueryStats row is expected per query.
         db_query_stats = db.exec(select(QueryStats.stats).where(QueryStats.query_id == query_id)).first()
 
-        logger.debug(f"query_id used: {query_id}")
-        logger.debug(f"Database response: {db_query_stats}")
-
         if not db_query_stats:
-            logger.error(f"No results found for query ID: {query_id}")
-            raise HTTPException(status_code=404, detail="No results returned from the database")
+            logger.debug(f"Cohort query {query_id} is still pending trust responses")
+            return JSONResponse(
+                status_code=202,
+                content={"status": "pending", "detail": "Results not yet available — trust responses pending"},
+            )
 
-        # Parse the results using model_validate instead of parse_obj
         query_stats = OmopCohortResultsResponse.model_validate(json.loads(db_query_stats))
-
         logger.info("Results have been successfully obtained")
-        logger.debug(f"Query results: {query_stats}")
-
-        # Return parsed results - FastAPI will handle JSON serialization
         return query_stats
 
     except HTTPException:
-        # Re-raise HTTP exceptions so they maintain their status codes
         raise
     except Exception as e:
         logger.error(f"Error retrieving cohort query results: {str(e)}")

--- a/flip-api/tests/unit/cohort_services/test_get_cohort_query_results.py
+++ b/flip-api/tests/unit/cohort_services/test_get_cohort_query_results.py
@@ -57,14 +57,23 @@ MOCK_STATS = {
 }
 
 
+def _configure_db_mock(mock_db: MagicMock, *, query_exists: bool, stats_json: str | None) -> None:
+    """Wire up two sequential db.exec().first() results: Queries lookup then QueryStats lookup."""
+    exec_results = [
+        MagicMock(first=MagicMock(return_value=TEST_QUERY_ID if query_exists else None)),
+        MagicMock(first=MagicMock(return_value=stats_json)),
+    ]
+    mock_db.exec.side_effect = exec_results
+
+
 @patch("flip_api.cohort_services.get_cohort_query_results.can_access_cohort_query", return_value=True)
 def test_get_cohort_results_success(mock_access):
     mock_db = MagicMock()
-    mock_db.exec.return_value.first.return_value = json.dumps(MOCK_STATS)
+    _configure_db_mock(mock_db, query_exists=True, stats_json=json.dumps(MOCK_STATS))
 
     result = get_cohort_query_results(query_id=TEST_QUERY_ID, db=mock_db, user_id=TEST_USER_ID)
 
-    # Check the response type
+    # 200 path returns the parsed model directly (FastAPI wraps it in a 200 response)
     assert result.record_count == 100
     assert len(result.trusts_results) == 2
 
@@ -90,15 +99,32 @@ def test_get_cohort_results_success(mock_access):
 
 
 @patch("flip_api.cohort_services.get_cohort_query_results.can_access_cohort_query", return_value=True)
-def test_get_cohort_results_not_found(mock_access):
+def test_get_cohort_results_pending_returns_202(mock_access):
+    """Query exists in the Queries table but no QueryStats row yet — results still being gathered."""
+    from fastapi.responses import JSONResponse
+
     mock_db = MagicMock()
-    mock_db.exec.return_value.first.return_value = None
+    _configure_db_mock(mock_db, query_exists=True, stats_json=None)
+
+    response = get_cohort_query_results(query_id=TEST_QUERY_ID, db=mock_db, user_id=TEST_USER_ID)
+
+    assert isinstance(response, JSONResponse)
+    assert response.status_code == 202
+    body = json.loads(response.body)
+    assert body["status"] == "pending"
+
+
+@patch("flip_api.cohort_services.get_cohort_query_results.can_access_cohort_query", return_value=True)
+def test_get_cohort_results_unknown_query_returns_404(mock_access):
+    """No Queries row at all — truly unknown query_id, return 404."""
+    mock_db = MagicMock()
+    _configure_db_mock(mock_db, query_exists=False, stats_json=None)
 
     with pytest.raises(HTTPException) as exc_info:
         get_cohort_query_results(query_id=TEST_QUERY_ID, db=mock_db, user_id=TEST_USER_ID)
 
     assert exc_info.value.status_code == 404
-    assert "No results returned from the database" in str(exc_info.value.detail)
+    assert "Cohort query not found" in str(exc_info.value.detail)
 
 
 @patch("flip_api.cohort_services.get_cohort_query_results.can_access_cohort_query", return_value=False)

--- a/flip-ui/src/services/__tests__/cohort-query-service.spec.ts
+++ b/flip-ui/src/services/__tests__/cohort-query-service.spec.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2026 Guy's and St Thomas' NHS Foundation Trust & King's College London
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, test, vi } from "vitest";
+
+import { _http } from "@/services/api";
+import { getOMOPResults } from "@/services/cohort-query-service";
+
+vi.mock("@/services/api", () => {
+    return { _http: { get: vi.fn() } };
+});
+
+describe("getOMOPResults", () => {
+    test("returns parsed results on HTTP 200", async () => {
+        const payload = { name: "X", results: [] };
+        vi.mocked(_http.get).mockResolvedValueOnce({ status: 200, data: payload });
+
+        const result = await getOMOPResults("/cohort/abc");
+
+        expect(result).toEqual(payload);
+    });
+
+    test("returns null on HTTP 202 so SWRV keeps polling without logging an error", async () => {
+        vi.mocked(_http.get).mockResolvedValueOnce({ status: 202, data: { status: "pending" } });
+
+        const result = await getOMOPResults("/cohort/abc");
+
+        expect(result).toBeNull();
+    });
+
+    test("accepts 202 as non-error via validateStatus override", async () => {
+        // Regression guard: without validateStatus including 202, axios would throw and surface
+        // a noisy console error to the user while the UI polls for a freshly-submitted query.
+        vi.mocked(_http.get).mockResolvedValueOnce({ status: 202, data: { status: "pending" } });
+
+        await getOMOPResults("/cohort/abc");
+
+        const [, config] = vi.mocked(_http.get).mock.calls[0];
+        expect(config?.validateStatus?.(202)).toBe(true);
+        expect(config?.validateStatus?.(200)).toBe(true);
+        expect(config?.validateStatus?.(404)).toBe(false);
+    });
+});

--- a/flip-ui/src/services/cohort-query-service.ts
+++ b/flip-ui/src/services/cohort-query-service.ts
@@ -68,10 +68,19 @@ export interface IResults {
 /**
  * Get Cohort Query Results
  * @param {string} url - The URL of the OMOP API endpoint.
- * @returns The data returned from the OMOP API.
+ * @returns The data returned from the OMOP API, or `null` while the hub is still waiting
+ *          for trusts to post their results (HTTP 202).
  */
-export async function getOMOPResults(url: string): Promise<IResults> {
-    const response = await _http.get<IResults>(url);
+export async function getOMOPResults(url: string): Promise<IResults | null> {
+    const response = await _http.get<IResults>(url, {
+        // Accept 202 (pending) as a non-error response so SWRV keeps polling
+        // on its refresh interval instead of logging an axios error in the console.
+        validateStatus: (status) => (status >= 200 && status < 300) || status === 202,
+    });
+
+    if (response.status === 202) {
+        return null;
+    }
 
     return response.data;
 }


### PR DESCRIPTION
## Summary

- The \`GET /api/cohort/{query_id}\` endpoint returned 404 whenever \`QueryStats\` had no row for the given id — including the expected window right after submit, while trusts are still running the query. The UI polls every 10s, so every freshly-submitted cohort produced a handful of \"404 (Not Found)\" lines in the browser console before results landed.
- Split the two cases so 404 is reserved for truly unknown query ids and 202 Accepted is returned while results are pending. UI handles 202 silently.

## Changes

**API** (\`flip-api/src/flip_api/cohort_services/get_cohort_query_results.py\`)

- Check \`Queries.id\` existence first; 404 only when the id is unknown.
- Return \`202 Accepted\` + \`{status: \"pending\", detail: \"...\"}\` when the query exists but no \`QueryStats\` row yet.
- \`200\` with results once stats are populated (unchanged).
- Declare both response codes on the route for OpenAPI/docs accuracy.

**UI** (\`flip-ui/src/services/cohort-query-service.ts\`)

- \`getOMOPResults\` accepts 202 via \`validateStatus\` override and returns \`null\` so SWRV keeps polling on its refresh interval without surfacing an axios error to the console.

**Tests**

- flip-api: two new cases (pending → 202, unknown query → 404); existing mock helper refactored so the existence + stats lookups are wired independently.
- flip-ui: new service-level spec covering the 200, 202, and \`validateStatus\` paths.

## Test plan

- [x] \`cd flip-api && make unit_test\` — 748 passed, 0 failed
- [x] \`cd flip-ui && npx vitest run\` — 125 passed, 0 failed (3 new cases in \`services/__tests__/cohort-query-service.spec.ts\`)
- [ ] Manual: submit a cohort query in the UI, confirm no \`404\` lines appear in the browser console while waiting for trust results, confirm results render once available