### PR TITLE
fix(local-trust): create /opt/flip/xnat/xnat-db-data during provisioning

### DIFF
--- a/deploy/providers/local/site_local_trust.yml
+++ b/deploy/providers/local/site_local_trust.yml
@@ -57,12 +57,14 @@
       loop:
         - "{{ flip_dir }}"
         - "{{ flip_dir }}/data/images"
-        # XNAT bind-mount directories (Docker Swarm does not auto-create them)
+        # XNAT bind-mount directories (Docker Swarm does not auto-create them).
+        # Keep this list in sync with deploy/providers/AWS/site.yml.
         - "{{ flip_dir }}/xnat"
         - "{{ flip_dir }}/xnat/xnat-data/tomcat_logs"
         - "{{ flip_dir }}/xnat/xnat-data/archive"
         - "{{ flip_dir }}/xnat/xnat-data/build"
         - "{{ flip_dir }}/xnat/xnat-data/cache"
+        - "{{ flip_dir }}/xnat/xnat-db-data"
 
     - name: Create FL client kit directories
       file:


### PR DESCRIPTION
## Summary

- The local-trust Ansible playbook (\`deploy/providers/local/site_local_trust.yml\`) was missing \`/opt/flip/xnat/xnat-db-data\` from its XNAT bind-mount directory list. Its cloud-side counterpart (\`deploy/providers/AWS/site.yml:232\`) already creates the directory, so this was pure drift.
- Without the host directory, the \`xnat-db\` Docker Swarm service is rejected in a retry loop with \`invalid mount config for type \"bind\": bind source path does not exist\`. \`xnat-web\` then hangs forever on \`Postgres is unavailable - sleeping\` — port 8108 accepts TCP via the Swarm ingress mesh but HTTP never responds.
- Fix: add the directory to the existing XNAT bind-mount loop and add a comment asking editors to keep the two playbooks in sync.

## Repro

On a clean on-prem trust host (or any host where \`add-local-trust\` provisions with this playbook):

1. \`make add-local-trust LOCAL_TRUST_IP=<ip>\` (no SSH key, local mode)
2. \`cd trust && PROD=<stag|true> make up-local-trust\`
3. \`docker service ps xnat-local_xnat-db\` → shows \`Rejected / invalid mount config\`
4. \`curl http://localhost:8108/\` → hangs

After this patch, \`xnat-db-data\` exists before the Swarm stack is started, xnat-db boots normally, and XNAT is reachable on 8108.

## Test plan

- [ ] Rerun \`make add-local-trust\` on a host and verify \`/opt/flip/xnat/xnat-db-data\` exists afterward
- [ ] \`make up-local-trust\` → \`docker service ls\` shows \`xnat-local_xnat-db\` as \`1/1\`
- [ ] \`curl -I http://localhost:8108/\` returns an HTTP response (200 or a redirect) within a reasonable startup window