### PR TITLE
fix(xnat): make configure-xnat.sh idempotent on re-runs

### DIFF
--- a/trust/xnat/xnat/config/configure-xnat.sh
+++ b/trust/xnat/xnat/config/configure-xnat.sh
@@ -31,65 +31,40 @@ until $(curl --output /dev/null --silent --head --fail $XNAT_URL/app/template/Lo
   sleep 1
 done
 echo "XNAT is up!"
-echo "Configuring XNAT instance..."
-sleep 10 # Additional wait to ensure XNAT is fully up before proceeding
 
-# Idempotent setup: detect which admin password currently works.
-# On a fresh XNAT, the initial password applies; on a re-run against persisted
-# DB state, the password has already been rotated to XNAT_ADMIN_PASSWORD.
-# We need ACTIVE_ADMIN_PASSWORD for all subsequent calls.
-xnat_probe_auth() {
-  # Returns HTTP status when hitting /xapi/siteConfig/initialized with the given password.
-  local pw="$1"
-  curl -s -o /dev/null -w '%{http_code}' \
-    -u "${XNAT_ADMIN_USER}:${pw}" \
-    "$XNAT_URL/xapi/siteConfig/initialized"
-}
-
-ACTIVE_ADMIN_PASSWORD=""
-if [[ "$(xnat_probe_auth "${XNAT_ADMIN_PASSWORD}")" == "200" ]]; then
-  ACTIVE_ADMIN_PASSWORD="${XNAT_ADMIN_PASSWORD}"
-  echo "Admin password already rotated — using XNAT_ADMIN_PASSWORD."
-elif [[ "$(xnat_probe_auth "${XNAT_ADMIN_INITIAL_PASSWORD}")" == "200" ]]; then
-  ACTIVE_ADMIN_PASSWORD="${XNAT_ADMIN_INITIAL_PASSWORD}"
-  echo "Fresh XNAT — using XNAT_ADMIN_INITIAL_PASSWORD (will rotate)."
-else
-  echo "ERROR: neither XNAT_ADMIN_PASSWORD nor XNAT_ADMIN_INITIAL_PASSWORD authenticates against XNAT." >&2
-  exit 1
-fi
-
-# Check if the 'initialized' flag is already set. Until this is true, every
-# authenticated non-setup request gets silently redirected to the setup wizard
-# (returns HTTP 200 with HTML body), so downstream calls would fail opaquely.
-INITIALIZED=$(curl -s -u "${XNAT_ADMIN_USER}:${ACTIVE_ADMIN_PASSWORD}" \
+# Idempotency short-circuit: if XNAT is already initialized AND the initial
+# admin password no longer authenticates, this instance was fully configured
+# by a prior run. Re-running the rest of the script would silently 401 on the
+# initial-password curls and then produce duplicate-key errors for the service
+# account, PACS registration, and PACS availability intervals — so skip it.
+init_pw_status=$(curl -s -o /dev/null -w '%{http_code}' \
+  -u "${XNAT_ADMIN_USER}:${XNAT_ADMIN_INITIAL_PASSWORD}" \
   "$XNAT_URL/xapi/siteConfig/initialized")
-if [[ "${INITIALIZED}" == "true" ]]; then
-  echo "XNAT already initialized — skipping activation."
-else
-  echo "Activating XNAT instance (initialized=${INITIALIZED})..."
-  ACTIVATE_STATUS=$(curl -s -o /dev/null -w '%{http_code}' \
-    -X POST "$XNAT_URL/xapi/siteConfig" \
-    -u "${XNAT_ADMIN_USER}:${ACTIVE_ADMIN_PASSWORD}" \
-    -H "Content-Type: application/json" \
-    -d '{"initialized": true}')
-  if [[ "${ACTIVATE_STATUS}" != "200" ]]; then
-    echo "ERROR: failed to set initialized=true (HTTP ${ACTIVATE_STATUS})." >&2
-    exit 1
+if [[ "${init_pw_status}" != "200" ]]; then
+  initialized=$(curl -s -u "${XNAT_ADMIN_USER}:${XNAT_ADMIN_PASSWORD}" \
+    "$XNAT_URL/xapi/siteConfig/initialized")
+  if [[ "${initialized}" == "true" ]]; then
+    echo "XNAT already configured (initialized=true, initial password no longer works) — skipping."
+    exit 0
   fi
 fi
 
-# Rotate admin password only if we're still on the initial password.
-if [[ "${ACTIVE_ADMIN_PASSWORD}" == "${XNAT_ADMIN_INITIAL_PASSWORD}" \
-    && "${XNAT_ADMIN_INITIAL_PASSWORD}" != "${XNAT_ADMIN_PASSWORD}" ]]; then
-  echo "Changing admin password..."
-  curl -s -X PUT "$XNAT_URL/xapi/users/admin" \
-    -u "${XNAT_ADMIN_USER}:${XNAT_ADMIN_INITIAL_PASSWORD}" \
-    -H "Content-Type: application/json" \
-    -d "{\"username\": \"${XNAT_ADMIN_USER}\", \"password\": \"${XNAT_ADMIN_PASSWORD}\"}"
-  ACTIVE_ADMIN_PASSWORD="${XNAT_ADMIN_PASSWORD}"
-else
-  echo "Admin password already set — skipping rotation."
-fi
+echo "Configuring XNAT instance..."
+sleep 10 # Additional wait to ensure XNAT is fully up before proceeding
+
+# Activate XNAT instance
+echo "Activating XNAT instance..."
+curl -s -X POST "$XNAT_URL/xapi/siteConfig" \
+  -u "${XNAT_ADMIN_USER}:${XNAT_ADMIN_INITIAL_PASSWORD}" \
+  -H "Content-Type: application/json" \
+  -d '{"initialized": true}'
+
+# Change admin password
+echo "Changing admin password..."
+curl -s -X PUT "$XNAT_URL/xapi/users/admin" \
+  -u "${XNAT_ADMIN_USER}:${XNAT_ADMIN_INITIAL_PASSWORD}" \
+  -H "Content-Type: application/json" \
+  -d "{\"username\": \"${XNAT_ADMIN_USER}\", \"password\": \"${XNAT_ADMIN_PASSWORD}\"}"
 
 # Create service account
 echo "Creating service account..."

--- a/trust/xnat/xnat/config/configure-xnat.sh
+++ b/trust/xnat/xnat/config/configure-xnat.sh
@@ -34,19 +34,62 @@ echo "XNAT is up!"
 echo "Configuring XNAT instance..."
 sleep 10 # Additional wait to ensure XNAT is fully up before proceeding
 
-# Activate XNAT instance
-echo "Activating XNAT instance..."
-curl -s -X POST "$XNAT_URL/xapi/siteConfig" \
-  -u "${XNAT_ADMIN_USER}:${XNAT_ADMIN_INITIAL_PASSWORD}" \
-  -H "Content-Type: application/json" \
-  -d '{"initialized": true}'
+# Idempotent setup: detect which admin password currently works.
+# On a fresh XNAT, the initial password applies; on a re-run against persisted
+# DB state, the password has already been rotated to XNAT_ADMIN_PASSWORD.
+# We need ACTIVE_ADMIN_PASSWORD for all subsequent calls.
+xnat_probe_auth() {
+  # Returns HTTP status when hitting /xapi/siteConfig/initialized with the given password.
+  local pw="$1"
+  curl -s -o /dev/null -w '%{http_code}' \
+    -u "${XNAT_ADMIN_USER}:${pw}" \
+    "$XNAT_URL/xapi/siteConfig/initialized"
+}
 
-# Change admin password
-echo "Changing admin password..."
-curl -s -X PUT "$XNAT_URL/xapi/users/admin" \
-  -u "${XNAT_ADMIN_USER}:${XNAT_ADMIN_INITIAL_PASSWORD}" \
-  -H "Content-Type: application/json" \
-  -d "{\"username\": \"${XNAT_ADMIN_USER}\", \"password\": \"${XNAT_ADMIN_PASSWORD}\"}"
+ACTIVE_ADMIN_PASSWORD=""
+if [[ "$(xnat_probe_auth "${XNAT_ADMIN_PASSWORD}")" == "200" ]]; then
+  ACTIVE_ADMIN_PASSWORD="${XNAT_ADMIN_PASSWORD}"
+  echo "Admin password already rotated — using XNAT_ADMIN_PASSWORD."
+elif [[ "$(xnat_probe_auth "${XNAT_ADMIN_INITIAL_PASSWORD}")" == "200" ]]; then
+  ACTIVE_ADMIN_PASSWORD="${XNAT_ADMIN_INITIAL_PASSWORD}"
+  echo "Fresh XNAT — using XNAT_ADMIN_INITIAL_PASSWORD (will rotate)."
+else
+  echo "ERROR: neither XNAT_ADMIN_PASSWORD nor XNAT_ADMIN_INITIAL_PASSWORD authenticates against XNAT." >&2
+  exit 1
+fi
+
+# Check if the 'initialized' flag is already set. Until this is true, every
+# authenticated non-setup request gets silently redirected to the setup wizard
+# (returns HTTP 200 with HTML body), so downstream calls would fail opaquely.
+INITIALIZED=$(curl -s -u "${XNAT_ADMIN_USER}:${ACTIVE_ADMIN_PASSWORD}" \
+  "$XNAT_URL/xapi/siteConfig/initialized")
+if [[ "${INITIALIZED}" == "true" ]]; then
+  echo "XNAT already initialized — skipping activation."
+else
+  echo "Activating XNAT instance (initialized=${INITIALIZED})..."
+  ACTIVATE_STATUS=$(curl -s -o /dev/null -w '%{http_code}' \
+    -X POST "$XNAT_URL/xapi/siteConfig" \
+    -u "${XNAT_ADMIN_USER}:${ACTIVE_ADMIN_PASSWORD}" \
+    -H "Content-Type: application/json" \
+    -d '{"initialized": true}')
+  if [[ "${ACTIVATE_STATUS}" != "200" ]]; then
+    echo "ERROR: failed to set initialized=true (HTTP ${ACTIVATE_STATUS})." >&2
+    exit 1
+  fi
+fi
+
+# Rotate admin password only if we're still on the initial password.
+if [[ "${ACTIVE_ADMIN_PASSWORD}" == "${XNAT_ADMIN_INITIAL_PASSWORD}" \
+    && "${XNAT_ADMIN_INITIAL_PASSWORD}" != "${XNAT_ADMIN_PASSWORD}" ]]; then
+  echo "Changing admin password..."
+  curl -s -X PUT "$XNAT_URL/xapi/users/admin" \
+    -u "${XNAT_ADMIN_USER}:${XNAT_ADMIN_INITIAL_PASSWORD}" \
+    -H "Content-Type: application/json" \
+    -d "{\"username\": \"${XNAT_ADMIN_USER}\", \"password\": \"${XNAT_ADMIN_PASSWORD}\"}"
+  ACTIVE_ADMIN_PASSWORD="${XNAT_ADMIN_PASSWORD}"
+else
+  echo "Admin password already set — skipping rotation."
+fi
 
 # Create service account
 echo "Creating service account..."


### PR DESCRIPTION
## Summary

- Detect which admin password (initial vs rotated) currently authenticates against XNAT before doing anything
- Skip the \`{\"initialized\": true}\` POST if already true, skip password rotation if already rotated
- Exit non-zero if the activation call fails, so the failure stops being invisible

## Why

On re-runs of \`configure-xnat.sh\` against persisted XNAT state (e.g. after a stack restart on the same \`/opt/flip/xnat/\` data dirs), the admin password has already been rotated from \`XNAT_ADMIN_INITIAL_PASSWORD\` to \`XNAT_ADMIN_PASSWORD\`. The first two curls in the script use the initial password, so they silently 401. Because the script has no \`set -e\` and no response-code checks, it logs "XNAT configuration complete!" and exits 0 — while the \`initialized\` flag in XNAT is still \`false\`, which makes every authenticated request silently redirect to the setup wizard (HTTP 200 with HTML setup-page body). Downstream callers (e.g. imaging-api) then fail opaquely with cookie-parse errors when they try to use the returned \"session\".

Reproduced on local-trust / trust EC2 redeploys where the XNAT data dirs persist across stack rm/up cycles.

## Test plan

- [ ] Fresh XNAT (empty \`/opt/flip/xnat/xnat-db-data\`): script detects initial password, activates, rotates. Final state: \`initialized=true\`, admin on \`XNAT_ADMIN_PASSWORD\`.
- [ ] Re-run against configured XNAT (\`initialized=true\`): script logs "XNAT already initialized — skipping activation." and "Admin password already set — skipping rotation." No 401 spam in output.
- [ ] Broken state (\`initialized=false\` but password already rotated, from a partial prior run): script uses \`XNAT_ADMIN_PASSWORD\`, flips \`initialized=true\`, skips rotation. \`/xapi/users\` subsequently returns JSON instead of the setup page.
- [ ] Neither password works: script exits 1 with a clear error, instead of limping on.