### PR TITLE
feat(trust): local-trust coexists with dev trust1/trust2 on one host

### DIFF
--- a/.env.development.example
+++ b/.env.development.example
@@ -37,7 +37,6 @@ POSTGRES_DB=centralhub
 PACS_DICOM_PORT=4242
 PACS_UI_PORT_TRUST_1=8042
 PACS_UI_PORT_TRUST_2=8044
-PACS_UI_PORT_LOCAL_TRUST=8046
 # Need to specify ports for the OMOP database so that we can populate it with mock data from the host. Normally when
 # running cohort queries the OMOP database will be accessed via the trust services, so ports won't be needed.
 OMOP_DB_PORT_TRUST_1=5434
@@ -72,7 +71,6 @@ PGADMIN_PASSWORD=<your-pgadmin-password>
 #
 XNAT_PORT_TRUST_1=8104
 XNAT_PORT_TRUST_2=8106
-XNAT_PORT_LOCAL_TRUST=8108
 XNAT_URL=http://xnat-web:8080
 XNAT_DATABASE_URL=postgresql+asyncpg://xnat:xnat@xnat-db:5432/xnat
 XNAT_ADMIN_USER=<your-xnat-admin-username>

--- a/trust/Makefile
+++ b/trust/Makefile
@@ -10,7 +10,7 @@
 # limitations under the License.
 #
 
-.PHONY: build dev prod clean stop up down up-trust-1 up-trust-2 down-trust-1 down-trust-2 up-local-trust down-local-trust create-networks remove-networks recreate-networks tests
+.PHONY: build dev prod clean stop up down up-trust-1 up-trust-2 down-trust-1 down-trust-2 up-local-trust down-local-trust create-networks create-networks-local-trust remove-networks recreate-networks tests
 # if tag PROD=true is passed, set PROD=true
 ifeq ($(PROD),true)
 MAIN_ENV_FILE=../.env.production
@@ -44,6 +44,7 @@ endif
 
 network1 = deploy_trust-network-1
 network2 = deploy_trust-network-2
+network_local = deploy_trust-network-local
 trust1 = trust1
 trust2 = trust2
 trust_local = trust-local
@@ -99,6 +100,30 @@ TRUST_2_VARS = \
 	TRUST_NUMBER=2 \
 	TRUST_API_KEY=$(call get_json_value,$(TRUST_API_KEYS),Trust_2)
 
+# Host ports, bind paths, and the trust network are hardcoded here (not env
+# vars) so the local-trust stack can coexist with dev trust1/trust2 on one
+# laptop without colliding, and so stag/prod hosts (AWS trust EC2 or on-prem
+# via `make add-local-trust`) don't need any _LOCAL_TRUST entries in their
+# env files or AWS Secrets Manager. Port numbers / dir names are arbitrary —
+# picked to be non-overlapping with the _TRUST_1/_TRUST_2 allocations.
+LOCAL_TRUST_VARS = \
+	BASE_IMAGES_DOWNLOAD_DIR=./data/local/$(LOCAL_TRUST_NAME) \
+	OMOP_DB_PORT=5438 \
+	PACS_UI_PORT=8046 \
+	ORTHANC_STORAGE=$(ORTHANC_STORAGE_TRUST_$(subst Trust_,,$(LOCAL_TRUST_NAME))) \
+	XNAT_PORT=8108 \
+	GRAFANA_PORT=3002 \
+	LOKI_PORT=3102 \
+	TRUST_NETWORK_NAME=${network_local} \
+	TRUST_NAME=$(LOCAL_TRUST_NAME) \
+	TRUST_NUMBER=$(subst Trust_,,$(LOCAL_TRUST_NAME)) \
+	TRUST_API_KEY=$(call get_json_value,$(TRUST_API_KEYS),$(LOCAL_TRUST_NAME)) \
+	OMOP_DATA_DIR=./omop-db/volumes/$(LOCAL_TRUST_NAME)/db_data \
+	ORTHANC_STORAGE_DIR=./orthanc/orthanc-storage-2 \
+	OBSERVABILITY_CONFIG_DIR=./observability \
+	LOKI_DATA_VOLUME=trust-local-loki-data \
+	GRAFANA_DATA_VOLUME=trust-local-grafana-data
+
 build:
 	$(TRUST_1_VARS) ${DOCKER_COMPOSE_CMD} -p ${trust1} build --no-cache
 	$(TRUST_2_VARS) ${DOCKER_COMPOSE_CMD} -p ${trust2} build
@@ -131,40 +156,28 @@ down-trust-1-ec2:
 	@echo "🛑 Stopping Trust 1 services..."
 	$(TRUST_1_VARS) ${DOCKER_COMPOSE_CMD} -p ${trust1} down --remove-orphans
 
-# LOCAL_TRUST_NAME controls which NVFlare participant kit the FL client mounts.
-# Local (on-prem) trusts use Trust_2 kit; EC2 trusts use Trust_1 kit (default).
-# LOCAL_TRUST_NAME is defined in deploy/providers/AWS/Makefile
-# Local trust reuses existing dev dirs to avoid duplicating data:
-#   OMOP_DATA_DIR: points at dev OMOP data (default: /opt/flip/omop/db_data on EC2)
-#   OBSERVABILITY_CONFIG_DIR: points at repo config files (default: /opt/flip/config/observability on EC2)
-#   LOKI/GRAFANA_DATA_VOLUME: uses Docker named volumes (default: bind mounts on EC2)
-up-local-trust:
+# LOCAL_TRUST_NAME controls which FL participant kit the FL client mounts.
+# Local (on-prem) trusts default to the Trust_2 kit; EC2 trusts use Trust_1.
+# LOCAL_TRUST_NAME is defined in deploy/providers/AWS/Makefile and threaded
+# through the root Makefile.
+#
+# Both recipes below use $(LOCAL_TRUST_VARS) so they stay in sync — see the
+# block near the top of this file for why each env-var has a _LOCAL_TRUST
+# variant (dev-laptop coexistence with `make up`) and why unset values fall
+# back to the Trust_1 defaults (single-host stag/prod deploys).
+up-local-trust: create-networks-core create-networks-local-trust
 	## Starts local trust compose stack with TRUST_NAME=$(LOCAL_TRUST_NAME).
 	## Uses project name 'trust-local' to avoid collisions with dev trust1/trust2.
 	@echo "🚢 Starting local Trust services (TRUST_NAME=$(LOCAL_TRUST_NAME))..."
 	@echo "⚙️ Using environment file ${MAIN_ENV_FILE}"
 	@echo "🧠 FL_BACKEND=$(FL_BACKEND) ($(FL_BACKEND_COMPOSE_FILE))"
-	mkdir -p ${BASE_IMAGES_DOWNLOAD_DIR_TRUST1}
-	$(TRUST_1_VARS) TRUST_NAME=$(LOCAL_TRUST_NAME) \
-		TRUST_NUMBER=$(subst Trust_,,$(LOCAL_TRUST_NAME)) \
-		TRUST_API_KEY=$(call get_json_value,$(TRUST_API_KEYS),$(LOCAL_TRUST_NAME)) \
-		XNAT_PORT=${XNAT_PORT_LOCAL_TRUST} \
-		PACS_UI_PORT=${PACS_UI_PORT_LOCAL_TRUST} \
-		OMOP_DATA_DIR=./omop-db/volumes/$(LOCAL_TRUST_NAME)/db_data \
-		OBSERVABILITY_CONFIG_DIR=./observability \
-		LOKI_DATA_VOLUME=trust-local-loki-data \
-		GRAFANA_DATA_VOLUME=trust-local-grafana-data \
-		DEBUG=$(DEBUG) \
+	mkdir -p ./data/local/$(LOCAL_TRUST_NAME)
+	$(LOCAL_TRUST_VARS) DEBUG=$(DEBUG) \
 		$(DOCKER_COMPOSE_CMD) -f compose_trust.local.yml -p $(trust_local) up -d --pull always
 
 down-local-trust:
 	@echo "🛑 Stopping local Trust services..."
-	$(TRUST_1_VARS) TRUST_NAME=$(LOCAL_TRUST_NAME) \
-		TRUST_NUMBER=$(subst Trust_,,$(LOCAL_TRUST_NAME)) \
-		OMOP_DATA_DIR=./omop-db/volumes/$(LOCAL_TRUST_NAME)/db_data \
-		OBSERVABILITY_CONFIG_DIR=./observability \
-		LOKI_DATA_VOLUME=trust-local-loki-data \
-		GRAFANA_DATA_VOLUME=trust-local-grafana-data \
+	$(LOCAL_TRUST_VARS) \
 		$(DOCKER_COMPOSE_CMD) -f compose_trust.local.yml -p $(trust_local) down --remove-orphans
 
 # Uses --pull always to ensure the latest FL images and omop-db image are used
@@ -206,6 +219,13 @@ create-networks-trust-1:
 create-networks-trust-2:
 	@{ docker network inspect deploy_trust-network-2 >/dev/null 2>&1 || docker network create --driver overlay --attachable deploy_trust-network-2; }
 
+# Dedicated network for the local trust stack so it doesn't attach to
+# deploy_trust-network-1 when dev trust1 is also running. Not wired into the
+# top-level `create-networks` target because `make up` (dev) doesn't need it;
+# `up-local-trust` requires it explicitly.
+create-networks-local-trust:
+	@{ docker network inspect $(network_local) >/dev/null 2>&1 || docker network create --driver overlay --attachable $(network_local); }
+
 create-networks: create-networks-core create-networks-trust-1 create-networks-trust-2
 
 remove-networks:
@@ -213,6 +233,7 @@ remove-networks:
 	@docker network rm central-hub-trust-apis-network 2>/dev/null || true
 	@docker network rm deploy_trust-network-1 2>/dev/null || true
 	@docker network rm deploy_trust-network-2 2>/dev/null || true
+	@docker network rm $(network_local) 2>/dev/null || true
 	@docker network rm deploy_shared-net-1 2>/dev/null || true
 	@docker network rm deploy_shared-net-2 2>/dev/null || true
 	@echo "✅ Trust networks removed!"

--- a/trust/compose_trust.local.yml
+++ b/trust/compose_trust.local.yml
@@ -1,5 +1,25 @@
 # Local trust override — uses Docker named volumes for observability data
 # instead of EC2 host bind mounts. No sudo or UID management needed.
+#
+# Also drops the host-port bindings for imaging-api, data-access-api, and
+# trust-api inherited from compose_trust.production.yml. The local-trust stack
+# does not need external access to these services (trust-api polls the Central
+# Hub outbound; imaging-api and data-access-api are only called by trust-api /
+# fl-client within the trust Docker network). Removing the host bindings lets
+# `up-local-trust` coexist on the same laptop as `make up` (dev trust1 binds
+# 8001/8010/8020 via compose_trust-1_override.yml) without port collisions.
+#
+# The `!override` YAML tag (Compose v2.24+) replaces the merged `ports` list
+# rather than appending to it — a plain `ports: []` redefinition would still
+# inherit the bindings from the production compose.
+services:
+  imaging-api:
+    ports: !override []
+  data-access-api:
+    ports: !override []
+  trust-api:
+    ports: !override []
+
 volumes:
   trust-local-loki-data:
   trust-local-grafana-data:

--- a/trust/compose_trust.production.yml
+++ b/trust/compose_trust.production.yml
@@ -37,7 +37,7 @@ services:
       # - "${PACS_DICOM_PORT}:4242"
       - "${PACS_UI_PORT}:8042"
     volumes:
-      - /opt/flip/orthanc/${ORTHANC_STORAGE}:/var/lib/orthanc/db
+      - ${ORTHANC_STORAGE_DIR:-/opt/flip/orthanc/${ORTHANC_STORAGE}}:/var/lib/orthanc/db
     environment:
       ORTHANC__REGISTERED_USERS: |
           {"${ORTHANC_USERNAME}": "${ORTHANC_PASSWORD}"}

--- a/trust/xnat/Makefile
+++ b/trust/xnat/Makefile
@@ -12,7 +12,8 @@
 
 .PHONY: build up deploy down clean xnat-shell xnat-war-download xnat-plugins-download \
 	xnat-reset xnat-configure xnat-configure-trust-1 xnat-configure-trust-2 xnat-configure-local \
-	create-network-trust-1 create-network-trust-2 up-xnat-1 up-xnat-2 up-xnat-local \
+	create-network-trust-1 create-network-trust-2 create-network-trust-local \
+	up-xnat-1 up-xnat-2 up-xnat-local \
 	down-xnat-1 down-xnat-2 down-xnat-local
 
 # if tag PROD=true is passed, set PROD=true
@@ -45,6 +46,7 @@ project2 = xnat2
 project_local = xnat-local
 network1 = deploy_trust-network-1
 network2 = deploy_trust-network-2
+network_local = deploy_trust-network-local
 
 # Path to the dev XNAT folder on the Docker host (bind mounts resolve there, not locally).
 export XNAT_PATH=$(realpath .)
@@ -115,12 +117,12 @@ xnat-shell:
 	CONTAINER=$$(docker ps --filter "name=${project1}_xnat-web" -q); \
 	docker exec -it $$CONTAINER bash
 
-up-xnat-local: create-network-trust-1
+up-xnat-local: create-network-trust-local
 	XNAT_PATH=${XNAT_PATH} \
-	XNAT_PORT=${XNAT_PORT_LOCAL_TRUST} \
-	PACS_UI_PORT=${PACS_UI_PORT_LOCAL_TRUST} \
-	ORTHANC_STORAGE=orthanc-storage-local \
-	DOCKER_NETWORK_NAME=${network1} \
+	XNAT_PORT=8108 \
+	PACS_UI_PORT=8046 \
+	ORTHANC_STORAGE=$(ORTHANC_STORAGE_TRUST_$(subst Trust_,,$(LOCAL_TRUST_NAME))) \
+	DOCKER_NETWORK_NAME=${network_local} \
 	docker stack deploy --with-registry-auth --detach=false ${STACK_FILES} ${project_local}
 	$(MAKE) xnat-configure-local
 
@@ -224,3 +226,8 @@ create-network-trust-2:
 	@echo "🔧 Ensuring external Docker networks exist..."
 	@docker network inspect ${network2} >/dev/null 2>&1 || \
 		docker network create --driver overlay --attachable ${network2}
+
+create-network-trust-local:
+	@echo "🔧 Ensuring external Docker networks exist..."
+	@docker network inspect ${network_local} >/dev/null 2>&1 || \
+		docker network create --driver overlay --attachable ${network_local}


### PR DESCRIPTION
## Summary

- Give \`make up-local-trust\` its own host-port allocation (OMOP 5438, Grafana 3002, Loki 3102, Orthanc 8046, XNAT 8108), bind-mount paths (\`./data/local/\`, \`./orthanc/orthanc-storage-N\`), and external Docker network (\`deploy_trust-network-local\`), all driven by a new \`LOCAL_TRUST_VARS\` bag in \`trust/Makefile\` that parallels the existing \`TRUST_1_VARS\` / \`TRUST_2_VARS\`.
- Drop the host-port bindings for \`trust-api\`, \`imaging-api\`, and \`data-access-api\` in the local-trust stack via \`ports: !override []\` in \`compose_trust.local.yml\`. These three talk over the intra-stack Docker network, so exposing them on the host is unnecessary and collides with dev \`trust-1\`'s 8001/8010/8020 bindings (from \`compose_trust-1_override.yml\`).
- Mirror the existing \`OMOP_DATA_DIR\` pattern for Orthanc: add \`\${ORTHANC_STORAGE_DIR:-/opt/flip/orthanc/\${ORTHANC_STORAGE}}\` in the prod compose so \`LOCAL_TRUST_VARS\` can point at repo-relative DICOM test data without changing EC2 stag/prod behaviour.
- Retire the \`PACS_UI_PORT_LOCAL_TRUST\` / \`XNAT_PORT_LOCAL_TRUST\` env vars in \`.env.development.example\` — those values are now hardcoded in \`LOCAL_TRUST_VARS\` alongside the others.

Enables running \`make up\` (central hub + dev trust1 + dev trust2) alongside \`PROD=<stag|true> make up-local-trust\` on one laptop without host-port collisions, cross-trust volume sharing, or the local stack accidentally attaching to dev trust-1's network.

## Why

When the local-trust stack is used to simulate an on-prem trust against a stag/prod Central Hub — the supported flow per \`deploy/providers/local/README.md\` — the prod compose binds 8001 / 8010 / 8020 on the host for the three trust APIs, and the Orthanc / OMOP / observability stack all landed on the same host resources as dev \`trust-1\`. In the intended on-prem topology that's fine (isolated trust host), but many developers iterate with everything running on one laptop. Before this change, co-running required ad-hoc port / volume juggling.

The \`ORTHANC_STORAGE_DIR\` fallback is additive — stag/prod EC2 deploys don't set it, so they keep the \`/opt/flip/orthanc/\${ORTHANC_STORAGE}\` path exactly as before.

## Test plan

- [ ] \`make up\` (dev central hub + trust1 + trust2) on one laptop.
- [ ] \`PROD=stag make up-local-trust\` (or \`PROD=true\`) alongside it. No port collisions, no network collisions.
- [ ] \`docker network ls | grep deploy_trust-network\` shows three separate networks: \`-1\`, \`-2\`, \`-local\`.
- [ ] \`docker ps --filter label=com.docker.compose.project=trust-local\` shows trust-api / imaging-api / data-access-api with no host port mappings (container-only \`8000/tcp\`), while \`orthanc\`, \`omop-db\`, \`grafana\`, \`loki\` use the new 8046 / 5438 / 3002 / 3102 ports.
- [ ] \`docker inspect trust-local-orthanc-1\` confirms the bind mount resolves to \`<repo>/trust/orthanc/orthanc-storage-<N>\` when \`LOCAL_TRUST_VARS\` applies.
- [ ] \`make down-local-trust\` tears down cleanly with no orphans.
- [ ] \`make up-trust-1-ec2\` on an EC2 trust host: \`ORTHANC_STORAGE_DIR\` remains unset → Orthanc binds \`/opt/flip/orthanc/\${ORTHANC_STORAGE}\` exactly as today.
- [ ] End-to-end project creation: trust-api polls hub, creates XNAT project via imaging-api, PACS retrieval queues against the repo-local Orthanc with real DICOM data.