### PR TITLE
docs: add security vulnerability disclosure workflow guide

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -19,3 +19,47 @@ Please use the private GitHub Security Advisory feature:
 The maintainers will acknowledge the report within **5 business days** and aim to release a fix within **90 days** under a coordinated-disclosure embargo.
 
 If you are unable to use GitHub, you can contact the maintainers by email: `gstt.ai-centre@nhs.net`.
+
+## Resolving a vulnerability (private PR workflow)
+
+Fixes for an accepted GitHub Security Advisory (GSA) must be developed and reviewed **privately**, before the advisory is published. Do **not** open a public pull request against `develop`, push a fix branch to `origin`, or reference the CVE/GHSA ID in any public commit, issue, or PR while the advisory is under embargo.
+
+The standard contribution rules in [`CONTRIBUTING.md`](CONTRIBUTING.md#submitting-pull-requests) (branch naming, DCO sign-off, tests, lint/type-check) still apply — the only things that change are **where** the branch and PR live, and **how careful** you are with public metadata.
+
+### 1. Create a temporary private fork
+
+1. Open the draft advisory in the [Security tab](https://github.com/londonaicentre/FLIP/security) and scroll to the **"Development"** panel.
+2. Click **"Start a temporary private fork"**. GitHub creates a fork that is visible only to repository maintainers and anyone explicitly added as a collaborator on the advisory.
+3. Clone that private fork locally in a **separate working tree** from your usual FLIP clone. Do not add the public `londonaicentre/FLIP` repo as a remote on the private-fork checkout — that avoids accidental `git push` to the public repo.
+
+### 2. Branch and commit inside the private fork
+
+- Base the fix branch on the advisory's target branch (usually `develop`).
+- Follow the normal `[ticket_id]-[task_name]` convention, but pick a **neutral task name** that does not describe the vulnerability. Prefer the GHSA ID, e.g. `ghsa-xxxx-yyyy-zzzz-hardening`, over something like `fix-sql-injection-in-login`.
+- Sign off every commit (`git commit -s`) — DCO still applies.
+- Keep commit messages factual and neutral until the advisory is published. Detailed impact analysis, affected versions, and reproduction steps live in the advisory itself, not in git history.
+
+### 3. Review and local verification
+
+- Open the pull request **inside the temporary private fork**, not against the public repo.
+- Request review from at least one other maintainer who is a collaborator on the advisory.
+- GitHub Actions workflows from the public repo do **not** run on the private fork, so lint, type-check, and tests must be verified locally before review:
+
+  ```bash
+  make test         # from the affected service directory (ruff + mypy + pytest)
+  make unit_test    # unit-only, if Docker isn't available
+  ```
+
+- Apply the same quality bar as a normal PR: tests that cover the fix, clean ruff/mypy/ESLint, and any documentation updates the change warrants.
+
+### 4. Merge and disclose
+
+1. Once approved, merge the PR **inside the private fork**. This stages the fix for release without exposing it.
+2. Coordinate a disclosure window with the reporter and maintainers.
+3. Publish the advisory. GitHub will offer to push the merged fix commits to the public repository at that moment — accept, and verify that `develop` (and any backport branches) now contain the fix.
+4. If a CVE was not auto-assigned, request one via the advisory, then cut a release that includes the fix.
+
+### 5. If you cannot use the private fork
+
+- Maintainers without access to the private fork feature may apply the patch on a **local** clone and push only at disclosure time. Never stage security fixes on `origin` (public) before the embargo lifts.
+- External contributors who cannot be added as advisory collaborators should send patches by email to `gstt.ai-centre@nhs.net`, signed off per DCO. A maintainer will apply them inside the private fork on the contributor's behalf and credit them in the advisory.


### PR DESCRIPTION
# Description

This PR adds comprehensive documentation for the private pull request workflow used to resolve accepted GitHub Security Advisories (GSAs). The new section in `SECURITY.md` provides step-by-step guidance for maintainers and contributors on how to develop and review security fixes under embargo before public disclosure.

The documentation covers:
- Creating and using temporary private forks for vulnerability fixes
- Branch naming and commit conventions for security work
- Local verification of tests, linting, and type-checking (since CI doesn't run on private forks)
- The merge and disclosure process
- Alternative workflows for contributors without private fork access

This ensures the project follows coordinated disclosure best practices and provides clear guidance to anyone involved in resolving security vulnerabilities.

## Linked Issues

N/A

## Checklist

- [x] Follows the project's coding conventions and style guide
- [x] Updates documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Type of Change

- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] In-line docstrings updated.
- [x] Documentation updated, tested `make -C docs/ docs`.

## Testing

No testing needed — this is a documentation-only change to the security policy.

## Additional Notes

This documentation is essential for maintaining security best practices and ensuring all contributors understand the proper workflow for handling vulnerability disclosures under embargo.

https://claude.ai/code/session_01PLVmYbpr5MbKMr3goMMsQT