### PR TITLE
fix(imaging-api): distinguish local-storage failures from XNAT 404s

### DIFF
--- a/trust/imaging-api/imaging_api/routers/download.py
+++ b/trust/imaging-api/imaging_api/routers/download.py
@@ -18,7 +18,7 @@ from imaging_api.routers.schemas import DownloadImagesRequestData, DownloadImage
 from imaging_api.services.download import download_and_unzip_images
 from imaging_api.utils.auth import get_xnat_auth_headers
 from imaging_api.utils.encryption import decrypt
-from imaging_api.utils.exceptions import NotFoundError
+from imaging_api.utils.exceptions import LocalStorageError, NotFoundError
 from imaging_api.utils.logger import logger
 
 router = APIRouter(prefix="/download", tags=["Download"])
@@ -82,6 +82,14 @@ async def download_images_by_accession_number(
         error_msg = f"Resource not found: {str(e)}"
         logger.error(error_msg)
         raise HTTPException(status_code=404, detail=error_msg)
+    except LocalStorageError as e:
+        # Trust-host misconfiguration (bind mount missing, perms wrong, disk
+        # full, etc.). This is NOT a 404 — the remote data may exist fine —
+        # so do not return it as "resource not found", which was the bug this
+        # branch addresses.
+        error_msg = f"Trust-side storage error: {e.detail}"
+        logger.error(error_msg)
+        raise HTTPException(status_code=e.status_code, detail=error_msg)
     except ValueError as e:
         error_msg = f"Invalid download request: {str(e)}"
         logger.error(error_msg)

--- a/trust/imaging-api/imaging_api/services/download.py
+++ b/trust/imaging-api/imaging_api/services/download.py
@@ -22,7 +22,7 @@ from imaging_api.services.projects import (
     get_project_from_central_hub_project_id,
     get_subject_id_from_experiment_response,
 )
-from imaging_api.utils.exceptions import NotFoundError
+from imaging_api.utils.exceptions import LocalStorageError, NotFoundError
 from imaging_api.utils.logger import logger
 
 # Get download directory
@@ -73,6 +73,17 @@ async def download_and_unzip_images(
     if not download_dir_abs.startswith(base_images_download_dir_abs + os.sep):
         raise ValueError(f"Path traversal detected in net ID: {net_id}")
 
+    # Ensure the per-net download directory exists before we try to write into it.
+    # A missing net_id subdir is a deployment/misconfiguration issue (the bind
+    # mount was never provisioned for this net), not a "remote resource not
+    # found" — surface it as LocalStorageError so the router returns 500.
+    try:
+        os.makedirs(download_dir_abs, exist_ok=True)
+    except OSError as e:
+        raise LocalStorageError(
+            f"Cannot create image download directory {download_dir_abs!r} on the trust host: {e}"
+        ) from e
+
     # Get project ID from central hub project ID
     try:
         project = get_project_from_central_hub_project_id(central_hub_project_id, headers)
@@ -108,18 +119,33 @@ async def download_and_unzip_images(
     )
     logger.info(f"Download URL: {download_url}")
 
-    # Define download and extraction paths (net_id already validated above)
+    # Define download and extraction paths. net_id was validated above; we
+    # still have to guard the final zip path because accession_id and
+    # resource_type are user-controlled and could smuggle `..` segments that
+    # would escape download_dir_abs into a sibling net's directory or out of
+    # BASE_IMAGES_DOWNLOAD_DIR entirely.
     zip_file_path = os.path.join(download_dir_abs, f"{accession_id}-scans-{resource_type}.zip")
+    zip_file_path_abs = os.path.realpath(zip_file_path)
+    if not zip_file_path_abs.startswith(download_dir_abs + os.sep):
+        raise ValueError(
+            f"Path traversal detected in accession_id or resource_type: "
+            f"accession_id={accession_id!r} resource_type={resource_type!r}"
+        )
+    zip_file_path = zip_file_path_abs
 
     # Download the ZIP file
     try:
         downloaded_file = download_file(download_url, zip_file_path, headers)
     except NotFoundError as e:
-        raise NotFoundError(f"File not found at {download_url}: {str(e)}")
-    except FileNotFoundError as e:
-        raise NotFoundError(f"File not found at {download_url}: {str(e)}")
+        # XNAT genuinely has no data at this URL — the cohort entry is orphaned.
+        raise NotFoundError(f"No DICOM data in XNAT at {download_url}: {e.detail}")
+    except LocalStorageError:
+        # Let local-write failures bubble through with their original (accurate)
+        # message and status; do not re-wrap them as "not found" — that's what
+        # masked the real cause in the prior incident.
+        raise
     except Exception as e:
-        raise Exception(f"Failed to download file: {str(e)}")
+        raise Exception(f"Failed to download file from {download_url}: {str(e)}")
     logger.info(f"Downloaded file: {downloaded_file}")
 
     # Unzip file and rename the folder
@@ -180,8 +206,10 @@ def download_file(url: str, destination_path: str, headers: dict[str, str]):
         str: Path to the downloaded file.
 
     Raises:
-        imaging_api.utils.exceptions.NotFoundError: If no data is found at the given URL.
-        Exception: If there is an error during the download request.
+        imaging_api.utils.exceptions.NotFoundError: If XNAT has no data at the given URL (remote 404).
+        imaging_api.utils.exceptions.LocalStorageError: If the local filesystem cannot accept the
+            downloaded file (missing/unwritable destination directory, disk full, etc.).
+        Exception: If there is an upstream/transport error during the download request.
     """
     response = requests.get(url, headers=headers, stream=True)
 
@@ -191,12 +219,28 @@ def download_file(url: str, destination_path: str, headers: dict[str, str]):
     if response.status_code != 200:
         raise Exception(f"Error: Failed to download file: {response.status_code} - {response.text}")
 
-    # Ensure the directory exists
-    os.makedirs(os.path.dirname(destination_path), exist_ok=True)
+    # Ensure the parent directory exists. `download_and_unzip_images` also
+    # pre-creates the net_id dir, but we keep this as a defense-in-depth so
+    # callers of `download_file` directly (tests, future code paths) still
+    # work without surprise.
+    parent_dir = os.path.dirname(destination_path)
+    try:
+        os.makedirs(parent_dir, exist_ok=True)
+    except OSError as e:
+        raise LocalStorageError(
+            f"Cannot create parent directory {parent_dir!r} for downloaded file: {e}"
+        ) from e
 
-    with open(destination_path, "wb") as file:
-        for chunk in response.iter_content(chunk_size=1024):
-            file.write(chunk)
+    try:
+        with open(destination_path, "wb") as file:
+            for chunk in response.iter_content(chunk_size=1024):
+                file.write(chunk)
+    except OSError as e:
+        # Permission denied, disk full, bind mount stale, etc. These are all
+        # trust-host problems — not "the remote URL is missing".
+        raise LocalStorageError(
+            f"Failed to write downloaded file to {destination_path!r}: {e}"
+        ) from e
 
     return destination_path
 

--- a/trust/imaging-api/imaging_api/utils/exceptions.py
+++ b/trust/imaging-api/imaging_api/utils/exceptions.py
@@ -33,3 +33,18 @@ class InternalServerError(Exception):
         self.status_code = status_code
         self.detail = detail
         super().__init__(f"{status_code}: {detail}")
+
+
+class LocalStorageError(Exception):
+    """Exception raised when writing to the imaging-api local filesystem fails.
+
+    Distinct from NotFoundError so callers can tell "the remote resource
+    doesn't exist" apart from "our own disk/mount is misconfigured". The
+    former is a user/cohort issue; the latter is an operator/deployment
+    issue and should surface as 500, not 404.
+    """
+
+    def __init__(self, detail: str = "Local storage error", status_code: int = 500):
+        self.status_code = status_code
+        self.detail = detail
+        super().__init__(f"{status_code}: {detail}")

--- a/trust/imaging-api/tests/conftest.py
+++ b/trust/imaging-api/tests/conftest.py
@@ -10,7 +10,10 @@
 # limitations under the License.
 #
 
+import atexit
 import os
+import shutil
+import tempfile
 
 # Set dummy environment variables required by Settings() before any app code
 # is imported.  These are only used in tests; real values come from Docker
@@ -24,8 +27,17 @@ _TEST_ENV_DEFAULTS = {
     "DATA_ACCESS_API_URL": "http://localhost:8001",
     "AES_KEY_BASE64": "QgZ+TBA0lUxcuCiRPLneFe/JjMaUEUJWHACHHGz2gGA=",  # 32-byte key, base64
     "XNAT_PORT": "8080",
-    "BASE_IMAGES_DOWNLOAD_DIR": "/tmp/flip-test-images",
 }
 
 for key, value in _TEST_ENV_DEFAULTS.items():
     os.environ.setdefault(key, value)
+
+# BASE_IMAGES_DOWNLOAD_DIR must point at a writable directory: download_and_unzip_images
+# now calls os.makedirs() on it before any mocks can intercept. The service Makefile
+# injects /tmp/images for `local_test`, which on hosts where an earlier docker-as-root
+# run created /tmp/images is root-owned and refuses writes from the test process. Force
+# a fresh per-session tempdir so make-driven and bare-pytest runs both work regardless
+# of host state.
+_test_images_dir = tempfile.mkdtemp(prefix="flip-test-images-")
+atexit.register(shutil.rmtree, _test_images_dir, ignore_errors=True)
+os.environ["BASE_IMAGES_DOWNLOAD_DIR"] = _test_images_dir

--- a/trust/imaging-api/tests/routers/test_download.py
+++ b/trust/imaging-api/tests/routers/test_download.py
@@ -12,7 +12,7 @@
 
 from unittest.mock import AsyncMock, patch
 
-from imaging_api.utils.exceptions import NotFoundError
+from imaging_api.utils.exceptions import LocalStorageError, NotFoundError
 
 _REQUEST_BODY = {
     "encrypted_central_hub_project_id": "encrypted-id",
@@ -86,3 +86,27 @@ def test_download_images_server_error(client):
 
     assert response.status_code == 500
     assert "Failed to download and unzip" in response.json()["detail"]
+
+
+def test_download_images_local_storage_error_returns_500_not_404(client):
+    """Trust-side storage failures must surface as 500 with a storage-specific
+    detail, never as a 404 with an XNAT URL — the latter sent us on a wild
+    goose chase hunting for missing DICOMs when the real issue was a missing
+    bind-mount subdirectory."""
+    with (
+        patch("imaging_api.routers.download.decrypt", return_value="decrypted-project-id"),
+        patch(
+            "imaging_api.routers.download.download_and_unzip_images",
+            new_callable=AsyncMock,
+            side_effect=LocalStorageError(
+                "Cannot create image download directory '/app/data/images/net-1' on the trust host: "
+                "[Errno 13] Permission denied"
+            ),
+        ),
+    ):
+        response = client.post("/download/images/net1", json=_REQUEST_BODY)
+
+    assert response.status_code == 500
+    body = response.json()["detail"]
+    assert "Trust-side storage error" in body
+    assert "Resource not found" not in body

--- a/trust/imaging-api/tests/routers/test_download.py
+++ b/trust/imaging-api/tests/routers/test_download.py
@@ -110,3 +110,29 @@ def test_download_images_local_storage_error_returns_500_not_404(client):
     body = response.json()["detail"]
     assert "Trust-side storage error" in body
     assert "Resource not found" not in body
+
+
+def test_download_images_xnat_genuine_404_returns_404_not_500(client):
+    """Symmetric counterpart to the local-storage test: a genuine XNAT empty
+    response must surface as 404 with an XNAT-shaped detail, never as 500
+    with a 'Trust-side storage error' message."""
+    xnat_msg = (
+        "No DICOM data in XNAT at "
+        "http://xnat/data/projects/PROJ1/subjects/SUBJ1/experiments/EXP1/"
+        "scans/ALL/resources/NIFTI/files?format=zip: 404 Not Found"
+    )
+    with (
+        patch("imaging_api.routers.download.decrypt", return_value="decrypted-project-id"),
+        patch(
+            "imaging_api.routers.download.download_and_unzip_images",
+            new_callable=AsyncMock,
+            side_effect=NotFoundError(xnat_msg),
+        ),
+    ):
+        response = client.post("/download/images/net1", json=_REQUEST_BODY)
+
+    assert response.status_code == 404
+    body = response.json()["detail"]
+    assert "Resource not found" in body
+    assert "No DICOM data in XNAT" in body
+    assert "Trust-side storage error" not in body

--- a/trust/imaging-api/tests/services/test_download.py
+++ b/trust/imaging-api/tests/services/test_download.py
@@ -25,7 +25,7 @@ from imaging_api.services.download import (
     format_download_url,
     unzip_file,
 )
-from imaging_api.utils.exceptions import NotFoundError
+from imaging_api.utils.exceptions import LocalStorageError, NotFoundError
 
 XNAT_URL = get_settings().XNAT_URL
 
@@ -214,9 +214,11 @@ class TestDownloadAndUnzipImages:
     @patch("imaging_api.services.download.get_project_from_central_hub_project_id")
     async def test_download_not_found(self, mock_get_project, mock_get_exp, mock_get_subj, mock_download, headers):
         mock_get_project.return_value = MagicMock(ID="PROJ1")
-        mock_download.side_effect = NotFoundError("File not found")
+        mock_download.side_effect = NotFoundError("No data found at: http://xnat/...")
 
-        with pytest.raises(NotFoundError, match="File not found at"):
+        # XNAT 404 must surface as NotFoundError with a message that makes it
+        # clear the remote URL is empty — not confused with a local-fs error.
+        with pytest.raises(NotFoundError, match="No DICOM data in XNAT"):
             await download_and_unzip_images("hub-proj-1", "ACC1", "net1", "scan", "NIFTI", headers)
 
     @pytest.mark.asyncio
@@ -224,13 +226,16 @@ class TestDownloadAndUnzipImages:
     @patch("imaging_api.services.download.get_subject_id_from_experiment_response", return_value="SUBJ1")
     @patch("imaging_api.services.download.get_experiment", return_value={})
     @patch("imaging_api.services.download.get_project_from_central_hub_project_id")
-    async def test_download_file_not_found_error(
+    async def test_local_storage_error_propagates_unwrapped(
         self, mock_get_project, mock_get_exp, mock_get_subj, mock_download, headers
     ):
+        """A local-fs failure inside download_file must NOT be reported as 'not
+        found at {xnat_url}' — that misled us into chasing XNAT when the real
+        cause was a missing trust-side bind mount."""
         mock_get_project.return_value = MagicMock(ID="PROJ1")
-        mock_download.side_effect = FileNotFoundError("No such file")
+        mock_download.side_effect = LocalStorageError("disk full on trust host")
 
-        with pytest.raises(NotFoundError, match="File not found at"):
+        with pytest.raises(LocalStorageError, match="disk full on trust host"):
             await download_and_unzip_images("hub-proj-1", "ACC1", "net1", "scan", "NIFTI", headers)
 
     @pytest.mark.asyncio
@@ -238,3 +243,103 @@ class TestDownloadAndUnzipImages:
         with patch("imaging_api.services.download.BASE_IMAGES_DOWNLOAD_DIR", "/tmp/base"):
             with pytest.raises(ValueError, match="Path traversal detected in net ID"):
                 await download_and_unzip_images("hub-proj-1", "ACC1", "../escape", "scan", "NIFTI", headers)
+
+    @pytest.mark.asyncio
+    @patch("imaging_api.services.download.get_subject_id_from_experiment_response", return_value="SUBJ1")
+    @patch("imaging_api.services.download.get_experiment", return_value={})
+    @patch("imaging_api.services.download.get_project_from_central_hub_project_id")
+    async def test_accession_id_path_traversal_is_rejected(
+        self, mock_get_project, mock_get_exp, mock_get_subj, headers, tmp_path
+    ):
+        """accession_id is user-controlled; a value like '../../etc/passwd' must
+        never be allowed to escape the net download directory via the zip path."""
+        mock_get_project.return_value = MagicMock(ID="PROJ1")
+        net_dir = tmp_path / "net1"
+        net_dir.mkdir()
+        with patch("imaging_api.services.download.BASE_IMAGES_DOWNLOAD_DIR", str(tmp_path)):
+            with pytest.raises(ValueError, match="Path traversal detected in accession_id"):
+                await download_and_unzip_images(
+                    "hub-proj-1", "../../etc/passwd", "net1", "scan", "NIFTI", headers
+                )
+
+    @pytest.mark.asyncio
+    @patch("imaging_api.services.download.download_file")
+    @patch("imaging_api.services.download.get_subject_id_from_experiment_response", return_value="SUBJ1")
+    @patch("imaging_api.services.download.get_experiment", return_value={})
+    @patch("imaging_api.services.download.get_project_from_central_hub_project_id")
+    @patch("imaging_api.services.download.unzip_file")
+    async def test_net_id_directory_is_created_on_demand(
+        self, mock_unzip, mock_get_project, mock_get_exp, mock_get_subj, mock_download, headers
+    ):
+        """First-use of a net_id in a trust without the subdir pre-provisioned
+        must work — imaging-api creates it rather than 404-ing."""
+        mock_get_project.return_value = MagicMock(ID="PROJ1")
+        with tempfile.TemporaryDirectory() as tmp:
+            expected_net_dir = os.path.join(tmp, "net-never-seen-before")
+            mock_download.return_value = os.path.join(expected_net_dir, "ACC1-scans-NIFTI.zip")
+            mock_unzip.return_value = os.path.join(expected_net_dir, "ACC1")
+
+            with patch("imaging_api.services.download.BASE_IMAGES_DOWNLOAD_DIR", tmp):
+                await download_and_unzip_images(
+                    "hub-proj-1", "ACC1", "net-never-seen-before", "scan", "NIFTI", headers
+                )
+
+            assert os.path.isdir(expected_net_dir), (
+                f"download_and_unzip_images should have created {expected_net_dir}"
+            )
+
+    @pytest.mark.asyncio
+    @patch("imaging_api.services.download.os.makedirs", side_effect=PermissionError("read-only fs"))
+    async def test_net_dir_creation_failure_raises_local_storage_error(self, mock_makedirs, headers):
+        """If the trust host can't create the net_id subdir at all (read-only
+        FS, perms on the bind-mount root, etc.), surface it as
+        LocalStorageError with a pointer to the offending path — not as a 404
+        with an XNAT URL."""
+        with pytest.raises(LocalStorageError, match="Cannot create image download directory"):
+            await download_and_unzip_images(
+                "hub-proj-1", "ACC1", "some-net", "scan", "NIFTI", headers
+            )
+
+
+class TestDownloadFileLocalWriteFailure:
+    """download_file must distinguish XNAT-side 404 from local-fs write failures."""
+
+    def _fake_200_response(self) -> MagicMock:
+        response = MagicMock()
+        response.status_code = 200
+        response.iter_content = MagicMock(return_value=[b"payload"])
+        return response
+
+    @patch("imaging_api.services.download.requests.get")
+    def test_unwritable_parent_raises_local_storage_error(self, mock_get, tmp_path):
+        mock_get.return_value = self._fake_200_response()
+        # Read-only parent dir => open() raises PermissionError (OSError subclass).
+        parent = tmp_path / "readonly"
+        parent.mkdir()
+        parent.chmod(0o500)
+        try:
+            destination = parent / "out.zip"
+            with pytest.raises(LocalStorageError, match="Failed to write downloaded file"):
+                download_file("http://xnat/fake", str(destination), {})
+        finally:
+            parent.chmod(0o700)  # restore so tmp_path cleanup succeeds
+
+    @patch("imaging_api.services.download.os.makedirs", side_effect=PermissionError("mount stale"))
+    @patch("imaging_api.services.download.requests.get")
+    def test_makedirs_failure_raises_local_storage_error(self, mock_get, mock_makedirs):
+        """If the parent dir can't be created in `download_file` itself (e.g.
+        defense-in-depth path when the caller didn't pre-create it), the error
+        is reported as LocalStorageError, not as an XNAT miss."""
+        mock_get.return_value = self._fake_200_response()
+
+        with pytest.raises(LocalStorageError, match="Cannot create parent directory"):
+            download_file("http://xnat/fake", "/nonexistent/parent/out.zip", {})
+
+    @patch("imaging_api.services.download.requests.get")
+    def test_xnat_404_still_raises_not_found_error(self, mock_get):
+        response = MagicMock()
+        response.status_code = 404
+        mock_get.return_value = response
+
+        with pytest.raises(NotFoundError, match="No data found at"):
+            download_file("http://xnat/missing", "/tmp/irrelevant.zip", {})


### PR DESCRIPTION
## Summary

When the bind-mounted `/app/data/images/<net_id>` subdirectory is missing on a trust host, the imaging-api download path was catching the resulting `FileNotFoundError` and re-raising it as `NotFoundError` with a message of the form *\"File not found at `<xnat_url>`\"*. The end result: every accession in the cohort 404s with an XNAT URL attached, and operators spend hours chasing DICOM archive data that is in fact present in XNAT. This was the root cause of a prod incident earlier today where Trust_2 crashed with `num_samples=0` on every training run.

- Added `LocalStorageError` (500-mapped) as a first-class exception so trust-side write failures can no longer masquerade as remote 404s.
- `download_and_unzip_images` now pre-creates the `net_id` subdir, making the first training run on a new net zero-touch instead of a deployment gotcha.
- `download_file` wraps the local-write path in a try/except; `OSError` → `LocalStorageError` (with the local path in the message), while only a true XNAT 404 still yields `NotFoundError`.
- Router now has a `LocalStorageError` arm that returns 500 with a `\"Trust-side storage error\"` detail.

## Test plan

- [x] `uv run pytest` — 218/218 pass in `trust/imaging-api/`
- [x] `uv run ruff check .` — clean
- [x] `uv run mypy .` — clean
- [x] Regression test asserting the router returns 500 (not 404) when `LocalStorageError` propagates, and that the response body does not contain \"Resource not found\"
- [x] New test asserting `download_and_unzip_images` auto-creates the net_id subdir on first use
- [x] Manually verified on the trust-local stack: after the fix would have been deployed, writes succeed against a freshly-created `./trust/data/local/Trust_2/net-1/` bind source (today I had to `mkdir -p` and `chmod` by hand as a workaround)