### PR TITLE
feat(connection-status): expose fl_backend in net status response

### DIFF
--- a/flip-api/src/flip_api/domain/interfaces/fl.py
+++ b/flip-api/src/flip_api/domain/interfaces/fl.py
@@ -13,6 +13,7 @@
 import json
 from enum import Enum
 from pathlib import Path
+from typing import Literal
 from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, computed_field, field_validator
@@ -129,6 +130,7 @@ class IClientStatus(BaseModel):
 
 class INetStatus(BaseModel):
     name: str
+    fl_backend: Literal["nvflare", "flower"]
     online: bool | None = None
     registered_clients: int | None = None
     net_in_use: bool | None = None

--- a/flip-api/src/flip_api/fl_services/get_net_status.py
+++ b/flip-api/src/flip_api/fl_services/get_net_status.py
@@ -16,6 +16,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from sqlmodel import Session
 
 from flip_api.auth.dependencies import verify_token
+from flip_api.config import get_settings
 from flip_api.db.database import get_session
 from flip_api.domain.interfaces.fl import IClientStatus, INetStatus
 from flip_api.domain.schemas.status import ClientStatus
@@ -90,6 +91,7 @@ def get_net_status(
         # Create net status response
         net_status = INetStatus(
             name=net_name,
+            fl_backend=get_settings().FL_BACKEND,
             online=True,  # Assuming the net is online if we reach this point
             registered_clients=len(trust_client_statuses),
             clients=trust_client_statuses,

--- a/flip-api/src/flip_api/fl_services/get_status.py
+++ b/flip-api/src/flip_api/fl_services/get_status.py
@@ -16,6 +16,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request, status
 from sqlmodel import Session
 
 from flip_api.auth.dependencies import verify_token
+from flip_api.config import get_settings
 from flip_api.db.database import get_session
 from flip_api.domain.interfaces.fl import (
     IClientStatus,
@@ -58,6 +59,7 @@ def get_status_endpoint(
 
     try:
         nets = get_nets(db)
+        fl_backend = get_settings().FL_BACKEND
 
         net_statuses: list[INetStatus] = []
 
@@ -68,7 +70,14 @@ def get_status_endpoint(
             if not server_status:
                 logger.error(f"{net.name}: No response from FL API")
                 net_statuses.append(
-                    INetStatus(name=net.name, online=False, registered_clients=0, clients=[], net_in_use=False)
+                    INetStatus(
+                        name=net.name,
+                        fl_backend=fl_backend,
+                        online=False,
+                        registered_clients=0,
+                        clients=[],
+                        net_in_use=False,
+                    )
                 )
                 continue
 
@@ -84,7 +93,14 @@ def get_status_endpoint(
             if not clients:
                 logger.error(f"{net.name}: No clients connected")
                 net_statuses.append(
-                    INetStatus(name=net.name, online=False, registered_clients=0, clients=[], net_in_use=False)
+                    INetStatus(
+                        name=net.name,
+                        fl_backend=fl_backend,
+                        online=False,
+                        registered_clients=0,
+                        clients=[],
+                        net_in_use=False,
+                    )
                 )
                 continue
 
@@ -112,6 +128,7 @@ def get_status_endpoint(
             net_statuses.append(
                 INetStatus(
                     name=net.name,
+                    fl_backend=fl_backend,
                     online=online,
                     registered_clients=len(trust_client_statuses),
                     net_in_use=server_status.status in [ServerEngineStatus.STARTING, ServerEngineStatus.STARTED],

--- a/flip-api/tests/unit/fl_services/test_get_net_status.py
+++ b/flip-api/tests/unit/fl_services/test_get_net_status.py
@@ -64,13 +64,31 @@ def mock_get_trusts():
         yield mock
 
 
-def test_get_net_status_success(fake_request, mock_db, mock_get_net_by_name, mock_fetch_client_status, mock_get_trusts):
+@pytest.fixture
+def mock_get_settings():
+    with patch("flip_api.fl_services.get_net_status.get_settings") as mock:
+        mock.return_value.FL_BACKEND = "nvflare"
+        yield mock
+
+
+def test_get_net_status_success(
+    fake_request, mock_db, mock_get_net_by_name, mock_fetch_client_status, mock_get_trusts, mock_get_settings
+):
     result = get_net_status("net-name", fake_request, mock_db)
     assert result.name == "net-name"
+    assert result.fl_backend == "nvflare"
     assert len(result.clients) == 3
     assert any(client.name == "client1" and client.online for client in result.clients)
     assert any(client.name == "client2" and not client.online for client in result.clients)
     assert any(client.name == "client3" and not client.online for client in result.clients)
+
+
+def test_get_net_status_reports_flower_backend(
+    fake_request, mock_db, mock_get_net_by_name, mock_fetch_client_status, mock_get_trusts, mock_get_settings
+):
+    mock_get_settings.return_value.FL_BACKEND = "flower"
+    result = get_net_status("net-name", fake_request, mock_db)
+    assert result.fl_backend == "flower"
 
 
 def test_get_net_status_net_not_found(fake_request, mock_db):

--- a/flip-api/tests/unit/fl_services/test_get_status.py
+++ b/flip-api/tests/unit/fl_services/test_get_status.py
@@ -78,19 +78,47 @@ def mock_fetch_client_status():
         yield mock
 
 
+@pytest.fixture
+def mock_get_settings():
+    with patch("flip_api.fl_services.get_status.get_settings") as mock:
+        mock.return_value.FL_BACKEND = "nvflare"
+        yield mock
+
+
 def test_get_status_endpoint_success(
-    fake_request, mock_db, mock_get_nets, mock_get_trusts, mock_fetch_server_status, mock_fetch_client_status
+    fake_request,
+    mock_db,
+    mock_get_nets,
+    mock_get_trusts,
+    mock_fetch_server_status,
+    mock_fetch_client_status,
+    mock_get_settings,
 ):
     result = get_status_endpoint(fake_request, mock_db, user_id="user-1")
     assert len(result) == 1
     net = result[0]
     assert net.name == "net-1"
+    assert net.fl_backend == "nvflare"
     assert net.online is True
     assert net.net_in_use is True
     assert net.registered_clients == 2
     assert len(net.clients) == 2
     assert any(c.name == "trust-1" and c.online for c in net.clients)
     assert any(c.name == "trust-2" and not c.online for c in net.clients)
+
+
+def test_get_status_endpoint_reports_flower_backend(
+    fake_request,
+    mock_db,
+    mock_get_nets,
+    mock_get_trusts,
+    mock_fetch_server_status,
+    mock_fetch_client_status,
+    mock_get_settings,
+):
+    mock_get_settings.return_value.FL_BACKEND = "flower"
+    result = get_status_endpoint(fake_request, mock_db, user_id="user-1")
+    assert result[0].fl_backend == "flower"
 
 
 def test_get_status_endpoint_error(fake_request, mock_db):
@@ -101,17 +129,24 @@ def test_get_status_endpoint_error(fake_request, mock_db):
 
 
 def test_get_status_endpoint_server_status_none(
-    fake_request, mock_db, mock_get_nets, mock_get_trusts, mock_fetch_server_status
+    fake_request, mock_db, mock_get_nets, mock_get_trusts, mock_fetch_server_status, mock_get_settings
 ):
     mock_fetch_server_status.return_value = None
     result = get_status_endpoint(fake_request, mock_db, user_id="user-1")
     assert len(result) == 1
     assert result[0].online is False
+    assert result[0].fl_backend == "nvflare"
     assert result[0].clients == []
 
 
 def test_get_status_endpoint_client_status_none(
-    fake_request, mock_db, mock_get_nets, mock_get_trusts, mock_fetch_server_status, mock_fetch_client_status
+    fake_request,
+    mock_db,
+    mock_get_nets,
+    mock_get_trusts,
+    mock_fetch_server_status,
+    mock_fetch_client_status,
+    mock_get_settings,
 ):
     mock_fetch_server_status.return_value = IServerStatus(
         status="stopped",
@@ -121,4 +156,5 @@ def test_get_status_endpoint_client_status_none(
     result = get_status_endpoint(fake_request, mock_db, user_id="user-1")
     assert len(result) == 1
     assert result[0].online is False
+    assert result[0].fl_backend == "nvflare"
     assert result[0].clients == []

--- a/flip-ui/src/pages/ConnectionStatus.vue
+++ b/flip-ui/src/pages/ConnectionStatus.vue
@@ -62,7 +62,7 @@
                                     <div class="flex flex-wrap items-center justify-between -mt-2 -ml-4 sm:flex-nowrap">
                                         <div class="mt-2 ml-4">
                                             <h3 class="text-lg font-medium leading-6 text-gray-900 uppercase dark:text-gray-300">
-                                                {{ net.name }}
+                                                {{ net.name }}<span v-if="net.fl_backend"> ({{ net.fl_backend }})</span>
                                             </h3>
                                         </div>
                                         <div class="flex-shrink-0 mt-2 ml-4">

--- a/flip-ui/src/pages/ConnectionStatus.vue
+++ b/flip-ui/src/pages/ConnectionStatus.vue
@@ -62,7 +62,7 @@
                                     <div class="flex flex-wrap items-center justify-between -mt-2 -ml-4 sm:flex-nowrap">
                                         <div class="mt-2 ml-4">
                                             <h3 class="text-lg font-medium leading-6 text-gray-900 uppercase dark:text-gray-300">
-                                                {{ net.name }}<span v-if="net.fl_backend"> ({{ net.fl_backend }})</span>
+                                                {{ net.name }}<span v-if="net.fl_backend" class="normal-case"> ({{ formatBackend(net.fl_backend) }})</span>
                                             </h3>
                                         </div>
                                         <div class="flex-shrink-0 mt-2 ml-4">
@@ -186,6 +186,9 @@ const hideDetails = () => {
 const offlineClients = (clients: IFLStatusClients[]) => {
     return clients.some(c => !c.online);
 };
+
+const formatBackend = (backend: "nvflare" | "flower") =>
+    backend === "nvflare" ? "NVFlare" : "Flower";
 
 const setAndShowDetails = async (netName: string) => {
     showDetails.value = true;

--- a/flip-ui/src/pages/__tests__/ConnectionStatus.spec.ts
+++ b/flip-ui/src/pages/__tests__/ConnectionStatus.spec.ts
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2026 Guy's and St Thomas' NHS Foundation Trust & King's College London
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createTestingPinia } from "@pinia/testing";
+import { mount } from "@vue/test-utils";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ref } from "vue";
+
+import { IFLStatus } from "@/services/fl-service";
+
+import ConnectionStatus from "../ConnectionStatus.vue";
+
+const mockSwrvData = ref<IFLStatus[] | undefined>(undefined);
+
+vi.mock("swrv", () => ({
+    default: () => ({
+        data: mockSwrvData,
+        mutate: vi.fn(),
+        error: ref(null)
+    })
+}));
+
+const stubs = {
+    Transition: { template: "<div><slot /></div>" },
+    AiCard: { template: "<div><slot /></div>" },
+    AiCommand: { template: "<div><slot /></div>" },
+    AiAlert: { template: "<div />" },
+    AiLoader: { template: "<div />" },
+    AiButton: { template: "<button><slot /></button>" },
+    "icon-ph-check-circle-duotone": { template: "<span />" },
+    "icon-ph-x-circle-duotone": { template: "<span />" },
+    "icon-ph-archive-duotone": { template: "<span />" }
+};
+
+function mountConnectionStatus() {
+    return mount(ConnectionStatus, {
+        global: {
+            plugins: [createTestingPinia({ createSpy: vi.fn, stubActions: false })],
+            stubs,
+            directives: { highlightjs: () => {} }
+        }
+    });
+}
+
+beforeEach(() => {
+    mockSwrvData.value = undefined;
+});
+
+describe("ConnectionStatus", () => {
+    it("mounts without errors", () => {
+        const wrapper = mountConnectionStatus();
+        expect(wrapper.exists()).toBe(true);
+    });
+
+    it("appends fl_backend to the NET title when present", () => {
+        mockSwrvData.value = [
+            { name: "net-1", fl_backend: "nvflare", clients: [] }
+        ];
+        const wrapper = mountConnectionStatus();
+        const titles = wrapper.findAll("h3");
+        const net1Title = titles.find(h => h.text().includes("net-1"));
+        expect(net1Title).toBeDefined();
+        expect(net1Title!.text()).toContain("(nvflare)");
+    });
+
+    it("renders flower backend value", () => {
+        mockSwrvData.value = [
+            { name: "net-2", fl_backend: "flower", clients: [] }
+        ];
+        const wrapper = mountConnectionStatus();
+        const titles = wrapper.findAll("h3");
+        const net2Title = titles.find(h => h.text().includes("net-2"));
+        expect(net2Title).toBeDefined();
+        expect(net2Title!.text()).toContain("(flower)");
+    });
+
+    it("omits parentheses when fl_backend is absent", () => {
+        mockSwrvData.value = [
+            { name: "net-1", clients: [] }
+        ];
+        const wrapper = mountConnectionStatus();
+        const titles = wrapper.findAll("h3");
+        const net1Title = titles.find(h => h.text().includes("net-1"));
+        expect(net1Title).toBeDefined();
+        expect(net1Title!.text()).not.toContain("(");
+    });
+});

--- a/flip-ui/src/pages/__tests__/ConnectionStatus.spec.ts
+++ b/flip-ui/src/pages/__tests__/ConnectionStatus.spec.ts
@@ -62,7 +62,7 @@ describe("ConnectionStatus", () => {
         expect(wrapper.exists()).toBe(true);
     });
 
-    it("appends fl_backend to the NET title when present", () => {
+    it("renders nvflare backend as 'NVFlare' next to the NET title", () => {
         mockSwrvData.value = [
             { name: "net-1", fl_backend: "nvflare", clients: [] }
         ];
@@ -70,10 +70,10 @@ describe("ConnectionStatus", () => {
         const titles = wrapper.findAll("h3");
         const net1Title = titles.find(h => h.text().includes("net-1"));
         expect(net1Title).toBeDefined();
-        expect(net1Title!.text()).toContain("(nvflare)");
+        expect(net1Title!.text()).toContain("(NVFlare)");
     });
 
-    it("renders flower backend value", () => {
+    it("renders flower backend as 'Flower' next to the NET title", () => {
         mockSwrvData.value = [
             { name: "net-2", fl_backend: "flower", clients: [] }
         ];
@@ -81,7 +81,7 @@ describe("ConnectionStatus", () => {
         const titles = wrapper.findAll("h3");
         const net2Title = titles.find(h => h.text().includes("net-2"));
         expect(net2Title).toBeDefined();
-        expect(net2Title!.text()).toContain("(flower)");
+        expect(net2Title!.text()).toContain("(Flower)");
     });
 
     it("omits parentheses when fl_backend is absent", () => {

--- a/flip-ui/src/services/fl-service.ts
+++ b/flip-ui/src/services/fl-service.ts
@@ -25,6 +25,7 @@ export interface IFLStatusClients {
 }
 export interface IFLStatus {
     name: string;
+    fl_backend?: "nvflare" | "flower";
     clients: IFLStatusClients[]
 }
 


### PR DESCRIPTION
Added UI feedback as to whether nets are NVFlare or Flower -- there's no way to know otherwise than to look in the deployment env variables, which requires access to the machine that did the deployment.

<img width="5344" height="3104" alt="Screenshot 2026-04-27 at 11 44 25" src="https://github.com/user-attachments/assets/edf003e6-d02d-49be-962a-54fb500826c5" />
<img width="5344" height="3104" alt="Screenshot 2026-04-27 at 11 44 28" src="https://github.com/user-attachments/assets/6ef2132e-5166-4b6c-857d-f4c6329e6b7e" />


## Summary

- Adds `fl_backend` field to `INetStatus`, populated from `get_settings().FL_BACKEND` in both `/fl/status` and `/fl/{net_name}/status` handlers. Operators viewing "View Detailed Response" on `/connectionstatus` can now see which FL framework each net is using.
- Cosmetic: renders the backend next to each NET card title on `/connectionstatus`, e.g. `NET-1 (NVFLARE)`. The existing `uppercase` CSS class on the `<h3>` normalises casing.
- Adds an optional `fl_backend?: "nvflare" | "flower"` to the `IFLStatus` TS interface (optional for forward/backward compatibility during rolling deploys; the template's `v-if` guard handles absence gracefully).

Closes #319.

## Why optional on TS / required on Python?

Server-side the value is always resolvable from `FL_BACKEND` (a Pydantic `Literal["nvflare", "flower"]` with a default), so the response contract is honest as required. Client-side we keep it optional so a UI bundle running briefly against an older API during a rolling deploy doesn't break.

## Out of scope

Per-net backend configuration. `FL_BACKEND` is a global app setting today — the current stack runs a single fl-server selected by `FL_BACKEND` at compose time. Making nets heterogeneous would need multi-server infra, DB schema, and seed changes, and is deferred.

## Test plan

- [x] Backend: `cd flip-api && make unit_test` — ruff + mypy + pytest all green. Added 2 new tests (`test_get_status_endpoint_reports_flower_backend`, `test_get_net_status_reports_flower_backend`) and extended existing success-path tests to assert `fl_backend` round-trips. Note: one unrelated pre-existing failure in `test_trust_tasks.py` (AES key placeholder in example env) — confirmed failing on develop without these changes, so not introduced here.
- [x] Frontend: `cd flip-ui && npm run test:unit` — 129 passed, 3 skipped. Added a new `ConnectionStatus.spec.ts` with 4 cases (mounts; nvflare in title; flower in title; title omits parens when field absent).
- [ ] Manual smoke: curl `/fl/status` and `/fl/NET-1/status`, confirm `fl_backend` field present. Load `/connectionstatus` and confirm `NET-1 (NVFLARE)` rendering and JSON modal shows the new field.

---
_Generated by [Claude Code](https://claude.ai/code/session_01B3MUSuxxL35e2erskiCEMh)_