### PR TITLE
docs: fix broken README links and align Makefile/port tables with code

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ For example:
 | `make up-no-trust` | Run all services except the trust services related services |
 | `make up-trusts` | Run the trust services related services (uses Docker Swarm for XNAT) |
 | `make central-hub` | Run the central API service and the database (does not start the UI — use `make ui` for that) |
+| `make ui` | Start the flip-ui container only (no-op when `PROD=stag`/`PROD=true`, since the UI is served from S3 + CloudFront) |
+| `make ui-off` | Stop the flip-ui container |
 | `make build` | Build all Docker images |
 | `make down` | Stop all services and remove the containers (including Swarm stacks) |
 | `make restart` | Stop and start all services |
@@ -83,7 +85,12 @@ For example:
 | `make clean` | Remove all stopped containers, networks, and images |
 | `make ci` | Run the CI pipeline locally using `act` |
 | `make up-local-trust` | Run a local (on-premises) trust (set `PROD=true` or `PROD=stag` for environment) |
-| `make unit_test` | Run the tests for all services |
+| `make unit_test` | Run unit tests across all services |
+| `make tests` | Run flip-ui unit tests and the full flip-api test suite (lint + mypy + pytest) |
+| `make debug SERVICE=<name>` | Restart one service in debug mode (waits for a debugger on port 5678). Services: `flip-api`, `fl-api-net-1`, `trust-api`, `imaging-api`, `data-access-api` |
+| `make debug-off SERVICE=<name>` | Take a single service back out of debug mode |
+| `make debug-all` | Restart every API service in debug mode |
+| `make debug-off-all` | Take every API service back out of debug mode |
 
 You can add new commands to the Makefile to create smaller deployments for testing and development.
 

--- a/deploy/providers/local/README.md
+++ b/deploy/providers/local/README.md
@@ -41,12 +41,14 @@ This is the **local provider** counterpart to the [AWS provider](../AWS/README.m
 
 Each local Trust host runs:
 
-| Service | Port | Protocol |
+| Service | Container port | Protocol |
 | --- | --- | --- |
 | trust-api | 8000 | HTTP (polls hub outbound) |
 | imaging-api | 8000 | HTTP (internal) |
 | data-access-api | 8000 | HTTP (internal) |
 | fl-client | — | TCP (connects outbound to FL server via NLB) |
+
+The `up-local-trust` stack does **not** publish these container ports to the host (see `trust/compose_trust.local.yml`) — services communicate over the internal Docker network only, which lets the local-trust stack coexist on a developer laptop with `make up` (whose dev `trust1` instance binds host ports `8001`/`8010`/`8020` via `compose_trust-1_override.yml`). When the same images run on a cloud Trust EC2 (production compose), the container ports are mapped to host ports `IMAGING_API_PORT` (8001), `DATA_ACCESS_API_PORT` (8010), and `TRUST_API_PORT` (8020) — see `.env.development.example`.
 
 ## Prerequisites
 

--- a/flip-api/README.md
+++ b/flip-api/README.md
@@ -89,4 +89,4 @@ See [`.env.development.example`](../.env.development.example) for the full list 
 ## Further Reading
 
 - [Full FLIP Documentation](https://londonaicentreflip.readthedocs.io/en/latest/)
-- [Contributing & Development Guide](CONTRIBUTING.md)
+- [Contributing & Development Guide](../CONTRIBUTING.md)

--- a/flip-ui/README.md
+++ b/flip-ui/README.md
@@ -83,7 +83,7 @@ Client ID are required for a production deployment.
 ## Further Reading
 
 - [Full FLIP Documentation](https://londonaicentreflip.readthedocs.io/en/latest/)
-- [Contributing & Development Guide](CONTRIBUTING.md)
+- [Contributing & Development Guide](../CONTRIBUTING.md)
 - [flip-api (backend)](../flip-api/README.md)
 
 ## License

--- a/trust/data-access-api/README.md
+++ b/trust/data-access-api/README.md
@@ -66,4 +66,4 @@ Key environment variables (set in [`.env.development.example`](../../.env.develo
 
 - [OMOP Database setup](../omop-db/README.md)
 - [Trust deployment overview](../README.md)
-- [Contributing & Development Guide](CONTRIBUTING.md)
+- [Contributing & Development Guide](../../CONTRIBUTING.md)

--- a/trust/imaging-api/README.md
+++ b/trust/imaging-api/README.md
@@ -150,4 +150,4 @@ Key environment variables (set in [`.env.development.example`](../../.env.develo
 - [XNAT setup](../xnat/README.md)
 - [Orthanc setup](../orthanc/README.md)
 - [Trust deployment overview](../README.md)
-- [Contributing & Development Guide](CONTRIBUTING.md)
+- [Contributing & Development Guide](../../CONTRIBUTING.md)

--- a/trust/omop-db/README.md
+++ b/trust/omop-db/README.md
@@ -35,4 +35,4 @@ This should not run any initialization scripts as the data volume already contai
 ## Further Reading
 
 - [Trust deployment overview](../README.md)
-- [Contributing & Development Guide](CONTRIBUTING.md)
+- [Contributing & Development Guide](../../CONTRIBUTING.md)

--- a/trust/trust-api/README.md
+++ b/trust/trust-api/README.md
@@ -81,4 +81,4 @@ one replica.
 
 - [Full FLIP Documentation](https://londonaicentreflip.readthedocs.io/en/latest/)
 - [Trust deployment overview](../README.md)
-- [Contributing & Development Guide](CONTRIBUTING.md)
+- [Contributing & Development Guide](../../CONTRIBUTING.md)


### PR DESCRIPTION
> _This is an **automated scheduled weekly task** by Alex's Claude Code._
>
> The job audits READMEs and ReadTheDocs sources against the actual code (Makefiles, compose files, env examples, FastAPI routers, Python signatures), and only opens a PR when it finds essential, demonstrable mismatches. No PR is opened in weeks where everything is in sync.

## Summary

This week's audit surfaced three classes of factual drift in the documentation. Docstring/type-annotation review of `flip-api`, `trust-api`, `data-access-api`, and `imaging-api` came back clean — no signature/docstring mismatches were found, so no Python files are touched.

### 1. Broken `CONTRIBUTING.md` relative links in 6 service READMEs

Each link pointed to `CONTRIBUTING.md` (bare filename) from inside a subdirectory, so the link 404'd in any markdown renderer that respects the document's directory. Fixed:

| File | Before | After |
| --- | --- | --- |
| `flip-api/README.md` | `CONTRIBUTING.md` | `../CONTRIBUTING.md` |
| `flip-ui/README.md` | `CONTRIBUTING.md` | `../CONTRIBUTING.md` |
| `trust/data-access-api/README.md` | `CONTRIBUTING.md` | `../../CONTRIBUTING.md` |
| `trust/imaging-api/README.md` | `CONTRIBUTING.md` | `../../CONTRIBUTING.md` |
| `trust/omop-db/README.md` | `CONTRIBUTING.md` | `../../CONTRIBUTING.md` |
| `trust/trust-api/README.md` | `CONTRIBUTING.md` | `../../CONTRIBUTING.md` |

### 2. Root `README.md` Makefile-targets table was missing real targets

The "Using the Makefile" table omitted several targets that actually exist in the root `Makefile` and that other docs (CLAUDE.md, DEBUG.md, the central-hub row itself) point at. Added rows for:

- `make ui` / `make ui-off` (referenced from the `central-hub` row but not previously listed)
- `make tests` (different from `unit_test` — runs the full flip-api `test` target)
- `make debug SERVICE=<name>` and `make debug-off SERVICE=<name>` (the parameterised debug entry points documented in CLAUDE.md)
- `make debug-all` and `make debug-off-all`

### 3. Misleading port table in `deploy/providers/local/README.md`

The table listed the same `8000` for trust-api / imaging-api / data-access-api with no caveat, which is the *container* port. In the local-trust stack these ports are intentionally **not** published to the host (`compose_trust.local.yml` uses `ports: !override []`), and on production the published host ports are `8001`/`8010`/`8020` from `IMAGING_API_PORT`/`DATA_ACCESS_API_PORT`/`TRUST_API_PORT`. Renamed the column to "Container port" and added a paragraph explaining the local-vs-production publishing behaviour and the coexistence-with-`make up` rationale.

## Test plan

- [ ] CI is green (only docs touched — no code paths changed)
- [ ] Verify the six `CONTRIBUTING.md` links resolve when browsing the rendered READMEs on GitHub
- [ ] Spot-check that the new Makefile-table entries match `make help`-style invocations on a developer machine

---

Reviewers: @garciadias @virginiafdez
Assignees: @garciadias @virginiafdez @atriaybagur

---
_Generated by [Claude Code](https://claude.ai/code/session_01TDEY6Kbr7un5E7Zr72jR9e)_