### PR TITLE
Add authorization check to process-scanned-file endpoint (P1-04)

### DIFF
--- a/flip-api/src/flip_api/file_services/uploaded_file.py
+++ b/flip-api/src/flip_api/file_services/uploaded_file.py
@@ -15,6 +15,7 @@ from uuid import UUID
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlmodel import Session, select
 
+from flip_api.auth.access_manager import can_modify_model
 from flip_api.auth.dependencies import verify_token
 from flip_api.config import get_settings
 from flip_api.db.database import get_session
@@ -44,7 +45,7 @@ router = APIRouter(prefix="/files", tags=["file_services"])
 # TODO [#114] This endpoint was not defined in the old repo.
 @router.post("/process-scanned-file/{model_id}/{file}", response_model=dict[str, str])
 def process_scanned_file(
-    model_id: str,
+    model_id: UUID,
     file: str,
     db: Session = Depends(get_session),
     user_id: UUID = Depends(verify_token),
@@ -65,9 +66,17 @@ def process_scanned_file(
         dict[str, str]: A message indicating the result of the file processing
 
     Raises:
-        HTTPException: If the file cannot be processed.
+        HTTPException: 403 if the caller is not allowed to modify the model, or 500 if
+            the file cannot be processed.
     """
     try:
+        if not can_modify_model(user_id, model_id, db):
+            logger.error(f"User ID: {user_id} is not allowed to modify model {model_id}")
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail=f"User with ID: {user_id} is not allowed to modify files for this model",
+            )
+
         s3 = S3Client()
 
         file_status = FileUploadStatus.COMPLETED
@@ -107,14 +116,6 @@ def process_scanned_file(
         # model_id = key_parts[0]
         file_name = file
         logger.debug(f"Extracted model ID: {model_id}, file name: {file_name} from the file's key: {file}")
-
-        # Validate model ID (simplified validation)
-        if not model_id:
-            logger.error("Invalid model ID")
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail="File does not belong to a model with a valid model ID",
-            )
 
         logger.info(f"Extracted the model ID from the file's key successfully. Model ID: {model_id}")
 

--- a/flip-api/tests/unit/file_services/test_uploaded_file.py
+++ b/flip-api/tests/unit/file_services/test_uploaded_file.py
@@ -15,12 +15,93 @@ import uuid
 from unittest.mock import MagicMock, patch
 
 import pytest
+from fastapi import status
 from fastapi.exceptions import HTTPException
+from fastapi.testclient import TestClient
 
+from flip_api.auth.dependencies import verify_token
 from flip_api.config import Settings
+from flip_api.db.database import get_session
 from flip_api.db.models.main_models import UploadedFiles
 from flip_api.domain.schemas.file import BucketStatus, FileUploadStatus, ScannedFileInput
 from flip_api.file_services.uploaded_file import process_scanned_file
+from flip_api.main import app
+
+# ---------- Authorisation tests for /files/process-scanned-file ----------
+
+client = TestClient(app)
+
+auth_test_user_id = uuid.uuid4()
+auth_test_model_id = uuid.uuid4()
+auth_test_file_name = "weights.bin"
+
+
+@pytest.fixture
+def override_auth_dependencies():
+    """Inject a deterministic user_id and a mock DB session into the endpoint."""
+    mock_session = MagicMock()
+    app.dependency_overrides[get_session] = lambda: mock_session
+    app.dependency_overrides[verify_token] = lambda: auth_test_user_id
+    yield mock_session
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def mocked_settings_for_auth():
+    settings = Settings(UPLOADED_MODEL_FILES_BUCKET="test-uploaded-bucket")
+    with patch("flip_api.file_services.uploaded_file.get_settings", return_value=settings):
+        yield settings
+
+
+@pytest.fixture
+def mock_s3_for_auth():
+    with patch("flip_api.file_services.uploaded_file.S3Client") as mock_client:
+        instance = MagicMock()
+        instance.head_object.return_value = {"ContentLength": 1024, "ContentType": "application/octet-stream"}
+        mock_client.return_value = instance
+        yield instance
+
+
+def test_process_scanned_file_returns_403_when_user_cannot_modify_model(
+    override_auth_dependencies, mocked_settings_for_auth, mock_s3_for_auth
+):
+    mock_session = override_auth_dependencies
+    with patch("flip_api.file_services.uploaded_file.can_modify_model", return_value=False):
+        response = client.post(f"/api/files/process-scanned-file/{auth_test_model_id}/{auth_test_file_name}")
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert str(auth_test_user_id) in response.json()["detail"]
+    mock_session.add.assert_not_called()
+    mock_session.commit.assert_not_called()
+    mock_s3_for_auth.head_object.assert_not_called()
+
+
+def test_process_scanned_file_succeeds_when_user_can_modify_model(
+    override_auth_dependencies, mocked_settings_for_auth, mock_s3_for_auth
+):
+    mock_session = override_auth_dependencies
+    mock_session.exec.return_value.first.return_value = None  # no existing row → insert path
+    with patch("flip_api.file_services.uploaded_file.can_modify_model", return_value=True):
+        response = client.post(f"/api/files/process-scanned-file/{auth_test_model_id}/{auth_test_file_name}")
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == {"message": "File processed successfully"}
+    mock_session.add.assert_called_once()
+    mock_session.commit.assert_called_once()
+
+
+def test_process_scanned_file_returns_422_for_non_uuid_model_id(
+    override_auth_dependencies, mocked_settings_for_auth, mock_s3_for_auth
+):
+    """FastAPI must reject malformed model_id at the path-parameter layer."""
+    with patch("flip_api.file_services.uploaded_file.can_modify_model", return_value=True) as can_modify:
+        response = client.post(f"/api/files/process-scanned-file/not-a-uuid/{auth_test_file_name}")
+
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    can_modify.assert_not_called()
+
+
+# ---------- Legacy SNS-pipeline tests (skipped, see comment below) ----------
 
 
 @pytest.fixture


### PR DESCRIPTION
# Description

This PR adds authorization validation to the `/files/process-scanned-file` endpoint to ensure users can only process files for models they have permission to modify.

## Changes

### Source Code
- **`uploaded_file.py`**:
  - Changed `model_id` parameter type from `str` to `UUID` for type safety and automatic FastAPI validation
  - Added `can_modify_model()` authorization check at the start of `process_scanned_file()` function
  - Returns HTTP 403 Forbidden if the user lacks permission to modify the model
  - Removed redundant manual model ID validation (now handled by FastAPI&#39;s UUID type validation)
  - Updated docstring to document the 403 error case

### Tests
- **`test_uploaded_file.py`**:
  - Added comprehensive authorization test suite with fixtures for mocking dependencies
  - `test_process_scanned_file_returns_403_when_user_cannot_modify_model`: Verifies 403 response and that no DB operations occur when authorization fails
  - `test_process_scanned_file_succeeds_when_user_can_modify_model`: Verifies successful processing when user has permission
  - `test_process_scanned_file_returns_422_for_non_uuid_model_id`: Verifies FastAPI rejects malformed UUIDs at the path parameter layer

## Relationship to the SNS / virus-scanning work

This is intentionally an **intermediate fix**, not a substitute for the full SNS + Lambda virus-scanning pipeline tracked under #52 . The reasoning:

- **The bug is reachable today.** `process-scanned-file` is currently invoked from the browser (`flip-ui` `ModelUpload.vue`) ~3 s after a presigned-URL upload — there is no SNS/Lambda subscription deployed. Until that work lands, the endpoint is a user-facing route with no model-level authorization, so any logged-in Cognito user can attach `UploadedFiles` rows to any other user's model. Waiting for that work leaves that hole open for the duration of that work.
- **The fix matches the pattern already used by the rest of the file_services package.** `delete_file.py` and `presigned_url_for_upload.py` both gate on `can_modify_model(user_id, model_id, db)`; this PR brings `process-scanned-file` in line with them. Nothing novel is introduced.
- **The UUID type tightening is independently correct.** With `model_id: str` the existing DB lookup (`WHERE UploadedFiles.model_id == model_id`) compared a `str` against a `UUID` column and never matched an existing row, so every call inserted a duplicate `UploadedFiles` record instead of updating. Worth fixing regardless of the scanning rollout.
- **Nothing here will need to be unwound when that work lands.** Once a real Lambda invokes the hub after a clean scan, the call shape changes: it should authenticate as a service (the existing `authenticate_internal_service` dependency used by `private_services/add_log.py`), not as a Cognito user, and likely move under `/private/...`. The `verify_token` + `can_modify_model` guard added here goes away naturally at that point — it isn't a stepping stone to be carried forward.

## Linked Issues

Fixes #

Related: #52 (virus scanning / SNS pipeline) — see section above.

## Type of Change

- [x] Non-breaking change (fix or new feature that would not break existing functionality)
- [x] New tests added to cover the changes
- [x] In-line docstrings updated

## Testing

Added unit tests that verify:
- Authorization check prevents unauthorized users from processing files (403 response)
- Authorized users can successfully process files
- Invalid UUID format is rejected by FastAPI validation layer

All new tests pass locally and cover the authorization logic comprehensively.

https://claude.ai/code/session_01Q3ozV7f6cgS6aqXG7oWupC