### PR TITLE
Add access control to file retrieval endpoints (P1-05)

### DIFF
--- a/flip-api/src/flip_api/file_services/retrieve_uploaded_file_info.py
+++ b/flip-api/src/flip_api/file_services/retrieve_uploaded_file_info.py
@@ -16,6 +16,7 @@ from uuid import UUID
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlmodel import Session, col, select
 
+from flip_api.auth.access_manager import can_access_model
 from flip_api.auth.dependencies import verify_token
 from flip_api.db.database import get_session
 from flip_api.db.models.main_models import UploadedFiles
@@ -23,6 +24,60 @@ from flip_api.domain.schemas.file import IdList
 from flip_api.utils.logger import logger
 
 router = APIRouter(prefix="/files", tags=["file_services"])
+
+
+def _filter_files_by_access(
+    files: list[UploadedFiles],
+    user_id: UUID,
+    db: Session,
+) -> list[UploadedFiles]:
+    """Filter files to those whose owning model the user can access.
+
+    Files with no ``model_id`` are denied by default — they are not attached to
+    any model and therefore have no scope under which a caller can claim access.
+    Access decisions are memoised per ``model_id`` to avoid redundant DB lookups
+    when several files share the same model.
+
+    Args:
+        files: Files retrieved from the database.
+        user_id: Authenticated caller.
+        db: Database session.
+
+    Returns:
+        The subset of ``files`` the caller is allowed to see.
+    """
+    access_cache: dict[UUID, bool] = {}
+    accessible: list[UploadedFiles] = []
+    for file in files:
+        if file.model_id is None:
+            logger.warning(f"Denying access to file {file.id}: no associated model_id.")
+            continue
+        if file.model_id not in access_cache:
+            access_cache[file.model_id] = can_access_model(user_id, file.model_id, db)
+        if access_cache[file.model_id]:
+            accessible.append(file)
+        else:
+            logger.warning(
+                f"User {user_id} denied access to file {file.id} (model {file.model_id})."
+            )
+    return accessible
+
+
+def _serialize_files(files: list[UploadedFiles]) -> list[dict[str, Any]]:
+    """Serialize file records into the API response shape."""
+    return [
+        {
+            "id": str(file.id) if file.id else None,
+            "name": file.name,
+            "status": file.status,
+            "size": file.size,
+            "type": file.type,
+            "modelId": str(file.model_id) if file.model_id else None,
+            "created": file.created.isoformat() if hasattr(file, "created") and file.created else None,
+            "modified": file.modified.isoformat() if hasattr(file, "modified") and file.modified else None,
+        }
+        for file in files
+    ]
 
 
 # TODO Remove duplicate code in these endpoints
@@ -38,6 +93,11 @@ def get_uploaded_files_info(
     """
     Get information about uploaded files based on a list of IDs.
 
+    Only files belonging to a model the caller can access are returned. Files
+    outside the caller's scope are filtered out — the response does not
+    distinguish between "does not exist" and "not authorised", to avoid
+    leaking the existence of files via metadata enumeration.
+
     Args:
         file_ids (str): Comma-separated string of file IDs
         db (Session): Database session
@@ -47,7 +107,7 @@ def get_uploaded_files_info(
         list[dict[str, Any]]: A list of dictionaries containing file information
 
     Raises:
-        HTTPException: If no files are found or if there is an error during the operation.
+        HTTPException: If no accessible files are found or if there is an error during the operation.
     """
     try:
         # Parse and validate the ID list
@@ -59,34 +119,23 @@ def get_uploaded_files_info(
         # Query files by ID
         files = db.exec(select(UploadedFiles).where(col(UploadedFiles.id).in_(id_list))).all()
 
-        if not files:
-            logger.error("No files found")
+        # Filter to files the caller is authorised to see
+        accessible_files = _filter_files_by_access(list(files), user_id, db)
+
+        if not accessible_files:
+            logger.error(f"No files accessible to user {user_id} for the requested IDs.")
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
                 detail="No files found",
             )
 
-        # Track which IDs were found and log missing IDs
-        retrieved_ids = [str(file.id) for file in files]
-
-        for id_str in [str(id) for id in id_list]:
+        # Track which IDs were returned and log the rest
+        retrieved_ids = {str(file.id) for file in accessible_files}
+        for id_str in (str(i) for i in id_list):
             if id_str not in retrieved_ids:
-                logger.error(f"File with ID: {id_str} not found")
+                logger.info(f"File with ID: {id_str} not returned (missing or access denied)")
 
-        # Format response
-        result = []
-        for file in files:
-            result.append({
-                "id": str(file.id) if file.id else None,
-                "name": file.name,
-                "status": file.status,
-                "size": file.size,
-                "type": file.type,
-                "modelId": str(file.model_id) if file.model_id else None,
-                "created": file.created.isoformat() if hasattr(file, "created") and file.created else None,
-                "modified": file.modified.isoformat() if hasattr(file, "modified") and file.modified else None,
-            })
-
+        result = _serialize_files(accessible_files)
         logger.info(f"Retrieved status for {len(result)} files")
         return result
 
@@ -118,6 +167,11 @@ def get_uploaded_files_info_post(
     """
     Get information about uploaded files based on a list of IDs (POST method).
 
+    Only files belonging to a model the caller can access are returned. Files
+    outside the caller's scope are filtered out — the response does not
+    distinguish between "does not exist" and "not authorised", to avoid
+    leaking the existence of files via metadata enumeration.
+
     Args:
         id_list (IdList): Pydantic model containing a list of file IDs
         db (Session): Database session
@@ -127,40 +181,29 @@ def get_uploaded_files_info_post(
         list[dict[str, Any]]: A list of dictionaries containing file information
 
     Raises:
-        HTTPException: If no files are found or if there is an error during the operation.
+        HTTPException: If no accessible files are found or if there is an error during the operation.
     """
     try:
         # Query files by ID
         files = db.exec(select(UploadedFiles).where(col(UploadedFiles.id).in_(id_list.ids))).all()
 
-        if not files:
-            logger.error("No files found")
+        # Filter to files the caller is authorised to see
+        accessible_files = _filter_files_by_access(list(files), user_id, db)
+
+        if not accessible_files:
+            logger.error(f"No files accessible to user {user_id} for the requested IDs.")
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
                 detail="No files found",
             )
 
-        # Track which IDs were found and log missing IDs
-        retrieved_ids = [str(file.id) for file in files]
-
-        for id_str in [str(id) for id in id_list.ids]:
+        # Track which IDs were returned and log the rest
+        retrieved_ids = {str(file.id) for file in accessible_files}
+        for id_str in (str(i) for i in id_list.ids):
             if id_str not in retrieved_ids:
-                logger.error(f"File with ID: {id_str} not found")
+                logger.info(f"File with ID: {id_str} not returned (missing or access denied)")
 
-        # Format response
-        result = []
-        for file in files:
-            result.append({
-                "id": str(file.id) if file.id else None,
-                "name": file.name,
-                "status": file.status,
-                "size": file.size,
-                "type": file.type,
-                "modelId": str(file.model_id) if file.model_id else None,
-                "created": file.created.isoformat() if hasattr(file, "created") and file.created else None,
-                "modified": file.modified.isoformat() if hasattr(file, "modified") and file.modified else None,
-            })
-
+        result = _serialize_files(accessible_files)
         logger.info(f"Retrieved status for {len(result)} files")
         return result
 

--- a/flip-api/src/flip_api/file_services/retrieve_uploaded_file_info.py
+++ b/flip-api/src/flip_api/file_services/retrieve_uploaded_file_info.py
@@ -123,7 +123,7 @@ def get_uploaded_files_info(
         accessible_files = _filter_files_by_access(list(files), user_id, db)
 
         if not accessible_files:
-            logger.error(f"No files accessible to user {user_id} for the requested IDs.")
+            logger.warning(f"No files accessible to user {user_id} for the requested IDs.")
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
                 detail="No files found",
@@ -191,7 +191,7 @@ def get_uploaded_files_info_post(
         accessible_files = _filter_files_by_access(list(files), user_id, db)
 
         if not accessible_files:
-            logger.error(f"No files accessible to user {user_id} for the requested IDs.")
+            logger.warning(f"No files accessible to user {user_id} for the requested IDs.")
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
                 detail="No files found",

--- a/flip-api/tests/unit/file_services/test_retrieve_uploaded_file_info.py
+++ b/flip-api/tests/unit/file_services/test_retrieve_uploaded_file_info.py
@@ -105,11 +105,15 @@ class TestGetUploadedFilesInfo:
     """Tests for the GET endpoint get_uploaded_files_info."""
 
     def test_get_files_info_success(self, mock_db_session, sample_files):
-        """Test successful retrieval of file information."""
+        """Authorised users see metadata for files in their scope."""
         _, sample_file_ids, model_id = sample_files
         file_ids_str = ",".join(str(fid) for fid in sample_file_ids[:2])
 
-        result = get_uploaded_files_info(file_ids=file_ids_str, db=mock_db_session, user_id="test-user-id")
+        with patch(
+            "flip_api.file_services.retrieve_uploaded_file_info.can_access_model",
+            return_value=True,
+        ):
+            result = get_uploaded_files_info(file_ids=file_ids_str, db=mock_db_session, user_id=uuid.uuid4())
 
         assert len(result) == 2
         assert result[0]["id"] == str(sample_file_ids[0])
@@ -125,13 +129,112 @@ class TestGetUploadedFilesInfo:
         assert result[1]["name"] == "test_file2.csv"
         assert result[1]["status"] == "SCANNING"
 
+    def test_get_files_info_access_denied(self, mock_db_session, sample_files):
+        """Files outside the caller's scope are not returned (404)."""
+        _, sample_file_ids, _ = sample_files
+        file_ids_str = ",".join(str(fid) for fid in sample_file_ids[:2])
+
+        with patch(
+            "flip_api.file_services.retrieve_uploaded_file_info.can_access_model",
+            return_value=False,
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                get_uploaded_files_info(file_ids=file_ids_str, db=mock_db_session, user_id=uuid.uuid4())
+
+        assert exc_info.value.status_code == status.HTTP_404_NOT_FOUND
+        assert "No files found" in exc_info.value.detail
+
+    def test_get_files_info_partial_access(self, sample_file_ids):
+        """When some files are in scope and others are not, only allowed files are returned."""
+        allowed_model_id = uuid.uuid4()
+        denied_model_id = uuid.uuid4()
+        files = [
+            UploadedFiles(
+                id=sample_file_ids[0],
+                name="allowed.txt",
+                size=10,
+                type="text/plain",
+                status="PROCESSED",
+                model_id=allowed_model_id,
+            ),
+            UploadedFiles(
+                id=sample_file_ids[1],
+                name="denied.txt",
+                size=20,
+                type="text/plain",
+                status="PROCESSED",
+                model_id=denied_model_id,
+            ),
+        ]
+
+        class MockSession:
+            def exec(self, query):
+                class MockResult:
+                    def all(self_inner):  # noqa: N805 - mock signature
+                        return files
+
+                return MockResult()
+
+        file_ids_str = ",".join(str(fid) for fid in sample_file_ids[:2])
+
+        def fake_can_access(_user_id, model_id, _db):
+            return model_id == allowed_model_id
+
+        with patch(
+            "flip_api.file_services.retrieve_uploaded_file_info.can_access_model",
+            side_effect=fake_can_access,
+        ):
+            result = get_uploaded_files_info(file_ids=file_ids_str, db=MockSession(), user_id=uuid.uuid4())
+
+        assert len(result) == 1
+        assert result[0]["name"] == "allowed.txt"
+        assert result[0]["modelId"] == str(allowed_model_id)
+
+    def test_get_files_info_orphan_file_denied(self, sample_file_ids):
+        """Files with no model_id are denied by default."""
+        files = [
+            UploadedFiles(
+                id=sample_file_ids[0],
+                name="orphan.txt",
+                size=10,
+                type="text/plain",
+                status="PROCESSED",
+                model_id=None,
+            ),
+        ]
+
+        class MockSession:
+            def exec(self, query):
+                class MockResult:
+                    def all(self_inner):  # noqa: N805 - mock signature
+                        return files
+
+                return MockResult()
+
+        with patch(
+            "flip_api.file_services.retrieve_uploaded_file_info.can_access_model",
+            return_value=True,
+        ) as access_check:
+            with pytest.raises(HTTPException) as exc_info:
+                get_uploaded_files_info(
+                    file_ids=str(sample_file_ids[0]), db=MockSession(), user_id=uuid.uuid4()
+                )
+
+        assert exc_info.value.status_code == status.HTTP_404_NOT_FOUND
+        # Orphan files must not even reach the access check.
+        access_check.assert_not_called()
+
     def test_get_files_info_no_files_found(self, empty_db_session, sample_files):
         """Test handling of no files found."""
         _, sample_file_ids, _ = sample_files
         file_ids_str = ",".join(str(fid) for fid in sample_file_ids[:2])
 
-        with pytest.raises(HTTPException) as exc_info:
-            get_uploaded_files_info(file_ids=file_ids_str, db=empty_db_session, user_id="test-user-id")
+        with patch(
+            "flip_api.file_services.retrieve_uploaded_file_info.can_access_model",
+            return_value=True,
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                get_uploaded_files_info(file_ids=file_ids_str, db=empty_db_session, user_id=uuid.uuid4())
 
         assert exc_info.value.status_code == status.HTTP_404_NOT_FOUND
         assert "No files found" in exc_info.value.detail
@@ -139,7 +242,7 @@ class TestGetUploadedFilesInfo:
     def test_get_files_info_invalid_uuid(self):
         """Test handling of invalid UUID format."""
         with pytest.raises(HTTPException) as exc_info:
-            get_uploaded_files_info(file_ids="invalid-uuid,another-invalid", db=MagicMock(), user_id="test-user-id")
+            get_uploaded_files_info(file_ids="invalid-uuid,another-invalid", db=MagicMock(), user_id=uuid.uuid4())
 
         assert exc_info.value.status_code == status.HTTP_400_BAD_REQUEST
         assert "Invalid UUID format" in exc_info.value.detail
@@ -151,8 +254,12 @@ class TestGetUploadedFilesInfo:
 
         mock_db_session.exec = MagicMock(side_effect=Exception("Database connection error"))
 
-        with pytest.raises(HTTPException) as exc_info:
-            get_uploaded_files_info(file_ids=file_ids_str, db=mock_db_session, user_id="test-user-id")
+        with patch(
+            "flip_api.file_services.retrieve_uploaded_file_info.can_access_model",
+            return_value=True,
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                get_uploaded_files_info(file_ids=file_ids_str, db=mock_db_session, user_id=uuid.uuid4())
 
         assert exc_info.value.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
         assert "Internal server error" in exc_info.value.detail
@@ -162,11 +269,15 @@ class TestGetUploadedFilesInfoPost:
     """Tests for the POST endpoint get_uploaded_files_info_post."""
 
     def test_post_files_info_success(self, mock_db_session, sample_files):
-        """Test successful retrieval of file information using POST."""
+        """Authorised users see metadata for files in their scope."""
         _, sample_file_ids, model_id = sample_files
         id_list = IdList(ids=sample_file_ids[:2])
 
-        result = get_uploaded_files_info_post(id_list=id_list, db=mock_db_session, user_id="test-user-id")
+        with patch(
+            "flip_api.file_services.retrieve_uploaded_file_info.can_access_model",
+            return_value=True,
+        ):
+            result = get_uploaded_files_info_post(id_list=id_list, db=mock_db_session, user_id=uuid.uuid4())
 
         assert len(result) == 2
         assert result[0]["id"] == str(sample_file_ids[0])
@@ -174,13 +285,32 @@ class TestGetUploadedFilesInfoPost:
         assert result[1]["id"] == str(sample_file_ids[1])
         assert result[1]["name"] == "test_file2.csv"
 
+    def test_post_files_info_access_denied(self, mock_db_session, sample_files):
+        """Files outside the caller's scope are not returned (404)."""
+        _, sample_file_ids, _ = sample_files
+        id_list = IdList(ids=sample_file_ids[:2])
+
+        with patch(
+            "flip_api.file_services.retrieve_uploaded_file_info.can_access_model",
+            return_value=False,
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                get_uploaded_files_info_post(id_list=id_list, db=mock_db_session, user_id=uuid.uuid4())
+
+        assert exc_info.value.status_code == status.HTTP_404_NOT_FOUND
+        assert "No files found" in exc_info.value.detail
+
     def test_post_files_info_no_files_found(self, empty_db_session, sample_files):
         """Test handling of no files found using POST."""
         _, sample_file_ids, _ = sample_files
         id_list = IdList(ids=sample_file_ids[:2])
 
-        with pytest.raises(HTTPException) as exc_info:
-            get_uploaded_files_info_post(id_list=id_list, db=empty_db_session, user_id="test-user-id")
+        with patch(
+            "flip_api.file_services.retrieve_uploaded_file_info.can_access_model",
+            return_value=True,
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                get_uploaded_files_info_post(id_list=id_list, db=empty_db_session, user_id=uuid.uuid4())
 
         assert exc_info.value.status_code == status.HTTP_404_NOT_FOUND
         assert "No files found" in exc_info.value.detail
@@ -192,8 +322,12 @@ class TestGetUploadedFilesInfoPost:
 
         mock_db_session.exec = MagicMock(side_effect=Exception("Database connection error"))
 
-        with pytest.raises(HTTPException) as exc_info:
-            get_uploaded_files_info_post(id_list=id_list, db=mock_db_session, user_id="test-user-id")
+        with patch(
+            "flip_api.file_services.retrieve_uploaded_file_info.can_access_model",
+            return_value=True,
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                get_uploaded_files_info_post(id_list=id_list, db=mock_db_session, user_id=uuid.uuid4())
 
         assert exc_info.value.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
         assert "Internal server error" in exc_info.value.detail


### PR DESCRIPTION
# Description

This PR adds authorization checks to the file retrieval endpoints (`get_uploaded_files_info` and `get_uploaded_files_info_post`) to ensure users can only access files belonging to models they have permission to view.

## Security Impact

This change implements proper authorization for file metadata retrieval. Previously, any authenticated user could retrieve metadata for any file in the system. Now, users can only see files belonging to models they have explicit access to.

## Changes

### Source Code
- **Added access filtering**: Introduced `_filter_files_by_access()` helper function that:
  - Filters files to only those whose owning model the user can access
  - Denies access to files with no `model_id` (orphaned files)
  - Caches access decisions per `model_id` to avoid redundant database lookups
  - Logs access denials for audit purposes

- **Added serialization helper**: Extracted `_serialize_files()` to reduce code duplication between the two endpoints

- **Updated both endpoints** to:
  - Call `_filter_files_by_access()` after retrieving files from the database
  - Return 404 for files outside the caller's scope (no distinction between "not found" and "not authorized" to prevent metadata enumeration attacks)
  - Updated docstrings to document the authorization behavior
  - Improved logging to distinguish between missing files and access-denied files

### Tests
- Updated existing tests to mock `can_access_model` calls
- Added `test_get_files_info_access_denied()`: Verifies 404 when user lacks access to all files
- Added `test_get_files_info_partial_access()`: Verifies only accessible files are returned when user has mixed access
- Added `test_get_files_info_orphan_file_denied()`: Verifies orphaned files (no model_id) are denied without calling access check
- Added `test_post_files_info_access_denied()`: POST endpoint equivalent of access denial test
- Updated all existing tests to use `uuid.uuid4()` instead of hardcoded user IDs and to patch `can_access_model`

## Linked Issues

Fixes #

## Checklist

- [x] Follows the project's coding conventions and style guide
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] In-line docstrings updated

## Type of Change

- [x] Non-breaking change (fix or new feature that would not break existing functionality)
- [x] New tests added to cover the changes
- [x] In-line docstrings updated

## Testing

Added comprehensive unit tests covering:
- Successful retrieval with proper authorization
- Access denial (404 response)
- Partial access (mixed allowed/denied files)
- Orphaned files (no model_id)
- Existing error handling scenarios

All tests pass with the new authorization logic in place.

https://claude.ai/code/session_01MMvkMVg42GFpaJo1pdGZxo