### PR TITLE
fix: override placeholder AES_KEY_BASE64 in trust test conftests

### DIFF
--- a/trust/data-access-api/tests/conftest.py
+++ b/trust/data-access-api/tests/conftest.py
@@ -23,4 +23,9 @@ _TEST_ENV_DEFAULTS = {
 }
 
 for key, value in _TEST_ENV_DEFAULTS.items():
-    os.environ.setdefault(key, value)
+    # Treat unset *and* unreplaced `<placeholder>` values from .env.development.example
+    # as missing — otherwise the placeholder leaks through and base64-decoding the
+    # AES key fails with "Incorrect padding" mid-test.
+    current = os.environ.get(key, "")
+    if not current or (current.startswith("<") and current.endswith(">")):
+        os.environ[key] = value

--- a/trust/imaging-api/tests/conftest.py
+++ b/trust/imaging-api/tests/conftest.py
@@ -30,7 +30,12 @@ _TEST_ENV_DEFAULTS = {
 }
 
 for key, value in _TEST_ENV_DEFAULTS.items():
-    os.environ.setdefault(key, value)
+    # Treat unset *and* unreplaced `<placeholder>` values from .env.development.example
+    # as missing — otherwise the placeholder leaks through and base64-decoding the
+    # AES key fails with "Incorrect padding" mid-test.
+    current = os.environ.get(key, "")
+    if not current or (current.startswith("<") and current.endswith(">")):
+        os.environ[key] = value
 
 # BASE_IMAGES_DOWNLOAD_DIR must point at a writable directory: download_and_unzip_images
 # now calls os.makedirs() on it before any mocks can intercept. The service Makefile

--- a/trust/trust-api/tests/conftest.py
+++ b/trust/trust-api/tests/conftest.py
@@ -26,4 +26,9 @@ _TEST_ENV_DEFAULTS = {
 }
 
 for key, value in _TEST_ENV_DEFAULTS.items():
-    os.environ.setdefault(key, value)
+    # Treat unset *and* unreplaced `<placeholder>` values from .env.development.example
+    # as missing — otherwise the placeholder leaks through and base64-decoding the
+    # AES key fails with "Incorrect padding" mid-test.
+    current = os.environ.get(key, "")
+    if not current or (current.startswith("<") and current.endswith(">")):
+        os.environ[key] = value


### PR DESCRIPTION
Closes #350.

## Summary
- Trust unit tests crashed with `binascii.Error: Incorrect padding` whenever `.env.development` still carried the unedited `AES_KEY_BASE64=<your-base64-encoded-32-byte-aes-key-for-testing>` placeholder, because `os.environ.setdefault()` in each conftest didn't override the leaked placeholder before `base64.b64decode()` ran.
- Each trust `tests/conftest.py` now treats values wrapped in `<...>` as missing and installs the per-service dummy AES key. Any real developer-supplied value is still preserved unchanged.

## Files changed
- `trust/data-access-api/tests/conftest.py`
- `trust/imaging-api/tests/conftest.py`
- `trust/trust-api/tests/conftest.py`

## Test plan
- [x] Reproduce original failure: `python3 -c "import base64; base64.b64decode('<your-base64-encoded-32-byte-aes-key-for-testing>')"` raises `Incorrect padding`.
- [x] `AES_KEY_BASE64='<your-base64-encoded-32-byte-aes-key-for-testing>' uv run pytest tests/utils/test_encryption.py` — passes for all three trust services (8/8 imaging-api, 6/6 data-access-api, 7/7 trust-api).
- [x] Full unit suite under each trust service passes with the placeholder env var (the one unrelated `test_unwritable_parent_raises_local_storage_error` failure is a pre-existing root-user filesystem-permissions issue, not AES-related).
- [x] Verified a real, non-placeholder developer-supplied `AES_KEY_BASE64` is still honoured (not overridden).

https://claude.ai/code/session_0144x58vcz1sJdcDaaYTMFxR

---
_Generated by [Claude Code](https://claude.ai/code/session_0144x58vcz1sJdcDaaYTMFxR)_