### PR TITLE
fix: bump fast-xml-parser to >=5.7.0 (XMLBuilder injection)

### DIFF
--- a/flip-ui/package-lock.json
+++ b/flip-ui/package-lock.json
@@ -1985,27 +1985,6 @@
                 "node": ">=18.0.0"
             }
         },
-        "node_modules/@aws-sdk/xml-builder/node_modules/fast-xml-parser": {
-            "version": "5.5.8",
-            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.8.tgz",
-            "integrity": "sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/NaturalIntelligence"
-                }
-            ],
-            "license": "MIT",
-            "dependencies": {
-                "fast-xml-builder": "^1.1.4",
-                "path-expression-matcher": "^1.2.0",
-                "strnum": "^2.2.0"
-            },
-            "bin": {
-                "fxparser": "src/cli/cli.js"
-            }
-        },
         "node_modules/@aws/lambda-invoke-store": {
             "version": "0.2.4",
             "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
@@ -6504,6 +6483,19 @@
                 "@emnapi/core": "^1.7.1",
                 "@emnapi/runtime": "^1.7.1"
             }
+        },
+        "node_modules/@nodable/entities": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+            "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/nodable"
+                }
+            ],
+            "license": "MIT"
         },
         "node_modules/@nodelib/fs.scandir": {
             "version": "2.1.5",
@@ -13172,9 +13164,9 @@
             "license": "MIT"
         },
         "node_modules/fast-xml-builder": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
-            "integrity": "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
+            "integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
             "dev": true,
             "funding": [
                 {
@@ -13188,9 +13180,9 @@
             }
         },
         "node_modules/fast-xml-parser": {
-            "version": "5.5.9",
-            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.9.tgz",
-            "integrity": "sha512-jldvxr1MC6rtiZKgrFnDSvT8xuH+eJqxqOBThUVjYrxssYTo1avZLGql5l0a0BAERR01CadYzZ83kVEkbyDg+g==",
+            "version": "5.7.2",
+            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.2.tgz",
+            "integrity": "sha512-P7oW7tLbYnhOLQk/Gv7cZgzgMPP/XN03K02/Jy6Y/NHzyIAIpxuZIM/YqAkfiXFPxA2CTm7NtCijK9EDu09u2w==",
             "dev": true,
             "funding": [
                 {
@@ -13200,9 +13192,10 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "fast-xml-builder": "^1.1.4",
-                "path-expression-matcher": "^1.2.0",
-                "strnum": "^2.2.2"
+                "@nodable/entities": "^2.1.0",
+                "fast-xml-builder": "^1.1.5",
+                "path-expression-matcher": "^1.5.0",
+                "strnum": "^2.2.3"
             },
             "bin": {
                 "fxparser": "src/cli/cli.js"
@@ -18791,9 +18784,9 @@
             }
         },
         "node_modules/path-expression-matcher": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.2.0.tgz",
-            "integrity": "sha512-DwmPWeFn+tq7TiyJ2CxezCAirXjFxvaiD03npak3cRjlP9+OjTmSy1EpIrEbh+l6JgUundniloMLDQ/6VTdhLQ==",
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+            "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
             "dev": true,
             "funding": [
                 {
@@ -20537,9 +20530,9 @@
             }
         },
         "node_modules/strnum": {
-            "version": "2.2.2",
-            "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.2.tgz",
-            "integrity": "sha512-DnR90I+jtXNSTXWdwrEy9FakW7UX+qUZg28gj5fk2vxxl7uS/3bpI4fjFYVmdK9etptYBPNkpahuQnEwhwECqA==",
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
+            "integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
             "dev": true,
             "funding": [
                 {

--- a/flip-ui/package.json
+++ b/flip-ui/package.json
@@ -111,7 +111,8 @@
         "xml2js": ">=0.5.0",
         "lodash": "^4.18.1",
         "lodash-es": "^4.18.1",
-        "follow-redirects": ">=1.15.12"
+        "follow-redirects": ">=1.15.12",
+        "fast-xml-parser": ">=5.7.0"
     },
     "babel": {
         "presets": [


### PR DESCRIPTION
## Description

Resolves a Dependabot alert for `fast-xml-parser` < 5.7.0, which is pulled in transitively by `aws-amplify` (a `flip-ui` devDependency). The vulnerable versions do not escape `-->` in comments or `]]>` in CDATA sections in `XMLBuilder`, allowing XML injection if user-controlled data ever reaches those nodes.

Before this change, `flip-ui/node_modules` contained two vulnerable copies:
- `fast-xml-parser@5.5.9` at the top level (via `@aws-amplify/storage`)
- `fast-xml-parser@5.5.8` nested under `@aws-sdk/xml-builder` (which pinned an exact version, blocking dedup with 5.5.9)

## Change

Added a top-level npm `overrides` entry in `flip-ui/package.json`:

```json
"fast-xml-parser": ">=5.7.0"
```

Both transitive consumers can satisfy `>=5.7.0`, so npm now dedupes them into a single `fast-xml-parser@5.7.2` install.

## Linked Issues

Fixes #

## Checklist

- [x] Follows the project's coding conventions and style guide
- [ ] Updates documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Type of Change

- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make -C docs/ docs`.

## Testing

- `npm install` — clean install resolves a single `fast-xml-parser@5.7.2`.
- `npm run test:unit` — 125 passed, 3 skipped (preexisting), no regressions.

## Additional Notes

`package-lock.json` is regenerated so the previously-nested `node_modules/@aws-sdk/xml-builder/node_modules/fast-xml-parser` entry is gone; only one top-level entry remains.

https://claude.ai/code/session_01NJ29yJahbcBKYpV1vCa7im