### PR TITLE
Add environment-based RDS hardening for production deployments (P2-03)

### DIFF
--- a/deploy/providers/AWS/Makefile
+++ b/deploy/providers/AWS/Makefile
@@ -53,6 +53,9 @@ endif
 endif
 
 ## SETTING VARIABLES FOR TERRAFORM
+# Map the Make-level PROD flag (true|stag) onto a Terraform-friendly environment name.
+# Used in main.tf to gate prod-only RDS hardening (deletion protection, final snapshot).
+export TF_VAR_environment=$(if $(filter true,$(PROD)),prod,stag)
 export TF_VAR_max_azs=2
 export TF_VAR_vpc_cidr=10.0.0.0/16
 export TF_VAR_public_subnets=["10.0.1.0/24", "10.0.2.0/24"]

--- a/deploy/providers/AWS/README.md
+++ b/deploy/providers/AWS/README.md
@@ -158,6 +158,8 @@ The `PROD` variable determines which environment files are loaded:
 
 If `PROD` is omitted when running the AWS provider Makefile, it defaults to staging.
 
+The Makefile maps `PROD` onto `TF_VAR_environment` (`prod` when `PROD=true`, otherwise `stag`). Terraform branches on this variable to gate prod-only RDS hardening — see [RDS lifecycle](#rds-lifecycle-stag-vs-prod).
+
 #### AWS profile aliases
 
 The Makefile guards refuse to apply unless `AWS_PROFILE` matches the expected profile for the chosen environment. Defaults are the short logical names `prod`, `stag`, and `dev` — add these aliases to `~/.aws/config` so commands like `AWS_PROFILE=stag make plan` work without thinking about account numbers:
@@ -233,7 +235,7 @@ make destroy
 - Trust EC2 instance
 - Central Hub EC2 instance
 - Application Load Balancer
-- RDS database (with skip-final-snapshot)
+- RDS database (in `stag` only — `prod` is protected, see [RDS lifecycle](#rds-lifecycle-stag-vs-prod))
 - VPC, subnets, security groups, NAT gateway
 - IAM roles and policies
 - Elastic IPs
@@ -243,6 +245,18 @@ make destroy
 - Cognito User Pool and users (authentication data)
 - Secrets Manager secret (FLIP_API configuration)
 - S3 bucket (application data)
+
+#### RDS lifecycle (stag vs prod)
+
+The RDS instance behaves differently per environment, driven by `TF_VAR_environment`:
+
+| Setting                            | `stag` (default) | `prod` (`PROD=true`)              |
+|------------------------------------|------------------|-----------------------------------|
+| `skip_final_snapshot`              | `true`           | `false`                           |
+| `deletion_protection`              | `false`          | `true`                            |
+| `final_snapshot_identifier_prefix` | `flip-database-final` | `flip-database-final`        |
+
+In production, `terraform destroy` (or any `make destroy` against the prod account) will refuse to delete the RDS instance until deletion protection is removed manually, and a final snapshot named `flip-database-final-<suffix>` is taken before deletion. Staging stays disposable so trees can be torn down and rebuilt without snapshot cleanup.
 
 ### Status Checking
 

--- a/deploy/providers/AWS/main.tf
+++ b/deploy/providers/AWS/main.tf
@@ -135,7 +135,9 @@ module "flip_db" {
   db_subnet_group_name       = aws_db_subnet_group.flip_db_subnet_group.name
   vpc_security_group_ids     = [module.rds_security_group.security_group.id]
   backup_retention_period    = 7
-  skip_final_snapshot        = true
+  skip_final_snapshot        = var.environment != "prod"
+  deletion_protection        = var.environment == "prod"
+  final_snapshot_identifier  = var.environment == "prod" ? "flip-database-final-${formatdate("YYYYMMDDhhmmss", timestamp())}" : null
   family                     = "postgres${split(".", var.postgres_version)[0]}"
 }
 

--- a/deploy/providers/AWS/main.tf
+++ b/deploy/providers/AWS/main.tf
@@ -122,23 +122,23 @@ resource "aws_db_subnet_group" "flip_db_subnet_group" {
 }
 
 module "flip_db" {
-  source                     = "terraform-aws-modules/rds/aws"
-  version                    = "~> 6.0"
-  identifier                 = "flip-database"
-  engine                     = "postgres"
-  engine_version             = var.postgres_version
-  auto_minor_version_upgrade = true
-  instance_class             = "db.t3.micro"
-  allocated_storage          = 20
-  username                   = var.POSTGRES_USER
-  db_name                    = var.POSTGRES_DB
-  db_subnet_group_name       = aws_db_subnet_group.flip_db_subnet_group.name
-  vpc_security_group_ids     = [module.rds_security_group.security_group.id]
-  backup_retention_period    = 7
-  skip_final_snapshot        = var.environment != "prod"
-  deletion_protection        = var.environment == "prod"
-  final_snapshot_identifier  = var.environment == "prod" ? "flip-database-final-${formatdate("YYYYMMDDhhmmss", timestamp())}" : null
-  family                     = "postgres${split(".", var.postgres_version)[0]}"
+  source                           = "terraform-aws-modules/rds/aws"
+  version                          = "~> 6.0"
+  identifier                       = "flip-database"
+  engine                           = "postgres"
+  engine_version                   = var.postgres_version
+  auto_minor_version_upgrade       = true
+  instance_class                   = "db.t3.micro"
+  allocated_storage                = 20
+  username                         = var.POSTGRES_USER
+  db_name                          = var.POSTGRES_DB
+  db_subnet_group_name             = aws_db_subnet_group.flip_db_subnet_group.name
+  vpc_security_group_ids           = [module.rds_security_group.security_group.id]
+  backup_retention_period          = 7
+  skip_final_snapshot              = var.environment != "prod"
+  deletion_protection              = var.environment == "prod"
+  final_snapshot_identifier_prefix = "flip-database-final"
+  family                           = "postgres${split(".", var.postgres_version)[0]}"
 }
 
 ############################

--- a/deploy/providers/AWS/variables.tf
+++ b/deploy/providers/AWS/variables.tf
@@ -16,6 +16,16 @@ variable "AWS_REGION" {
   type = string
 }
 
+variable "environment" {
+  description = "Deployment environment. 'prod' enables RDS hardening (deletion protection + final snapshot); any other value (e.g. 'stag') keeps the database disposable for fast tear-down."
+  type        = string
+  default     = "stag"
+  validation {
+    condition     = contains(["prod", "stag"], var.environment)
+    error_message = "environment must be either 'prod' or 'stag'."
+  }
+}
+
 variable "VPC_NAME" {
   type = string
 }


### PR DESCRIPTION
# Description

This PR introduces environment-aware RDS configuration to enable production-grade database protection while maintaining fast tear-down capabilities for staging environments.

**Changes:**
- Added `environment` variable (prod/stag) to Terraform configuration with validation
- Conditionally enable RDS deletion protection and final snapshots only in production
- Map Make-level `PROD` flag to Terraform `environment` variable for seamless integration
- Production deployments now automatically create timestamped final snapshots before deletion

**Behavior:**
- **Production (`prod`)**: Deletion protection enabled, final snapshot created with timestamp
- **Staging (`stag`)**: Database remains disposable for rapid tear-down, no snapshots retained

## Linked Issues

Fixes #

## Checklist

- [x] Follows the project's coding conventions and style guide
- [x] Updates documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Type of Change

- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make -C docs/ docs`.

## Testing

The changes are configuration-driven and will be validated by Terraform's built-in variable validation. The `environment` variable includes explicit validation to ensure only "prod" or "stag" values are accepted.

Verification can be performed by:
1. Running `make deploy PROD=true` to verify production hardening is applied
2. Running `make deploy` (or `PROD=stag`) to verify staging remains disposable
3. Inspecting generated Terraform plan to confirm conditional logic is correct

## Additional Notes

This change is backward compatible—the default environment is "stag", maintaining existing behavior for deployments that don't explicitly set the `PROD` flag.

https://claude.ai/code/session_01WCPHnX6MXJU9xrPhtCZQux