### PR TITLE
Scope imaging-api cohort fetch to accession_id only (P1-01)

### DIFF
--- a/trust/data-access-api/data_access_api/routers/cohort.py
+++ b/trust/data-access-api/data_access_api/routers/cohort.py
@@ -16,7 +16,12 @@ from fastapi import APIRouter, HTTPException
 from sqlalchemy.exc import SQLAlchemyError
 
 from data_access_api.config import get_settings
-from data_access_api.routers.schema import CohortQueryInput, DataframeQuery, StatisticsResponse
+from data_access_api.routers.schema import (
+    AccessionIdsResponse,
+    CohortQueryInput,
+    DataframeQuery,
+    StatisticsResponse,
+)
 from data_access_api.services.cohort import get_records, get_statistics, validate_query
 from data_access_api.utils.encryption import decrypt
 from data_access_api.utils.logger import logger
@@ -120,3 +125,58 @@ def get_dataframe(query_input: DataframeQuery) -> dict[str, list[Any]]:
         raise HTTPException(status_code=500, detail=str(e))
 
     return df.to_dict(orient="list")
+
+
+@router.post("/accession-ids", response_model=AccessionIdsResponse)
+def get_accession_ids(query_input: DataframeQuery) -> AccessionIdsResponse:
+    """
+    Returns only the ``accession_id`` column of the cohort, projected server-side.
+
+    The caller's query is wrapped as ``SELECT accession_id FROM (<query>) sub`` so
+    no other columns ever cross the trust boundary. This is the minimal-disclosure
+    endpoint used by imaging-api to fetch the accession numbers it needs to import
+    studies from PACS — it does not expose row-level patient attributes.
+
+    Args:
+        query_input (DataframeQuery): The cohort query.
+
+    Returns:
+        AccessionIdsResponse: The accession IDs returned by the cohort query.
+
+    Raises:
+        HTTPException: If the query is invalid, does not select an ``accession_id``
+            column, or fails during execution.
+    """
+    project_id = decrypt(query_input.encrypted_project_id)
+
+    logger.info(f"Received accession-ids query for project {project_id}")
+
+    try:
+        validate_query(query_input.query)
+    except ValueError as e:
+        logger.error(f"Invalid query: {str(e)}")
+        raise HTTPException(status_code=400, detail=str(e))
+
+    # Strip trailing whitespace and a single optional trailing semicolon so the
+    # caller's SQL composes cleanly inside a SELECT subquery.
+    inner_query = query_input.query.rstrip().rstrip(";").rstrip()
+    wrapped_query = f"SELECT accession_id FROM ({inner_query}) AS cohort_subquery"
+
+    try:
+        df = get_records(wrapped_query)
+    except HTTPException:
+        raise
+    except SQLAlchemyError as e:
+        raise HTTPException(status_code=500, detail=str(e))
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+    if "accession_id" not in df.columns:
+        raise HTTPException(
+            status_code=400,
+            detail="Cohort query did not return an 'accession_id' column.",
+        )
+
+    accession_ids = [str(value) for value in df["accession_id"].tolist()]
+    logger.info(f"accession-ids query for project {project_id} returned {len(accession_ids)} ids")
+    return AccessionIdsResponse(accession_ids=accession_ids)

--- a/trust/data-access-api/data_access_api/routers/schema.py
+++ b/trust/data-access-api/data_access_api/routers/schema.py
@@ -68,3 +68,12 @@ class StatisticsResponse(BaseModel):
     record_count: int
     created: str
     data: list[dict[str, Any]]
+
+
+class AccessionIdsResponse(BaseModel):
+    """Represents the response for an accession-ids query."""
+
+    accession_ids: list[str] = Field(
+        ...,
+        description="The accession IDs of the cohort, in query order.",
+    )

--- a/trust/data-access-api/tests/routers/test_cohort.py
+++ b/trust/data-access-api/tests/routers/test_cohort.py
@@ -14,6 +14,7 @@ from unittest.mock import MagicMock, patch
 
 import pandas as pd
 import pytest
+from fastapi import HTTPException
 from fastapi.testclient import TestClient
 from sqlalchemy.exc import SQLAlchemyError
 
@@ -267,6 +268,22 @@ def test_get_accession_ids_missing_column(mock_get_records, mock_decrypt):
 
     assert response.status_code == 400
     assert "accession_id" in response.json()["detail"]
+
+
+@patch("data_access_api.routers.cohort.decrypt")
+@patch("data_access_api.routers.cohort.get_records")
+def test_get_accession_ids_propagates_http_exception(mock_get_records, mock_decrypt):
+    """``get_records`` raises HTTPException for things like undefined tables/columns;
+    the wrapping ``except`` clauses must not swallow that into a 500."""
+    mock_decrypt.return_value = "decrypted-id"
+    mock_get_records.side_effect = HTTPException(
+        status_code=400, detail="The table 'omop.bogus' does not exist."
+    )
+
+    response = client.post("/cohort/accession-ids", json=sample_dataframe_query)
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "The table 'omop.bogus' does not exist."
 
 
 @patch("data_access_api.routers.cohort.decrypt")

--- a/trust/data-access-api/tests/routers/test_cohort.py
+++ b/trust/data-access-api/tests/routers/test_cohort.py
@@ -203,3 +203,91 @@ def test_get_dataframe_generic_error(mock_get_records, mock_decrypt):
 
     assert response.status_code == 500
     assert response.json()["detail"] == "Unexpected failure"
+
+
+# ---------------------------------------------------------------------------
+# /cohort/accession-ids
+# ---------------------------------------------------------------------------
+
+
+@patch("data_access_api.routers.cohort.decrypt")
+@patch("data_access_api.routers.cohort.get_records")
+def test_get_accession_ids_success(mock_get_records, mock_decrypt):
+    mock_decrypt.return_value = "decrypted-id"
+    mock_get_records.return_value = pd.DataFrame({"accession_id": ["ACC1", "ACC2", "ACC3"]})
+
+    response = client.post("/cohort/accession-ids", json=sample_dataframe_query)
+
+    assert response.status_code == 200
+    assert response.json() == {"accession_ids": ["ACC1", "ACC2", "ACC3"]}
+    mock_decrypt.assert_called_once_with("encrypted-id")
+    # The caller's query must be wrapped server-side so only accession_id is projected.
+    called_query = mock_get_records.call_args[0][0]
+    assert called_query.startswith("SELECT accession_id FROM (")
+    assert sample_dataframe_query["query"] in called_query
+
+
+@patch("data_access_api.routers.cohort.decrypt")
+@patch("data_access_api.routers.cohort.get_records")
+def test_get_accession_ids_strips_trailing_semicolon(mock_get_records, mock_decrypt):
+    mock_decrypt.return_value = "decrypted-id"
+    mock_get_records.return_value = pd.DataFrame({"accession_id": ["ACC1"]})
+
+    response = client.post(
+        "/cohort/accession-ids",
+        json={"encrypted_project_id": "encrypted-id", "query": "SELECT * FROM cohort;  "},
+    )
+
+    assert response.status_code == 200
+    called_query = mock_get_records.call_args[0][0]
+    # No bare semicolon should leak into the wrapped subquery.
+    assert "SELECT * FROM cohort)" in called_query
+    assert ";" not in called_query
+
+
+@patch("data_access_api.routers.cohort.decrypt")
+@patch("data_access_api.routers.cohort.validate_query")
+def test_get_accession_ids_invalid_query(mock_validate_query, mock_decrypt):
+    mock_decrypt.return_value = "decrypted-id"
+    mock_validate_query.side_effect = ValueError("Invalid query syntax")
+
+    response = client.post("/cohort/accession-ids", json=sample_dataframe_query)
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Invalid query syntax"
+
+
+@patch("data_access_api.routers.cohort.decrypt")
+@patch("data_access_api.routers.cohort.get_records")
+def test_get_accession_ids_missing_column(mock_get_records, mock_decrypt):
+    mock_decrypt.return_value = "decrypted-id"
+    mock_get_records.return_value = pd.DataFrame({"some_other_column": [1, 2]})
+
+    response = client.post("/cohort/accession-ids", json=sample_dataframe_query)
+
+    assert response.status_code == 400
+    assert "accession_id" in response.json()["detail"]
+
+
+@patch("data_access_api.routers.cohort.decrypt")
+@patch("data_access_api.routers.cohort.get_records")
+def test_get_accession_ids_sqlalchemy_error(mock_get_records, mock_decrypt):
+    mock_decrypt.return_value = "decrypted-id"
+    mock_get_records.side_effect = SQLAlchemyError("SQLAlchemy error")
+
+    response = client.post("/cohort/accession-ids", json=sample_dataframe_query)
+
+    assert response.status_code == 500
+    assert response.json()["detail"] == "SQLAlchemy error"
+
+
+@patch("data_access_api.routers.cohort.decrypt")
+@patch("data_access_api.routers.cohort.get_records")
+def test_get_accession_ids_generic_error(mock_get_records, mock_decrypt):
+    mock_decrypt.return_value = "decrypted-id"
+    mock_get_records.side_effect = RuntimeError("Unexpected failure")
+
+    response = client.post("/cohort/accession-ids", json=sample_dataframe_query)
+
+    assert response.status_code == 500
+    assert response.json()["detail"] == "Unexpected failure"

--- a/trust/imaging-api/imaging_api/services/retrieval.py
+++ b/trust/imaging-api/imaging_api/services/retrieval.py
@@ -28,7 +28,7 @@ from imaging_api.routers.schemas import (
 )
 from imaging_api.services.imaging import query_by_accession_number, queue_image_import_request
 from imaging_api.services.projects import get_experiments, get_project
-from imaging_api.services_external.data_access import get_dataframe
+from imaging_api.services_external.data_access import get_accession_ids
 from imaging_api.utils.auth import get_xnat_auth_headers
 from imaging_api.utils.encryption import encrypt
 from imaging_api.utils.exceptions import NotFoundError
@@ -44,11 +44,10 @@ async def retrieve_images_for_project(project_id: str, query: str, headers: XNAT
     Steps:
 
     1. Encrypt project ID to send to the data access API
-    2. Get dataframe from data access API, using the provided query
-    3. Get accession IDs, unencrypt them
-    4. Query PACS to find study for each accession ID -> put into a list
-    5. Make a ImportStudyRequest object with the list of studies
-    6. Check response gives all to QUEUED
+    2. Fetch the cohort's accession IDs from the data access API
+    3. Query PACS to find study for each accession ID -> put into a list
+    4. Make a ImportStudyRequest object with the list of studies
+    5. Check response gives all to QUEUED
 
     Args:
         project_id (str): The imaging project ID to retrieve the data about.
@@ -69,21 +68,12 @@ async def retrieve_images_for_project(project_id: str, query: str, headers: XNAT
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 
-    # Get dataframe from data access API
+    # Get accession IDs from data access API. The endpoint projects the cohort
+    # query to the accession_id column server-side, so no other columns are
+    # transmitted across the trust boundary.
     encrypted_project_id = encrypt(project_id)
-    cohort_df = await get_dataframe(encrypted_project_id, query)
-    cohort_df.to_csv("dataframe.csv")
+    accession_ids: list[str] = await get_accession_ids(encrypted_project_id, query)
 
-    # QC check if cohort dataframe has an accession_id column
-    accession_id_column = "accession_id"
-    if accession_id_column not in cohort_df.columns:
-        raise HTTPException(
-            status_code=400,
-            detail=f"Dataframe does not contain a column '{accession_id_column}' [{cohort_df.columns.tolist()}]",
-        )
-
-    # For each accession ID, unencrypt it and find the study
-    accession_ids: list[str] = cohort_df["accession_id"]
     studies_list: list[ImportStudy] = []
 
     total_accessions = len(accession_ids)
@@ -147,7 +137,7 @@ async def get_import_status(project_id: str, query: str, headers: XNATAuthHeader
     * `Queued`: Studies waiting in the queue
     * `QueueFailed`: Studies that couldn't be queued for import
 
-    1. Get dataframe from data access API
+    1. Fetch the cohort's accession IDs from the data access API
     2. Get project experiments
     3. Get project import status
 
@@ -165,22 +155,13 @@ async def get_import_status(project_id: str, query: str, headers: XNATAuthHeader
     # Encrypt project ID to send to the data access API
     encrypted_project_id = encrypt(project_id)
 
-    # Get dataframe from data access API
-    cohort_df = await get_dataframe(encrypted_project_id, query)
-    cohort_df.to_csv("dataframe.csv")
-
-    # QC check if cohort dataframe has an accession_id column
-    accession_id_column = "accession_id"
-    if accession_id_column not in cohort_df.columns:
-        raise HTTPException(
-            status_code=400,
-            detail=f"Dataframe does not contain a column '{accession_id_column}' [{cohort_df.columns.tolist()}]",
-        )
+    # Get accession IDs from data access API (server-side projection — no other
+    # cohort columns leave the trust).
+    accession_ids: list[str] = await get_accession_ids(encrypted_project_id, query)
 
     # Fetches a list of XNAT experiments associated with a given XNAT project.
     experiments = get_experiments(project_id, headers)
     experiments_df = pd.DataFrame([exp.model_dump(by_alias=True) for exp in experiments])
-    # experiments_df.to_csv("experiments.csv")
 
     # We need to check if there are any experiments at all in the dataframe
     successfully_imported_accession_numbers: list[str] = (
@@ -206,8 +187,6 @@ async def get_import_status(project_id: str, query: str, headers: XNATAuthHeader
     logger.debug(f"Queued PACS requests: {len(queued_pacs_requests)}")
 
     import_status = ImportStatus()
-
-    accession_ids: list[str] = cohort_df["accession_id"]
 
     for accession_number in accession_ids:
         # TODO Unlike in the old repo, accession numbers are now not encrypted in OMOP database, so no need to decrypt

--- a/trust/imaging-api/imaging_api/services_external/data_access.py
+++ b/trust/imaging-api/imaging_api/services_external/data_access.py
@@ -13,7 +13,6 @@
 # Interacts with Data Access API
 
 import httpx
-import pandas as pd
 from pydantic import BaseModel, Field
 
 from imaging_api.config import get_settings
@@ -23,44 +22,47 @@ DATA_ACCESS_API_URL = get_settings().DATA_ACCESS_API_URL
 logger.info(f"Data Access API URL: {DATA_ACCESS_API_URL}")
 
 
-class DataframeRequest(BaseModel):
-    """Request model for the Data Access API to fetch a DataFrame."""
+class AccessionIdsRequest(BaseModel):
+    """Request model for the Data Access API to fetch a cohort's accession IDs."""
 
     encrypted_project_id: str = Field(..., description="The unique identifier for the project")
     query: str = Field(..., description="The raw SQL query to execute")
 
 
-async def get_dataframe(encrypted_project_id: str, query: str) -> pd.DataFrame:
+async def get_accession_ids(encrypted_project_id: str, query: str) -> list[str]:
     """
-    Calls the remote data access API endpoint using HTTPX and returns its raw JSON response.
+    Calls the data-access-api ``/cohort/accession-ids`` endpoint and returns the
+    list of accession IDs for the cohort.
+
+    The endpoint projects the cohort query to the ``accession_id`` column
+    server-side, so no other patient attributes leave the trust's data store.
 
     Args:
         encrypted_project_id (str): The encrypted project ID.
         query (str): The SQL query to execute.
 
     Returns:
-        pd.DataFrame: The DataFrame containing the results of the query.
+        list[str]: The accession IDs returned by the cohort query, in query order.
 
     Raises:
         RuntimeError: If the HTTP call to the Data Access API fails (network error or non-2xx
             response).
     """
-    dataframe_request = DataframeRequest(encrypted_project_id=encrypted_project_id, query=query)
+    request = AccessionIdsRequest(encrypted_project_id=encrypted_project_id, query=query)
 
-    logger.debug(f"get_dataframe: Sending request to Data Access API with {encrypted_project_id=} and {query=}")
+    logger.debug(f"get_accession_ids: Sending request to Data Access API with {encrypted_project_id=}")
 
     try:
         async with httpx.AsyncClient() as client:
             response = await client.post(
-                f"{DATA_ACCESS_API_URL}/cohort/dataframe",
-                json=dataframe_request.model_dump(),
+                f"{DATA_ACCESS_API_URL}/cohort/accession-ids",
+                json=request.model_dump(),
             )
 
         response.raise_for_status()
-        dataframe = pd.DataFrame(response.json())
-        return dataframe
+        return list(response.json().get("accession_ids", []))
 
     except httpx.HTTPError as exc:
-        error_message = f"get_dataframe: HTTP error occurred while calling the Data Access API: {exc}"
+        error_message = f"get_accession_ids: HTTP error occurred while calling the Data Access API: {exc}"
         logger.error(error_message)
         raise RuntimeError(error_message) from exc

--- a/trust/imaging-api/tests/services/test_retrieval.py
+++ b/trust/imaging-api/tests/services/test_retrieval.py
@@ -13,7 +13,6 @@
 from datetime import datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
-import pandas as pd
 import pytest
 from fastapi import HTTPException
 
@@ -64,17 +63,16 @@ def _make_import_response(accession_number: str = "ACC1", status: str = "QUEUED"
 @pytest.mark.asyncio
 @patch("imaging_api.services.retrieval.queue_image_import_request")
 @patch("imaging_api.services.retrieval.query_by_accession_number")
-@patch("imaging_api.services.retrieval.get_dataframe", new_callable=AsyncMock)
+@patch("imaging_api.services.retrieval.get_accession_ids", new_callable=AsyncMock)
 @patch("imaging_api.services.retrieval.encrypt")
 @patch("imaging_api.services.retrieval.get_project")
 async def test_retrieve_images_success(
-    mock_get_project, mock_encrypt, mock_get_dataframe,
-    mock_query, mock_queue, headers, tmp_path, monkeypatch,
+    mock_get_project, mock_encrypt, mock_get_accession_ids,
+    mock_query, mock_queue, headers,
 ):
-    monkeypatch.chdir(tmp_path)
     mock_get_project.return_value = MagicMock()
     mock_encrypt.return_value = "encrypted_id"
-    mock_get_dataframe.return_value = pd.DataFrame({"accession_id": ["ACC1", "ACC2"]})
+    mock_get_accession_ids.return_value = ["ACC1", "ACC2"]
     mock_query.side_effect = [
         [_make_study("ACC1", "1.2.3.1")],
         [_make_study("ACC2", "1.2.3.2")],
@@ -110,36 +108,16 @@ async def test_retrieve_images_project_generic_error(mock_get_project, headers):
 
 
 @pytest.mark.asyncio
-@patch("imaging_api.services.retrieval.get_dataframe", new_callable=AsyncMock)
-@patch("imaging_api.services.retrieval.encrypt")
-@patch("imaging_api.services.retrieval.get_project")
-async def test_retrieve_images_missing_accession_column(
-    mock_get_project, mock_encrypt, mock_get_dataframe, headers, tmp_path, monkeypatch,
-):
-    monkeypatch.chdir(tmp_path)
-    mock_get_project.return_value = MagicMock()
-    mock_encrypt.return_value = "encrypted_id"
-    mock_get_dataframe.return_value = pd.DataFrame({"patient_id": ["P1"]})
-
-    with pytest.raises(HTTPException) as exc_info:
-        await retrieve_images_for_project("proj1", "SELECT *", headers)
-    assert exc_info.value.status_code == 400
-    assert "accession_id" in exc_info.value.detail
-
-
-@pytest.mark.asyncio
 @patch("imaging_api.services.retrieval.query_by_accession_number")
-@patch("imaging_api.services.retrieval.get_dataframe", new_callable=AsyncMock)
+@patch("imaging_api.services.retrieval.get_accession_ids", new_callable=AsyncMock)
 @patch("imaging_api.services.retrieval.encrypt")
 @patch("imaging_api.services.retrieval.get_project")
 async def test_retrieve_images_no_studies_found(
-    mock_get_project, mock_encrypt, mock_get_dataframe, mock_query,
-    headers, tmp_path, monkeypatch,
+    mock_get_project, mock_encrypt, mock_get_accession_ids, mock_query, headers,
 ):
-    monkeypatch.chdir(tmp_path)
     mock_get_project.return_value = MagicMock()
     mock_encrypt.return_value = "encrypted_id"
-    mock_get_dataframe.return_value = pd.DataFrame({"accession_id": ["ACC1"]})
+    mock_get_accession_ids.return_value = ["ACC1"]
     mock_query.return_value = []
 
     result = await retrieve_images_for_project("proj1", "SELECT *", headers)
@@ -148,17 +126,15 @@ async def test_retrieve_images_no_studies_found(
 
 @pytest.mark.asyncio
 @patch("imaging_api.services.retrieval.query_by_accession_number")
-@patch("imaging_api.services.retrieval.get_dataframe", new_callable=AsyncMock)
+@patch("imaging_api.services.retrieval.get_accession_ids", new_callable=AsyncMock)
 @patch("imaging_api.services.retrieval.encrypt")
 @patch("imaging_api.services.retrieval.get_project")
 async def test_retrieve_images_query_exception_skips_study(
-    mock_get_project, mock_encrypt, mock_get_dataframe, mock_query,
-    headers, tmp_path, monkeypatch,
+    mock_get_project, mock_encrypt, mock_get_accession_ids, mock_query, headers,
 ):
-    monkeypatch.chdir(tmp_path)
     mock_get_project.return_value = MagicMock()
     mock_encrypt.return_value = "encrypted_id"
-    mock_get_dataframe.return_value = pd.DataFrame({"accession_id": ["ACC1"]})
+    mock_get_accession_ids.return_value = ["ACC1"]
     mock_query.side_effect = Exception("PACS timeout")
 
     result = await retrieve_images_for_project("proj1", "SELECT *", headers)
@@ -168,17 +144,16 @@ async def test_retrieve_images_query_exception_skips_study(
 @pytest.mark.asyncio
 @patch("imaging_api.services.retrieval.queue_image_import_request")
 @patch("imaging_api.services.retrieval.query_by_accession_number")
-@patch("imaging_api.services.retrieval.get_dataframe", new_callable=AsyncMock)
+@patch("imaging_api.services.retrieval.get_accession_ids", new_callable=AsyncMock)
 @patch("imaging_api.services.retrieval.encrypt")
 @patch("imaging_api.services.retrieval.get_project")
 async def test_retrieve_images_partial_queue_failure(
-    mock_get_project, mock_encrypt, mock_get_dataframe,
-    mock_query, mock_queue, headers, tmp_path, monkeypatch,
+    mock_get_project, mock_encrypt, mock_get_accession_ids,
+    mock_query, mock_queue, headers,
 ):
-    monkeypatch.chdir(tmp_path)
     mock_get_project.return_value = MagicMock()
     mock_encrypt.return_value = "encrypted_id"
-    mock_get_dataframe.return_value = pd.DataFrame({"accession_id": ["ACC1"]})
+    mock_get_accession_ids.return_value = ["ACC1"]
     mock_query.return_value = [_make_study("ACC1")]
     mock_queue.return_value = [_make_import_response("ACC1", status="FAILED")]
 
@@ -189,18 +164,17 @@ async def test_retrieve_images_partial_queue_failure(
 @pytest.mark.asyncio
 @patch("imaging_api.services.retrieval.queue_image_import_request")
 @patch("imaging_api.services.retrieval.query_by_accession_number")
-@patch("imaging_api.services.retrieval.get_dataframe", new_callable=AsyncMock)
+@patch("imaging_api.services.retrieval.get_accession_ids", new_callable=AsyncMock)
 @patch("imaging_api.services.retrieval.encrypt")
 @patch("imaging_api.services.retrieval.get_project")
 async def test_retrieve_images_multiple_studies_for_accession(
-    mock_get_project, mock_encrypt, mock_get_dataframe,
-    mock_query, mock_queue, headers, tmp_path, monkeypatch,
+    mock_get_project, mock_encrypt, mock_get_accession_ids,
+    mock_query, mock_queue, headers,
 ):
     """When multiple studies match an accession number, only the first is used."""
-    monkeypatch.chdir(tmp_path)
     mock_get_project.return_value = MagicMock()
     mock_encrypt.return_value = "encrypted_id"
-    mock_get_dataframe.return_value = pd.DataFrame({"accession_id": ["ACC1"]})
+    mock_get_accession_ids.return_value = ["ACC1"]
     mock_query.return_value = [_make_study("ACC1", "1.2.3.1"), _make_study("ACC1", "1.2.3.2")]
     mock_queue.return_value = [_make_import_response("ACC1")]
 
@@ -242,14 +216,13 @@ def _mock_get_session(direct_archive=None, executed=None, queued=None):
 
 @pytest.mark.asyncio
 @patch("imaging_api.services.retrieval.get_experiments")
-@patch("imaging_api.services.retrieval.get_dataframe", new_callable=AsyncMock)
+@patch("imaging_api.services.retrieval.get_accession_ids", new_callable=AsyncMock)
 @patch("imaging_api.services.retrieval.encrypt")
 async def test_get_import_status_all_successful(
-    mock_encrypt, mock_get_dataframe, mock_get_experiments, headers, tmp_path, monkeypatch,
+    mock_encrypt, mock_get_accession_ids, mock_get_experiments, headers,
 ):
-    monkeypatch.chdir(tmp_path)
     mock_encrypt.return_value = "encrypted_id"
-    mock_get_dataframe.return_value = pd.DataFrame({"accession_id": ["ACC1", "ACC2"]})
+    mock_get_accession_ids.return_value = ["ACC1", "ACC2"]
     mock_get_experiments.return_value = [
         Experiment(ID="e1", label="ACC1", date="2023-01-01", project="proj1",
                    insert_date="2023-01-01", xsiType="xnat:ctScanData", URI="/exp/e1"),
@@ -269,16 +242,13 @@ async def test_get_import_status_all_successful(
 
 @pytest.mark.asyncio
 @patch("imaging_api.services.retrieval.get_experiments")
-@patch("imaging_api.services.retrieval.get_dataframe", new_callable=AsyncMock)
+@patch("imaging_api.services.retrieval.get_accession_ids", new_callable=AsyncMock)
 @patch("imaging_api.services.retrieval.encrypt")
 async def test_get_import_status_mixed(
-    mock_encrypt, mock_get_dataframe, mock_get_experiments, headers, tmp_path, monkeypatch,
+    mock_encrypt, mock_get_accession_ids, mock_get_experiments, headers,
 ):
-    monkeypatch.chdir(tmp_path)
     mock_encrypt.return_value = "encrypted_id"
-    mock_get_dataframe.return_value = pd.DataFrame({
-        "accession_id": ["ACC_OK", "ACC_EXEC", "ACC_QUEUED", "ACC_UNKNOWN"],
-    })
+    mock_get_accession_ids.return_value = ["ACC_OK", "ACC_EXEC", "ACC_QUEUED", "ACC_UNKNOWN"]
     mock_get_experiments.return_value = [
         Experiment(ID="e1", label="ACC_OK", date="2023-01-01", project="proj1",
                    insert_date="2023-01-01", xsiType="xnat:ctScanData", URI="/exp/e1"),
@@ -302,30 +272,14 @@ async def test_get_import_status_mixed(
 
 
 @pytest.mark.asyncio
-@patch("imaging_api.services.retrieval.get_dataframe", new_callable=AsyncMock)
-@patch("imaging_api.services.retrieval.encrypt")
-async def test_get_import_status_missing_accession_column(
-    mock_encrypt, mock_get_dataframe, headers, tmp_path, monkeypatch,
-):
-    monkeypatch.chdir(tmp_path)
-    mock_encrypt.return_value = "encrypted_id"
-    mock_get_dataframe.return_value = pd.DataFrame({"patient_id": ["P1"]})
-
-    with pytest.raises(HTTPException) as exc_info:
-        await get_import_status("proj1", "SELECT *", headers)
-    assert exc_info.value.status_code == 400
-
-
-@pytest.mark.asyncio
 @patch("imaging_api.services.retrieval.get_experiments")
-@patch("imaging_api.services.retrieval.get_dataframe", new_callable=AsyncMock)
+@patch("imaging_api.services.retrieval.get_accession_ids", new_callable=AsyncMock)
 @patch("imaging_api.services.retrieval.encrypt")
 async def test_get_import_status_no_experiments(
-    mock_encrypt, mock_get_dataframe, mock_get_experiments, headers, tmp_path, monkeypatch,
+    mock_encrypt, mock_get_accession_ids, mock_get_experiments, headers,
 ):
-    monkeypatch.chdir(tmp_path)
     mock_encrypt.return_value = "encrypted_id"
-    mock_get_dataframe.return_value = pd.DataFrame({"accession_id": ["ACC1"]})
+    mock_get_accession_ids.return_value = ["ACC1"]
     mock_get_experiments.return_value = []
 
     p_session, p_direct, p_executed, p_queued = _mock_get_session()

--- a/trust/imaging-api/tests/services_external/test_data_access.py
+++ b/trust/imaging-api/tests/services_external/test_data_access.py
@@ -15,18 +15,15 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import httpx
 import pytest
 
-from imaging_api.services_external.data_access import get_dataframe
+from imaging_api.services_external.data_access import get_accession_ids
 
 
-class TestGetDataframe:
+class TestGetAccessionIds:
     @pytest.mark.asyncio
     @patch("imaging_api.services_external.data_access.httpx.AsyncClient")
     async def test_success(self, mock_client_cls):
         mock_response = MagicMock()
-        mock_response.json.return_value = [
-            {"accession_id": "ACC001", "patient_id": "P1"},
-            {"accession_id": "ACC002", "patient_id": "P2"},
-        ]
+        mock_response.json.return_value = {"accession_ids": ["ACC001", "ACC002"]}
         mock_response.raise_for_status = MagicMock()
 
         mock_client = AsyncMock()
@@ -35,11 +32,34 @@ class TestGetDataframe:
         mock_client.__aexit__ = AsyncMock(return_value=False)
         mock_client_cls.return_value = mock_client
 
-        df = await get_dataframe("encrypted-proj-id", "SELECT * FROM cohort")
+        accession_ids = await get_accession_ids("encrypted-proj-id", "SELECT * FROM cohort")
 
-        assert len(df) == 2
-        assert list(df.columns) == ["accession_id", "patient_id"]
+        assert accession_ids == ["ACC001", "ACC002"]
         mock_client.post.assert_called_once()
+        call_kwargs = mock_client.post.call_args.kwargs
+        assert call_kwargs["json"] == {
+            "encrypted_project_id": "encrypted-proj-id",
+            "query": "SELECT * FROM cohort",
+        }
+        # Endpoint must be the projected accession-ids one, not the raw dataframe one.
+        assert mock_client.post.call_args.args[0].endswith("/cohort/accession-ids")
+
+    @pytest.mark.asyncio
+    @patch("imaging_api.services_external.data_access.httpx.AsyncClient")
+    async def test_empty_response(self, mock_client_cls):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"accession_ids": []}
+        mock_response.raise_for_status = MagicMock()
+
+        mock_client = AsyncMock()
+        mock_client.post.return_value = mock_response
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client_cls.return_value = mock_client
+
+        accession_ids = await get_accession_ids("encrypted-proj-id", "SELECT * FROM cohort")
+
+        assert accession_ids == []
 
     @pytest.mark.asyncio
     @patch("imaging_api.services_external.data_access.httpx.AsyncClient")
@@ -51,4 +71,4 @@ class TestGetDataframe:
         mock_client_cls.return_value = mock_client
 
         with pytest.raises(RuntimeError, match="HTTP error occurred"):
-            await get_dataframe("encrypted-proj-id", "SELECT * FROM cohort")
+            await get_accession_ids("encrypted-proj-id", "SELECT * FROM cohort")


### PR DESCRIPTION
## Description

Imaging-api only ever consumes the `accession_id` column from the cohort dataframe (to drive PACS imports), but it was calling `/cohort/dataframe`, which returns the full row-level cohort dataframe — every column the project SQL happens to select, including identifiers and free-text fields.

This PR adds a dedicated `/cohort/accession-ids` endpoint and switches imaging-api to use it. **`/cohort/dataframe` is left unchanged** — flip-fl-base genuinely needs project-defined label columns for FL training and continues to use it. That caller will be addressed separately with a per-project column allowlist.

### Key Changes

**data-access-api:**
- Added new `POST /cohort/accession-ids` endpoint that wraps the caller's query as `SELECT accession_id FROM (<query>) AS cohort_subquery` and returns `{accession_ids: list[str]}`. Server-side projection, so no other columns can leave the trust boundary on this path.
- Strips a single trailing `;` so the caller's SQL composes cleanly inside the wrapping subquery.
- Returns 400 if the cohort query does not yield an `accession_id` column.
- Added `AccessionIdsResponse` schema.
- **`/cohort/dataframe` is unchanged** — still serves flip-fl-base's FL label-fetch use case.

**imaging-api:**
- `services_external/data_access.py`: replaced the `get_dataframe()` helper with `get_accession_ids()` returning `list[str]`. (The helper is internal to imaging-api; the data-access-api `/cohort/dataframe` endpoint itself is untouched.)
- `services/retrieval.py`: `retrieve_images_for_project` and `get_import_status` now call `get_accession_ids`. The previous client-side QC check for the `accession_id` column is removed (the projection guarantees it server-side, and a missing column now returns a clear 400 from data-access-api).
- Removed the debug `cohort_df.to_csv("dataframe.csv")` calls in `retrieval.py` — they dumped the full row-level cohort to a fixed-name CSV inside the imaging-api container on every call, with no project scoping or cleanup. Pure debug artefact, no callers.

**Tests:**
- Added unit tests for `/cohort/accession-ids` covering success, trailing-semicolon handling, invalid-query validation, missing-column detection, SQLAlchemy errors, and generic errors.
- Updated imaging-api retrieval tests to mock `get_accession_ids` (returning `list[str]`) instead of `get_dataframe`.
- Dropped the imaging-api-side "missing accession_id column" tests — that responsibility moved into data-access-api and is covered there.
- Removed `tmp_path`/`monkeypatch` plumbing that only existed because of the deleted CSV dump.

### Security Benefit

The imaging-api → data-access-api path no longer transmits row-level patient attributes — only accession IDs. The substring-based `validate_query` in data-access-api remains weak in general, but for this caller it no longer matters: the wrapping subquery structurally limits the response to a single column. Disclosure controls for the remaining `/cohort/dataframe` consumer (flip-fl-base) will be added in a follow-up via per-project column allowlists.

## Linked Issues

Addresses Codex security review finding **P1-01** (raw `/cohort/dataframe` returns row-level results, bypassing aggregated-cohort flow).

## Checklist

- [x] Follows the project's coding conventions and style guide
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Type of Change

- [x] Non-breaking change (fix or new feature that would not break existing functionality)
- [x] New tests added to cover the changes
- [x] In-line docstrings updated

## Testing

- `make local_test` in `trust/data-access-api`: ruff + mypy + 79/79 pytest pass; coverage 99%.
- `make local_test` in `trust/imaging-api`: ruff + mypy + 220/221 pytest pass. The single failure (`test_download.py::test_unwritable_parent_raises_local_storage_error`) reproduces on the unmodified parent commit — it's a pre-existing filesystem-permissions test that fails when pytest runs as root, unrelated to this PR.

https://claude.ai/code/session_01TUHtrCqVWoES5rZNNZkesb