### PR TITLE
Add trust integration test scaffolds

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,11 +73,12 @@ make debug-off-all         # Remove all debug modes
 
 ```bash
 make unit_test             # All unit tests across all services (from root)
+make integration_test      # flip-api + trust integration tests (from root)
 make tests                 # flip-ui + flip-api tests (from root)
 # From a service directory (e.g., flip-api/):
 make test                  # ruff + mypy + pytest (unit + integration)
 make unit_test             # Unit tests only
-make integration_test      # Integration tests only
+make integration_test      # Integration tests only (also available from root and trust/)
 make local_test            # Tests without Docker
 ```
 

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@
 
 .PHONY: build dev prod clean stop up down up-no-trust up-trusts central-fl central-hub \
 		restart restart-no-trust ci tests debug create-networks remove-networks recreate-networks consolidate-deps \
-		check-aws-access up-local-trust generate-trust-api-keys generate-internal-service-key
+		check-aws-access up-local-trust generate-trust-api-keys generate-internal-service-key integration_test
 
 ifeq ($(PROD),true)
 MAIN_ENV_FILE=.env.production
@@ -261,6 +261,10 @@ unit_test:
 	$(MAKE) -C trust/imaging-api unit_test
 	$(MAKE) -C trust/trust-api unit_test
 	$(MAKE) -C trust/xnat unit_test
+
+integration_test:
+	$(MAKE) -C flip-api integration_test
+	$(MAKE) -C trust integration_test
 
 generate-trust-api-keys:
 	$(MAKE) -C flip-api generate-trust-api-keys $(if $(ENV_FILE),ENV_FILE=$(ENV_FILE))

--- a/trust/Makefile
+++ b/trust/Makefile
@@ -10,7 +10,7 @@
 # limitations under the License.
 #
 
-.PHONY: build dev prod clean stop up down up-trust-1 up-trust-2 down-trust-1 down-trust-2 up-local-trust down-local-trust create-networks create-networks-local-trust remove-networks recreate-networks tests update-omop-data update-orthanc-data
+.PHONY: build dev prod clean stop up down up-trust-1 up-trust-2 down-trust-1 down-trust-2 up-local-trust down-local-trust create-networks create-networks-local-trust remove-networks recreate-networks tests update-omop-data update-orthanc-data integration_test
 # if tag PROD=true is passed, set PROD=true
 ifeq ($(PROD),true)
 MAIN_ENV_FILE=../.env.production
@@ -273,3 +273,9 @@ debug-imaging-api-off:
 debug-trust-api-off:
 	DEBUG=false $(TRUST_1_VARS) ${DEBUG_OVERRIDE_COMPOSE_COMMAND} -p ${trust1} up --remove-orphans -d trust-api
 
+
+
+integration_test:
+	$(MAKE) -C data-access-api integration_test
+	$(MAKE) -C imaging-api integration_test
+	$(MAKE) -C trust-api integration_test

--- a/trust/data-access-api/Makefile
+++ b/trust/data-access-api/Makefile
@@ -27,7 +27,7 @@ endif
 service_name = data-access-api
 lint_command = uv run ruff check . --fix
 test_coverage_html_command = uv run pytest --tb=short --disable-warnings --cov=data_access_api/ --cov-report=html --cov-report=term-missing --cov-report=xml:coverage.xml
-test_coverage_html_command_integration = uv run pytest ./tests/integration --tb=short --disable-warnings --cov=data_access_api/ --cov-report=html --cov-report=term-missing --cov-report=xml:coverage.xml
+test_coverage_html_command_integration = uv run pytest ./tests/integration --tb=short --disable-warnings --cov=data_access_api/ --cov-report=html:htmlcov-integration --cov-report=term-missing --cov-report=xml:coverage-integration.xml
 docker_command = docker compose -f ../compose_trust.development.yml
 run_clean = run --rm --remove-orphans
 mypy_command = uv run mypy . --ignore-missing-imports
@@ -60,5 +60,5 @@ local_test:
 	$(lint_command) && $(mypy_command) && $(test_coverage_html_command)
 unit_test: local_test
 integration_test:
-	BASE_IMAGES_DOWNLOAD_DIR="/tmp/images" \
+	@export BASE_IMAGES_DOWNLOAD_DIR="/tmp/images"; \
 	$(lint_command) && $(mypy_command) && $(test_coverage_html_command_integration)

--- a/trust/data-access-api/Makefile
+++ b/trust/data-access-api/Makefile
@@ -27,6 +27,7 @@ endif
 service_name = data-access-api
 lint_command = uv run ruff check . --fix
 test_coverage_html_command = uv run pytest --tb=short --disable-warnings --cov=data_access_api/ --cov-report=html --cov-report=term-missing --cov-report=xml:coverage.xml
+test_coverage_html_command_integration = uv run pytest ./tests/integration --tb=short --disable-warnings --cov=data_access_api/ --cov-report=html --cov-report=term-missing --cov-report=xml:coverage.xml
 docker_command = docker compose -f ../compose_trust.development.yml
 run_clean = run --rm --remove-orphans
 mypy_command = uv run mypy . --ignore-missing-imports
@@ -58,3 +59,6 @@ local_test:
 	BASE_IMAGES_DOWNLOAD_DIR="/tmp/images" \
 	$(lint_command) && $(mypy_command) && $(test_coverage_html_command)
 unit_test: local_test
+integration_test:
+	BASE_IMAGES_DOWNLOAD_DIR="/tmp/images" \
+	$(lint_command) && $(mypy_command) && $(test_coverage_html_command_integration)

--- a/trust/data-access-api/tests/integration/__init__.py
+++ b/trust/data-access-api/tests/integration/__init__.py
@@ -1,0 +1,12 @@
+# Copyright (c) 2026 Guy's and St Thomas' NHS Foundation Trust & King's College London
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Integration test scaffolding for data-access-api."""

--- a/trust/data-access-api/tests/integration/test_placeholder.py
+++ b/trust/data-access-api/tests/integration/test_placeholder.py
@@ -14,5 +14,5 @@ import pytest
 
 def test_integration_scaffold_placeholder():
     pytest.skip(
-        "Integration test scaffold for #63; replace with B3 trust-api + data-access-api + omop-db cohort tests coverage."
+        "Integration scaffold for #63; replace with B3 trust-api + data-access-api + omop-db cohort tests coverage."
     )

--- a/trust/data-access-api/tests/integration/test_placeholder.py
+++ b/trust/data-access-api/tests/integration/test_placeholder.py
@@ -1,0 +1,18 @@
+# Copyright (c) 2026 Guy's and St Thomas' NHS Foundation Trust & King's College London
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import pytest
+
+
+def test_integration_scaffold_placeholder():
+    pytest.skip(
+        "Integration test scaffold for #63; replace with B3 trust-api + data-access-api + omop-db cohort tests coverage."
+    )

--- a/trust/imaging-api/Makefile
+++ b/trust/imaging-api/Makefile
@@ -27,7 +27,7 @@ endif
 service_name = imaging-api
 lint_command = uv run ruff check . --fix
 test_coverage_html_command = uv run pytest --tb=short --disable-warnings --cov=imaging_api/ --cov-report=html --cov-report=term-missing --cov-report=xml:coverage.xml
-test_coverage_html_command_integration = uv run pytest ./tests/integration --tb=short --disable-warnings --cov=imaging_api/ --cov-report=html --cov-report=term-missing --cov-report=xml:coverage.xml
+test_coverage_html_command_integration = uv run pytest ./tests/integration --tb=short --disable-warnings --cov=imaging_api/ --cov-report=html:htmlcov-integration --cov-report=term-missing --cov-report=xml:coverage-integration.xml
 docker_command = docker compose -f ../compose_trust.development.yml
 run_clean = run --rm --remove-orphans
 mypy_command = uv run mypy . --ignore-missing-imports

--- a/trust/imaging-api/Makefile
+++ b/trust/imaging-api/Makefile
@@ -27,6 +27,7 @@ endif
 service_name = imaging-api
 lint_command = uv run ruff check . --fix
 test_coverage_html_command = uv run pytest --tb=short --disable-warnings --cov=imaging_api/ --cov-report=html --cov-report=term-missing --cov-report=xml:coverage.xml
+test_coverage_html_command_integration = uv run pytest ./tests/integration --tb=short --disable-warnings --cov=imaging_api/ --cov-report=html --cov-report=term-missing --cov-report=xml:coverage.xml
 docker_command = docker compose -f ../compose_trust.development.yml
 run_clean = run --rm --remove-orphans
 mypy_command = uv run mypy . --ignore-missing-imports
@@ -64,3 +65,8 @@ local_test:
 	export BASE_IMAGES_DOWNLOAD_DIR=/tmp/images; \
 	$(lint_command) && $(mypy_command) && $(test_coverage_html_command)
 unit_test: local_test
+integration_test:
+# 	Just set the XNAT_PORT to a dummy value for the tests to run
+	@export XNAT_PORT=1111; \
+	export BASE_IMAGES_DOWNLOAD_DIR=/tmp/images; \
+	$(lint_command) && $(mypy_command) && $(test_coverage_html_command_integration)

--- a/trust/imaging-api/tests/integration/__init__.py
+++ b/trust/imaging-api/tests/integration/__init__.py
@@ -1,0 +1,12 @@
+# Copyright (c) 2026 Guy's and St Thomas' NHS Foundation Trust & King's College London
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Integration test scaffolding for imaging-api."""

--- a/trust/imaging-api/tests/integration/test_placeholder.py
+++ b/trust/imaging-api/tests/integration/test_placeholder.py
@@ -14,5 +14,5 @@ import pytest
 
 def test_integration_scaffold_placeholder():
     pytest.skip(
-        "Integration test scaffold for #63; replace with B4 trust-api + imaging-api + Orthanc imaging tests coverage."
+        "Integration scaffold for #63; replace with B4 trust-api + imaging-api + DICOM/PACS tests coverage."
     )

--- a/trust/imaging-api/tests/integration/test_placeholder.py
+++ b/trust/imaging-api/tests/integration/test_placeholder.py
@@ -1,0 +1,18 @@
+# Copyright (c) 2026 Guy's and St Thomas' NHS Foundation Trust & King's College London
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import pytest
+
+
+def test_integration_scaffold_placeholder():
+    pytest.skip(
+        "Integration test scaffold for #63; replace with B4 trust-api + imaging-api + Orthanc imaging tests coverage."
+    )

--- a/trust/trust-api/Makefile
+++ b/trust/trust-api/Makefile
@@ -18,7 +18,7 @@ endif
 service_name = trust-api
 lint_command = uv run ruff check . --fix
 test_coverage_html_command = uv run pytest --tb=short --disable-warnings --cov=trust_api/ --cov-report=html --cov-report=term-missing --cov-report=xml:coverage.xml
-test_coverage_html_command_integration = uv run pytest ./tests/integration --tb=short --disable-warnings --cov=trust_api/ --cov-report=html --cov-report=term-missing --cov-report=xml:coverage.xml
+test_coverage_html_command_integration = uv run pytest ./tests/integration --tb=short --disable-warnings --cov=trust_api/ --cov-report=html:htmlcov-integration --cov-report=term-missing --cov-report=xml:coverage-integration.xml
 docker_command = docker compose -f ../compose_trust.development.yml
 run_clean = run --rm --remove-orphans
 mypy_command = uv run mypy . --ignore-missing-imports

--- a/trust/trust-api/Makefile
+++ b/trust/trust-api/Makefile
@@ -18,6 +18,7 @@ endif
 service_name = trust-api
 lint_command = uv run ruff check . --fix
 test_coverage_html_command = uv run pytest --tb=short --disable-warnings --cov=trust_api/ --cov-report=html --cov-report=term-missing --cov-report=xml:coverage.xml
+test_coverage_html_command_integration = uv run pytest ./tests/integration --tb=short --disable-warnings --cov=trust_api/ --cov-report=html --cov-report=term-missing --cov-report=xml:coverage.xml
 docker_command = docker compose -f ../compose_trust.development.yml
 run_clean = run --rm --remove-orphans
 mypy_command = uv run mypy . --ignore-missing-imports
@@ -50,3 +51,6 @@ local_test:
 	@export BASE_IMAGES_DOWNLOAD_DIR=/tmp/images TRUST_NAME=TestTrust; \
 	$(lint_command) && $(mypy_command) && $(test_coverage_html_command)
 unit_test: local_test
+integration_test:
+	@export BASE_IMAGES_DOWNLOAD_DIR=/tmp/images TRUST_NAME=TestTrust; \
+	$(lint_command) && $(mypy_command) && $(test_coverage_html_command_integration)

--- a/trust/trust-api/tests/integration/__init__.py
+++ b/trust/trust-api/tests/integration/__init__.py
@@ -1,0 +1,12 @@
+# Copyright (c) 2026 Guy's and St Thomas' NHS Foundation Trust & King's College London
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Integration test scaffolding for trust-api."""

--- a/trust/trust-api/tests/integration/test_placeholder.py
+++ b/trust/trust-api/tests/integration/test_placeholder.py
@@ -1,0 +1,18 @@
+# Copyright (c) 2026 Guy's and St Thomas' NHS Foundation Trust & King's College London
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import pytest
+
+
+def test_integration_scaffold_placeholder():
+    pytest.skip(
+        "Integration test scaffold for #63; replace with B3 trust-api + data-access-api + omop-db cohort tests coverage."
+    )

--- a/trust/trust-api/tests/integration/test_placeholder.py
+++ b/trust/trust-api/tests/integration/test_placeholder.py
@@ -14,5 +14,5 @@ import pytest
 
 def test_integration_scaffold_placeholder():
     pytest.skip(
-        "Integration test scaffold for #63; replace with B3 trust-api + data-access-api + omop-db cohort tests coverage."
+        "Integration scaffold for #63; replace with B3/B4 trust-api + data/imaging service tests coverage."
     )


### PR DESCRIPTION
## Summary
- add `tests/integration/` scaffolds for `trust-api`, `imaging-api`, and `data-access-api`
- add placeholder integration tests with Apache 2.0 headers and #63/B3/B4 TODO context so empty integration dirs have an explicit collection target
- add service-level `integration_test` Make targets mirroring `flip-api` while preserving each trust service's existing env setup

Fixes #385.

## Verification
- `git diff --check`
- `python3 -m compileall -q trust/trust-api/tests/integration trust/imaging-api/tests/integration trust/data-access-api/tests/integration`
- `make -C trust/trust-api -n integration_test`
- `make -C trust/imaging-api -n integration_test`
- `make -C trust/data-access-api -n integration_test`

Not run: full `make integration_test`/`make test` because this runner is not provisioned with the repo's uv/Docker service dependencies.