### PR TITLE
docs: trust-internal service keys, ECS migration foundation, AWS troubleshooting

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -130,17 +130,20 @@ To get started, copy the example file:
 cp .env.development.example .env.development
 ```
 
-Then generate per-trust API keys and the internal service key (the trust keys must be done before `make up`; the
-internal service key is also generated automatically by `make up`):
+Then generate per-trust API keys, the internal service key, and the per-trust internal service keys (the trust
+keys must be done before `make up`; the internal service key is also generated automatically by `make up`):
 
 ```bash
 make generate-trust-api-keys
 make generate-internal-service-key
+make generate-trust-internal-service-keys
 ```
 
 These commands write all API keys directly into `.env.development`: trust plaintext keys
-in `TRUST_API_KEYS` (JSON dict) with their hashes in `TRUST_API_KEY_HASHES`, and `INTERNAL_SERVICE_KEY`
-with `INTERNAL_SERVICE_KEY_HASH` for fl-server-to-hub authentication. No separate key files are used.
+in `TRUST_API_KEYS` (JSON dict) with their hashes in `TRUST_API_KEY_HASHES`, `INTERNAL_SERVICE_KEY`
+with `INTERNAL_SERVICE_KEY_HASH` for fl-server-to-hub authentication, and per-trust plaintext keys in
+`TRUST_INTERNAL_SERVICE_KEYS` (JSON dict) for trust-internal service-to-service authentication. No
+separate key files are used.
 
 Docker services receive these variables via the `env_file` directive in the
 compose file — avoid hardcoding values in Dockerfiles or compose files directly.
@@ -153,6 +156,14 @@ compose file — avoid hardcoding values in Dockerfiles or compose files directl
 - `INTERNAL_SERVICE_KEY_HEADER` — HTTP header name for fl-server-to-hub authentication.
 - `INTERNAL_SERVICE_KEY` — internal service key used by the fl-server on the Central Hub.
 - `INTERNAL_SERVICE_KEY_HASH` — hub-side SHA-256 hash of the internal service key.
+- `TRUST_INTERNAL_SERVICE_KEY_HEADER` — HTTP header name for trust-internal service auth (default
+  `X-Trust-Internal-Service-Key`). Sent by every caller (trust-api, imaging-api, fl-client) on every
+  call to imaging-api or data-access-api.
+- `TRUST_INTERNAL_SERVICE_KEYS` — JSON dict of per-trust plaintext keys. Each trust uses a distinct key;
+  `trust/Makefile` extracts the per-trust value at deploy time and injects it into every trust-internal
+  container as `TRUST_INTERNAL_SERVICE_KEY`. The hub never sees these keys — they live only in trust-side
+  env. Distinct from `INTERNAL_SERVICE_KEY*` (which protects fl-server → flip-api on the Central Hub).
+  See [`CLAUDE.md`](CLAUDE.md#trust-internal-service-authentication) for the threat model.
 
 FL clients (trust side) intentionally do **not** receive Central Hub API credentials. Only the fl-server (on the Central
 Hub) communicates with flip-api. FL clients relay metrics and exceptions to the fl-server, which forwards them.

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,8 @@
 
 .PHONY: build dev prod clean stop up down up-no-trust up-trusts central-fl central-hub \
 		restart restart-no-trust ci tests debug create-networks remove-networks recreate-networks consolidate-deps \
-		check-aws-access up-local-trust generate-trust-api-keys generate-internal-service-key integration_test
+		check-aws-access up-local-trust generate-trust-api-keys generate-internal-service-key \
+		generate-trust-internal-service-keys integration_test
 
 ifeq ($(PROD),true)
 MAIN_ENV_FILE=.env.production
@@ -270,6 +271,9 @@ generate-trust-api-keys:
 
 generate-internal-service-key:
 	$(MAKE) -C flip-api generate-internal-service-key $(if $(ENV_FILE),ENV_FILE=$(ENV_FILE)) $(if $(FORCE),FORCE=$(FORCE))
+
+generate-trust-internal-service-keys:
+	$(MAKE) -C flip-api generate-trust-internal-service-keys $(if $(ENV_FILE),ENV_FILE=$(ENV_FILE)) $(if $(FORCE),FORCE=$(FORCE))
 
 check-aws-access:
 	@echo "🔎 Checking AWS CLI access..."

--- a/README.md
+++ b/README.md
@@ -143,14 +143,15 @@ make xnat-shell  # Get a shell in the XNAT container
 
 ### Trust API Key Setup
 
-Before starting the platform, generate per-trust API keys and the internal service key, and write them into `.env.development` using:
+Before starting the platform, generate per-trust API keys, the internal service key, and the per-trust internal service keys, and write them into `.env.development` using:
 
 ```bash
 make generate-trust-api-keys
 make generate-internal-service-key
+make generate-trust-internal-service-keys
 ```
 
-`generate-trust-api-keys` generates a unique key for each trust found in `.env.development`, and writes both `TRUST_API_KEYS` and `TRUST_API_KEY_HASHES` (JSON dicts) directly into the env file. `generate-internal-service-key` writes `INTERNAL_SERVICE_KEY` and `INTERNAL_SERVICE_KEY_HASH` for fl-server-to-hub authentication. `make up` invokes `generate-internal-service-key` automatically.
+`generate-trust-api-keys` generates a unique key for each trust found in `.env.development`, and writes both `TRUST_API_KEYS` and `TRUST_API_KEY_HASHES` (JSON dicts) directly into the env file. `generate-internal-service-key` writes `INTERNAL_SERVICE_KEY` and `INTERNAL_SERVICE_KEY_HASH` (plain strings) for fl-server-to-hub authentication. `make up` invokes `generate-internal-service-key` automatically. `generate-trust-internal-service-keys` writes `TRUST_INTERNAL_SERVICE_KEYS` (JSON dict) used by trust-api / imaging-api / data-access-api / fl-client to authenticate to one another inside each trust — distinct from the hub's `INTERNAL_SERVICE_KEY` and never sent to the hub. See [`CLAUDE.md`](CLAUDE.md#trust-internal-service-authentication) for the threat model.
 
 To generate a key for a single trust (e.g. when adding a new trust):
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -229,7 +229,14 @@ This runbook is for the case where **you** have lost access to your TOTP device 
 
 ## Service Authentication
 
-FLIP uses two separate authentication mechanisms for service-to-hub communication:
+FLIP uses three separate authentication mechanisms for service-to-service communication. Generate all keys
+in one go with:
+
+```bash
+make generate-trust-api-keys
+make generate-internal-service-key
+make generate-trust-internal-service-keys
+```
 
 ### Trust API Keys (trust-api → flip-api)
 
@@ -237,13 +244,25 @@ Each trust has a unique API key stored in the `TRUST_API_KEYS` JSON dict and sen
 The hub stores only SHA-256 hashes of these keys in `TRUST_API_KEY_HASHES`. Used for task polling, cohort result
 submission, and heartbeat endpoints.
 
-Generate keys with `make generate-trust-api-keys` and `make generate-internal-service-key`.
-
 ### Internal Service Key (fl-server → flip-api)
 
-The fl-server on the Central Hub authenticates to flip-api using `INTERNAL_SERVICE_KEY` sent in the
-`INTERNAL_SERVICE_KEY_HEADER` header. The hub validates it against
-`INTERNAL_SERVICE_KEY_HASH`. Used for model status updates, training metrics, and training log endpoints.
+The fl-server on the Central Hub authenticates to flip-api using `INTERNAL_SERVICE_KEY` (a plain string) sent
+in the `INTERNAL_SERVICE_KEY_HEADER` header. The hub validates it against `INTERNAL_SERVICE_KEY_HASH` (the
+SHA-256 hash of the key). Used for model status updates, training metrics, and training log endpoints. This
+is a **single, hub-internal** secret and is separate from the per-trust internal keys below.
+
+### Trust-Internal Service Keys (trust-api / imaging-api / fl-client → imaging-api / data-access-api)
+
+Inside each trust, every call from trust-api / imaging-api / fl-client to imaging-api or data-access-api
+carries a shared-secret header. The header name comes from `TRUST_INTERNAL_SERVICE_KEY_HEADER` (default
+`X-Trust-Internal-Service-Key`); the value is the per-trust plaintext key from `TRUST_INTERNAL_SERVICE_KEYS`
+(a JSON dict keyed by trust name). Receivers compare the header against their own copy with a constant-time
+compare. `/health` is intentionally exempt so liveness probes still work.
+
+Each trust gets a distinct key — a leak in `Trust_1` cannot drive operations on `Trust_2`'s APIs. The hub
+never sees these keys: they live only in trust-side env (extracted by `trust/Makefile` via `get_json_value`
+at deploy time, exactly like `TRUST_API_KEYS`). See the **Trust-internal Service Authentication** section
+in the repo-root [`CLAUDE.md`](../CLAUDE.md) for the full threat model.
 
 FL clients (trust side) **do not** have Central Hub API credentials. Only the fl-server communicates with flip-api.
 FL clients relay metrics and exceptions to the fl-server, which forwards them to the Central Hub.
@@ -261,16 +280,20 @@ outside the hub's Docker network.
 | `TRUST_API_KEYS` | trust-api | JSON dict of trust name → plaintext key |
 | `TRUST_API_KEY_HASHES` | flip-api | JSON dict of trust name → SHA-256 hash |
 | `INTERNAL_SERVICE_KEY_HEADER` | flip-api, fl-server | Header name for internal service auth |
-| `INTERNAL_SERVICE_KEY` | fl-server | Internal service plaintext key |
-| `INTERNAL_SERVICE_KEY_HASH` | flip-api | SHA-256 hash of internal service key |
+| `INTERNAL_SERVICE_KEY` | fl-server | Internal service plaintext key (plain string) |
+| `INTERNAL_SERVICE_KEY_HASH` | flip-api | SHA-256 hash of internal service key (plain string) |
+| `TRUST_INTERNAL_SERVICE_KEY_HEADER` | trust-api, imaging-api, data-access-api, fl-client | Header name for trust-internal service auth (default `X-Trust-Internal-Service-Key`) |
+| `TRUST_INTERNAL_SERVICE_KEYS` | trust-side only | JSON dict of trust name → per-trust plaintext key. The hub never sees these. |
 | `CENTRAL_HUB_API_URL` | flip-ui, trust-api | Public base URL of flip-api (in prod: CloudFront URL) |
 | `FLIP_API_INTERNAL_URL` | fl-server | Docker-network URL of flip-api on the Central Hub (e.g. `http://flip-api:8000/api`) |
 
-#### Note on future ECS migration
+#### Note on the ECS migration
 
-`FLIP_API_INTERNAL_URL` names the intent ("flip-api's internal URL on the Central Hub"), not the
-mechanism, so the split survives a move from EC2 + docker-compose to ECS. When migrating, point it
-at whichever in-VPC, header-preserving endpoint flip-api exposes:
+The Central Hub is moving from EC2 + docker-compose to ECS Fargate; the foundation Terraform (cluster,
+EFS, IAM, parameter store, service discovery, VPC endpoints) has landed under `deploy/providers/AWS/`,
+but task definitions and services are still being rolled out. `FLIP_API_INTERNAL_URL` names the intent
+("flip-api's internal URL on the Central Hub"), not the mechanism, so the split survives the move. When
+migrating, point it at whichever in-VPC, header-preserving endpoint flip-api exposes:
 
 | ECS layout | `FLIP_API_INTERNAL_URL` |
 |---|---|
@@ -282,3 +305,7 @@ at whichever in-VPC, header-preserving endpoint flip-api exposes:
 What it must not be: the public CloudFront URL. That's orthogonal to compute — CloudFront strips
 `X-Internal-Service-Key` regardless of whether flip-api runs on EC2 or ECS. Internal ALBs preserve
 all request headers by default, so that option works; CloudFront doesn't.
+
+> **Note on troubleshooting**: AWS-deployment-specific failure modes (Terraform state drift, ECS
+> service stuck in `PENDING`, CloudFront cache invalidation, RDS connectivity) are documented in
+> [`providers/AWS/TROUBLESHOOTING.md`](providers/AWS/TROUBLESHOOTING.md).

--- a/deploy/providers/AWS/README.md
+++ b/deploy/providers/AWS/README.md
@@ -214,7 +214,17 @@ See [`dev/README.md`](./dev/README.md) for the one-time `terraform import` workf
 
 ```
 deploy/providers/AWS/
-├── main.tf / services.tf       # prod + stag stack root
+├── main.tf / services.tf       # prod + stag stack root (VPC, RDS, Cognito, SES, EC2)
+├── ecs.tf                      # ECS cluster + capacity providers (Central Hub migration foundation)
+├── efs.tf                      # EFS file systems for shared workspace volumes
+├── iam_ecs.tf                  # IAM execution + task roles for ECS Fargate tasks
+├── parameter_store.tf          # SSM Parameter Store entries consumed by ECS tasks
+├── service_discovery.tf        # Cloud Map private DNS namespace for ECS services
+├── vpc_endpoints.tf            # Interface endpoints (ECR, Secrets Manager, SSM, etc.)
+├── dhcp.tf                     # VPC DHCP option set
+├── locals.tf                   # Shared locals
+├── cloudfront.tf               # CloudFront distribution for flip-ui
+├── certificate.tf              # ACM certificates (ALB + CloudFront)
 ├── modules/
 │   ├── cognito/                # shared: pool, domain, client, seed users
 │   ├── ses/                    # shared: sender identity, transactional templates
@@ -222,6 +232,10 @@ deploy/providers/AWS/
 │   └── trust_ec2/              # prod/stag only
 └── dev/                        # dev-account root (calls cognito + ses modules)
 ```
+
+The ECS / EFS / parameter store files are the **foundation** for the Central Hub migration from EC2 +
+docker-compose to ECS Fargate. The cluster, IAM, and networking are provisioned today; task definitions
+and services land in subsequent PRs.
 
 The Cognito and SES resources used to live at the root of the prod/stag stack. `services.tf` and `main.tf` ship `moved` blocks that re-anchor the old root addresses onto the new `module.cognito.*` / `module.ses.*` paths, so any state still on the old layout self-heals on the next plan — no manual `terraform state mv` needed. `scripts/import-resources.sh` already targets the module addresses, so a fresh import lands in the right place too.
 
@@ -373,6 +387,13 @@ This will automatically diagnose:
 - System resource usage
 
 Review the output for failed checks and follow the specific troubleshooting steps below.
+
+### Detailed Troubleshooting Guide
+
+For known failure modes encountered during staging/production deployment — including Terraform state
+drift, ECS service errors, CloudFront cache invalidation, RDS connectivity, and SSM Session Manager
+issues — see [`TROUBLESHOOTING.md`](TROUBLESHOOTING.md). Each entry includes symptoms, root cause, and
+fix.
 
 ## Architecture
 

--- a/flip-api/README.md
+++ b/flip-api/README.md
@@ -48,14 +48,15 @@ or as part of the full platform:
 make up
 ```
 
-Before starting the platform, generate per-trust API keys and the internal service key:
+Before starting the platform, generate per-trust API keys, the internal service key, and the per-trust internal service keys:
 
 ```bash
-make generate-trust-api-keys        # from repo root
-make generate-internal-service-key  # from repo root (also invoked automatically by `make up`)
+make generate-trust-api-keys                  # from repo root
+make generate-internal-service-key            # from repo root (also invoked automatically by `make up`)
+make generate-trust-internal-service-keys     # from repo root
 ```
 
-`generate-trust-api-keys` updates `TRUST_API_KEYS` and `TRUST_API_KEY_HASHES` in `.env.development`. `generate-internal-service-key` writes `INTERNAL_SERVICE_KEY` and `INTERNAL_SERVICE_KEY_HASH` (used for fl-server-to-hub authentication).
+`generate-trust-api-keys` updates `TRUST_API_KEYS` and `TRUST_API_KEY_HASHES` in `.env.development`. `generate-internal-service-key` writes `INTERNAL_SERVICE_KEY` and `INTERNAL_SERVICE_KEY_HASH` (used for fl-server-to-hub authentication). `generate-trust-internal-service-keys` writes `TRUST_INTERNAL_SERVICE_KEYS` (per-trust JSON dict) used for trust-api / imaging-api / data-access-api / fl-client authentication inside each trust — never sent to the hub.
 See [`.env.development.example`](../.env.development.example) for the expected format.
 
 The API is served on the port defined by `API_PORT` in [`.env.development.example`](../.env.development.example)


### PR DESCRIPTION
> _This is an automated scheduled weekly task by Alex's Claude Code._

## Summary

Weekly review of READMEs, ReadTheDocs sources, and Python docstrings for drift against the current code on `develop`. Findings actionable as documentation/wrapper changes are applied here; no behavioural code changes.

### What was wrong

1. **`make generate-trust-internal-service-keys` was referenced everywhere but did not exist at the root.** `.env.development.example` (Quick-start step 4), the repo-root `CLAUDE.md` "Trust-internal Service Authentication" section, and the `generate_trust_internal_service_keys.py` docstring all instruct users to run `make generate-trust-internal-service-keys` from the repo root, but the root `Makefile` only had wrappers for the other two key-generation scripts (`generate-trust-api-keys`, `generate-internal-service-key`). The bare command failed.
2. **`TRUST_INTERNAL_SERVICE_KEY_HEADER` / `TRUST_INTERNAL_SERVICE_KEYS` were absent from contributor-facing docs.** They appear in `.env.development.example`, `CLAUDE.md`, and the per-service trust READMEs, but `CONTRIBUTING.md`'s "Authentication environment variables" list and `deploy/README.md`'s service-auth reference table both omitted them.
3. **`deploy/README.md`** described `INTERNAL_SERVICE_KEY*` as "JSON dicts directly into the env file" — they're plain strings; only `TRUST_API_KEYS`/`TRUST_API_KEY_HASHES` are JSON dicts.
4. **`deploy/README.md`** still framed the ECS Central Hub move as "future ECS migration", but the foundation Terraform (cluster, EFS, IAM-ECS, parameter store, service discovery, VPC endpoints) has now landed via PR #401.
5. **`deploy/providers/AWS/TROUBLESHOOTING.md` existed but was unreferenced** from the AWS README and `deploy/README.md`.
6. **The new ECS-foundation TF files** (`ecs.tf`, `efs.tf`, `iam_ecs.tf`, `parameter_store.tf`, `service_discovery.tf`, `vpc_endpoints.tf`, `dhcp.tf`, `locals.tf`) were not listed in the AWS README's "Terraform module layout" section.
7. **Docstrings** in `mfa_status.py` / `reset_user_mfa.py` / `generate_trust_internal_service_keys.py` were already accurate — no type-annotation mismatches found, so no docstring changes are included in this PR.

### What changed

- `Makefile`: add `generate-trust-internal-service-keys` wrapper that delegates to `flip-api/Makefile`, mirroring the existing `generate-trust-api-keys` and `generate-internal-service-key` wrappers (passes through `ENV_FILE` / `FORCE`).
- `README.md`: add the third generation step in the Trust API Key Setup section with a note pointing at the threat model in `CLAUDE.md`.
- `CONTRIBUTING.md`: add the third generation step in the env-var setup flow and add `TRUST_INTERNAL_SERVICE_KEY_HEADER` / `TRUST_INTERNAL_SERVICE_KEYS` to the Authentication environment variables list, with the per-trust scope explanation and a link to `CLAUDE.md`.
- `flip-api/README.md`: add the third generation step alongside the other two.
- `deploy/README.md`:
  - new "Trust-Internal Service Keys" subsection under Service Authentication summarising the threat model and per-trust scope.
  - reference table now lists `TRUST_INTERNAL_SERVICE_KEY_HEADER` / `TRUST_INTERNAL_SERVICE_KEYS` and clarifies that `INTERNAL_SERVICE_KEY*` are plain strings (not JSON dicts).
  - section retitled "Note on the ECS migration" to reflect that foundation has landed but service cutover is in progress.
  - added pointer to `providers/AWS/TROUBLESHOOTING.md`.
- `deploy/providers/AWS/README.md`:
  - module-layout listing extended with the new ECS-foundation TF files and a note that they're foundation-only today.
  - new "Detailed Troubleshooting Guide" subsection links `TROUBLESHOOTING.md`.

## Test plan

- [x] `make -n generate-trust-internal-service-keys` resolves to `make -C flip-api generate-trust-internal-service-keys` → `uv run python -m flip_api.scripts.generate_trust_internal_service_keys`.
- [x] No code changes outside docs and the one Makefile wrapper, so no service tests are required.
- [ ] Reviewers please sanity-check the threat-model wording in `deploy/README.md` matches the trust-internal auth implementation in `trust/imaging-api/imaging_api/utils/internal_auth.py` and `trust/data-access-api/data_access_api/utils/internal_auth.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01P3UMTydUhSnRuBQFHh4fZG)_