### PR TITLE
Add GitHub issue reference to CSP policy comment

### DIFF
--- a/deploy/providers/AWS/cloudfront.tf
+++ b/deploy/providers/AWS/cloudfront.tf
@@ -519,7 +519,8 @@ resource "aws_wafv2_web_acl_logging_configuration" "flip_ui_cloudfront" {
 # browser console + `Content-Security-Policy-Report-Only` response headers
 # without blocking traffic. After one release cycle with no real-user
 # violations, move the policy body from `content_security_policy_report_only`
-# to `content_security_policy` (enforcing).
+# to `content_security_policy` (enforcing). Tracked in
+# https://github.com/londonaicentre/FLIP/issues/417.
 resource "aws_cloudfront_response_headers_policy" "flip_ui_spa" {
   name    = "flip-ui-spa-${replace(var.flip_alb_subdomain, "/[^a-zA-Z0-9]/", "-")}"
   comment = "Security response headers for the flip-ui SPA at ${var.flip_alb_subdomain}"


### PR DESCRIPTION
# Description

Updated the inline comment for the CloudFront response headers policy to include a reference to the GitHub issue tracking the Content-Security-Policy enforcement task. This improves traceability by linking the code comment directly to the related issue #417.

## Linked Issues

Fixes #417

## Type of Change

- [x] Non-breaking change (fix or new feature that would not break existing functionality).

## Testing

N/A - This is a documentation/comment update with no functional changes to the infrastructure code.

## Additional Notes

This change adds a reference to the GitHub issue that tracks the planned migration from `content_security_policy_report_only` to `content_security_policy` (enforcing mode) for the FLIP UI SPA security headers.

https://claude.ai/code/session_01GNLbB94b2yDLjwYwVqMres