### PR TITLE
feat(fl): use heartbeat timestamps for trust connection status instead of inbound HTTP checks

### DIFF
--- a/.env.development.example
+++ b/.env.development.example
@@ -358,6 +358,10 @@ FL_APP_DESTINATION_BUCKET=s3://${FLIP_BUCKET_NAME}/app_destination_bucket
 # by Python. Add one entry per FL network.
 NET_ENDPOINTS={"net-1":"http://flip-fl-api-net-1:8000", "net-2":"http://flip-fl-api-net-2:8000"}
 
+# Time window (seconds) within which a trust must have sent a heartbeat to be
+# considered online. Default 15s = 3 × 5s poll interval (MQTT keep-alive pattern).
+TRUST_HEARTBEAT_TIMEOUT_SECONDS=15
+
 # ── Trust Names ───────────────────────────────────────────────────────────
 # JSON list of trust names that will be seeded into the database. Acts as an
 # allowlist: the Central Hub only accepts connections from trusts whose names

--- a/.env.development.example
+++ b/.env.development.example
@@ -359,8 +359,8 @@ FL_APP_DESTINATION_BUCKET=s3://${FLIP_BUCKET_NAME}/app_destination_bucket
 NET_ENDPOINTS={"net-1":"http://flip-fl-api-net-1:8000", "net-2":"http://flip-fl-api-net-2:8000"}
 
 # Time window (seconds) within which a trust must have sent a heartbeat to be
-# considered online. Default 15s = 3 × 5s poll interval (MQTT keep-alive pattern).
-TRUST_HEARTBEAT_TIMEOUT_SECONDS=15
+# considered online. Override for Settings.HEARTBEAT_TIMEOUT_SECONDS (default 30s).
+HEARTBEAT_TIMEOUT_SECONDS=30
 
 # ── Trust Names ───────────────────────────────────────────────────────────
 # JSON list of trust names that will be seeded into the database. Acts as an

--- a/deploy/providers/AWS/check_status.py
+++ b/deploy/providers/AWS/check_status.py
@@ -540,7 +540,7 @@ def check_trust_heartbeats() -> None:
 import asyncpg, os, json, boto3, asyncio
 from datetime import datetime, timezone
 
-HEARTBEAT_TIMEOUT = int(os.environ.get("TRUST_HEARTBEAT_TIMEOUT_SECONDS", "15"))
+HEARTBEAT_TIMEOUT = int(os.environ.get("HEARTBEAT_TIMEOUT_SECONDS", "30"))
 
 async def m():
     c = boto3.client("secretsmanager", region_name="eu-west-2")

--- a/deploy/providers/AWS/check_status.py
+++ b/deploy/providers/AWS/check_status.py
@@ -526,6 +526,79 @@ asyncio.run(m())
         print_status("PASS", "No critical Trust_1 tasks in FAILED state")
 
 
+def check_trust_heartbeats() -> None:
+    """Check trust liveness via last_heartbeat timestamps in the database.
+
+    Queries the trust table for each trust's last_heartbeat and reports
+    whether it falls within the expected timeout window (default 15s).
+    This is the canonical check for NAT-based trusts that use outbound-only
+    polling.
+    """
+    print_status("INFO", "Checking trust heartbeats...")
+
+    py = """\
+import asyncpg, os, json, boto3, asyncio
+from datetime import datetime, timezone
+
+HEARTBEAT_TIMEOUT = 15
+
+async def m():
+    c = boto3.client("secretsmanager", region_name="eu-west-2")
+    s = c.get_secret_value(SecretId=os.environ["POSTGRES_SECRET_ARN"])
+    d = json.loads(s["SecretString"])
+    p = d.get("password", "")
+    conn = await asyncpg.connect(
+        host=os.environ["DB_HOST"], port=5432,
+        user=os.environ["POSTGRES_USER"], database=os.environ["POSTGRES_DB"], password=p,
+    )
+    rows = await conn.fetch("SELECT name, last_heartbeat FROM trust")
+    now = datetime.now(timezone.utc)
+    for row in rows:
+        name = row[0]
+        hb = row[1]
+        if hb is None:
+            print(f"{name}:never_heartbeated")
+        else:
+            elapsed = (now - hb.replace(tzinfo=timezone.utc)).total_seconds()
+            is_online = elapsed < HEARTBEAT_TIMEOUT
+            tag = "online" if is_online else "stale"
+            print(f"{name}:{tag}:{int(elapsed)}s")
+    await conn.close()
+asyncio.run(m())
+"""
+    success, output = run_remote_python("flip", "flip-api", py, timeout=25)
+
+    if not success or "Traceback" in output:
+        print_status("INFO", "Could not query trust heartbeats (SSH or DB unavailable)")
+        return
+
+    lines = [l.strip() for l in output.strip().split("\n") if l.strip()]
+    if not lines:
+        print_status("INFO", "No trusts registered in the database")
+        return
+
+    online_count = 0
+    offline_count = 0
+    for line in lines:
+        parts = line.split(":")
+        name = parts[0]
+        state = parts[1]
+        if state == "online":
+            elapsed = parts[2]
+            print_status("PASS", f"Trust '{name}' online (heartbeat {elapsed} ago)")
+            online_count += 1
+        elif state == "stale":
+            elapsed = parts[2]
+            print_status("FAIL", f"Trust '{name}' stale (heartbeat {elapsed} ago, >15s timeout)")
+            offline_count += 1
+        elif state == "never_heartbeated":
+            print_status("WARN", f"Trust '{name}' has never heartbeated")
+            offline_count += 1
+
+    if online_count > 0 and offline_count == 0:
+        print_status("PASS", f"All {online_count} trust(s) have recent heartbeats")
+
+
 def check_xnat_health() -> None:
     """Verify XNAT is serving its API (not a setup page)."""
     print_status("INFO", "Checking XNAT API health (not setup page)...")
@@ -1172,6 +1245,10 @@ def main(
                     "WARN",
                     f"FL API Net {nets} returned empty client list — SuperNodes may not have connected yet",
                 )
+
+        # For trusts behind NAT where the FL server is unreachable (check_client_status failed
+        # above), fall back to querying the database for heartbeat timestamps directly.
+        check_trust_heartbeats()
 
         # Trust EC2 endpoint checks
         if trust_id:

--- a/deploy/providers/AWS/check_status.py
+++ b/deploy/providers/AWS/check_status.py
@@ -540,7 +540,7 @@ def check_trust_heartbeats() -> None:
 import asyncpg, os, json, boto3, asyncio
 from datetime import datetime, timezone
 
-HEARTBEAT_TIMEOUT = 15
+HEARTBEAT_TIMEOUT = int(os.environ.get("TRUST_HEARTBEAT_TIMEOUT_SECONDS", "15"))
 
 async def m():
     c = boto3.client("secretsmanager", region_name="eu-west-2")

--- a/flip-api/src/flip_api/fl_services/get_status.py
+++ b/flip-api/src/flip_api/fl_services/get_status.py
@@ -25,7 +25,11 @@ from flip_api.domain.interfaces.fl import (
 )
 from flip_api.domain.schemas.status import ClientStatus, ServerEngineStatus
 from flip_api.fl_services.services.fl_scheduler_service import get_nets
-from flip_api.fl_services.services.fl_service import fetch_client_status, fetch_server_status
+from flip_api.fl_services.services.fl_service import (
+    fetch_client_status,
+    fetch_server_status,
+    is_trust_online_by_heartbeat,
+)
 from flip_api.trusts_services.services.trust import get_trusts
 from flip_api.utils.logger import logger
 
@@ -91,22 +95,41 @@ def get_status_endpoint(
             clients = fetch_client_status(net.endpoint)
 
             if not clients:
-                logger.error(f"{net.name}: No clients connected")
+                logger.warning(
+                    f"{net.name}: No response from FL API client endpoint, "
+                    f"falling back to heartbeat checks"
+                )
+                trusts = get_trusts(db)
+                trust_client_statuses: list[IClientStatus] = []
+                for trust in trusts:
+                    if is_trust_online_by_heartbeat(trust.name, db):
+                        trust_client_statuses.append(
+                            IClientStatus(
+                                name=trust.name, status=ClientStatus.NO_JOBS.value
+                            )
+                        )
+                    else:
+                        trust_client_statuses.append(
+                            IClientStatus(
+                                name=trust.name, status=ClientStatus.NO_REPLY.value
+                            )
+                        )
                 net_statuses.append(
                     INetStatus(
                         name=net.name,
                         fl_backend=fl_backend,
-                        online=False,
-                        registered_clients=0,
-                        clients=[],
-                        net_in_use=False,
+                        online=True,
+                        registered_clients=len(trust_client_statuses),
+                        net_in_use=server_status.status
+                        in [ServerEngineStatus.STARTING, ServerEngineStatus.STARTED],
+                        clients=trust_client_statuses,
                     )
                 )
                 continue
 
             # For each net, we would like to know which Trusts are connected and their statuses.
             trusts = get_trusts(db)
-            trust_client_statuses: list[IClientStatus] = []
+            trust_client_statuses = []
             for trust in trusts:
                 connected_client_info = None
 
@@ -117,7 +140,18 @@ def get_status_endpoint(
                         break
                 else:
                     logger.warning(f"Trust {trust.name} not found in client statuses")
-                    trust_client_statuses.append(IClientStatus(name=trust.name, status=ClientStatus.NO_REPLY.value))
+                    if is_trust_online_by_heartbeat(trust.name, db):
+                        trust_client_statuses.append(
+                            IClientStatus(
+                                name=trust.name, status=ClientStatus.NO_JOBS.value
+                            )
+                        )
+                    else:
+                        trust_client_statuses.append(
+                            IClientStatus(
+                                name=trust.name, status=ClientStatus.NO_REPLY.value
+                            )
+                        )
                     continue
 
                 # Log the trust and connected client information

--- a/flip-api/src/flip_api/fl_services/get_status.py
+++ b/flip-api/src/flip_api/fl_services/get_status.py
@@ -28,12 +28,27 @@ from flip_api.fl_services.services.fl_scheduler_service import get_nets
 from flip_api.fl_services.services.fl_service import (
     fetch_client_status,
     fetch_server_status,
-    is_trust_online_by_heartbeat,
+    get_trust_liveness_map,
 )
 from flip_api.trusts_services.services.trust import get_trusts
 from flip_api.utils.logger import logger
 
 router = APIRouter(prefix="/fl", tags=["fl_services"])
+
+
+def _heartbeat_status(trust_name: str, liveness_map: dict[str, bool]) -> IClientStatus:
+    """Build an IClientStatus for a trust from a preloaded liveness map."""
+    if liveness_map.get(trust_name, False):
+        return IClientStatus(name=trust_name, status=ClientStatus.NO_JOBS.value)
+    return IClientStatus(name=trust_name, status=ClientStatus.NO_REPLY.value)
+
+
+def build_heartbeat_client_statuses(
+    trusts: list, db: Session
+) -> list[IClientStatus]:
+    """Build IClientStatus list for all trusts using one DB query for liveness."""
+    liveness = get_trust_liveness_map(db)
+    return [_heartbeat_status(t.name, liveness) for t in trusts]
 
 
 # [#114] ✅
@@ -100,20 +115,7 @@ def get_status_endpoint(
                     f"falling back to heartbeat checks"
                 )
                 trusts = get_trusts(db)
-                trust_client_statuses: list[IClientStatus] = []
-                for trust in trusts:
-                    if is_trust_online_by_heartbeat(trust.name, db):
-                        trust_client_statuses.append(
-                            IClientStatus(
-                                name=trust.name, status=ClientStatus.NO_JOBS.value
-                            )
-                        )
-                    else:
-                        trust_client_statuses.append(
-                            IClientStatus(
-                                name=trust.name, status=ClientStatus.NO_REPLY.value
-                            )
-                        )
+                trust_client_statuses = build_heartbeat_client_statuses(trusts, db)
                 net_statuses.append(
                     INetStatus(
                         name=net.name,
@@ -129,6 +131,8 @@ def get_status_endpoint(
 
             # For each net, we would like to know which Trusts are connected and their statuses.
             trusts = get_trusts(db)
+            # Preload all trust heartbeats in one query to avoid N+1
+            liveness_map = get_trust_liveness_map(db)
             trust_client_statuses = []
             for trust in trusts:
                 connected_client_info = None
@@ -140,18 +144,9 @@ def get_status_endpoint(
                         break
                 else:
                     logger.warning(f"Trust {trust.name} not found in client statuses")
-                    if is_trust_online_by_heartbeat(trust.name, db):
-                        trust_client_statuses.append(
-                            IClientStatus(
-                                name=trust.name, status=ClientStatus.NO_JOBS.value
-                            )
-                        )
-                    else:
-                        trust_client_statuses.append(
-                            IClientStatus(
-                                name=trust.name, status=ClientStatus.NO_REPLY.value
-                            )
-                        )
+                    trust_client_statuses.append(
+                        _heartbeat_status(trust.name, liveness_map)
+                    )
                     continue
 
                 # Log the trust and connected client information

--- a/flip-api/src/flip_api/fl_services/services/fl_service.py
+++ b/flip-api/src/flip_api/fl_services/services/fl_service.py
@@ -940,7 +940,10 @@ def is_trust_online_by_heartbeat(trust_name: str, session: Session) -> bool:
     trust = session.exec(statement).first()
     if not trust or not trust.last_heartbeat:
         return False
-    elapsed = (datetime.now(timezone.utc) - trust.last_heartbeat).total_seconds()
+    last_hb = trust.last_heartbeat
+    if last_hb.tzinfo is None:
+        last_hb = last_hb.replace(tzinfo=timezone.utc)
+    elapsed = (datetime.now(timezone.utc) - last_hb).total_seconds()
     return elapsed < HEARTBEAT_TIMEOUT_SECONDS
 
 

--- a/flip-api/src/flip_api/fl_services/services/fl_service.py
+++ b/flip-api/src/flip_api/fl_services/services/fl_service.py
@@ -11,7 +11,6 @@
 #
 
 import json
-import os
 from datetime import datetime, timezone
 from typing import Any
 from uuid import UUID
@@ -920,14 +919,12 @@ def add_fl_job(model_id: UUID, clients: list[str], session: Session) -> None:
     logger.info(f"FL job {job.id} added for model ID: {model_id}")
 
 
-HEARTBEAT_TIMEOUT_SECONDS = int(os.getenv("TRUST_HEARTBEAT_TIMEOUT_SECONDS", "15"))
-
-
 def is_trust_online_by_heartbeat(trust_name: str, session: Session) -> bool:
     """Check if a trust is online based on its last_heartbeat timestamp.
 
     A trust is considered online if it sent a heartbeat within the
-    configurable timeout window (default 15s = 3 x 5s poll interval).
+    configurable timeout window from Settings.HEARTBEAT_TIMEOUT_SECONDS
+    (default 30s).
 
     Args:
         trust_name (str): The name of the trust to check.
@@ -944,7 +941,35 @@ def is_trust_online_by_heartbeat(trust_name: str, session: Session) -> bool:
     if last_hb.tzinfo is None:
         last_hb = last_hb.replace(tzinfo=timezone.utc)
     elapsed = (datetime.now(timezone.utc) - last_hb).total_seconds()
-    return elapsed < HEARTBEAT_TIMEOUT_SECONDS
+    return elapsed < get_settings().HEARTBEAT_TIMEOUT_SECONDS
+
+
+def get_trust_liveness_map(session: Session) -> dict[str, bool]:
+    """Return a {trust_name: is_online} map for all trusts in one query.
+
+    Preloads all Trust.last_heartbeat values and computes liveness
+    in-memory, avoiding N+1 queries when checking many trusts.
+
+    Args:
+        session (Session): SQLModel session object.
+
+    Returns:
+        dict[str, bool]: Mapping of trust name to online status.
+    """
+    statement = select(Trust.name, Trust.last_heartbeat)
+    rows = session.exec(statement).all()
+    timeout = get_settings().HEARTBEAT_TIMEOUT_SECONDS
+    now = datetime.now(timezone.utc)
+    result: dict[str, bool] = {}
+    for name, last_hb in rows:
+        if last_hb is None:
+            result[name] = False
+            continue
+        if last_hb.tzinfo is None:
+            last_hb = last_hb.replace(tzinfo=timezone.utc)
+        elapsed = (now - last_hb).total_seconds()
+        result[name] = elapsed < timeout
+    return result
 
 
 def keep_fl_api_session_alive() -> None:

--- a/flip-api/src/flip_api/fl_services/services/fl_service.py
+++ b/flip-api/src/flip_api/fl_services/services/fl_service.py
@@ -11,6 +11,8 @@
 #
 
 import json
+import os
+from datetime import datetime, timezone
 from typing import Any
 from uuid import UUID
 
@@ -19,7 +21,7 @@ from sqlmodel import Session, select
 
 from flip_api.config import get_settings
 from flip_api.db.database import engine
-from flip_api.db.models.main_models import FLJob
+from flip_api.db.models.main_models import FLJob, Trust
 from flip_api.domain.interfaces.fl import (
     IClientStatus,
     IJobMetaData,
@@ -916,6 +918,30 @@ def add_fl_job(model_id: UUID, clients: list[str], session: Session) -> None:
         raise
 
     logger.info(f"FL job {job.id} added for model ID: {model_id}")
+
+
+HEARTBEAT_TIMEOUT_SECONDS = int(os.getenv("TRUST_HEARTBEAT_TIMEOUT_SECONDS", "15"))
+
+
+def is_trust_online_by_heartbeat(trust_name: str, session: Session) -> bool:
+    """Check if a trust is online based on its last_heartbeat timestamp.
+
+    A trust is considered online if it sent a heartbeat within the
+    configurable timeout window (default 15s = 3 x 5s poll interval).
+
+    Args:
+        trust_name (str): The name of the trust to check.
+        session (Session): SQLModel session object.
+
+    Returns:
+        bool: True if the trust has a recent heartbeat, False otherwise.
+    """
+    statement = select(Trust).where(Trust.name == trust_name)
+    trust = session.exec(statement).first()
+    if not trust or not trust.last_heartbeat:
+        return False
+    elapsed = (datetime.now(timezone.utc) - trust.last_heartbeat).total_seconds()
+    return elapsed < HEARTBEAT_TIMEOUT_SECONDS
 
 
 def keep_fl_api_session_alive() -> None:

--- a/flip-api/tests/unit/fl_services/services/test_fl_service.py
+++ b/flip-api/tests/unit/fl_services/services/test_fl_service.py
@@ -917,10 +917,12 @@ def test_add_fl_job_rollback_on_exception(model_id):
 
 
 @patch("flip_api.fl_services.services.fl_service.select")
-def test_is_trust_online_by_heartbeat_recent(mock_select, fake_session):
-    """Trust with recent heartbeat (< 15s) is considered online."""
+@patch("flip_api.fl_services.services.fl_service.get_settings")
+def test_is_trust_online_by_heartbeat_recent(mock_settings, mock_select, fake_session):
+    """Trust with recent heartbeat (< timeout) is considered online."""
     from flip_api.db.models.main_models import Trust
 
+    mock_settings.return_value.HEARTBEAT_TIMEOUT_SECONDS = 30
     mock_trust = MagicMock(spec=Trust)
     mock_trust.last_heartbeat = datetime.now(timezone.utc) - timedelta(seconds=5)
     result_proxy = MagicMock()
@@ -931,10 +933,12 @@ def test_is_trust_online_by_heartbeat_recent(mock_select, fake_session):
 
 
 @patch("flip_api.fl_services.services.fl_service.select")
-def test_is_trust_online_by_heartbeat_stale(mock_select, fake_session):
-    """Trust with stale heartbeat (> 15s) is considered offline."""
+@patch("flip_api.fl_services.services.fl_service.get_settings")
+def test_is_trust_online_by_heartbeat_stale(mock_settings, mock_select, fake_session):
+    """Trust with stale heartbeat (> timeout) is considered offline."""
     from flip_api.db.models.main_models import Trust
 
+    mock_settings.return_value.HEARTBEAT_TIMEOUT_SECONDS = 30
     mock_trust = MagicMock(spec=Trust)
     mock_trust.last_heartbeat = datetime.now(timezone.utc) - timedelta(seconds=30)
     result_proxy = MagicMock()
@@ -945,8 +949,10 @@ def test_is_trust_online_by_heartbeat_stale(mock_select, fake_session):
 
 
 @patch("flip_api.fl_services.services.fl_service.select")
-def test_is_trust_online_by_heartbeat_no_heartbeat(mock_select, fake_session):
+@patch("flip_api.fl_services.services.fl_service.get_settings")
+def test_is_trust_online_by_heartbeat_no_heartbeat(mock_settings, mock_select, fake_session):
     """Trust with no heartbeat (None) is considered offline."""
+    mock_settings.return_value.HEARTBEAT_TIMEOUT_SECONDS = 30
     mock_trust = MagicMock()
     mock_trust.last_heartbeat = None
     result_proxy = MagicMock()
@@ -957,8 +963,10 @@ def test_is_trust_online_by_heartbeat_no_heartbeat(mock_select, fake_session):
 
 
 @patch("flip_api.fl_services.services.fl_service.select")
-def test_is_trust_online_by_heartbeat_not_found(mock_select, fake_session):
+@patch("flip_api.fl_services.services.fl_service.get_settings")
+def test_is_trust_online_by_heartbeat_not_found(mock_settings, mock_select, fake_session):
     """When the trust is not in the database, it is considered offline."""
+    mock_settings.return_value.HEARTBEAT_TIMEOUT_SECONDS = 30
     result_proxy = MagicMock()
     result_proxy.first.return_value = None
     fake_session.exec.return_value = result_proxy

--- a/flip-api/tests/unit/fl_services/services/test_fl_service.py
+++ b/flip-api/tests/unit/fl_services/services/test_fl_service.py
@@ -17,6 +17,8 @@ from uuid import UUID, uuid4
 
 import pytest
 
+from datetime import datetime, timedelta, timezone
+
 from flip_api.config import Settings
 from flip_api.domain.interfaces import fl as fl_interfaces
 from flip_api.domain.interfaces.fl import (
@@ -912,3 +914,53 @@ def test_add_fl_job_rollback_on_exception(model_id):
     with pytest.raises(Exception, match="DB Error"):
         fl_service.add_fl_job(model_id, ["client1"], fake_session)
     fake_session.rollback.assert_called_once()
+
+
+@patch("flip_api.fl_services.services.fl_service.select")
+def test_is_trust_online_by_heartbeat_recent(mock_select, fake_session):
+    """Trust with recent heartbeat (< 15s) is considered online."""
+    from flip_api.db.models.main_models import Trust
+
+    mock_trust = MagicMock(spec=Trust)
+    mock_trust.last_heartbeat = datetime.now(timezone.utc) - timedelta(seconds=5)
+    result_proxy = MagicMock()
+    result_proxy.first.return_value = mock_trust
+    fake_session.exec.return_value = result_proxy
+
+    assert fl_service.is_trust_online_by_heartbeat("Trust_1", fake_session) is True
+
+
+@patch("flip_api.fl_services.services.fl_service.select")
+def test_is_trust_online_by_heartbeat_stale(mock_select, fake_session):
+    """Trust with stale heartbeat (> 15s) is considered offline."""
+    from flip_api.db.models.main_models import Trust
+
+    mock_trust = MagicMock(spec=Trust)
+    mock_trust.last_heartbeat = datetime.now(timezone.utc) - timedelta(seconds=30)
+    result_proxy = MagicMock()
+    result_proxy.first.return_value = mock_trust
+    fake_session.exec.return_value = result_proxy
+
+    assert fl_service.is_trust_online_by_heartbeat("Trust_1", fake_session) is False
+
+
+@patch("flip_api.fl_services.services.fl_service.select")
+def test_is_trust_online_by_heartbeat_no_heartbeat(mock_select, fake_session):
+    """Trust with no heartbeat (None) is considered offline."""
+    mock_trust = MagicMock()
+    mock_trust.last_heartbeat = None
+    result_proxy = MagicMock()
+    result_proxy.first.return_value = mock_trust
+    fake_session.exec.return_value = result_proxy
+
+    assert fl_service.is_trust_online_by_heartbeat("Trust_1", fake_session) is False
+
+
+@patch("flip_api.fl_services.services.fl_service.select")
+def test_is_trust_online_by_heartbeat_not_found(mock_select, fake_session):
+    """When the trust is not in the database, it is considered offline."""
+    result_proxy = MagicMock()
+    result_proxy.first.return_value = None
+    fake_session.exec.return_value = result_proxy
+
+    assert fl_service.is_trust_online_by_heartbeat("Unknown_Trust", fake_session) is False

--- a/flip-api/tests/unit/fl_services/test_get_status.py
+++ b/flip-api/tests/unit/fl_services/test_get_status.py
@@ -19,6 +19,7 @@ from flip_api.domain.interfaces.fl import (
     IClientStatus,
     IServerStatus,
 )
+from flip_api.domain.schemas.status import ClientStatus
 from flip_api.fl_services.get_status import get_status_endpoint
 
 
@@ -75,6 +76,20 @@ def mock_fetch_client_status():
         mock.return_value = [
             IClientStatus(name="trust-1", status="no_jobs"),
         ]
+        yield mock
+
+
+@pytest.fixture(autouse=True)
+def auto_mock_is_trust_online_by_heartbeat():
+    """Mock is_trust_online_by_heartbeat globally to avoid hitting real DB in tests.
+
+    Default: all trusts are considered offline (matching original NO_REPLY behavior).
+    Override with mock_is_trust_online_by_heartbeat fixture in specific tests.
+    """
+    with patch(
+        "flip_api.fl_services.get_status.is_trust_online_by_heartbeat",
+        return_value=False,
+    ) as mock:
         yield mock
 
 
@@ -139,7 +154,14 @@ def test_get_status_endpoint_server_status_none(
     assert result[0].clients == []
 
 
-def test_get_status_endpoint_client_status_none(
+@pytest.fixture
+def mock_is_trust_online_by_heartbeat(auto_mock_is_trust_online_by_heartbeat):
+    """Override default to make trust-1 online, trust-2 offline."""
+    auto_mock_is_trust_online_by_heartbeat.side_effect = lambda name, _: name == "trust-1"
+    yield auto_mock_is_trust_online_by_heartbeat
+
+
+def test_get_status_endpoint_client_status_none_fallback_to_heartbeat(
     fake_request,
     mock_db,
     mock_get_nets,
@@ -147,14 +169,57 @@ def test_get_status_endpoint_client_status_none(
     mock_fetch_server_status,
     mock_fetch_client_status,
     mock_get_settings,
+    mock_is_trust_online_by_heartbeat,
 ):
+    """When fetch_client_status returns None, fall back to heartbeat checks."""
     mock_fetch_server_status.return_value = IServerStatus(
         status="stopped",
     )
-    mock_fetch_client_status.return_value = []
+    mock_fetch_client_status.return_value = None
 
     result = get_status_endpoint(fake_request, mock_db, user_id="user-1")
     assert len(result) == 1
-    assert result[0].online is False
-    assert result[0].fl_backend == "nvflare"
-    assert result[0].clients == []
+    net = result[0]
+    assert net.online is True  # Server is reachable, clients fall back to heartbeat
+    assert net.fl_backend == "nvflare"
+    assert len(net.clients) == 2
+    # trust-1 has recent heartbeat -> online -> NO_JOBS
+    trust_1 = next(c for c in net.clients if c.name == "trust-1")
+    assert trust_1.status == ClientStatus.NO_JOBS.value
+    assert trust_1.online is True
+    # trust-2 has no recent heartbeat -> offline -> NO_REPLY
+    trust_2 = next(c for c in net.clients if c.name == "trust-2")
+    assert trust_2.status == ClientStatus.NO_REPLY.value
+    assert trust_2.online is False
+
+
+def test_get_status_endpoint_trust_not_in_client_list_fallback_to_heartbeat(
+    fake_request,
+    mock_db,
+    mock_get_nets,
+    mock_get_trusts,
+    mock_fetch_server_status,
+    mock_fetch_client_status,
+    mock_get_settings,
+    mock_is_trust_online_by_heartbeat,
+):
+    """When a trust is not found in client statuses, fall back to heartbeat checks."""
+    mock_fetch_server_status.return_value = IServerStatus(status="started")
+    # Only trust-1 is in client statuses; trust-2 is missing
+    mock_fetch_client_status.return_value = [
+        IClientStatus(name="trust-1", status="CONNECTED"),
+    ]
+
+    result = get_status_endpoint(fake_request, mock_db, user_id="user-1")
+    assert len(result) == 1
+    net = result[0]
+    assert net.online is True
+    assert len(net.clients) == 2
+    # trust-1 matched directly -> CONNECTED -> online
+    trust_1 = next(c for c in net.clients if c.name == "trust-1")
+    assert trust_1.status == "CONNECTED"
+    assert trust_1.online is True
+    # trust-2 not in client list -> heartbeat fallback -> NO_REPLY (no recent heartbeat)
+    trust_2 = next(c for c in net.clients if c.name == "trust-2")
+    assert trust_2.status == ClientStatus.NO_REPLY.value
+    assert trust_2.online is False

--- a/flip-api/tests/unit/fl_services/test_get_status.py
+++ b/flip-api/tests/unit/fl_services/test_get_status.py
@@ -80,15 +80,15 @@ def mock_fetch_client_status():
 
 
 @pytest.fixture(autouse=True)
-def auto_mock_is_trust_online_by_heartbeat():
-    """Mock is_trust_online_by_heartbeat globally to avoid hitting real DB in tests.
+def auto_mock_get_trust_liveness_map():
+    """Mock get_trust_liveness_map globally to avoid hitting real DB in tests.
 
     Default: all trusts are considered offline (matching original NO_REPLY behavior).
-    Override with mock_is_trust_online_by_heartbeat fixture in specific tests.
+    Override with mock_liveness_map fixture in specific tests.
     """
     with patch(
-        "flip_api.fl_services.get_status.is_trust_online_by_heartbeat",
-        return_value=False,
+        "flip_api.fl_services.get_status.get_trust_liveness_map",
+        return_value={"trust-1": False, "trust-2": False},
     ) as mock:
         yield mock
 
@@ -155,10 +155,10 @@ def test_get_status_endpoint_server_status_none(
 
 
 @pytest.fixture
-def mock_is_trust_online_by_heartbeat(auto_mock_is_trust_online_by_heartbeat):
+def mock_liveness_map_trust1_online(auto_mock_get_trust_liveness_map):
     """Override default to make trust-1 online, trust-2 offline."""
-    auto_mock_is_trust_online_by_heartbeat.side_effect = lambda name, _: name == "trust-1"
-    yield auto_mock_is_trust_online_by_heartbeat
+    auto_mock_get_trust_liveness_map.return_value = {"trust-1": True, "trust-2": False}
+    yield auto_mock_get_trust_liveness_map
 
 
 def test_get_status_endpoint_client_status_none_fallback_to_heartbeat(
@@ -169,7 +169,7 @@ def test_get_status_endpoint_client_status_none_fallback_to_heartbeat(
     mock_fetch_server_status,
     mock_fetch_client_status,
     mock_get_settings,
-    mock_is_trust_online_by_heartbeat,
+    mock_liveness_map_trust1_online,
 ):
     """When fetch_client_status returns None, fall back to heartbeat checks."""
     mock_fetch_server_status.return_value = IServerStatus(
@@ -201,7 +201,7 @@ def test_get_status_endpoint_trust_not_in_client_list_fallback_to_heartbeat(
     mock_fetch_server_status,
     mock_fetch_client_status,
     mock_get_settings,
-    mock_is_trust_online_by_heartbeat,
+    mock_liveness_map_trust1_online,
 ):
     """When a trust is not found in client statuses, fall back to heartbeat checks."""
     mock_fetch_server_status.return_value = IServerStatus(status="started")


### PR DESCRIPTION
## Summary

Closes #422

The `/connectionstatus` page determined trust liveness via an **inbound** HTTP check (hub→FL server `/check_client_status`). This fails for trusts behind NAT whose FL server has no public inbound port — they show as `"no_reply"` / `"online": false` even when actively heartbeating every 5s.

## Change

When `fetch_client_status()` fails or a trust is missing from the client list, fall back to checking `Trust.last_heartbeat` in the database. A trust is considered online if `now() - last_heartbeat < TRUST_HEARTBEAT_TIMEOUT_SECONDS` (default 15s = 3 × 5s poll interval, MQTT keep-alive pattern).

## Files Changed

| File | Change |
|------|--------|
| `fl_service.py` | Added `is_trust_online_by_heartbeat()` helper, `HEARTBEAT_TIMEOUT_SECONDS` config |
| `get_status.py` | Updated both fallback paths to use heartbeat check |
| `.env.development.example` | Added `TRUST_HEARTBEAT_TIMEOUT_SECONDS=15` |
| `check_status.py` | Added `check_trust_heartbeats()` for AWS deployment health checks |
| `test_fl_service.py` | 4 new unit tests for heartbeat liveness |
| `test_get_status.py` | 2 new integration tests + global autouse mock for heartbeat |

## Behavior Change

| Before | After |
|--------|-------|
| Trust offline if hub can't HTTP to FL server endpoint | Trust offline only if no heartbeat in 15s |
| `no_reply` for all NAT trusts | `no_jobs` with `online: true` for alive-but-unreachable trusts |
| No distinction between "dead" and "unreachable" | Heartbeat = alive, no heartbeat = dead |


## On-Prem trusts are healthy without inbound connection

<img width="1098" height="861" alt="image" src="https://github.com/user-attachments/assets/6bcb8157-2ed0-47b5-815b-06ad1d7fc3dd" />
