### PR TITLE
[codex] Fix Codecov coverage report overwrites

### DIFF
--- a/.github/workflows/test_flip_api.yml
+++ b/.github/workflows/test_flip_api.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
         with:
-          files: flip-api/coverage.xml
+          files: flip-api/coverage-unit.xml,flip-api/coverage-integration.xml
           flags: flip-api
           fail_ci_if_error: false
         env:

--- a/.github/workflows/test_trust_data_access_api.yml
+++ b/.github/workflows/test_trust_data_access_api.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
         with:
-          files: trust/data-access-api/coverage.xml
+          files: trust/data-access-api/coverage-unit.xml
           flags: data-access-api
           fail_ci_if_error: false
         env:

--- a/.github/workflows/test_trust_trust_api.yml
+++ b/.github/workflows/test_trust_trust_api.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
         with:
-          files: trust/trust-api/coverage.xml
+          files: trust/trust-api/coverage-unit.xml
           flags: trust-api
           fail_ci_if_error: false
         env:

--- a/flip-api/Makefile
+++ b/flip-api/Makefile
@@ -23,10 +23,10 @@ endif
 
 service_name = flip-api
 lint_command = uv run ruff check . --fix
-test_args = --tb=short --disable-warnings --cov=src/ --cov-report=html --cov-report=term-missing --cov-report=xml:coverage.xml
-test_coverage_html_command = uv run pytest $(test_args)
-test_coverage_html_command_unit = uv run pytest ./tests/unit ./tests/step_functions_services $(test_args)
-test_coverage_html_command_integration = uv run pytest ./tests/integration $(test_args)
+test_args = --tb=short --disable-warnings --cov=src/ --cov-report=term-missing
+test_coverage_html_command = uv run pytest $(test_args) --cov-report=html --cov-report=xml:coverage.xml
+test_coverage_html_command_unit = uv run pytest ./tests/unit ./tests/step_functions_services $(test_args) --cov-report=html:htmlcov-unit --cov-report=xml:coverage-unit.xml
+test_coverage_html_command_integration = uv run pytest ./tests/integration $(test_args) --cov-report=html:htmlcov-integration --cov-report=xml:coverage-integration.xml
 docker_command = DEBUG=$(DEBUG) docker compose -f ../deploy/compose.development.yml
 run_clean = run --rm --remove-orphans
 mypy_command = uv run mypy . --ignore-missing-imports

--- a/trust/data-access-api/Makefile
+++ b/trust/data-access-api/Makefile
@@ -28,7 +28,7 @@ service_name = data-access-api
 lint_command = uv run ruff check . --fix
 # Integration tests live under ./tests/integration and bring up a Docker Compose stack
 # (omop-db + data-access-api) — they don't run as part of the default unit suite.
-test_coverage_html_command = uv run pytest --ignore=./tests/integration --tb=short --disable-warnings --cov=data_access_api/ --cov-report=html --cov-report=term-missing --cov-report=xml:coverage.xml
+test_coverage_html_command = uv run pytest --ignore=./tests/integration --tb=short --disable-warnings --cov=data_access_api/ --cov-report=html:htmlcov-unit --cov-report=term-missing --cov-report=xml:coverage-unit.xml
 test_coverage_html_command_integration = uv run pytest ./tests/integration --tb=short --disable-warnings --cov=data_access_api/ --cov-report=html:htmlcov-integration --cov-report=term-missing --cov-report=xml:coverage-integration.xml
 docker_command = docker compose -f ../compose_trust.development.yml
 run_clean = run --rm --remove-orphans

--- a/trust/trust-api/Makefile
+++ b/trust/trust-api/Makefile
@@ -19,7 +19,7 @@ service_name = trust-api
 lint_command = uv run ruff check . --fix
 # Integration tests live under ./tests/integration and bring up a Docker Compose stack
 # (omop-db + data-access-api) — they don't run as part of the default unit suite.
-test_coverage_html_command = uv run pytest --ignore=./tests/integration --tb=short --disable-warnings --cov=trust_api/ --cov-report=html --cov-report=term-missing --cov-report=xml:coverage.xml
+test_coverage_html_command = uv run pytest --ignore=./tests/integration --tb=short --disable-warnings --cov=trust_api/ --cov-report=html:htmlcov-unit --cov-report=term-missing --cov-report=xml:coverage-unit.xml
 test_coverage_html_command_integration = uv run pytest ./tests/integration --tb=short --disable-warnings --cov=trust_api/ --cov-report=html:htmlcov-integration --cov-report=term-missing --cov-report=xml:coverage-integration.xml
 docker_command = docker compose -f ../compose_trust.development.yml
 run_clean = run --rm --remove-orphans


### PR DESCRIPTION
## Summary

- Split FLIP API unit and integration coverage XML outputs into `coverage-unit.xml` and `coverage-integration.xml`.
- Upload both FLIP API coverage reports to Codecov.
- Rename trust API unit coverage XML outputs to `coverage-unit.xml` for consistency with their existing `coverage-integration.xml` reports.

## Root Cause

`flip-api/Makefile` previously used one shared pytest coverage XML output, `coverage.xml`, for both `unit_test` and `integration_test`. The FLIP API workflow runs unit tests and then integration tests in the same job, so the integration run overwrote the unit coverage report before Codecov uploaded it. Codecov then evaluated patch coverage using only integration coverage and missed lines that were covered by unit tests.

## Validation

- Parsed the changed GitHub Actions workflows as YAML.
- Ran `make -n unit_test` and `make -n integration_test` in `flip-api` to verify the split report paths.
- Ran `make -n local_test` in `trust/data-access-api` and `trust/trust-api` to verify the renamed unit report paths.
- Ran `make local_test` in `flip-api`: 941 passed, 7 skipped.