### PR TITLE
FLIP-PT-013: remove dead HS256 JWT fallback from auth_utils

### DIFF
--- a/flip-api/src/flip_api/auth/auth_utils.py
+++ b/flip-api/src/flip_api/auth/auth_utils.py
@@ -10,27 +10,12 @@
 # limitations under the License.
 #
 
-import os
 from uuid import UUID
 
-from fastapi.security import OAuth2PasswordBearer
-from pydantic import BaseModel
 from sqlmodel import Session, select
 
 from flip_api.db.models.user_models import PermissionRef, Role, RolePermission, UserRole
 from flip_api.utils.logger import logger
-
-# OAuth2 scheme for token authentication
-oauth2_scheme = OAuth2PasswordBearer(tokenUrl="token")
-
-# JWT settings
-SECRET_KEY = os.getenv("SECRET_KEY", "default-secret-key")  # Load from environment variables
-ALGORITHM = "HS256"
-
-
-class TokenPayload(BaseModel):
-    sub: str
-    exp: int | None = None
 
 
 def has_permissions(user_id: UUID, required_permissions: list[PermissionRef], db: Session) -> bool:

--- a/flip-api/tests/unit/auth/test_auth_utils.py
+++ b/flip-api/tests/unit/auth/test_auth_utils.py
@@ -1,0 +1,75 @@
+# Copyright (c) Guy's and St Thomas' NHS Foundation Trust & King's College London
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+from flip_api.auth import auth_utils
+from flip_api.auth.auth_utils import has_permissions
+from flip_api.db.models.user_models import PermissionRef
+
+
+def test_module_does_not_expose_local_jwt_primitives():
+    """
+    The Hub authenticates callers with Cognito-issued RS256 JWTs in
+    ``flip_api.auth.dependencies``. ``auth_utils`` must not ship parallel
+    HS256 / shared-secret JWT primitives — a developer importing them by
+    mistake would build a verifier whose signing key the attacker also
+    knows.
+    """
+    forbidden = {"SECRET_KEY", "ALGORITHM", "oauth2_scheme", "TokenPayload"}
+    leaked = forbidden & set(vars(auth_utils))
+    assert not leaked, f"auth_utils re-introduced JWT primitives: {sorted(leaked)}"
+
+
+def test_has_permissions_returns_true_when_user_has_every_required_permission():
+    """Happy path: every required permission resolves to a role-permission row."""
+    user_id = uuid4()
+    role = MagicMock(id=uuid4())
+    required = [PermissionRef.CAN_CREATE_PROJECTS, PermissionRef.CAN_APPROVE_PROJECTS]
+
+    db = MagicMock()
+    db.exec.return_value.all.side_effect = [
+        [role],
+        [p.value for p in required],
+    ]
+
+    assert has_permissions(user_id, required, db) is True
+
+
+def test_has_permissions_returns_false_when_a_required_permission_is_missing():
+    """A required permission with no matching role-permission row fails the check."""
+    user_id = uuid4()
+    role = MagicMock(id=uuid4())
+
+    db = MagicMock()
+    db.exec.return_value.all.side_effect = [
+        [role],
+        [PermissionRef.CAN_CREATE_PROJECTS.value],
+    ]
+
+    assert (
+        has_permissions(
+            user_id,
+            [PermissionRef.CAN_CREATE_PROJECTS, PermissionRef.CAN_APPROVE_PROJECTS],
+            db,
+        )
+        is False
+    )
+
+
+def test_has_permissions_returns_false_when_db_raises():
+    """A DB exception is logged and surfaced as a deny, not a 500."""
+    db = MagicMock()
+    db.exec.side_effect = RuntimeError("db down")
+
+    assert has_permissions(uuid4(), [PermissionRef.CAN_CREATE_PROJECTS], db) is False


### PR DESCRIPTION
## Summary

- `flip_api.auth.auth_utils` declared a parallel HS256 JWT verifier surface — `SECRET_KEY` (with a literal `"default-secret-key"` fallback), `ALGORITHM`, `oauth2_scheme`, and `TokenPayload` — that no caller imports. The Hub authenticates exclusively via Cognito-issued RS256 JWTs in `flip_api.auth.dependencies`.
- Dead today, but a forward-looking footgun: a developer reaching for the canonical-looking `auth_utils` module to validate a JWT would build an HS256 verifier whose signing key any attacker also knows — instant token forgery. Deleting the primitives removes the option.
- The only symbol the codebase actually uses from this module, `has_permissions`, is untouched (14 callers + the existing `tests/integration/test_auth_permissions_db_flow.py` integration coverage).

## Changes

- `flip-api/src/flip_api/auth/auth_utils.py`: drop `SECRET_KEY`, `ALGORITHM`, `oauth2_scheme`, `TokenPayload`, plus the now-unused `os`, `OAuth2PasswordBearer`, and `BaseModel` imports.
- `flip-api/tests/unit/auth/test_auth_utils.py` (new): regression test that the four dead symbols stay out of the module's public surface, plus mocked unit coverage for the three `has_permissions` happy/sad paths (true-when-granted, false-when-missing, false-when-DB-raises).

## Test plan

- [x] `make unit_test` (lint + mypy + 871 unit tests) green locally.
- [x] New `tests/unit/auth/test_auth_utils.py` runs as part of `make unit_test` (4 tests, all pass).
- [ ] CI green on PR.

## Risk

Tiny. The deleted symbols had zero importers (verified by grep across `*.py`, `*.ts`, `*.vue`, `*.yml`, `*.toml`, `*.env*`). `has_permissions` and its callers are unchanged.

https://claude.ai/code/session_01DHRd5JjtiidAQmzfB26nyz

---
_Generated by [Claude Code](https://claude.ai/code/session_01DHRd5JjtiidAQmzfB26nyz)_