### PR TITLE
FLIP-PT-014: validate Cognito ListUsers filter inputs in cognito_helpers

### DIFF
--- a/flip-api/src/flip_api/utils/cognito_helpers.py
+++ b/flip-api/src/flip_api/utils/cognito_helpers.py
@@ -254,7 +254,8 @@ def get_user_by_email_or_id(
         safe_email = _safe_email_for_cognito_filter(email)
         filter_expr = f'email = "{safe_email}"'
     else:
-        safe_user_id = _safe_uuid_for_cognito_filter(user_id)  # type: ignore[arg-type]
+        assert user_id is not None  # guaranteed by the guard above
+        safe_user_id = _safe_uuid_for_cognito_filter(user_id)
         filter_expr = f'sub = "{safe_user_id}"'
 
     params = {"UserPoolId": user_pool_id, "Filter": filter_expr, "Limit": 1}

--- a/flip-api/src/flip_api/utils/cognito_helpers.py
+++ b/flip-api/src/flip_api/utils/cognito_helpers.py
@@ -23,6 +23,8 @@ from uuid import UUID
 import boto3
 from botocore.exceptions import ClientError
 from fastapi import HTTPException, Request, status
+from pydantic import TypeAdapter, ValidationError
+from pydantic.networks import EmailStr
 from sqlmodel import Session, col, select
 
 from flip_api.config import get_settings
@@ -30,6 +32,8 @@ from flip_api.db.models.user_models import Role, UserRole
 from flip_api.domain.schemas.users import CognitoUser, Disabled, IRole, IUser
 from flip_api.utils.logger import logger
 from flip_api.utils.paging_utils import PagingInfo
+
+_EMAIL_VALIDATOR: TypeAdapter[str] = TypeAdapter(EmailStr)
 
 boto3.set_stream_logger("boto3.resources", logging.INFO)
 
@@ -183,6 +187,47 @@ def get_cognito_users(params: dict[str, Any] | None = None) -> list[CognitoUser]
         ) from e
 
 
+def _safe_email_for_cognito_filter(email: str) -> str:
+    """Validate that ``email`` is safe to interpolate into a Cognito ListUsers
+    Filter expression.
+
+    Cognito's filter syntax delimits values with double quotes; an unescaped
+    ``"`` (or backslash) in the value can break out of the quoted context and
+    inject additional clauses. EmailStr already forbids the characters that
+    would let an attacker do this, but rejecting them explicitly here keeps
+    this helper safe to call from any future caller that forgets the
+    upstream validation.
+    """
+    try:
+        validated = _EMAIL_VALIDATOR.validate_python(email)
+    except ValidationError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid email address format"
+        ) from exc
+    if '"' in validated or "\\" in validated:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid email address format"
+        )
+    return validated
+
+
+def _safe_uuid_for_cognito_filter(user_id: str | UUID) -> str:
+    """Coerce ``user_id`` to its canonical string UUID form, raising 400 if
+    it isn't a valid UUID.
+
+    A valid UUID's string form is hex+hyphen only, so once normalised it
+    can be interpolated into Cognito's filter syntax without escaping.
+    """
+    if isinstance(user_id, UUID):
+        return str(user_id)
+    try:
+        return str(UUID(user_id))
+    except (ValueError, AttributeError, TypeError) as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid user ID format"
+        ) from exc
+
+
 def get_user_by_email_or_id(
     user_pool_id: str, email: str | None = None, user_id: UUID | None = None
 ) -> CognitoUser:
@@ -198,13 +243,19 @@ def get_user_by_email_or_id(
         CognitoUser: The user matching the email or ID.
 
     Raises:
-        HTTPException: If neither email nor user_id is provided
+        HTTPException: If neither email nor user_id is provided, or if the
+            supplied identifier fails format validation.
     """
     if not email and not user_id:
         logger.error("No user email address or ID provided")
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="No user email address or ID provided")
 
-    filter_expr = f'email = "{email}"' if email else f'sub = "{user_id}"'
+    if email:
+        safe_email = _safe_email_for_cognito_filter(email)
+        filter_expr = f'email = "{safe_email}"'
+    else:
+        safe_user_id = _safe_uuid_for_cognito_filter(user_id)  # type: ignore[arg-type]
+        filter_expr = f'sub = "{safe_user_id}"'
 
     params = {"UserPoolId": user_pool_id, "Filter": filter_expr, "Limit": 1}
 
@@ -243,11 +294,13 @@ def get_username(user_id: str, user_pool_id: str) -> str:
         str: The username (email) associated with the user ID.
 
     Raises:
-        HTTPException: 404 if no matching user, 500 on Cognito errors.
+        HTTPException: 400 if ``user_id`` isn't a valid UUID, 404 if no
+            matching user, 500 on Cognito errors.
     """
+    safe_user_id = _safe_uuid_for_cognito_filter(user_id)
     params = {
         "UserPoolId": user_pool_id,
-        "Filter": f'sub="{user_id}"',
+        "Filter": f'sub="{safe_user_id}"',
     }
 
     users = get_cognito_users(params)

--- a/flip-api/tests/unit/utils/test_cognito_helpers.py
+++ b/flip-api/tests/unit/utils/test_cognito_helpers.py
@@ -1746,6 +1746,24 @@ class TestGetUserByEmailOrId:
             assert params["Limit"] == 1
             assert params["UserPoolId"] == USER_POOL_ID
 
+    def test_explicit_quote_guard_fires_if_email_validator_relaxes(self):
+        """The explicit `"`/`\\` rejection in `_safe_email_for_cognito_filter`
+        is belt-and-braces against a future Pydantic update relaxing
+        ``EmailStr``. Bypass the validator with a mock to confirm the inner
+        guard still catches an unsafe value."""
+        unsafe = 'a@b.com" or email = "*'
+        with patch(
+            "flip_api.utils.cognito_helpers._EMAIL_VALIDATOR.validate_python",
+            return_value=unsafe,
+        ):
+            with patch("flip_api.utils.cognito_helpers.get_cognito_users") as mock_list:
+                with pytest.raises(HTTPException) as exc_info:
+                    get_user_by_email_or_id(USER_POOL_ID, email=unsafe)
+
+                assert exc_info.value.status_code == HTTP_400_BAD_REQUEST
+                assert exc_info.value.detail == "Invalid email address format"
+                mock_list.assert_not_called()
+
     def test_uuid_branch_uses_canonical_form(self):
         """A UUID-typed user_id must produce the canonical hex+hyphen form;
         the resulting filter expression contains no characters that could

--- a/flip-api/tests/unit/utils/test_cognito_helpers.py
+++ b/flip-api/tests/unit/utils/test_cognito_helpers.py
@@ -1502,6 +1502,29 @@ class TestGetUsername:
                 f"Multiple users found for ID {user1}, returning the first one"
             )
 
+    @pytest.mark.parametrize(
+        "bad_user_id",
+        [
+            'not-a-uuid" or sub = "*',  # filter-injection payload
+            "",
+            "123",
+            "abc-def",
+        ],
+    )
+    def test_rejects_non_uuid_user_id(self, bad_user_id):
+        """Refuse to interpolate a non-UUID into the Cognito filter — the
+        unsafe f-string would otherwise let a caller smuggle additional
+        clauses into the ListUsers request."""
+        with patch("flip_api.utils.cognito_helpers.get_cognito_users") as mock_list:
+            from flip_api.utils.cognito_helpers import get_username
+
+            with pytest.raises(HTTPException) as exc_info:
+                get_username(bad_user_id, USER_POOL_ID)
+
+            assert exc_info.value.status_code == HTTP_400_BAD_REQUEST
+            assert exc_info.value.detail == "Invalid user ID format"
+            mock_list.assert_not_called()
+
 
 class TestUpdateUser:
     """Cover update_user — it's a pre-existing helper but the PR refactored
@@ -1685,3 +1708,52 @@ class TestGetUserByEmailOrId:
         # Same instance, not a re-wrapped one — verifies the `raise` (no `from`).
         assert exc_info.value is inner
         mock_logger.exception.assert_called_with("SKIPPING COGNITO USER LISTING")
+
+    @pytest.mark.parametrize(
+        "bad_email",
+        [
+            'a@b.com" or email = "*',  # break out of the quoted value
+            'foo"@bar.com',  # double-quote inside the local part
+            '"a\\b"@example.com',  # backslash-escaped local part
+            "no-at-sign",
+            "user@",
+            "@example.com",
+            "spaces in@email.com",
+        ],
+    )
+    def test_rejects_malformed_or_injecting_email(self, bad_email):
+        """The function must validate email format itself, even when the
+        caller forgets — a `"` in the value is what enables the Cognito
+        ListUsers filter-injection payload. Reject before sending."""
+        with patch("flip_api.utils.cognito_helpers.get_cognito_users") as mock_list:
+            with pytest.raises(HTTPException) as exc_info:
+                get_user_by_email_or_id(USER_POOL_ID, email=bad_email)
+
+            assert exc_info.value.status_code == HTTP_400_BAD_REQUEST
+            assert exc_info.value.detail == "Invalid email address format"
+            mock_list.assert_not_called()
+
+    def test_safe_email_is_passed_to_filter(self):
+        """A well-formed email should produce the expected filter expression
+        and reach Cognito unmodified (modulo email_validator's normalisation)."""
+        with patch("flip_api.utils.cognito_helpers.get_cognito_users") as mock_list:
+            mock_list.return_value = [CognitoUserFactory(email="user@example.com")]
+
+            get_user_by_email_or_id(USER_POOL_ID, email="user@example.com")
+
+            params = mock_list.call_args.args[0]
+            assert params["Filter"] == 'email = "user@example.com"'
+            assert params["Limit"] == 1
+            assert params["UserPoolId"] == USER_POOL_ID
+
+    def test_uuid_branch_uses_canonical_form(self):
+        """A UUID-typed user_id must produce the canonical hex+hyphen form;
+        the resulting filter expression contains no characters that could
+        break out of the quoted value."""
+        with patch("flip_api.utils.cognito_helpers.get_cognito_users") as mock_list:
+            mock_list.return_value = [CognitoUserFactory(id=user1)]
+
+            get_user_by_email_or_id(USER_POOL_ID, user_id=user1)
+
+            params = mock_list.call_args.args[0]
+            assert params["Filter"] == f'sub = "{user1}"'


### PR DESCRIPTION
## Summary

Addresses **FLIP-PT-014** (Medium, flip-api / cognito_helpers): the `email`/`user_id` arguments to `get_user_by_email_or_id` and the `user_id` argument to `get_username` were interpolated into AWS Cognito's `ListUsers` Filter expression via f-strings. A `"` (or `\`) in the value would let a caller break out of the quoted context and inject extra filter clauses.

### Current exploitability
Low in practice — every active caller already validates input as `EmailStr` or `UUID`. But the helpers themselves were unsafe and a future caller could legitimately omit the validation, so the report's "latent foot-gun" framing is accurate.

### Fix
Add internal validators in `cognito_helpers.py` so the helpers are defence-in-depth regardless of caller-side validation:
- `_safe_email_for_cognito_filter` runs the value through `EmailStr` (which rejects `"` and `\` in the local part) **and** explicitly rejects either character as belt-and-braces.
- `_safe_uuid_for_cognito_filter` coerces `user_id` to its canonical hex+hyphen UUID string, raising 400 otherwise. Applied in both `get_user_by_email_or_id` (UUID branch) and `get_username`.
- A failed validation surfaces as a generic 400 — no Cognito internals leaked.

### Scope notes
- The PT report flagged only `get_user_by_email_or_id`, but `get_username` (line 234) had the identical pattern (`f'sub="{user_id}"'` with a plain-`str` user_id). Fixing only one would have left an obvious foot-gun, so this PR covers both.
- No changes to the existing `except HTTPException` re-raise path that was added in a prior security fix.

## Test plan

- [x] Added parametrised tests covering injection payloads (`a@b.com" or email = "*`, `foo"@bar.com`, `"a\b"@example.com`, plus malformed strings) — each must raise 400 and never reach Cognito.
- [x] Added tests for non-UUID `user_id` to `get_username` covering an injection-style payload.
- [x] Added regressions confirming the safe filter expression for valid email and UUID inputs (`email = "user@example.com"`, `sub = "<uuid>"`).
- [x] `make local_test` equivalent: 868 unit tests pass, ruff clean, mypy clean.
- [x] Manual: confirmed Pydantic `EmailStr` rejects every malformed payload in the parametrised list.

https://claude.ai/code/session_01BTmabgrwEiNyGKnLFW7iy7

---
_Generated by [Claude Code](https://claude.ai/code/session_01BTmabgrwEiNyGKnLFW7iy7)_