### PR TITLE
ci: restore deleted Run tests step in trust imaging-api workflow

### DIFF
--- a/.github/workflows/test_trust_imaging_api.yml
+++ b/.github/workflows/test_trust_imaging_api.yml
@@ -56,6 +56,8 @@ jobs:
           echo "OMOP_POSTGRES_PASSWORD=${{ secrets.POSTGRES_PASSWORD }}" >> ../../.env.development
           echo "POSTGRES_PASSWORD=${{ secrets.POSTGRES_PASSWORD }}" >> ../../.env.development
           echo "ENV=development" >> ../../.env.development
+
+      - name: Run tests with pytest (example)
         run: make local_test
 
       - name: Upload coverage to Codecov


### PR DESCRIPTION
## Summary

Fixes the `Invalid workflow file: .github/workflows/test_trust_imaging_api.yml#L1 (Line: 59, Col: 9): 'run' is already defined` failure that's been blocking CI on every PR to `main`/`develop`.

## What happened

In **`28b6559`** (PR #401, *"feat(infra): ECS foundation for Central Hub migration (PR 1/3)"*), the diff for this workflow file was meant to append one line — `echo "ENV=development" >> ../../.env.development` — to the existing **Setup environment file** step's `run:` block. But the hunk also wrongly **removed the next line** that started the next step (`- name: Run tests with pytest (example)`):

```diff
           echo "POSTGRES_PASSWORD=${{ secrets.POSTGRES_PASSWORD }}" >> ../../.env.development
-      - name: Run tests with pytest (example)
+          echo "ENV=development" >> ../../.env.development
         run: make local_test
```

That left `run: make local_test` dangling inside the previous step, so the step ended up with two `run:` keys — invalid YAML by GitHub's schema. The parser bails on the whole file, so the workflow shows up as "Invalid workflow file" on every PR.

The three sibling trust workflows (`test_trust_data_access_api.yml`, `test_trust_trust_api.yml`, `test_trust_xnat_anon.yml`) all still have the correct two-step structure — only this one was clipped, presumably an inadvertent over-deletion when staging the env-var change.

## Why every PR is affected

The `pull_request:` trigger here has `branches: [main, develop]` with **no `paths:` filter**, so the workflow loads (and fails to parse) for any PR targeting those branches, regardless of whether the PR touches `trust/imaging-api`. That's why CI on the open security-fix PR (#435) and any other in-flight PR is showing this red check.

## Fix

Restore the `- name: Run tests with pytest (example)` line so `run: make local_test` is its own step again. Verified locally with `python3 -c "import yaml; yaml.safe_load(open(...))"`.

## Test plan

- [x] YAML parses locally.
- [x] Diff matches the structure of the three sibling workflows.
- [ ] CI green on this PR.

https://claude.ai/code/session_01DHRd5JjtiidAQmzfB26nyz

---
_Generated by [Claude Code](https://claude.ai/code/session_01DHRd5JjtiidAQmzfB26nyz)_