### PR TITLE
FLIP-PT-034: Document flip-ui Dockerfile security rationale and constraints

### DIFF
--- a/flip-ui/Dockerfile
+++ b/flip-ui/Dockerfile
@@ -15,18 +15,18 @@
 # the UI is served as a static bundle from S3 + CloudFront (see
 # deploy/providers/AWS/cloudfront.tf and `make deploy-ui`).
 #
-# Accepted risk (FLIP-PT-034, Minimal/Info): this image runs as root. No USER
-# directive is set, deliberately — the dev workflow bind-mounts the host repo
-# into /app and runs `npm install` against it on container start
-# (docker/ui-entrypoint.sh), which needs to write into the bind-mounted tree
-# regardless of the host UID/GID. Matching host UID/GID at build time (as
-# flip-api/Dockerfile does) was rejected because the UI image is shared across
-# contributor machines via GHCR and would have to be rebuilt per host. The
-# blast radius is bounded: the container is dev-only, never reachable from
-# stag/prod, and only ever runs the Vite dev server against a local checkout.
-# Production has no flip-ui container at all — a compromise of this image
-# cannot affect any deployed FLIP environment. Reassess if this image is ever
-# repurposed for stag/prod or exposed beyond localhost.
+# This image runs as root. No USER directive is set, deliberately — the dev
+# workflow bind-mounts the host repo into /app and runs `npm install` against
+# it on container start (docker/ui-entrypoint.sh), which needs to write into
+# the bind-mounted tree regardless of the host UID/GID. Matching host UID/GID
+# at build time (as flip-api/Dockerfile does) was rejected because the UI
+# image is shared across contributor machines via GHCR and would have to be
+# rebuilt per host. The blast radius is bounded: the container is dev-only,
+# never reachable from stag/prod, and only ever runs the Vite dev server
+# against a local checkout. Production has no flip-ui container at all — a
+# compromise of this image cannot affect any deployed FLIP environment.
+# Reassess if this image is ever repurposed for stag/prod or exposed beyond
+# localhost.
 FROM node:22-alpine
 
 # Install dependencies for building node modules

--- a/flip-ui/Dockerfile
+++ b/flip-ui/Dockerfile
@@ -14,6 +14,19 @@
 # mount of the repo into /app. Stag/prod do not run flip-ui as a container;
 # the UI is served as a static bundle from S3 + CloudFront (see
 # deploy/providers/AWS/cloudfront.tf and `make deploy-ui`).
+#
+# Accepted risk (FLIP-PT-034, Minimal/Info): this image runs as root. No USER
+# directive is set, deliberately — the dev workflow bind-mounts the host repo
+# into /app and runs `npm install` against it on container start
+# (docker/ui-entrypoint.sh), which needs to write into the bind-mounted tree
+# regardless of the host UID/GID. Matching host UID/GID at build time (as
+# flip-api/Dockerfile does) was rejected because the UI image is shared across
+# contributor machines via GHCR and would have to be rebuilt per host. The
+# blast radius is bounded: the container is dev-only, never reachable from
+# stag/prod, and only ever runs the Vite dev server against a local checkout.
+# Production has no flip-ui container at all — a compromise of this image
+# cannot affect any deployed FLIP environment. Reassess if this image is ever
+# repurposed for stag/prod or exposed beyond localhost.
 FROM node:22-alpine
 
 # Install dependencies for building node modules

--- a/flip-ui/Dockerfile
+++ b/flip-ui/Dockerfile
@@ -15,18 +15,25 @@
 # the UI is served as a static bundle from S3 + CloudFront (see
 # deploy/providers/AWS/cloudfront.tf and `make deploy-ui`).
 #
+# ⚠️  Do not use in production. This Dockerfile exists only to support the
+# local Vite dev server. Stag/prod do not consume it (no GHCR publish, no
+# remote pull) and any deployed FLIP environment serves the UI as static
+# assets from S3 + CloudFront.
+#
 # This image runs as root. No USER directive is set, deliberately — the dev
 # workflow bind-mounts the host repo into /app and runs `npm install` against
 # it on container start (docker/ui-entrypoint.sh), which needs to write into
 # the bind-mounted tree regardless of the host UID/GID. Matching host UID/GID
-# at build time (as flip-api/Dockerfile does) was rejected because the UI
-# image is shared across contributor machines via GHCR and would have to be
-# rebuilt per host. The blast radius is bounded: the container is dev-only,
-# never reachable from stag/prod, and only ever runs the Vite dev server
-# against a local checkout. Production has no flip-ui container at all — a
-# compromise of this image cannot affect any deployed FLIP environment.
-# Reassess if this image is ever repurposed for stag/prod or exposed beyond
-# localhost.
+# at build time (as flip-api/Dockerfile does) was rejected because this
+# Dockerfile is the shared artifact across every contributor's machine —
+# baking in one UID/GID would force every contributor whose host IDs don't
+# match to rebuild the image locally, defeating the point of having a single
+# checked-in image definition. The blast radius is bounded: the container is
+# dev-only, never reachable from stag/prod, and only ever runs the Vite dev
+# server against a local checkout. Production has no flip-ui container at
+# all — a compromise of this image cannot affect any deployed FLIP
+# environment. Reassess if this image is ever repurposed for stag/prod or
+# exposed beyond localhost.
 FROM node:22-alpine
 
 # Install dependencies for building node modules


### PR DESCRIPTION
# Description

Added comprehensive documentation to the flip-ui Dockerfile explaining the security model and design decisions around running the container as root. The comment clarifies:

- Why the container runs as root (to support bind-mounted repo with `npm install`)
- Why UID/GID matching (used in flip-api) was rejected for the UI image
- The blast radius and risk mitigation (dev-only, localhost-only, never in stag/prod)
- Future reassessment triggers if the image is repurposed

This is a documentation-only change with no functional impact on the build or runtime behavior.

## Linked Issues

<!-- Link related issues if applicable -->

## Checklist

- [x] Follows the project's coding conventions and style guide
- [x] Updates documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Type of Change

- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [x] In-line docstrings updated.
- [ ] Documentation updated, tested `make -C docs/ docs`.

## Testing

No testing needed — this is a documentation-only change with no functional impact.

## Additional Notes

This change improves maintainability by documenting the security trade-offs and constraints of the flip-ui development container, making it easier for future maintainers to understand why the current approach was chosen and when it should be reconsidered.

https://claude.ai/code/session_01SX6ZXLQqk3cML5fWvRmH1A