### PR TITLE
fix(docs): improve contrast of version dropdown in sidebar

### DIFF
--- a/docs/source/_static/style.css
+++ b/docs/source/_static/style.css
@@ -155,8 +155,7 @@ body, .wy-body-for-nav,
     background: rgba(255,255,255,0.14);
     outline: none;
 }
-.wy-side-nav-search > a,
-.wy-side-nav-search .wy-dropdown > a {
+.wy-side-nav-search > a {
     font-family: var(--font-heading);
     font-weight: 700;
     font-size: 22px;
@@ -167,8 +166,12 @@ body, .wy-body-for-nav,
     max-width: 140px;
     margin-bottom: 6px;
 }
-.wy-side-nav-search > div.version {
-    color: rgba(255,255,255,0.55);
+.wy-side-nav-search > div.version,
+.wy-side-nav-search .wy-dropdown > a,
+.wy-side-nav-search > div.version a,
+.wy-side-nav-search > div.version select,
+.wy-side-nav-search select {
+    color: var(--flip-primary-400) !important;
     font-family: var(--font-mono);
     font-size: 11.5px;
     letter-spacing: 0.04em;

--- a/docs/source/_static/style.css
+++ b/docs/source/_static/style.css
@@ -166,6 +166,12 @@ body, .wy-body-for-nav,
     max-width: 140px;
     margin-bottom: 6px;
 }
+/* Default any interactive element in the search area to readable purple
+   so future additions (e.g. a language picker) don't fail contrast. */
+.wy-side-nav-search select,
+.wy-side-nav-search button {
+    color: var(--flip-primary-400);
+}
 .wy-side-nav-search > div.version,
 .wy-side-nav-search .wy-dropdown > a,
 .wy-side-nav-search > div.version a,

--- a/docs/source/_static/style.css
+++ b/docs/source/_static/style.css
@@ -169,8 +169,7 @@ body, .wy-body-for-nav,
 .wy-side-nav-search > div.version,
 .wy-side-nav-search .wy-dropdown > a,
 .wy-side-nav-search > div.version a,
-.wy-side-nav-search > div.version select,
-.wy-side-nav-search select {
+.wy-side-nav-search > div.version select {
     color: var(--flip-primary-400) !important;
     font-family: var(--font-mono);
     font-size: 11.5px;


### PR DESCRIPTION
@garciadias I configured readthedocs to build from pull requests so we can have a preview -- see new github action

<img width="1490" height="858" alt="Screenshot 2026-05-08 at 09 01 51" src="https://github.com/user-attachments/assets/088e56e2-f93b-427c-a7e1-0529759755a3" />


## Summary

The "latest" / "stable" version dropdown in the ReadTheDocs sidebar was rendering white text on the light purple search-area background, failing contrast (see screenshot in the linked conversation). This swaps the dropdown text color to the same purple (`var(--flip-primary-400)` / `#9452A8`) used by the search input, matching the rest of the FLIP-themed sidebar.

## Changes

- `docs/source/_static/style.css` — split the brand `> a` rule from the dropdown rule so the (hidden, `logo_only: True`) brand link keeps white while the version selector gets the legible purple.
- Added selector coverage for `.wy-dropdown > a`, `div.version a`, and `select` elements inside `.wy-side-nav-search` to cover whichever DOM ReadTheDocs' addons happen to render.

## Test plan

- [ ] Open this PR's RTD preview build (now that "Build pull requests" is enabled) and confirm "latest" in the sidebar version dropdown renders purple, not white.
- [ ] Confirm the search input text and placeholder are unchanged.
- [ ] Confirm the brand logo at the top of the sidebar is unchanged.
- [ ] If the dropdown is still white, the live HTML uses an element my selectors don't reach (likely a ReadTheDocs web component with shadow DOM) — follow up with the addons' CSS variables.

https://claude.ai/code/session_014eQ1hCzsi9hsgiFmqW8aos

---
_Generated by [Claude Code](https://claude.ai/code/session_014eQ1hCzsi9hsgiFmqW8aos)_