### PR TITLE
feat(infra): cutover Central Hub + FL stack to ECS Fargate (PR 2/3)

### DIFF
--- a/deploy/providers/AWS/Makefile
+++ b/deploy/providers/AWS/Makefile
@@ -104,6 +104,14 @@ export TF_VAR_SES_VERIFIED_EMAIL=${SES_VERIFIED_EMAIL}
 export TF_VAR_flip_alb_subdomain=${ALB_SUBDOMAIN}
 export TF_VAR_flip_nlb_subdomain=${NLB_SUBDOMAIN}
 export TF_VAR_FLIP_UI_BUCKET_NAME=${FLIP_UI_BUCKET_NAME}
+# flip-api / fl-* env vars consumed by ECS task definitions (locals.tf).
+# These mirror compose.production.yml so the running container sees the same
+# values whether it runs on EC2+compose or ECS Fargate.
+export TF_VAR_TRUST_NAMES=${TRUST_NAMES}
+export TF_VAR_TRUST_API_KEY_HEADER=${TRUST_API_KEY_HEADER}
+export TF_VAR_INTERNAL_SERVICE_KEY_HEADER=${INTERNAL_SERVICE_KEY_HEADER}
+export TF_VAR_FL_ADMIN_DIRECTORY=${FL_ADMIN_DIRECTORY}
+export TF_VAR_ENFORCE_MFA=${ENFORCE_MFA}
 CENTRALHUB_IMAGES = \
 	$(DOCKER_REGISTRY)flip-api:$(DOCKER_TAG)
 

--- a/deploy/providers/AWS/Makefile
+++ b/deploy/providers/AWS/Makefile
@@ -81,6 +81,14 @@ $(if $(INTERNAL_SERVICE_KEY),,$(error 🔑 INTERNAL_SERVICE_KEY must be set in $
 $(if $(INTERNAL_SERVICE_KEY_HASH),,$(error 🔑 INTERNAL_SERVICE_KEY_HASH must be set in $(MAIN_ENV_FILE) — must be sha256 of INTERNAL_SERVICE_KEY))
 export TF_VAR_MIN_CLIENTS=${MIN_CLIENTS}
 export TF_VAR_docker_image_tag=${DOCKER_TAG}
+export TF_VAR_flip_fl_image_tag=${DOCKER_FL_TAG}
+export TF_VAR_docker_registry=${DOCKER_REGISTRY}
+export TF_VAR_fl_api_name=${DOCKER_FL_API_NAME}
+export TF_VAR_fl_server_name=${DOCKER_FL_SERVER_NAME}
+export TF_VAR_fl_client_name=${DOCKER_FL_CLIENT_NAME}
+export TF_VAR_fl_backend=${FL_BACKEND}
+export TF_VAR_flare_kit_date=${FLARE_KIT_DATE}
+export TF_VAR_flower_kit_date=${FLOWER_KIT_DATE}
 export TF_VAR_POSTGRES_USER=${POSTGRES_USER}
 export TF_VAR_DB_PORT=${DB_PORT}
 export TF_VAR_UI_PORT=${UI_PORT}

--- a/deploy/providers/AWS/TROUBLESHOOTING.md
+++ b/deploy/providers/AWS/TROUBLESHOOTING.md
@@ -118,7 +118,30 @@ If the existing resource has a mismatched attribute (e.g., different public key 
 
 ---
 
-### 1.5 AWS SSO token expired
+### 1.5 Trust EC2 runs out of disk during `make deploy-trust`
+
+**Symptom**: `make deploy-trust` fails partway through `docker compose pull` with:
+
+```
+failed to extract layer ... torch/_inductor/codegen/cpp_micro_gemm.py:
+no space left on device
+```
+
+`df -h /` on the trust EC2 shows the root volume near 100 % used, even though it was nominally 30+ GB free at the start of the pull.
+
+**Root cause**: The full trust image set (NVFLARE `flare-fl-client` with multi-GB torch deps, XNAT Tomcat ~4 GB compressed, Orthanc, OMOP, observability stack, three trust APIs) blows through 50 GB of overlayfs snapshot space when extracted concurrently. The 50 GB default sized for the legacy compose stack is no longer adequate.
+
+**Fix**: The trust EC2 module now provisions a 100 GB root volume (`modules/trust_ec2/main.tf`). Volume modification is in-place — no instance replacement — but the partition + filesystem still need an online resize once after `terraform apply`:
+
+```bash
+ssh flip-trust 'sudo growpart /dev/nvme0n1 1 && sudo resize2fs /dev/nvme0n1p1'
+```
+
+Then retry `make deploy-trust`. Verify with `df -h /` (should show ~100 GB).
+
+---
+
+### 1.6 AWS SSO token expired
 
 **Symptom**: All `aws` commands return `Unable to locate credentials` or `AccessDenied`.
 
@@ -129,6 +152,28 @@ aws sso login --profile FlipDeveloperAccess-080369786334 --use-device-code
 ```
 
 Use `--use-device-code` for headless/SSH environments.
+
+---
+
+### 1.7 ALB returns 502 / NLB shows unhealthy targets after ECS cutover
+
+**Symptom**: After bringing ECS Fargate up alongside the legacy EC2 stack, the ALB still returns 502 for `/api/*` and the NLB target group shows the legacy EC2 target as unhealthy. Trust-side fl-client cannot reach fl-server. trust-api heartbeats may also return 401 because they hit the legacy flip-api whose secret hashes are stale.
+
+**Root cause**: The ALB listener rule and NLB TCP listener still forward to the EC2-instance target groups. Adding ECS services without `load_balancer` blocks does not register the task ENI IPs anywhere — the LBs keep routing to the now-stopped EC2 containers.
+
+**Fix** (already in place on `develop`): in `main.tf`, ECS task IPs are registered to dedicated `target_type = "ip"` target groups (`ecs_flip_api`, `ecs_fl_server_tcp`) and the listener rules / default actions point at them. The `ecs_services.tf` services include `load_balancer` blocks so each running task auto-registers. The legacy module-managed `ec2-instance-fl-server-tcp` target group is removed from the NLB module config so it stops registering an unhealthy EC2 target.
+
+If you regress this: confirm the ALB listener rule's `target_group_arn` is `aws_lb_target_group.ecs_flip_api.arn` and the NLB TCP listener default action targets `aws_lb_target_group.ecs_fl_server_tcp.arn`. `target_type = "ip"` is mandatory for awsvpc Fargate — `instance` will not register.
+
+---
+
+### 1.8 ECS-internal call from fl-api → fl-server hangs in `try_connect`
+
+**Symptom**: On ECS `fl-api-net-1` boots, registers in Cloud Map, but its NVFLARE admin client hangs trying to reach fl-server. `fl-server-net-1` is healthy on the NLB and reachable from the trust EC2.
+
+**Root cause**: fl-api is the NVFLARE admin client and connects directly to fl-server inside the VPC (the NLB path is reserved for off-VPC trust FL clients). The fl-server SG had no ingress on 8002 from the fl-api SG, so the in-VPC connect attempt timed out.
+
+**Fix**: `ecs_sg.tf` now opens fl-server SG ingress on 8002 from the fl-api SG. If you add another in-VPC NVFLARE admin consumer, add its SG to the same ingress rule.
 
 ---
 
@@ -202,6 +247,59 @@ ssh flip-trust "docker service update --force xnat1_xnat-web"
 ```bash
 ssh flip-trust "docker restart trust1-imaging-api-1"
 ```
+
+---
+
+### 2.5 NVFLARE participant kit fails `LoadResult.INVALID_SIGNATURE` on fl-api / fl-server boot
+
+**Symptom**: After regenerating an NVFLARE participant kit and redeploying, fl-api or fl-server crash-loops with `LoadResult.INVALID_SIGNATURE`. Or fl-client connects to fl-server but TLS handshake fails with `SSLV3_ALERT_BAD_CERTIFICATE` / `CERTIFICATE_VERIFY_FAILED`.
+
+**Root cause**: NVFLARE signs every file in the kit at provision time (`signature.json` references a hash of `fed_admin.json`, `rootCA.pem`, `client.crt`, etc.). Two failure modes:
+
+1. **In-place edits**: Sed-patching `fed_admin.json` after the kit lands (e.g. to swap a hostname) tears the signature.
+2. **Stale `aws s3 sync`**: `aws s3 sync` skips files when source and destination have similar size + mtime, so a freshly regenerated kit can leave a stale `rootCA.pem` / `client.crt` / `fed_client.json` next to a fresh `signature.json` (or vice versa). The on-disk kit is then signed by one rootCA but presents a cert from another.
+
+**Fix**:
+
+1. Never edit the kit after provision. If a hostname needs to change, regenerate the kit with the right hostname baked in.
+2. The EFS provisioner (`ecs_efs_provision.tf`) and the trust Ansible playbook (`site.yml`, both NVFLARE Trust_1 and Flower trust syncs) now wipe the destination with `find <dest> -mindepth 1 -delete` immediately before the `aws s3 sync` / `aws s3 cp`. This forces a clean copy. If you script your own kit sync somewhere new, mirror this pattern.
+
+To recover a stuck stack: re-run `make full-deploy` (central hub) or `make deploy-trust` (trust EC2). Both now wipe before sync.
+
+---
+
+### 2.6 fl-client returns 401 from data-access-api or imaging-api
+
+**Symptom**: A new model run fails with:
+
+```
+requests.exceptions.HTTPError: 401 Client Error: Unauthorized for url: http://data-access-api:8000//cohort/dataframe
+```
+
+(or the same on `imaging-api`). Trust-api → data-access-api / imaging-api calls succeed; only fl-client calls fail.
+
+**Root cause**: The running fl-client / fl-server / fl-api images predate `flip-fl-base` PR #111, which added `headers=_trust_internal_headers()` to every outbound `flip.get_dataframe` / `flip.get_by_accession_number` / `flip.add_resource` call. Without that header, the data-access-api / imaging-api router-level auth check rejects the request with 401.
+
+**Fix**: bump `DOCKER_FL_TAG` in `.env.stag` (and `.env.production` for prod) to a `flip-fl-base` SHA that includes PR #111, then redeploy. A single tag bump rolls all three images:
+
+```bash
+# Pick a flip-fl-base SHA on develop after PR #111 merged
+sed -i 's/^DOCKER_FL_TAG=.*/DOCKER_FL_TAG=<sha>/' .env.stag
+
+# fl-api + fl-server (ECS task defs read TF_VAR_flip_fl_image_tag)
+make apply PROD=stag
+
+# fl-client (trust EC2 compose pulls the same tag)
+make deploy-trust PROD=stag
+```
+
+Verify the running fl-client has the header wiring:
+
+```bash
+ssh flip-trust 'docker exec trust1-fl-client-net-1 grep -n "_trust_internal_headers" /app/flip/core/standard.py'
+```
+
+You should see calls at `get_dataframe`, `get_by_accession_number`, and `add_resource`.
 
 ---
 
@@ -314,6 +412,52 @@ ssh flip-trust "docker restart trust1-imaging-api-1"
 ```
 
 The code fix (adding `timeout=120` to all XNAT calls) prevents recurrence.
+
+---
+
+### 3.6 FL training aborts with `num_samples=0` (looks like a data bug)
+
+**Symptom**: A model run reaches the FL training stage and immediately dies with:
+
+```
+ValueError: num_samples should be a positive integer value, but got num_samples=0
+```
+
+The cohort query returned a non-empty dataframe (visible in trust-api logs), so this looks like a preprocessing or trainer bug at first glance.
+
+**Root cause** (the one we hit; confirm with logs before assuming): every `imaging-api/download/images/net-1` call from fl-client returned 500 with `[Errno 13] Permission denied: '/app/data/images/net-1'` and `Found 0 files in total`. The bind-mount source on the trust EC2 (`/opt/flip/data/trust-1` / `trust-2`) was owned by root because Docker auto-created it as root when no Ansible play pre-created it. imaging-api runs as uid 1000 (`flip`) and could not `mkdir` inside.
+
+**Diagnosis**: pull the fl-client log directly from the workspace, then cross-check imaging-api:
+
+```bash
+ssh flip-trust 'docker exec trust1-fl-client-net-1 \
+  find /app -name "log.txt" -path "*<run-id>*" -exec tail -200 {} \;'
+
+ssh flip-trust 'docker logs trust1-imaging-api-1 --since 10m 2>&1 | \
+  grep -iE "permission|errno|500"'
+```
+
+If you see `Permission denied` on `/app/data/images/...`, you have the same bug.
+
+**Fix** (sticky): `site.yml` now pre-creates `/opt/flip/data/trust-1` and `/opt/flip/data/trust-2` owned by `ubuntu:ubuntu` (uid 1000 inside the containers) and removes the unused `/opt/flip/data/images` entry. Re-run `make full-deploy PROD=stag`.
+
+**Hot-fix** (existing host, no redeploy):
+
+```bash
+ssh flip-trust 'sudo chown -R 1000:1000 /opt/flip/data/trust-1 /opt/flip/data/trust-2'
+```
+
+The general principle: anywhere a non-root container bind-mounts a host path, pre-create the host path with the right uid in Ansible. Letting Docker auto-create it leaves a root-owned source that silently breaks every non-root container that touches it.
+
+---
+
+### 3.7 Single net permanently starved of new training jobs
+
+**Symptom**: One FL net never picks up new training jobs even though scheduler logs show jobs being queued. Other nets are fine.
+
+**Root cause**: `FLScheduler` rows transition to `BUSY` while a job runs. If `prepare_and_start_training` raised mid-flight in a previous cycle, the row was left `BUSY` with no live job — `run_jobs_core` then refused to schedule new work for that net forever.
+
+**Fix** (already in place on `develop`): `_recover_stale_busy_schedulers()` runs at the top of every `run_jobs_core` cycle and resets `BUSY` rows whose associated job no longer exists. No manual intervention needed; just confirm the next cycle clears the row.
 
 ---
 

--- a/deploy/providers/AWS/check_status.py
+++ b/deploy/providers/AWS/check_status.py
@@ -24,13 +24,16 @@ PREREQUISITES:
 
 WHAT IT CHECKS:
   ✓ AWS Resources (EC2 instances, RDS, S3, Secrets Manager)
-  ✓ Network Connectivity (SSH via SSM, HTTP) for both Central Hub & Trust EC2
-  ✓ Application Endpoints (UI, API, FL API on Central Hub)
-  ✓ Trust Endpoints (Trust API, Imaging API, Data Access API on Trust EC2)
-  ✓ Docker Containers (Central Hub & Trust EC2)
-  ✓ Trust Services (FL clients, OMOP database, Trust APIs)
+  ✓ Network Connectivity (SSH via SSM, HTTP) for Central Hub bastion & Trust EC2
+  ✓ Application Endpoints (UI + flip-api via ALB/CloudFront)
+  ✓ ECS services (flip-api, fl-api-net-N, fl-server-net-N) — desired vs running,
+    deployment rollout state, ALB/NLB target group health
+  ✓ Trust Endpoints (Trust API, Imaging API, Data Access API on Trust EC2 — /health)
+  ✓ Trust Services (FL clients, OMOP database, Trust APIs) via Docker on Trust EC2
   ✓ System Resources (disk, memory) on both EC2 instances
-  ✓ CloudWatch Logs for both Central Hub & Trust EC2
+  ✓ CloudWatch Logs (ECS log groups for flip-api / fl-server / fl-api,
+    EC2 log groups for the SSM bastion + Trust EC2)
+  ✓ Recent error scans against CloudWatch (no docker exec required)
 
 EXIT CODES:
   0 - All checks passed (warnings are acceptable)
@@ -483,47 +486,20 @@ def check_vpc_endpoints() -> None:
 
 
 def check_trust_pipeline() -> None:
-    """Check Trust task pipeline health: recent FAILED tasks.
+    """Trust task pipeline health used to query the DB via ``docker exec flip-api``.
 
-    Detects: CREATE_IMAGING or REIMPORT_STUDIES stuck in FAILED state.
+    flip-api now runs on ECS Fargate with ``enableExecuteCommand=false`` so the
+    in-container DB query is no longer reachable from the smoke test. Checking
+    the pipeline state still has value, but it requires a bastion container
+    that holds DB credentials and the right SG egress to RDS — that is not yet
+    in place. Surface the gap as INFO so operators know the check exists in
+    intent but not in implementation, and skip cleanly.
     """
-    print_status("INFO", "Checking Trust_1 task pipeline health...")
-
-    py = """\
-import asyncpg, os, json, boto3, asyncio
-async def m():
-    c = boto3.client("secretsmanager", region_name="eu-west-2")
-    s = c.get_secret_value(SecretId=os.environ["POSTGRES_SECRET_ARN"])
-    d = json.loads(s["SecretString"])
-    p = d.get("password", "")
-    conn = await asyncpg.connect(
-        host=os.environ["DB_HOST"], port=5432,
-        user=os.environ["POSTGRES_USER"], database=os.environ["POSTGRES_DB"], password=p,
+    print_status(
+        "INFO",
+        "Trust task pipeline DB check skipped — requires ECS Exec or a bastion task on the ECS network "
+        "(both unavailable). Run the ad-hoc query in TROUBLESHOOTING.md §5 from a developer workstation.",
     )
-    rows = await conn.fetch(
-        "SELECT task_type, status FROM trust_task ORDER BY created_at DESC LIMIT 5"
-    )
-    for row in rows:
-        print(row[0], row[1])
-    await conn.close()
-asyncio.run(m())
-"""
-    success, output = run_remote_python("flip", "flip-api", py, timeout=25)
-
-    if not success or "Traceback" in output:
-        print_status("INFO", "Could not query Trust_1 task pipeline (SSH or DB unavailable)")
-        return
-
-    critical = {"CREATE_IMAGING", "REIMPORT_STUDIES"}
-    failed_count = sum(
-        1
-        for line in output.split("\n")
-        if line and line.split(" ", 1)[-1] == "FAILED" and line.split(" ", 1)[0] in critical
-    )
-    if failed_count:
-        print_status("FAIL", f"{failed_count} critical Trust_1 task(s) in FAILED state")
-    else:
-        print_status("PASS", "No critical Trust_1 tasks in FAILED state")
 
 
 def check_xnat_health() -> None:
@@ -569,172 +545,358 @@ print(r.status_code, r.headers.get("content-type", "").split(";")[0])
 
 
 def check_reimport_status() -> None:
-    """Warn if any approved projects have zero reimports after >10 minutes."""
-    print_status("INFO", "Checking for projects stuck without reimports...")
-
-    py = """\
-import asyncpg, os, json, boto3, asyncio
-async def m():
-    c = boto3.client("secretsmanager", region_name="eu-west-2")
-    s = c.get_secret_value(SecretId=os.environ["POSTGRES_SECRET_ARN"])
-    d = json.loads(s["SecretString"])
-    p = d.get("password", "")
-    conn = await asyncpg.connect(
-        host=os.environ["DB_HOST"], port=5432,
-        user=os.environ["POSTGRES_USER"], database=os.environ["POSTGRES_DB"], password=p,
-    )
-    rows = await conn.fetch(
-        "SELECT p.id, p.name, x.reimport_count, x.retrieve_image_status, x.last_reimport "
-        "FROM xnat_project_status x "
-        "JOIN projects p ON x.project_id = p.id "
-        "WHERE x.reimport_count = 0 "
-        "AND x.last_reimport < NOW() - interval '10 minutes' "
-        "AND p.status = 'APPROVED'"
-    )
-    for row in rows:
-        print(str(row[0])[:8], str(row[1])[:30], row[2], row[3])
-    await conn.close()
-asyncio.run(m())
-"""
-    success, output = run_remote_python("flip", "flip-api", py, timeout=25)
-
-    if not success or "Traceback" in output:
-        print_status("INFO", "Could not check reimport status (advanced check)")
-        return
-
-    stuck = [l for l in output.split("\n") if l.strip()]
-    if stuck:
-        for line in stuck:
-            print_status("WARN", f"Project {line} — zero reimports, may be stuck")
-    else:
-        print_status("PASS", "No projects stuck with zero reimports")
-
-
-def check_fl_server_clients() -> None:
-    """Verify the FL server has connected clients (Trust_1)."""
-    print_status("INFO", "Checking FL server clients...")
-    success, output = run_ssh_command(
-        "",
-        "flip",
-        "docker logs fl-server-net-1 2>&1 | grep -c 'Re-activate the client' | tail -1",
-        timeout=10,
-    )
-    if not success:
-        print_status("INFO", "Could not check FL server logs (SSH unavailable)")
-        return
-
-    count = int(output.strip() or "0")
-    if count > 0:
-        print_status("PASS", f"FL server has re-activated clients at least once (found {count})")
-    else:
-        success2, output2 = run_ssh_command(
-            "",
-            "flip",
-            "docker logs fl-server-net-1 2>&1 | grep 'Client: New' | tail -3",
-            timeout=10,
-        )
-        if success2 and output2.strip():
-            print_status("PASS", "FL server has connected clients")
-        else:
-            print_status("WARN", "FL server has no connected clients — check NLB and trust FL client")
-
-
-def check_container_errors() -> None:
-    """Scan central hub container logs for recent errors."""
-    print_status("INFO", "Scanning central hub container logs for recent errors...")
-    success, output = run_ssh_command(
-        "",
-        "flip",
-        "docker logs flip-api --since 5m 2>&1 | grep -cE ' ERROR |Traceback|Exception|Name or service not known' || echo 0",
-        timeout=15,
+    """Stuck-reimport check used the same ``docker exec flip-api`` path that
+    the trust pipeline check did. Same blocker post-ECS — surface the gap and
+    skip rather than silently passing.
+    """
+    print_status(
+        "INFO",
+        "Reimport-stall check skipped — same ECS Exec dependency as the trust pipeline check. "
+        "Verify manually via the SQL in TROUBLESHOOTING.md §5 if you suspect a stall.",
     )
 
-    if not success:
-        print_status("INFO", "Could not scan container logs (SSH unavailable)")
-        return
 
+def _filter_log_events(log_group: str, pattern: str, minutes: int = 60) -> tuple[bool, list[str]]:
+    """Return matching CloudWatch log messages from the last N minutes.
+
+    Args:
+        log_group: CloudWatch log group name (e.g. ``/ecs/flip-api``).
+        pattern: CloudWatch Logs filter pattern (terms separated by spaces are
+            ANDed; quoted phrases match literally; prefix with ``?`` for OR).
+        minutes: Lookback window in minutes.
+
+    Returns:
+        Tuple of (success, list of message strings). On API/parse failure,
+        success is False and the list is empty.
+    """
+    import time
+
+    start_time_ms = int((time.time() - minutes * 60) * 1000)
+    success, output = run_aws_command([
+        "logs",
+        "filter-log-events",
+        "--log-group-name",
+        log_group,
+        "--start-time",
+        str(start_time_ms),
+        "--filter-pattern",
+        pattern,
+        "--query",
+        "events[].message",
+        "--output",
+        "json",
+    ])
+    if not success or not output:
+        return False, []
     try:
-        count = int(output.strip().split("\n")[-1])
-    except ValueError:
-        count = 0
-    if count == 0:
-        print_status("PASS", "No errors in flip-api logs (last 5 min)")
-    elif count <= 5:
-        print_status("WARN", f"{count} error(s) in flip-api logs (last 5 min) — review if recurring")
-    else:
-        print_status("FAIL", f"{count} errors in flip-api logs (last 5 min) — investigate immediately")
+        return True, json.loads(output)
+    except json.JSONDecodeError:
+        return False, []
+
+
+def check_fl_server_clients(net_numbers: list[int]) -> None:
+    """Verify the ECS fl-server log shows trust FL clients connected.
+
+    Reads ``/ecs/fl-server-net-N`` CloudWatch logs (last 24h) for the
+    ``Re-activate the client`` line NVFLARE emits when a registered client
+    reconnects. Falls back to ``Client: New`` for first-time registrations.
+    """
+    print_status("INFO", "Checking FL server clients (CloudWatch /ecs/fl-server-net-N)...")
+    for net in net_numbers:
+        log_group = f"/ecs/fl-server-net-{net}"
+        ok, events = _filter_log_events(log_group, '"Re-activate the client"', minutes=24 * 60)
+        if ok and events:
+            print_status("PASS", f"fl-server-net-{net} has re-activated clients ({len(events)} events in 24h)")
+            continue
+        ok2, events2 = _filter_log_events(log_group, '"Client: New"', minutes=24 * 60)
+        if ok2 and events2:
+            print_status("PASS", f"fl-server-net-{net} has new client registrations ({len(events2)} events in 24h)")
+        elif ok or ok2:
+            print_status(
+                "WARN",
+                f"fl-server-net-{net} has no connected clients in last 24h — "
+                "check NLB target group health and trust fl-client logs",
+            )
+        else:
+            print_status("INFO", f"Could not query CloudWatch log group {log_group}")
+
+
+def check_container_errors(net_numbers: list[int]) -> None:
+    """Scan ECS log groups for recent errors.
+
+    Pulls from ``/ecs/flip-api``, ``/ecs/fl-api-net-N``, and
+    ``/ecs/fl-server-net-N`` over the last 5 minutes and counts events
+    matching ERROR / Traceback / Exception / DNS resolution failures.
+    """
+    print_status("INFO", "Scanning ECS log groups for recent errors (last 5 min)...")
+    pattern = '?ERROR ?Traceback ?Exception ?"Name or service not known"'
+
+    log_groups = ["/ecs/flip-api"]
+    for net in net_numbers:
+        log_groups += [f"/ecs/fl-api-net-{net}", f"/ecs/fl-server-net-{net}"]
+
+    for log_group in log_groups:
+        ok, events = _filter_log_events(log_group, pattern, minutes=5)
+        if not ok:
+            print_status("INFO", f"Could not query CloudWatch log group {log_group}")
+            continue
+        count = len(events)
+        if count == 0:
+            print_status("PASS", f"No errors in {log_group} (last 5 min)")
+        elif count <= 5:
+            print_status("WARN", f"{count} error(s) in {log_group} (last 5 min) — review if recurring")
+        else:
+            print_status("FAIL", f"{count} errors in {log_group} (last 5 min) — investigate immediately")
 
 
 def check_net_endpoints_consistency() -> None:
-    """Verify NET_ENDPOINTS env var matches the fl_nets database table."""
-    print_status("INFO", "Checking NET_ENDPOINTS consistency (env vs DB)...")
-    env_value = os.getenv("NET_ENDPOINTS", "{}")
-    try:
-        env_nets = json.loads(env_value.replace("'", '"'))
-    except json.JSONDecodeError:
-        print_status("WARN", "NET_ENDPOINTS not set or invalid JSON")
-        return
+    """NET_ENDPOINTS env-vs-DB consistency.
 
-    py = """\
-import asyncpg, os, json, boto3, asyncio
-async def m():
-    c = boto3.client("secretsmanager", region_name="eu-west-2")
-    s = c.get_secret_value(SecretId=os.environ["POSTGRES_SECRET_ARN"])
-    d = json.loads(s["SecretString"])
-    p = d.get("password", "")
-    conn = await asyncpg.connect(
-        host=os.environ["DB_HOST"], port=5432,
-        user=os.environ["POSTGRES_USER"], database=os.environ["POSTGRES_DB"], password=p,
+    Used to query the DB via ``docker exec flip-api`` on EC2. Same blocker as
+    ``check_trust_pipeline``. The env-vs-DB cache divergence the original
+    check guarded against is also less load-bearing now that NET_ENDPOINTS
+    points at Cloud Map FQDNs (resolution is done by the VPC resolver, not
+    cached anywhere).
+    """
+    print_status(
+        "INFO",
+        "NET_ENDPOINTS env-vs-DB check skipped — required ``docker exec flip-api`` and is now "
+        "obsolete with Cloud Map (FQDNs resolve via the VPC resolver, not the fl_nets cache).",
     )
-    rows = await conn.fetch("SELECT name, endpoint FROM fl_nets")
-    for r in rows:
-        print(str(r[0]), str(r[1]))
-    await conn.close()
-asyncio.run(m())
-"""
-    success, output = run_remote_python("flip", "flip-api", py, timeout=25)
-
-    if not success or "Traceback" in output:
-        print_status("INFO", "Could not check NET_ENDPOINTS consistency (advanced check)")
-        return
-
-    db_nets = {}
-    for line in output.strip().split("\n"):
-        parts = line.split(" ", 1)
-        if len(parts) == 2:
-            db_nets[parts[0]] = parts[1]
-
-    for net_name, endpoint in env_nets.items():
-        db_value = db_nets.get(net_name, "")
-        if db_value and db_value != endpoint:
-            print_status("FAIL", f"NET_ENDPOINTS mismatch for {net_name}: env={endpoint}, DB={db_value}")
-        elif not db_value:
-            print_status("WARN", f"NET_ENDPOINTS for {net_name} not found in fl_nets table")
-        else:
-            print_status("PASS", f"NET_ENDPOINTS consistent for {net_name}")
 
 
 def check_mfa_config() -> None:
-    """Check ENFORCE_MFA configuration on flip-api."""
-    print_status("INFO", "Checking MFA enforcement configuration...")
-    success, output = run_ssh_command(
-        "",
-        "flip",
-        'docker exec flip-api python3 -c "from flip_api.config import get_settings; print(get_settings().ENFORCE_MFA)"',
-        timeout=10,
-    )
+    """ENFORCE_MFA configuration on flip-api.
 
-    if not success:
-        print_status("INFO", "Could not check MFA config (SSH unavailable)")
+    Read directly from the ECS task definition ``environment`` block — this
+    is the source of truth for what the running container sees. The Settings
+    default is ``true``; absence of an explicit ``false`` is a pass.
+    """
+    print_status("INFO", "Checking ENFORCE_MFA on flip-api ECS task definition...")
+    success, output = run_aws_command([
+        "ecs",
+        "describe-services",
+        "--cluster",
+        "flip-cluster",
+        "--services",
+        "flip-api",
+        "--query",
+        "services[0].taskDefinition",
+        "--output",
+        "text",
+    ])
+    if not success or not output:
+        print_status("INFO", "Could not read flip-api task definition")
         return
 
-    value = output.strip().lower()
+    success2, td = run_aws_command([
+        "ecs",
+        "describe-task-definition",
+        "--task-definition",
+        output.strip(),
+        "--query",
+        "taskDefinition.containerDefinitions[0].environment",
+        "--output",
+        "json",
+    ])
+    if not success2 or not td:
+        print_status("INFO", "Could not read flip-api task definition environment")
+        return
+
+    try:
+        env = {e["name"]: e["value"] for e in json.loads(td)}
+    except (json.JSONDecodeError, KeyError, TypeError):
+        print_status("WARN", "Could not parse flip-api task definition environment")
+        return
+
+    value = env.get("ENFORCE_MFA", "<unset — Settings default true>").lower()
     if value == "false":
-        print_status("WARN", "ENFORCE_MFA=false — TOTP enforcement disabled")
-    elif value == "true":
-        print_status("PASS", "ENFORCE_MFA=true — TOTP enforcement enabled")
+        print_status("WARN", "ENFORCE_MFA=false on flip-api task — TOTP enforcement disabled")
+    elif value == "true" or "default" in value:
+        print_status("PASS", f"ENFORCE_MFA={value} — TOTP enforcement enabled")
     else:
-        print_status("WARN", f"Unexpected ENFORCE_MFA value: {value}")
+        print_status("WARN", f"Unexpected ENFORCE_MFA value on flip-api task: {value}")
+
+
+# ── ECS-specific deep checks ──────────────────────────────────────
+
+
+def check_ecs_services_running(net_numbers: list[int]) -> None:
+    """Verify each ECS service has runningCount == desiredCount and no failed deployment.
+
+    A service is considered healthy when:
+      • status == ACTIVE
+      • runningCount == desiredCount (and desiredCount > 0)
+      • the latest deployment rolloutState == COMPLETED (or the service hasn't
+        deployed yet but is steady)
+
+    Mid-rollout transitions (IN_PROGRESS) downgrade to WARN — useful for
+    distinguishing "currently rolling" from "stuck rolling".
+    """
+    print_status("INFO", "Checking ECS service rollout state...")
+    services = ["flip-api"] + [f"fl-api-net-{n}" for n in net_numbers] + [f"fl-server-net-{n}" for n in net_numbers]
+    success, output = run_aws_command([
+        "ecs",
+        "describe-services",
+        "--cluster",
+        "flip-cluster",
+        "--services",
+        *services,
+        "--query",
+        (
+            "services[].{name:serviceName,status:status,desired:desiredCount,"
+            "running:runningCount,"
+            "deployments:deployments[?status==`PRIMARY`].rolloutState | [0]}"
+        ),
+        "--output",
+        "json",
+    ])
+    if not success or not output:
+        print_status("FAIL", "Could not describe ECS services")
+        return
+
+    try:
+        data = json.loads(output)
+    except json.JSONDecodeError:
+        print_status("WARN", "Could not parse ECS service data")
+        return
+
+    for svc in data:
+        name = svc.get("name", "?")
+        status = svc.get("status", "?")
+        desired = svc.get("desired", 0)
+        running = svc.get("running", 0)
+        rollout = svc.get("deployments") or "?"
+        if status == "ACTIVE" and desired == running and desired > 0 and rollout == "COMPLETED":
+            print_status("PASS", f"ECS service '{name}' is steady ({running}/{desired}, {rollout})")
+        elif rollout == "IN_PROGRESS":
+            print_status("WARN", f"ECS service '{name}' deployment in progress ({running}/{desired})")
+        elif rollout == "FAILED":
+            print_status("FAIL", f"ECS service '{name}' deployment FAILED ({running}/{desired})")
+        else:
+            print_status(
+                "FAIL",
+                f"ECS service '{name}' unhealthy: "
+                f"status={status}, {running}/{desired}, rollout={rollout}",
+            )
+
+
+def check_ecs_target_group_health() -> None:
+    """Verify ALB + NLB target groups for ECS services have all targets healthy.
+
+    Hits both ``ecs-flip-api`` (ALB, HTTP 8000, target_type=ip) and
+    ``ecs-fl-server-tcp`` (NLB, TCP 8002, target_type=ip). target_type=ip
+    means each Fargate task ENI registers as a separate target.
+    """
+    print_status("INFO", "Checking ECS target group health (ALB + NLB)...")
+
+    success, tgs = run_aws_command([
+        "elbv2",
+        "describe-target-groups",
+        "--query",
+        "TargetGroups[?starts_with(TargetGroupName, `ecs-`)].{name:TargetGroupName,arn:TargetGroupArn}",
+        "--output",
+        "json",
+    ])
+    if not success or not tgs:
+        print_status("WARN", "Could not list ECS target groups")
+        return
+
+    try:
+        tg_list = json.loads(tgs)
+    except json.JSONDecodeError:
+        print_status("WARN", "Could not parse target group data")
+        return
+
+    if not tg_list:
+        print_status("WARN", "No ECS target groups found (expected ecs-flip-api and ecs-fl-server-tcp)")
+        return
+
+    for tg in tg_list:
+        name = tg.get("name", "?")
+        arn = tg.get("arn", "")
+        if not arn:
+            continue
+        success2, health = run_aws_command([
+            "elbv2",
+            "describe-target-health",
+            "--target-group-arn",
+            arn,
+            "--query",
+            "TargetHealthDescriptions[].{id:Target.Id,state:TargetHealth.State,reason:TargetHealth.Reason}",
+            "--output",
+            "json",
+        ])
+        if not success2 or not health:
+            print_status("WARN", f"Target group '{name}': could not query health")
+            continue
+        try:
+            targets = json.loads(health)
+        except json.JSONDecodeError:
+            print_status("WARN", f"Target group '{name}': could not parse health")
+            continue
+        if not targets:
+            print_status("FAIL", f"Target group '{name}' has no registered targets")
+            continue
+        unhealthy = [t for t in targets if t.get("state") != "healthy"]
+        if not unhealthy:
+            print_status("PASS", f"Target group '{name}' has {len(targets)} healthy target(s)")
+        else:
+            for t in unhealthy:
+                print_status(
+                    "FAIL",
+                    f"Target group '{name}': target {t.get('id', '?')} is "
+                    f"{t.get('state', '?')} ({t.get('reason', '')})",
+                )
+
+
+def check_ecs_log_streams(net_numbers: list[int]) -> None:
+    """Verify ECS log groups have log streams written within the last hour.
+
+    Stale log streams indicate a task that crashed and never restarted (or a
+    misconfigured awslogs driver).
+    """
+    import time
+
+    print_status("INFO", "Checking ECS log groups for recent activity...")
+    log_groups = ["/ecs/flip-api"]
+    for net in net_numbers:
+        log_groups += [f"/ecs/fl-api-net-{net}", f"/ecs/fl-server-net-{net}"]
+    threshold_ms = int((time.time() - 60 * 60) * 1000)
+
+    for log_group in log_groups:
+        success, output = run_aws_command([
+            "logs",
+            "describe-log-streams",
+            "--log-group-name",
+            log_group,
+            "--order-by",
+            "LastEventTime",
+            "--descending",
+            "--max-items",
+            "1",
+            "--query",
+            "logStreams[0].lastEventTimestamp",
+            "--output",
+            "text",
+        ])
+        # ``--max-items 1`` adds a NextToken line ("None" or token) after the
+        # value, so take just the first line.
+        first_line = output.strip().split("\n", 1)[0] if output else ""
+        if not first_line or first_line == "None":
+            print_status("WARN", f"{log_group} has no log streams")
+            continue
+        try:
+            last_ts = int(first_line)
+        except ValueError:
+            print_status("WARN", f"{log_group}: could not parse lastEventTimestamp ({first_line!r})")
+            continue
+        if last_ts >= threshold_ms:
+            age_min = int((time.time() * 1000 - last_ts) / 60000)
+            print_status("PASS", f"{log_group} active (last event {age_min} min ago)")
+        else:
+            age_min = int((time.time() * 1000 - last_ts) / 60000)
+            print_status("WARN", f"{log_group} stale (last event {age_min} min ago)")
 
 
 @click.command()
@@ -1083,95 +1245,20 @@ def main(
     if not skip_endpoints:
         print_section("Application Endpoint Checks")
 
-        # Central Hub EC2 ports
-        UI_PORT = os.getenv("UI_PORT", "")
-        API_PORT = os.getenv("API_PORT", "")
-        FL_API_PORT = os.getenv("FL_API_PORT", "")
-
-        # Check UI via HTTPS domain alias
+        # Public endpoints via CloudFront / ALB. flip-api now runs on ECS
+        # Fargate behind the ALB, so the legacy EC2 ``http://localhost:8080``
+        # check has been retired — the ALB endpoint is the source of truth.
         check_http_endpoint(f"https://{alb_subdomain}", "FLIP UI", 200)
-
-        # Check API health endpoint via ALB
         check_http_endpoint(f"https://{alb_subdomain}/api/health", "FLIP API Health (ALB)", 200)
-
-        # Check API docs endpoint via ALB
         check_http_endpoint(f"https://{alb_subdomain}/api/docs", "FLIP API Docs (ALB)", 200)
 
-        # Check FL API health and docs endpoints via docker exec using urllib.request
-        # (curl is not present in the NVFlare-based FL API containers; iptables also blocks
-        # loopback→bridge traffic from the EC2 host, so we exec directly into
-        # the container instead of curling from the host; urllib.request is stdlib
-        # so it is always available regardless of installed packages)
-        for net_num in configured_net_numbers:
-            container = f"flip-fl-api-net-{net_num}"
-            command = (
-                f"docker exec {container} python -c "
-                '"import urllib.request; '
-                "r=urllib.request.urlopen('http://localhost:8000/health', timeout=5); "
-                'print(r.status)"'
-            )
-
-            success, output = run_ssh_command(
-                ssh_key="",
-                host="flip",
-                command=(command),
-            )
-            if success and output.strip() == "200":
-                print_status("PASS", f"FL API Net-{net_num} health endpoint is accessible (via docker exec)")
-            else:
-                print_status("FAIL", f"FL API Net-{net_num} health endpoint not accessible (via docker exec): {output}")
-                print(command)
-
-        for net_num in configured_net_numbers:
-            container = f"flip-fl-api-net-{net_num}"
-            success, output = run_ssh_command(
-                ssh_key="",
-                host="flip",
-                command=(
-                    f"docker exec {container} python -c "
-                    f"\"import urllib.request; r=urllib.request.urlopen('http://localhost:8000/docs', timeout=5); print(r.status)\""
-                ),
-            )
-            if success and output.strip() == "200":
-                print_status("PASS", f"FL API Net-{net_num} docs endpoint is accessible (via docker exec)")
-            else:
-                print_status("FAIL", f"FL API Net-{net_num} docs endpoint not accessible (via docker exec): {output}")
-
-        # Check Central Hub API is reachable inside Central Hub EC2 via SSH
-        check_endpoint_over_ssh("flip", f"http://localhost:{API_PORT}/api/health", 200)
-
-        # Check FL API client status from the flip-api container (which shares the Docker network).
-        # The FL API /check_client_status endpoint queries the SuperLink Control API.
-        # An empty list is normal if SuperNodes haven't connected yet — report as WARN, not FAIL.
-        for nets in configured_net_numbers:
-            success, message = run_ssh_command(
-                ssh_key="",
-                host="flip",
-                command=(
-                    f"docker exec flip-api python -c "
-                    f"\"import urllib.request; r=urllib.request.urlopen('http://fl-api-net-{nets}:8000/check_client_status', timeout=5); import sys; sys.stdout.write(r.read().decode())\""
-                ),
-            )
-            if not success or not message:
-                print_status("WARN", f"FL API Net {nets} check_client_status not reachable from flip-api container")
-                continue
-            start = message.find("[")
-            json_part = message[start:]
-            try:
-                client_info = json.loads(json_part)
-            except json.JSONDecodeError:
-                print_status(
-                    "FAIL",
-                    f"FL API Net {nets} clients returned invalid JSON from flip-api container:\n{message}",
-                )
-                continue
-            if client_info:
-                print_status("PASS", f"FL API Net {nets} clients are reachable from flip-api container")
-            else:
-                print_status(
-                    "WARN",
-                    f"FL API Net {nets} returned empty client list — SuperNodes may not have connected yet",
-                )
+        # FL API and FL server health: the per-net containers are ECS tasks
+        # behind Cloud Map (fl-api-net-N.flip.local:8000) reachable only from
+        # inside the VPC, so we cannot curl them from a developer workstation.
+        # Their health is covered by check_ecs_services_running() (running
+        # count + rollout state) and check_ecs_target_group_health() (NLB
+        # ENI registration). The previous SSH+docker exec on the EC2 host
+        # no longer applies — those containers do not run on EC2 anymore.
 
         # Trust EC2 endpoint checks
         if trust_id:
@@ -1182,32 +1269,38 @@ def main(
             # Use 127.0.0.1 instead of 'localhost' — Docker port publishing (including
             # Swarm ingress for XNAT) binds to 0.0.0.0 (IPv4); 'localhost' may resolve
             # to ::1 first on this host and hang the TCP connection.
+            # Trust services use /health (always-on, exempt from internal-auth).
+            # /docs is gated off in production builds, so it returned 404 here.
+            # Grafana is part of the optional observability stack — treat its
+            # absence as WARN, not FAIL.
             trust_endpoints = [
-                ("XNAT", "http://127.0.0.1:8104/", ["200", "302"]),
-                ("Orthanc", "http://127.0.0.1:8042/", ["200", "401"]),
-                ("trust-api", "http://127.0.0.1:8020/docs", ["200"]),
-                ("imaging-api", "http://127.0.0.1:8001/docs", ["200"]),
-                ("data-access-api", "http://127.0.0.1:8010/docs", ["200"]),
-                ("Grafana", "http://127.0.0.1:3000/", ["200", "302"]),
+                ("XNAT", "http://127.0.0.1:8104/", ["200", "302"], "FAIL"),
+                ("Orthanc", "http://127.0.0.1:8042/", ["200", "401"], "FAIL"),
+                ("trust-api", "http://127.0.0.1:8020/health", ["200"], "FAIL"),
+                ("imaging-api", "http://127.0.0.1:8001/health", ["200"], "FAIL"),
+                ("data-access-api", "http://127.0.0.1:8010/health", ["200"], "FAIL"),
+                ("Grafana", "http://127.0.0.1:3000/", ["200", "302"], "WARN"),
             ]
-            for name, url, expected in trust_endpoints:
+            for name, url, expected, severity in trust_endpoints:
                 cmd = f"curl -s -o /dev/null -w '%{{http_code}}' --connect-timeout 10 --max-time 15 {url}"
                 success, output = run_ssh_command("", "flip-trust", cmd, timeout=25)
                 if not success:
-                    print_status("FAIL", f"{name}: SSM/SSH transport failed — {output} — {url}")
+                    print_status(severity, f"{name}: SSM/SSH transport failed — {output} — {url}")
                     continue
                 code = output.strip()
                 if code in expected:
                     print_status("PASS", f"{name} responding (HTTP {code}) — {url}")
                 elif code == "000":
                     print_status(
-                        "FAIL",
-                        f"{name}: connection refused / service not listening — check `docker ps` on Trust EC2 — {url}",
+                        severity,
+                        f"{name}: connection refused / service not listening "
+                        f"({severity}-level — `docker ps` on Trust EC2 if FAIL) — {url}",
                     )
                 else:
                     print_status(
-                        "FAIL",
-                        f"{name}: unexpected HTTP {code} (expected {expected}) — service responding but unhealthy — {url}",
+                        severity,
+                        f"{name}: unexpected HTTP {code} (expected {expected}) — "
+                        f"service responding but unhealthy — {url}",
                     )
 
             print_status(
@@ -1231,58 +1324,17 @@ def main(
         else:
             print_status("INFO", "LOCAL_TRUST_IP not set — skipping local Trust checks")
 
-    # Docker container checks (via SSH — Central Hub uses 'flip' alias with SSM)
+    # Central Hub EC2 is now an SSM bastion only — flip-api, fl-api, and
+    # fl-server all run as ECS Fargate tasks. We still check the bastion for
+    # disk/memory headroom (SSM agent, CloudWatch agent, occasional ad-hoc
+    # diagnostics), but the application-container checks moved to the ECS
+    # section (check_ecs_services_running, check_ecs_target_group_health).
     if not skip_docker:
-        # Test SSH connectivity first
         success, _ = run_ssh_command("", "flip", "true", timeout=10)
 
         if success:
-            print_section("Docker Container Status (Central Hub)")
+            print_section("Central Hub EC2 (SSM Bastion)")
 
-            print_status("INFO", "Checking Docker containers on Central Hub...")
-
-            # Get container status
-            success, containers = run_ssh_command(
-                "",
-                "flip",
-                "docker ps --format '{{.Names}}:{{.Status}}'",
-            )
-
-            if not success or not containers:
-                print_status("FAIL", "Could not retrieve Docker container status")
-            else:
-                # Check each expected container.
-                # Note: the UI is served from S3 + CloudFront (no container on the hub) —
-                # UI availability is covered by the HTTPS endpoint check above.
-                expected_containers = [
-                    "flip-api",
-                ]
-                # Add only configured FL server and API containers
-                for net_num in configured_net_numbers:
-                    expected_containers.append(f"fl-server-net-{net_num}")
-                    expected_containers.append(f"flip-fl-api-net-{net_num}")
-
-                for container in expected_containers:
-                    container_found = False
-                    for line in containers.split("\n"):
-                        if line.startswith(f"{container}:") and "Up" in line:
-                            status = line.split(":", 1)[1] if ":" in line else ""
-                            print_status("PASS", f"Container '{container}' is running ({status})")
-                            container_found = True
-                            break
-                    if not container_found:
-                        print_status("FAIL", f"Container '{container}' is not running")
-
-                # Check for any exited containers
-                success, exited = run_ssh_command(
-                    "",
-                    "flip",
-                    "docker ps -a --filter 'status=exited' --format '{{.Names}}' 2>/dev/null",
-                )
-                if success and exited:
-                    print_status("WARN", f"Exited containers found: {exited}")
-
-            # Check disk space
             print_status("INFO", "Checking disk space...")
             success, disk_output = run_ssh_command(
                 "",
@@ -1292,11 +1344,10 @@ def main(
             if success and disk_output:
                 disk_usage = int(disk_output.strip().rstrip("%"))
                 if disk_usage < 80:
-                    print_status("PASS", f"Disk usage is {disk_usage}%")
+                    print_status("PASS", f"Bastion disk usage is {disk_usage}%")
                 else:
-                    print_status("WARN", f"Disk usage is {disk_usage}% (consider cleanup if >80%)")
+                    print_status("WARN", f"Bastion disk usage is {disk_usage}% (consider cleanup if >80%)")
 
-            # Check memory usage
             print_status("INFO", "Checking memory usage...")
             success, mem_output = run_ssh_command(
                 "",
@@ -1307,17 +1358,17 @@ def main(
                 try:
                     mem_usage = int(mem_output.strip())
                     if mem_usage < 90:
-                        print_status("PASS", f"Memory usage is {mem_usage}%")
+                        print_status("PASS", f"Bastion memory usage is {mem_usage}%")
                     else:
-                        print_status("WARN", f"Memory usage is {mem_usage}% (high memory usage detected)")
+                        print_status("WARN", f"Bastion memory usage is {mem_usage}% (high memory usage detected)")
                 except ValueError:
-                    print_status("WARN", "Could not parse memory usage")
-
+                    print_status("WARN", "Could not parse bastion memory usage")
         else:
             print_status(
-                "FAIL",
-                "Cannot SSH to Central Hub via SSM — skipping Docker container checks. "
-                "Verify SSM agent, IAM role, and SSH config.",
+                "WARN",
+                "Cannot SSH to Central Hub bastion via SSM. Application services run on ECS "
+                "(checked separately) — bastion is only used for ad-hoc diagnostics. "
+                "Verify SSM agent, IAM role, and SSH config if you need shell access.",
             )
 
         # Trust EC2 checks (via SSM)
@@ -1539,8 +1590,11 @@ def main(
         print_section("Deep Smoke Tests")
 
         check_ecs_cluster()
+        check_ecs_services_running(configured_net_numbers)
+        check_ecs_target_group_health()
         check_vpc_endpoints()
-        check_container_errors()
+        check_ecs_log_streams(configured_net_numbers)
+        check_container_errors(configured_net_numbers)
         check_mfa_config()
         check_net_endpoints_consistency()
 
@@ -1551,7 +1605,7 @@ def main(
         check_trust_pipeline()
         check_xnat_health()
         check_reimport_status()
-        check_fl_server_clients()
+        check_fl_server_clients(configured_net_numbers)
 
     # Final summary
     print_section("Summary")

--- a/deploy/providers/AWS/check_status.py
+++ b/deploy/providers/AWS/check_status.py
@@ -1250,8 +1250,6 @@ def main(
         # check has been retired — the ALB endpoint is the source of truth.
         check_http_endpoint(f"https://{alb_subdomain}", "FLIP UI", 200)
         check_http_endpoint(f"https://{alb_subdomain}/api/health", "FLIP API Health (ALB)", 200)
-        check_http_endpoint(f"https://{alb_subdomain}/api/docs", "FLIP API Docs (ALB)", 200)
-
         # FL API and FL server health: the per-net containers are ECS tasks
         # behind Cloud Map (fl-api-net-N.flip.local:8000) reachable only from
         # inside the VPC, so we cannot curl them from a developer workstation.

--- a/deploy/providers/AWS/ecs_efs_provision.tf
+++ b/deploy/providers/AWS/ecs_efs_provision.tf
@@ -19,7 +19,14 @@
 # so we need a bootstrap run that creates the required directory layout.
 
 locals {
-  fl_provision_base_s3 = "s3://${aws_s3_bucket.flip_bucket.id}/base-application/${var.fl_backend}/${var.flare_kit_date}"
+  # NVFLARE participant kits are produced by `nvflare provision` and uploaded
+  # to the AI Centre bucket - NOT the FLIP bucket. The path mirrors the
+  # source-of-truth used by site.yml's central-hub kit sync (lines 168-169).
+  # Bucket: aicentre_bucket; layout:
+  #   fl-flare-participant-kits/{date}/net-1/services/fl-server-net-1/{startup,local}/...
+  #   fl-flare-participant-kits/{date}/net-1/services/flip-fl-api-net-1/{startup,local}/...
+  # NB: the fl-api kit dir on S3 keeps the docker-prefix `flip-fl-api-net-1`.
+  fl_provision_base_s3 = "s3://${aws_s3_bucket.aicentre_bucket.id}/fl-flare-participant-kits/${var.flare_kit_date}/net-1/services"
 }
 
 resource "null_resource" "provision_efs_certs" {
@@ -29,7 +36,7 @@ resource "null_resource" "provision_efs_certs" {
   }
 
   provisioner "local-exec" {
-    command = <<-EOT
+    command     = <<-EOT
       aws ecs run-task \
         --cluster ${aws_ecs_cluster.flip.name} \
         --task-definition ${aws_ecs_task_definition.efs_provision.arn} \
@@ -54,27 +61,31 @@ resource "aws_ecs_task_definition" "efs_provision" {
 
   container_definitions = jsonencode([
     {
-      name    = "provision-efs-certs"
-      image   = "amazon/aws-cli:latest"
+      name  = "provision-efs-certs"
+      image = "amazon/aws-cli:latest"
+      # The amazon/aws-cli image's ENTRYPOINT is `aws`, so a command like
+      # ["/bin/sh", "-c", ...] would get appended as args to aws and fail
+      # with "Found invalid choice '/bin/sh'". Override entryPoint so the
+      # shell is the actual entrypoint and the heredoc is its argument.
+      entryPoint = ["/bin/sh", "-c"]
       command = [
-        "/bin/sh", "-c",
         <<-SCRIPT
         set -e
         S3_BASE=${local.fl_provision_base_s3}
-        echo "Syncing certs from $S3_BASE to EFS..."
+        echo "Syncing NVFLARE participant kit from $S3_BASE to EFS..."
 
-        # fl-api-net-1
+        # fl-api-net-1: kit dir on S3 keeps the docker-prefix `flip-fl-api-net-1`
         mkdir -p /mnt/fl-api/local /mnt/fl-api/startup
-        aws s3 sync "$S3_BASE/fl-api-net-1/local/" /mnt/fl-api/local/ --delete || true
-        aws s3 sync "$S3_BASE/fl-api-net-1/startup/" /mnt/fl-api/startup/ --delete || true
+        aws s3 sync "$S3_BASE/flip-fl-api-net-1/local/" /mnt/fl-api/local/ --delete
+        aws s3 sync "$S3_BASE/flip-fl-api-net-1/startup/" /mnt/fl-api/startup/ --delete
 
-        # fl-server-net-1
-        mkdir -p /mnt/fl-server/local /mnt/fl-server/startup /mnt/fl-server/transfer /mnt/fl-server/certs /mnt/fl-server/keys
-        aws s3 sync "$S3_BASE/fl-server-net-1/local/" /mnt/fl-server/local/ --delete || true
-        aws s3 sync "$S3_BASE/fl-server-net-1/startup/" /mnt/fl-server/startup/ --delete || true
-        aws s3 sync "$S3_BASE/fl-server-net-1/transfer/" /mnt/fl-server/transfer/ --delete || true
-        aws s3 sync "$S3_BASE/fl-server-net-1/certs/" /mnt/fl-server/certs/ --delete || true
-        aws s3 sync "$S3_BASE/fl-server-net-1/keys/" /mnt/fl-server/keys/ --delete || true
+        # fl-server-net-1: SSL key + cert live inside `local/` (NVFLARE puts
+        # them under site-1/ssl-*), so no separate certs/keys mounts are
+        # synced here. transfer/ is created empty for runtime use by the
+        # NVFLARE server (training jobs write checkpoints there).
+        mkdir -p /mnt/fl-server/local /mnt/fl-server/startup /mnt/fl-server/transfer
+        aws s3 sync "$S3_BASE/fl-server-net-1/local/" /mnt/fl-server/local/ --delete
+        aws s3 sync "$S3_BASE/fl-server-net-1/startup/" /mnt/fl-server/startup/ --delete
 
         echo "EFS provisioning complete."
         SCRIPT
@@ -101,14 +112,6 @@ resource "aws_ecs_task_definition" "efs_provision" {
           sourceVolume  = "efs-fl-server-transfer"
           containerPath = "/mnt/fl-server/transfer"
         },
-        {
-          sourceVolume  = "efs-fl-server-certs"
-          containerPath = "/mnt/fl-server/certs"
-        },
-        {
-          sourceVolume  = "efs-fl-server-keys"
-          containerPath = "/mnt/fl-server/keys"
-        },
       ]
 
       logConfiguration = {
@@ -122,22 +125,23 @@ resource "aws_ecs_task_definition" "efs_provision" {
     }
   ])
 
-  # Mount the same EFS access points as the runtime services
+  # Mount the same EFS access points as the runtime services. certs/keys
+  # access points still exist in efs.tf for state continuity, but the
+  # provisioning task no longer touches them (kit puts SSL files under
+  # local/site-1/ssl-*).
   dynamic "volume" {
     for_each = {
-      "efs-fl-api-local"    = "fl_api_local"
-      "efs-fl-api-startup"  = "fl_api_startup"
-      "efs-fl-server-local" = "fl_server_local"
-      "efs-fl-server-startup" = "fl_server_startup"
+      "efs-fl-api-local"       = "fl_api_local"
+      "efs-fl-api-startup"     = "fl_api_startup"
+      "efs-fl-server-local"    = "fl_server_local"
+      "efs-fl-server-startup"  = "fl_server_startup"
       "efs-fl-server-transfer" = "fl_server_transfer"
-      "efs-fl-server-certs" = "fl_server_certs"
-      "efs-fl-server-keys"  = "fl_server_keys"
     }
     content {
       name = volume.key
       efs_volume_configuration {
-        file_system_id = aws_efs_file_system.flip_fl[0].id
-        root_directory = "/"
+        file_system_id     = aws_efs_file_system.flip_fl[0].id
+        root_directory     = "/"
         transit_encryption = "ENABLED"
         authorization_config {
           access_point_id = aws_efs_access_point.flip_fl[volume.value].id

--- a/deploy/providers/AWS/ecs_efs_provision.tf
+++ b/deploy/providers/AWS/ecs_efs_provision.tf
@@ -74,7 +74,15 @@ resource "aws_ecs_task_definition" "efs_provision" {
         S3_BASE=${local.fl_provision_base_s3}
         echo "Syncing NVFLARE participant kit from $S3_BASE to EFS..."
 
-        # fl-api-net-1: kit dir on S3 keeps the docker-prefix `flip-fl-api-net-1`
+        # fl-api-net-1: kit dir on S3 keeps the docker-prefix `flip-fl-api-net-1`.
+        # NVFLARE participant kits are signed at provision time (signature.json
+        # over each file), so we sync the kit verbatim - any post-sync edit
+        # would trip LoadResult.INVALID_SIGNATURE on fl-api startup. The kit
+        # hard-codes the short hostname `fl-server-net-1` in fed_admin.json
+        # which does not resolve on Fargate awsvpc; getting fl-api to talk
+        # to fl-server on ECS therefore needs the kit to be regenerated with
+        # an ECS-aware hostname (e.g. fl-server-net-1.flip.local) - tracked
+        # as a follow-up in the cutover PR.
         mkdir -p /mnt/fl-api/local /mnt/fl-api/startup
         aws s3 sync "$S3_BASE/flip-fl-api-net-1/local/" /mnt/fl-api/local/ --delete
         aws s3 sync "$S3_BASE/flip-fl-api-net-1/startup/" /mnt/fl-api/startup/ --delete

--- a/deploy/providers/AWS/ecs_efs_provision.tf
+++ b/deploy/providers/AWS/ecs_efs_provision.tf
@@ -114,7 +114,7 @@ resource "aws_ecs_task_definition" "efs_provision" {
       logConfiguration = {
         logDriver = "awslogs"
         options = {
-          awslogs-group         = aws_cloudwatch_log_group.ecs_fl_server.name
+          awslogs-group         = aws_cloudwatch_log_group.ecs_fl_server_net_1.name
           awslogs-region        = var.AWS_REGION
           awslogs-stream-prefix = "efs-provision"
         }

--- a/deploy/providers/AWS/ecs_efs_provision.tf
+++ b/deploy/providers/AWS/ecs_efs_provision.tf
@@ -62,7 +62,7 @@ resource "aws_ecs_task_definition" "efs_provision" {
   container_definitions = jsonencode([
     {
       name  = "provision-efs-certs"
-      image = "amazon/aws-cli:latest"
+      image = "amazon/aws-cli:2.22.35"
       # The amazon/aws-cli image's ENTRYPOINT is `aws`, so a command like
       # ["/bin/sh", "-c", ...] would get appended as args to aws and fail
       # with "Found invalid choice '/bin/sh'". Override entryPoint so the

--- a/deploy/providers/AWS/ecs_efs_provision.tf
+++ b/deploy/providers/AWS/ecs_efs_provision.tf
@@ -1,0 +1,149 @@
+# Copyright (c) 2026 Guy's and St Thomas' NHS Foundation Trust & King's College London
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# One-shot provisioning task that syncs FL certificates and keys from S3
+# onto the EFS file system before the fl-api and fl-server ECS services
+# start. On EC2 this was done by Ansible (site.yml copying to
+# /opt/flip/services/...). On Fargate the EFS access points start empty,
+# so we need a bootstrap run that creates the required directory layout.
+
+locals {
+  fl_provision_base_s3 = "s3://${aws_s3_bucket.flip_bucket.id}/base-application/${var.fl_backend}/${var.flare_kit_date}"
+}
+
+resource "null_resource" "provision_efs_certs" {
+  triggers = {
+    s3_source = local.fl_provision_base_s3
+    task_def  = aws_ecs_task_definition.efs_provision.arn
+  }
+
+  provisioner "local-exec" {
+    command = <<-EOT
+      aws ecs run-task \
+        --cluster ${aws_ecs_cluster.flip.name} \
+        --task-definition ${aws_ecs_task_definition.efs_provision.arn} \
+        --launch-type FARGATE \
+        --network-configuration "awsvpcConfiguration={subnets=[${join(",", module.flip_vpc.private_subnets)}],securityGroups=[${aws_security_group.ecs_fl_server.id}],assignPublicIp=DISABLED}" \
+        --count 1 \
+        --region ${var.AWS_REGION} \
+        --no-cli-pager
+    EOT
+    interpreter = ["bash", "-c"]
+  }
+}
+
+resource "aws_ecs_task_definition" "efs_provision" {
+  family                   = "efs-provision-certs"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = "256"
+  memory                   = "512"
+  execution_role_arn       = aws_iam_role.ecs_task_execution.arn
+  task_role_arn            = aws_iam_role.ecs_fl_server_task.arn
+
+  container_definitions = jsonencode([
+    {
+      name    = "provision-efs-certs"
+      image   = "amazon/aws-cli:latest"
+      command = [
+        "/bin/sh", "-c",
+        <<-SCRIPT
+        set -e
+        S3_BASE=${local.fl_provision_base_s3}
+        echo "Syncing certs from $S3_BASE to EFS..."
+
+        # fl-api-net-1
+        mkdir -p /mnt/fl-api/local /mnt/fl-api/startup
+        aws s3 sync "$S3_BASE/fl-api-net-1/local/" /mnt/fl-api/local/ --delete || true
+        aws s3 sync "$S3_BASE/fl-api-net-1/startup/" /mnt/fl-api/startup/ --delete || true
+
+        # fl-server-net-1
+        mkdir -p /mnt/fl-server/local /mnt/fl-server/startup /mnt/fl-server/transfer /mnt/fl-server/certs /mnt/fl-server/keys
+        aws s3 sync "$S3_BASE/fl-server-net-1/local/" /mnt/fl-server/local/ --delete || true
+        aws s3 sync "$S3_BASE/fl-server-net-1/startup/" /mnt/fl-server/startup/ --delete || true
+        aws s3 sync "$S3_BASE/fl-server-net-1/transfer/" /mnt/fl-server/transfer/ --delete || true
+        aws s3 sync "$S3_BASE/fl-server-net-1/certs/" /mnt/fl-server/certs/ --delete || true
+        aws s3 sync "$S3_BASE/fl-server-net-1/keys/" /mnt/fl-server/keys/ --delete || true
+
+        echo "EFS provisioning complete."
+        SCRIPT
+      ]
+
+      mountPoints = [
+        {
+          sourceVolume  = "efs-fl-api-local"
+          containerPath = "/mnt/fl-api/local"
+        },
+        {
+          sourceVolume  = "efs-fl-api-startup"
+          containerPath = "/mnt/fl-api/startup"
+        },
+        {
+          sourceVolume  = "efs-fl-server-local"
+          containerPath = "/mnt/fl-server/local"
+        },
+        {
+          sourceVolume  = "efs-fl-server-startup"
+          containerPath = "/mnt/fl-server/startup"
+        },
+        {
+          sourceVolume  = "efs-fl-server-transfer"
+          containerPath = "/mnt/fl-server/transfer"
+        },
+        {
+          sourceVolume  = "efs-fl-server-certs"
+          containerPath = "/mnt/fl-server/certs"
+        },
+        {
+          sourceVolume  = "efs-fl-server-keys"
+          containerPath = "/mnt/fl-server/keys"
+        },
+      ]
+
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          awslogs-group         = aws_cloudwatch_log_group.ecs_fl_server.name
+          awslogs-region        = var.AWS_REGION
+          awslogs-stream-prefix = "efs-provision"
+        }
+      }
+    }
+  ])
+
+  # Mount the same EFS access points as the runtime services
+  dynamic "volume" {
+    for_each = {
+      "efs-fl-api-local"    = "fl_api_local"
+      "efs-fl-api-startup"  = "fl_api_startup"
+      "efs-fl-server-local" = "fl_server_local"
+      "efs-fl-server-startup" = "fl_server_startup"
+      "efs-fl-server-transfer" = "fl_server_transfer"
+      "efs-fl-server-certs" = "fl_server_certs"
+      "efs-fl-server-keys"  = "fl_server_keys"
+    }
+    content {
+      name = volume.key
+      efs_volume_configuration {
+        file_system_id = aws_efs_file_system.flip_fl[0].id
+        root_directory = "/"
+        transit_encryption = "ENABLED"
+        authorization_config {
+          access_point_id = aws_efs_access_point.flip_fl[volume.value].id
+          iam             = "ENABLED"
+        }
+      }
+    }
+  }
+}

--- a/deploy/providers/AWS/ecs_efs_provision.tf
+++ b/deploy/providers/AWS/ecs_efs_provision.tf
@@ -30,27 +30,53 @@ locals {
 }
 
 resource "null_resource" "provision_efs_certs" {
+  count = var.enable_efs ? 1 : 0
+
   triggers = {
     s3_source = local.fl_provision_base_s3
-    task_def  = aws_ecs_task_definition.efs_provision.arn
+    task_def  = aws_ecs_task_definition.efs_provision[0].arn
   }
 
   provisioner "local-exec" {
     command     = <<-EOT
-      aws ecs run-task \
+      TASK_ARN=$(aws ecs run-task \
         --cluster ${aws_ecs_cluster.flip.name} \
-        --task-definition ${aws_ecs_task_definition.efs_provision.arn} \
+        --task-definition ${aws_ecs_task_definition.efs_provision[0].arn} \
         --launch-type FARGATE \
         --network-configuration "awsvpcConfiguration={subnets=[${join(",", module.flip_vpc.private_subnets)}],securityGroups=[${aws_security_group.ecs_fl_server.id}],assignPublicIp=DISABLED}" \
         --count 1 \
         --region ${var.AWS_REGION} \
-        --no-cli-pager
+        --no-cli-pager \
+        --query 'tasks[0].taskArn' \
+        --output text)
+
+      echo "Provisioning task ARN: $TASK_ARN"
+
+      aws ecs wait tasks-stopped \
+        --cluster ${aws_ecs_cluster.flip.name} \
+        --tasks "$TASK_ARN" \
+        --region ${var.AWS_REGION}
+
+      EXIT_CODE=$(aws ecs describe-tasks \
+        --cluster ${aws_ecs_cluster.flip.name} \
+        --tasks "$TASK_ARN" \
+        --region ${var.AWS_REGION} \
+        --query 'tasks[0].containers[0].exitCode' \
+        --output text)
+
+      if [ "$EXIT_CODE" != "0" ]; then
+        echo "EFS provisioning task failed with exit code $EXIT_CODE"
+        exit 1
+      fi
+
+      echo "EFS provisioning task completed successfully."
     EOT
     interpreter = ["bash", "-c"]
   }
 }
 
 resource "aws_ecs_task_definition" "efs_provision" {
+  count = var.enable_efs ? 1 : 0
   family                   = "efs-provision-certs"
   network_mode             = "awsvpc"
   requires_compatibilities = ["FARGATE"]

--- a/deploy/providers/AWS/ecs_efs_provision.tf
+++ b/deploy/providers/AWS/ecs_efs_provision.tf
@@ -76,24 +76,34 @@ resource "aws_ecs_task_definition" "efs_provision" {
 
         # fl-api-net-1: kit dir on S3 keeps the docker-prefix `flip-fl-api-net-1`.
         # NVFLARE participant kits are signed at provision time (signature.json
-        # over each file), so we sync the kit verbatim - any post-sync edit
-        # would trip LoadResult.INVALID_SIGNATURE on fl-api startup. The kit
-        # hard-codes the short hostname `fl-server-net-1` in fed_admin.json
-        # which does not resolve on Fargate awsvpc; getting fl-api to talk
-        # to fl-server on ECS therefore needs the kit to be regenerated with
-        # an ECS-aware hostname (e.g. fl-server-net-1.flip.local) - tracked
-        # as a follow-up in the cutover PR.
+        # over each file). Editing any file post-sync trips
+        # LoadResult.INVALID_SIGNATURE on fl-api startup, so the kit must be
+        # regenerated upstream (see net-1_project_stag.yml in flip-fl-base)
+        # whenever a hostname/SAN changes and re-uploaded to S3 under a new
+        # FLARE_KIT_DATE prefix.
+        #
+        # We wipe the access-point contents first because `aws s3 sync` skips
+        # files when source/dest size + mtime "look equivalent", and a fresh
+        # kit can have files with sizes coincidentally similar to the
+        # previous one - leaving fed_admin.json or signature.json stale and
+        # producing INVALID_SIGNATURE at fl-api boot. `find ... -delete` is
+        # cheaper than recreating the access point and avoids a DB-level
+        # lifecycle on the EFS file system.
         mkdir -p /mnt/fl-api/local /mnt/fl-api/startup
-        aws s3 sync "$S3_BASE/flip-fl-api-net-1/local/" /mnt/fl-api/local/ --delete
-        aws s3 sync "$S3_BASE/flip-fl-api-net-1/startup/" /mnt/fl-api/startup/ --delete
+        find /mnt/fl-api/local -mindepth 1 -delete 2>/dev/null || true
+        find /mnt/fl-api/startup -mindepth 1 -delete 2>/dev/null || true
+        aws s3 sync "$S3_BASE/flip-fl-api-net-1/local/" /mnt/fl-api/local/
+        aws s3 sync "$S3_BASE/flip-fl-api-net-1/startup/" /mnt/fl-api/startup/
 
         # fl-server-net-1: SSL key + cert live inside `local/` (NVFLARE puts
         # them under site-1/ssl-*), so no separate certs/keys mounts are
         # synced here. transfer/ is created empty for runtime use by the
         # NVFLARE server (training jobs write checkpoints there).
         mkdir -p /mnt/fl-server/local /mnt/fl-server/startup /mnt/fl-server/transfer
-        aws s3 sync "$S3_BASE/fl-server-net-1/local/" /mnt/fl-server/local/ --delete
-        aws s3 sync "$S3_BASE/fl-server-net-1/startup/" /mnt/fl-server/startup/ --delete
+        find /mnt/fl-server/local -mindepth 1 -delete 2>/dev/null || true
+        find /mnt/fl-server/startup -mindepth 1 -delete 2>/dev/null || true
+        aws s3 sync "$S3_BASE/fl-server-net-1/local/" /mnt/fl-server/local/
+        aws s3 sync "$S3_BASE/fl-server-net-1/startup/" /mnt/fl-server/startup/
 
         echo "EFS provisioning complete."
         SCRIPT

--- a/deploy/providers/AWS/ecs_efs_provision.tf
+++ b/deploy/providers/AWS/ecs_efs_provision.tf
@@ -76,7 +76,7 @@ resource "null_resource" "provision_efs_certs" {
 }
 
 resource "aws_ecs_task_definition" "efs_provision" {
-  count = var.enable_efs ? 1 : 0
+  count                    = var.enable_efs ? 1 : 0
   family                   = "efs-provision-certs"
   network_mode             = "awsvpc"
   requires_compatibilities = ["FARGATE"]

--- a/deploy/providers/AWS/ecs_services.tf
+++ b/deploy/providers/AWS/ecs_services.tf
@@ -36,7 +36,7 @@ resource "aws_ecs_service" "flip_api" {
   }
 
   service_registries {
-    registry_arn = aws_service_discovery_service.flip_api.arn
+    registry_arn = aws_service_discovery_service.flip_api[0].arn
   }
 
   health_check_grace_period_seconds = 120
@@ -66,7 +66,7 @@ resource "aws_ecs_service" "fl_api_net_1" {
   }
 
   service_registries {
-    registry_arn = aws_service_discovery_service.fl_api.arn
+    registry_arn = aws_service_discovery_service.fl_api[0].arn
   }
 
   deployment_minimum_healthy_percent = 100
@@ -96,7 +96,7 @@ resource "aws_ecs_service" "fl_server_net_1" {
   }
 
   service_registries {
-    registry_arn = aws_service_discovery_service.fl_server.arn
+    registry_arn = aws_service_discovery_service.fl_server[0].arn
   }
 
   deployment_minimum_healthy_percent = 100

--- a/deploy/providers/AWS/ecs_services.tf
+++ b/deploy/providers/AWS/ecs_services.tf
@@ -23,6 +23,8 @@
 ############################
 
 resource "aws_ecs_service" "flip_api" {
+  count = var.enable_service_discovery ? 1 : 0
+
   name            = "flip-api"
   cluster         = aws_ecs_cluster.flip.id
   task_definition = aws_ecs_task_definition.flip_api.arn
@@ -64,9 +66,11 @@ resource "aws_ecs_service" "flip_api" {
 ############################
 
 resource "aws_ecs_service" "fl_api_net_1" {
+  count = var.enable_service_discovery ? 1 : 0
+
   name            = "fl-api-net-1"
   cluster         = aws_ecs_cluster.flip.id
-  task_definition = aws_ecs_task_definition.fl_api_net_1.arn
+  task_definition = aws_ecs_task_definition.fl_api_net_1[0].arn
   desired_count   = 1
   launch_type     = "FARGATE"
 
@@ -84,8 +88,8 @@ resource "aws_ecs_service" "fl_api_net_1" {
   deployment_maximum_percent         = 200
 
   depends_on = [
-    aws_ecs_task_definition.fl_api_net_1,
-    null_resource.provision_efs_certs,
+    aws_ecs_task_definition.fl_api_net_1[0],
+    null_resource.provision_efs_certs[0],
   ]
 }
 
@@ -94,9 +98,11 @@ resource "aws_ecs_service" "fl_api_net_1" {
 ############################
 
 resource "aws_ecs_service" "fl_server_net_1" {
+  count = var.enable_service_discovery ? 1 : 0
+
   name            = "fl-server-net-1"
   cluster         = aws_ecs_cluster.flip.id
-  task_definition = aws_ecs_task_definition.fl_server_net_1.arn
+  task_definition = aws_ecs_task_definition.fl_server_net_1[0].arn
   desired_count   = 1
   launch_type     = "FARGATE"
 
@@ -124,7 +130,7 @@ resource "aws_ecs_service" "fl_server_net_1" {
   deployment_maximum_percent         = 200
 
   depends_on = [
-    aws_ecs_task_definition.fl_server_net_1,
-    null_resource.provision_efs_certs,
+    aws_ecs_task_definition.fl_server_net_1[0],
+    null_resource.provision_efs_certs[0],
   ]
 }

--- a/deploy/providers/AWS/ecs_services.tf
+++ b/deploy/providers/AWS/ecs_services.tf
@@ -1,0 +1,109 @@
+# Copyright (c) 2026 Guy's and St Thomas' NHS Foundation Trust & King's College London
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# ECS Fargate services — one per Central Hub component. Each service:
+#   - Runs the corresponding task definition from ecs_tasks.tf
+#   - Registers with AWS Cloud Map (Service Discovery) under flip.local
+#   - Runs in private subnets (outbound Internet via NAT, AWS APIs via VPC endpoints)
+#   - Assigns a public IP only if explicitly enabled (never by default)
+
+############################
+# flip-api
+############################
+
+resource "aws_ecs_service" "flip_api" {
+  name            = "flip-api"
+  cluster         = aws_ecs_cluster.flip.id
+  task_definition = aws_ecs_task_definition.flip_api.arn
+  desired_count   = 1
+  launch_type     = "FARGATE"
+
+  network_configuration {
+    subnets          = module.flip_vpc.private_subnets
+    security_groups  = [aws_security_group.ecs_flip_api.id]
+    assign_public_ip = false
+  }
+
+  service_registries {
+    registry_arn = aws_service_discovery_service.flip_api.arn
+  }
+
+  health_check_grace_period_seconds = 120
+  deployment_minimum_healthy_percent = 100
+  deployment_maximum_percent         = 200
+
+  depends_on = [
+    aws_ecs_task_definition.flip_api,
+  ]
+}
+
+############################
+# fl-api-net-1
+############################
+
+resource "aws_ecs_service" "fl_api_net_1" {
+  name            = "fl-api-net-1"
+  cluster         = aws_ecs_cluster.flip.id
+  task_definition = aws_ecs_task_definition.fl_api_net_1.arn
+  desired_count   = 1
+  launch_type     = "FARGATE"
+
+  network_configuration {
+    subnets          = module.flip_vpc.private_subnets
+    security_groups  = [aws_security_group.ecs_fl_api.id]
+    assign_public_ip = false
+  }
+
+  service_registries {
+    registry_arn = aws_service_discovery_service.fl_api.arn
+  }
+
+  deployment_minimum_healthy_percent = 100
+  deployment_maximum_percent         = 200
+
+  depends_on = [
+    aws_ecs_task_definition.fl_api_net_1,
+    null_resource.provision_efs_certs,
+  ]
+}
+
+############################
+# fl-server-net-1
+############################
+
+resource "aws_ecs_service" "fl_server_net_1" {
+  name            = "fl-server-net-1"
+  cluster         = aws_ecs_cluster.flip.id
+  task_definition = aws_ecs_task_definition.fl_server_net_1.arn
+  desired_count   = 1
+  launch_type     = "FARGATE"
+
+  network_configuration {
+    subnets          = module.flip_vpc.private_subnets
+    security_groups  = [aws_security_group.ecs_fl_server.id]
+    assign_public_ip = false
+  }
+
+  service_registries {
+    registry_arn = aws_service_discovery_service.fl_server.arn
+  }
+
+  deployment_minimum_healthy_percent = 100
+  deployment_maximum_percent         = 200
+
+  depends_on = [
+    aws_ecs_task_definition.fl_server_net_1,
+    null_resource.provision_efs_certs,
+  ]
+}

--- a/deploy/providers/AWS/ecs_services.tf
+++ b/deploy/providers/AWS/ecs_services.tf
@@ -39,12 +39,23 @@ resource "aws_ecs_service" "flip_api" {
     registry_arn = aws_service_discovery_service.flip_api[0].arn
   }
 
-  health_check_grace_period_seconds = 120
+  # Register each running task's ENI IP with the ALB target group so
+  # /api/* on the public ALB reaches the Fargate task. Without this block
+  # the ECS service stays invisible to the ALB and the listener rule
+  # falls back to its default action (or stale legacy target).
+  load_balancer {
+    target_group_arn = aws_lb_target_group.ecs_flip_api.arn
+    container_name   = "flip-api"
+    container_port   = local.api_container_port
+  }
+
+  health_check_grace_period_seconds  = 120
   deployment_minimum_healthy_percent = 100
   deployment_maximum_percent         = 200
 
   depends_on = [
     aws_ecs_task_definition.flip_api,
+    aws_lb_listener_rule.api_routing,
   ]
 }
 
@@ -99,6 +110,16 @@ resource "aws_ecs_service" "fl_server_net_1" {
     registry_arn = aws_service_discovery_service.fl_server[0].arn
   }
 
+  # Register the running task's ENI IP with the NLB target group so FL
+  # clients reaching fl.<env>.flip.aicentre.co.uk:8002 hit the Fargate task
+  # over gRPC. NLB on TCP forwards the gRPC stream untouched.
+  load_balancer {
+    target_group_arn = aws_lb_target_group.ecs_fl_server_tcp.arn
+    container_name   = "fl-server-net-1"
+    container_port   = var.FL_SERVER_PORT
+  }
+
+  health_check_grace_period_seconds  = 120
   deployment_minimum_healthy_percent = 100
   deployment_maximum_percent         = 200
 

--- a/deploy/providers/AWS/ecs_sg.tf
+++ b/deploy/providers/AWS/ecs_sg.tf
@@ -1,0 +1,128 @@
+# Copyright (c) 2026 Guy's and St Thomas' NHS Foundation Trust & King's College London
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Security groups for the three ECS Fargate services. Each SG is a
+# standalone aws_security_group with standalone aws_security_group_rule
+# resources — never inline rules — to prevent AWS provider drift between
+# plan and apply cycles.
+
+############################
+# flip-api
+############################
+
+resource "aws_security_group" "ecs_flip_api" {
+  name        = "ecs-flip-api"
+  description = "ECS flip-api task — inbound HTTP from ALB"
+  vpc_id      = module.flip_vpc.vpc_id
+}
+
+resource "aws_security_group_rule" "ecs_flip_api_ingress_alb_http" {
+  type                     = "ingress"
+  description              = "HTTP from ALB"
+  from_port                = local.api_container_port
+  to_port                  = local.api_container_port
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.ecs_flip_api.id
+  source_security_group_id = module.alb_security_group.security_group.id
+}
+
+resource "aws_security_group_rule" "ecs_flip_api_ingress_vpc_http" {
+  type                     = "ingress"
+  description              = "HTTP from VPC (fl-server callbacks via Service Discovery)"
+  from_port                = local.api_container_port
+  to_port                  = local.api_container_port
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.ecs_flip_api.id
+  cidr_blocks              = [var.vpc_cidr]
+}
+
+resource "aws_security_group_rule" "ecs_flip_api_egress_all" {
+  type              = "egress"
+  description       = "Allow all outbound (NAT for AWS API calls, RDS, VPC endpoints)"
+  from_port         = 0
+  to_port           = 0
+  protocol          = "-1"
+  security_group_id = aws_security_group.ecs_flip_api.id
+  cidr_blocks       = ["0.0.0.0/0"]
+}
+
+############################
+# fl-api-net-1
+############################
+
+resource "aws_security_group" "ecs_fl_api" {
+  name        = "ecs-fl-api"
+  description = "ECS fl-api-net-1 task — inbound HTTP from VPC"
+  vpc_id      = module.flip_vpc.vpc_id
+}
+
+resource "aws_security_group_rule" "ecs_fl_api_ingress_vpc_http" {
+  type              = "ingress"
+  description       = "HTTP from VPC (fl-server → fl-api)"
+  from_port         = local.api_container_port
+  to_port           = local.api_container_port
+  protocol          = "tcp"
+  security_group_id = aws_security_group.ecs_fl_api.id
+  cidr_blocks       = [var.vpc_cidr]
+}
+
+resource "aws_security_group_rule" "ecs_fl_api_egress_all" {
+  type              = "egress"
+  description       = "Allow all outbound"
+  from_port         = 0
+  to_port           = 0
+  protocol          = "-1"
+  security_group_id = aws_security_group.ecs_fl_api.id
+  cidr_blocks       = ["0.0.0.0/0"]
+}
+
+############################
+# fl-server-net-1
+############################
+
+resource "aws_security_group" "ecs_fl_server" {
+  name        = "ecs-fl-server"
+  description = "ECS fl-server-net-1 task — inbound gRPC from NLB + HTTP from VPC"
+  vpc_id      = module.flip_vpc.vpc_id
+}
+
+resource "aws_security_group_rule" "ecs_fl_server_ingress_nlb_grpc" {
+  type                     = "ingress"
+  description              = "gRPC from NLB (FL client connections)"
+  from_port                = 8002
+  to_port                  = 8002
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.ecs_fl_server.id
+  source_security_group_id = module.fl_server_nlb.security_group_id
+}
+
+resource "aws_security_group_rule" "ecs_fl_server_ingress_vpc_http" {
+  type              = "ingress"
+  description       = "HTTP from VPC (internal API calls)"
+  from_port         = local.api_container_port
+  to_port           = local.api_container_port
+  protocol          = "tcp"
+  security_group_id = aws_security_group.ecs_fl_server.id
+  cidr_blocks       = [var.vpc_cidr]
+}
+
+resource "aws_security_group_rule" "ecs_fl_server_egress_all" {
+  type              = "egress"
+  description       = "Allow all outbound (NAT for AWS API calls, Service Discovery)"
+  from_port         = 0
+  to_port           = 0
+  protocol          = "-1"
+  security_group_id = aws_security_group.ecs_fl_server.id
+  cidr_blocks       = ["0.0.0.0/0"]
+}

--- a/deploy/providers/AWS/ecs_sg.tf
+++ b/deploy/providers/AWS/ecs_sg.tf
@@ -69,7 +69,7 @@ resource "aws_security_group" "ecs_fl_api" {
 
 resource "aws_security_group_rule" "ecs_fl_api_ingress_vpc_http" {
   type              = "ingress"
-  description       = "HTTP from VPC (fl-server → fl-api)"
+  description       = "HTTP from VPC (fl-server to fl-api)"
   from_port         = local.api_container_port
   to_port           = local.api_container_port
   protocol          = "tcp"

--- a/deploy/providers/AWS/ecs_sg.tf
+++ b/deploy/providers/AWS/ecs_sg.tf
@@ -23,7 +23,7 @@
 
 resource "aws_security_group" "ecs_flip_api" {
   name        = "ecs-flip-api"
-  description = "ECS flip-api task — inbound HTTP from ALB"
+  description = "ECS flip-api task - inbound HTTP from ALB"
   vpc_id      = module.flip_vpc.vpc_id
 }
 
@@ -63,7 +63,7 @@ resource "aws_security_group_rule" "ecs_flip_api_egress_all" {
 
 resource "aws_security_group" "ecs_fl_api" {
   name        = "ecs-fl-api"
-  description = "ECS fl-api-net-1 task — inbound HTTP from VPC"
+  description = "ECS fl-api-net-1 task - inbound HTTP from VPC"
   vpc_id      = module.flip_vpc.vpc_id
 }
 
@@ -93,7 +93,7 @@ resource "aws_security_group_rule" "ecs_fl_api_egress_all" {
 
 resource "aws_security_group" "ecs_fl_server" {
   name        = "ecs-fl-server"
-  description = "ECS fl-server-net-1 task — inbound gRPC from NLB + HTTP from VPC"
+  description = "ECS fl-server-net-1 task - inbound gRPC from NLB + HTTP from VPC"
   vpc_id      = module.flip_vpc.vpc_id
 }
 

--- a/deploy/providers/AWS/ecs_sg.tf
+++ b/deploy/providers/AWS/ecs_sg.tf
@@ -38,13 +38,13 @@ resource "aws_security_group_rule" "ecs_flip_api_ingress_alb_http" {
 }
 
 resource "aws_security_group_rule" "ecs_flip_api_ingress_vpc_http" {
-  type                     = "ingress"
-  description              = "HTTP from VPC (fl-server callbacks via Service Discovery)"
-  from_port                = local.api_container_port
-  to_port                  = local.api_container_port
-  protocol                 = "tcp"
-  security_group_id        = aws_security_group.ecs_flip_api.id
-  cidr_blocks              = [var.vpc_cidr]
+  type              = "ingress"
+  description       = "HTTP from VPC (fl-server callbacks via Service Discovery)"
+  from_port         = local.api_container_port
+  to_port           = local.api_container_port
+  protocol          = "tcp"
+  security_group_id = aws_security_group.ecs_flip_api.id
+  cidr_blocks       = [var.vpc_cidr]
 }
 
 resource "aws_security_group_rule" "ecs_flip_api_egress_all" {
@@ -105,6 +105,21 @@ resource "aws_security_group_rule" "ecs_fl_server_ingress_nlb_grpc" {
   protocol                 = "tcp"
   security_group_id        = aws_security_group.ecs_fl_server.id
   source_security_group_id = module.fl_server_nlb.security_group_id
+}
+
+# fl-api (the NVFLARE admin client) connects directly to fl-server on the
+# admin port (same 8002 as the gRPC client port; NVFLARE multiplexes admin
+# and client RPC over a single HTTP/2 stream). It does NOT go through the
+# NLB - that path is reserved for off-VPC FL clients on trusts. Without
+# this rule fl-api startup hangs in `try_connect` until the 20s timeout.
+resource "aws_security_group_rule" "ecs_fl_server_ingress_fl_api_admin" {
+  type                     = "ingress"
+  description              = "NVFLARE admin from fl-api task (direct, not via NLB)"
+  from_port                = 8002
+  to_port                  = 8002
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.ecs_fl_server.id
+  source_security_group_id = aws_security_group.ecs_fl_api.id
 }
 
 resource "aws_security_group_rule" "ecs_fl_server_ingress_vpc_http" {

--- a/deploy/providers/AWS/ecs_tasks.tf
+++ b/deploy/providers/AWS/ecs_tasks.tf
@@ -200,6 +200,19 @@ resource "aws_ecs_task_definition" "fl_server_net_1" {
       cpu               = 1024
       memoryReservation = 2048
 
+      # CRITICAL: The image's /app/entrypoint.sh runs `./start.sh` which
+      # executes `./sub_start.sh &` -- but because start.sh is a *subshell*,
+      # its background jobs become orphaned when it exits. The entrypoint's
+      # `wait` returns immediately because it sees zero background jobs, so
+      # the container exits with code 0 in ~1 second.
+      #
+      # Workaround: source start.sh (`. ./start.sh`) so sub_start.sh & runs
+      # in the SAME shell as the entrypoint. `wait` then properly blocks on
+      # sub_start.sh's while-true loop, keeping the container alive.
+      # Trap is set BEFORE the blocking source so SIGTERM is caught and
+      # stop_fl.sh runs gracefully.
+      entryPoint = ["/bin/bash", "-c", "source /app/.venv/bin/activate && echo '[custom-ep] Starting...' && cd /app/startup && trap \"echo 'SIGTERM caught'; /app/startup/stop_fl.sh\" SIGTERM && . ./start.sh && wait"]
+
       portMappings = [
         {
           containerPort = 8002

--- a/deploy/providers/AWS/ecs_tasks.tf
+++ b/deploy/providers/AWS/ecs_tasks.tf
@@ -90,6 +90,7 @@ resource "aws_ecs_task_definition" "flip_api" {
 ############################
 
 resource "aws_ecs_task_definition" "fl_api_net_1" {
+  count = var.enable_efs ? 1 : 0
   family                   = "fl-api-net-1"
   network_mode             = "awsvpc"
   requires_compatibilities = ["FARGATE"]
@@ -183,6 +184,7 @@ resource "aws_ecs_task_definition" "fl_api_net_1" {
 ############################
 
 resource "aws_ecs_task_definition" "fl_server_net_1" {
+  count = var.enable_efs ? 1 : 0
   family                   = "fl-server-net-1"
   network_mode             = "awsvpc"
   requires_compatibilities = ["FARGATE"]

--- a/deploy/providers/AWS/ecs_tasks.tf
+++ b/deploy/providers/AWS/ecs_tasks.tf
@@ -59,21 +59,15 @@ resource "aws_ecs_task_definition" "flip_api" {
         }
       ]
 
-      environment = [
-        for k, v in local.ecs_task_env.flip_api :
-        { name = k, value = v }
-      ]
+      environment = concat(
+        [for k, v in local.ecs_task_env.flip_api : { name = k, value = v }],
+        [
+          { name = "DB_HOST", value = module.flip_db.db_instance_address },
+          { name = "DB_PORT", value = "5432" },
+        ],
+      )
 
-      secrets = [
-        {
-          name      = "DB_HOST"
-          valueFrom = "${module.flip_db.db_instance_address}:5432"
-        },
-        {
-          name      = "DB_PORT"
-          valueFrom = "5432"
-        },
-      ]
+      secrets = []
 
       logConfiguration = {
         logDriver = "awslogs"
@@ -137,7 +131,7 @@ resource "aws_ecs_task_definition" "fl_api_net_1" {
       logConfiguration = {
         logDriver = "awslogs"
         options = {
-          awslogs-group         = aws_cloudwatch_log_group.ecs_fl_api.name
+          awslogs-group         = aws_cloudwatch_log_group.ecs_fl_api_net_1.name
           awslogs-region        = var.AWS_REGION
           awslogs-stream-prefix = "fl-api-net-1"
         }
@@ -238,7 +232,7 @@ resource "aws_ecs_task_definition" "fl_server_net_1" {
       logConfiguration = {
         logDriver = "awslogs"
         options = {
-          awslogs-group         = aws_cloudwatch_log_group.ecs_fl_server.name
+          awslogs-group         = aws_cloudwatch_log_group.ecs_fl_server_net_1.name
           awslogs-region        = var.AWS_REGION
           awslogs-stream-prefix = "fl-server-net-1"
         }

--- a/deploy/providers/AWS/ecs_tasks.tf
+++ b/deploy/providers/AWS/ecs_tasks.tf
@@ -1,0 +1,327 @@
+# Copyright (c) 2026 Guy's and St Thomas' NHS Foundation Trust & King's College London
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# ECS task definitions for the three Central Hub services. Each definition
+# mirrors the env+volume+port configuration from the corresponding
+# compose.production.yml service, adapted for Fargate:
+#
+#   flip-api         — REST API (container port 8000)
+#   fl-api-net-1     — FL network API (container port 8000)
+#   fl-server-net-1  — FL server (container port 8002 + gRPC)
+#
+# Images are tagged with var.docker_image_tag for flip-api and
+# var.flip_fl_image_tag for FL services. Env vars come from
+# locals.ecs_task_env with secrets sourced from AWS Secrets Manager.
+#
+# EFS volumes mount the non-root access points from efs.tf so certs,
+# keys, startup files and transfer directories survive task restarts.
+
+locals {
+  fl_api_image         = "${var.docker_registry}${var.fl_api_name}:${var.flip_fl_image_tag}"
+  fl_server_image      = "${var.docker_registry}${var.fl_server_name}:${var.flip_fl_image_tag}"
+}
+
+############################
+# flip-api
+############################
+
+resource "aws_ecs_task_definition" "flip_api" {
+  family                   = "flip-api"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = "512"
+  memory                   = "1024"
+  execution_role_arn       = aws_iam_role.ecs_task_execution.arn
+  task_role_arn            = aws_iam_role.ecs_flip_api_task.arn
+
+  container_definitions = jsonencode([
+    {
+      name   = "flip-api"
+      image  = "${var.docker_registry}flip-api:${var.docker_image_tag}"
+      cpu    = 512
+      memory = 1024
+
+      portMappings = [
+        {
+          containerPort = local.api_container_port
+          protocol      = "tcp"
+        }
+      ]
+
+      environment = [
+        for k, v in local.ecs_task_env.flip_api :
+        { name = k, value = v }
+      ]
+
+      secrets = [
+        {
+          name      = "DB_HOST"
+          valueFrom = "${module.flip_db.db_instance_address}:5432"
+        },
+        {
+          name      = "DB_PORT"
+          valueFrom = "5432"
+        },
+      ]
+
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          awslogs-group         = aws_cloudwatch_log_group.ecs_flip_api.name
+          awslogs-region        = var.AWS_REGION
+          awslogs-stream-prefix = "flip-api"
+        }
+      }
+    }
+  ])
+
+  tags = {
+    Name = "flip-api"
+  }
+}
+
+############################
+# fl-api-net-1
+############################
+
+resource "aws_ecs_task_definition" "fl_api_net_1" {
+  family                   = "fl-api-net-1"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = "512"
+  memory                   = "1024"
+  execution_role_arn       = aws_iam_role.ecs_task_execution.arn
+  task_role_arn            = aws_iam_role.ecs_fl_api_task.arn
+
+  container_definitions = jsonencode([
+    {
+      name  = "fl-api-net-1"
+      image = local.fl_api_image
+      cpu   = 512
+      memoryReservation = 1024
+
+      portMappings = [
+        {
+          containerPort = local.api_container_port
+          protocol      = "tcp"
+        }
+      ]
+
+      environment = [
+        for k, v in local.ecs_task_env.fl_api :
+        { name = k, value = v }
+      ]
+
+      mountPoints = [
+        {
+          sourceVolume  = "efs-fl-api-net-1-local"
+          containerPath = "/app/data/fl-api-net-1/local"
+        },
+        {
+          sourceVolume  = "efs-fl-api-net-1-startup"
+          containerPath = "/app/data/fl-api-net-1/startup"
+        },
+      ]
+
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          awslogs-group         = aws_cloudwatch_log_group.ecs_fl_api.name
+          awslogs-region        = var.AWS_REGION
+          awslogs-stream-prefix = "fl-api-net-1"
+        }
+      }
+    }
+  ])
+
+  volume {
+    name = "efs-fl-api-net-1-local"
+
+    efs_volume_configuration {
+      file_system_id     = aws_efs_file_system.flip_fl[0].id
+      root_directory     = "/"
+      transit_encryption = "ENABLED"
+
+      authorization_config {
+        access_point_id = aws_efs_access_point.flip_fl["fl_api_local"].id
+        iam             = "ENABLED"
+      }
+    }
+  }
+
+  volume {
+    name = "efs-fl-api-net-1-startup"
+
+    efs_volume_configuration {
+      file_system_id     = aws_efs_file_system.flip_fl[0].id
+      root_directory     = "/"
+      transit_encryption = "ENABLED"
+
+      authorization_config {
+        access_point_id = aws_efs_access_point.flip_fl["fl_api_startup"].id
+        iam             = "ENABLED"
+      }
+    }
+  }
+
+  tags = {
+    Name = "fl-api-net-1"
+  }
+}
+
+############################
+# fl-server-net-1
+############################
+
+resource "aws_ecs_task_definition" "fl_server_net_1" {
+  family                   = "fl-server-net-1"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = "1024"
+  memory                   = "2048"
+  execution_role_arn       = aws_iam_role.ecs_task_execution.arn
+  task_role_arn            = aws_iam_role.ecs_fl_server_task.arn
+
+  container_definitions = jsonencode([
+    {
+      name  = "fl-server-net-1"
+      image = local.fl_server_image
+      cpu   = 1024
+      memoryReservation = 2048
+
+      portMappings = [
+        {
+          containerPort = 8002
+          protocol      = "tcp"
+        }
+      ]
+
+      environment = [
+        for k, v in local.ecs_task_env.fl_server :
+        { name = k, value = v }
+      ]
+
+      mountPoints = [
+        {
+          sourceVolume  = "efs-fl-server-net-1-local"
+          containerPath = "/app/data/fl-server-net-1/local"
+        },
+        {
+          sourceVolume  = "efs-fl-server-net-1-startup"
+          containerPath = "/app/data/fl-server-net-1/startup"
+        },
+        {
+          sourceVolume  = "efs-fl-server-net-1-transfer"
+          containerPath = "/app/data/fl-server-net-1/transfer"
+        },
+        {
+          sourceVolume  = "efs-fl-server-net-1-certs"
+          containerPath = "/app/data/fl-server-net-1/certs"
+        },
+        {
+          sourceVolume  = "efs-fl-server-net-1-keys"
+          containerPath = "/app/data/fl-server-net-1/keys"
+        },
+      ]
+
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          awslogs-group         = aws_cloudwatch_log_group.ecs_fl_server.name
+          awslogs-region        = var.AWS_REGION
+          awslogs-stream-prefix = "fl-server-net-1"
+        }
+      }
+    }
+  ])
+
+  volume {
+    name = "efs-fl-server-net-1-local"
+
+    efs_volume_configuration {
+      file_system_id     = aws_efs_file_system.flip_fl[0].id
+      root_directory     = "/"
+      transit_encryption = "ENABLED"
+
+      authorization_config {
+        access_point_id = aws_efs_access_point.flip_fl["fl_server_local"].id
+        iam             = "ENABLED"
+      }
+    }
+  }
+
+  volume {
+    name = "efs-fl-server-net-1-startup"
+
+    efs_volume_configuration {
+      file_system_id     = aws_efs_file_system.flip_fl[0].id
+      root_directory     = "/"
+      transit_encryption = "ENABLED"
+
+      authorization_config {
+        access_point_id = aws_efs_access_point.flip_fl["fl_server_startup"].id
+        iam             = "ENABLED"
+      }
+    }
+  }
+
+  volume {
+    name = "efs-fl-server-net-1-transfer"
+
+    efs_volume_configuration {
+      file_system_id     = aws_efs_file_system.flip_fl[0].id
+      root_directory     = "/"
+      transit_encryption = "ENABLED"
+
+      authorization_config {
+        access_point_id = aws_efs_access_point.flip_fl["fl_server_transfer"].id
+        iam             = "ENABLED"
+      }
+    }
+  }
+
+  volume {
+    name = "efs-fl-server-net-1-certs"
+
+    efs_volume_configuration {
+      file_system_id     = aws_efs_file_system.flip_fl[0].id
+      root_directory     = "/"
+      transit_encryption = "ENABLED"
+
+      authorization_config {
+        access_point_id = aws_efs_access_point.flip_fl["fl_server_certs"].id
+        iam             = "ENABLED"
+      }
+    }
+  }
+
+  volume {
+    name = "efs-fl-server-net-1-keys"
+
+    efs_volume_configuration {
+      file_system_id     = aws_efs_file_system.flip_fl[0].id
+      root_directory     = "/"
+      transit_encryption = "ENABLED"
+
+      authorization_config {
+        access_point_id = aws_efs_access_point.flip_fl["fl_server_keys"].id
+        iam             = "ENABLED"
+      }
+    }
+  }
+
+  tags = {
+    Name = "fl-server-net-1"
+  }
+}

--- a/deploy/providers/AWS/ecs_tasks.tf
+++ b/deploy/providers/AWS/ecs_tasks.tf
@@ -28,8 +28,8 @@
 # keys, startup files and transfer directories survive task restarts.
 
 locals {
-  fl_api_image         = "${var.docker_registry}${var.fl_api_name}:${var.flip_fl_image_tag}"
-  fl_server_image      = "${var.docker_registry}${var.fl_server_name}:${var.flip_fl_image_tag}"
+  fl_api_image    = "${var.docker_registry}${var.fl_api_name}:${var.flip_fl_image_tag}"
+  fl_server_image = "${var.docker_registry}${var.fl_server_name}:${var.flip_fl_image_tag}"
 }
 
 ############################
@@ -100,9 +100,9 @@ resource "aws_ecs_task_definition" "fl_api_net_1" {
 
   container_definitions = jsonencode([
     {
-      name  = "fl-api-net-1"
-      image = local.fl_api_image
-      cpu   = 512
+      name              = "fl-api-net-1"
+      image             = local.fl_api_image
+      cpu               = 512
       memoryReservation = 1024
 
       portMappings = [
@@ -117,14 +117,18 @@ resource "aws_ecs_task_definition" "fl_api_net_1" {
         { name = k, value = v }
       ]
 
+      # Container paths must match what the fl-api image expects (mirrors
+      # compose.production.nvflare.yml: /app/admin/{local,startup}). NVFLARE
+      # initialises a Workspace from FL_ADMIN_DIRECTORY/startup at boot - if
+      # the dir is missing the lifespan startup raises and the task crashes.
       mountPoints = [
         {
           sourceVolume  = "efs-fl-api-net-1-local"
-          containerPath = "/app/data/fl-api-net-1/local"
+          containerPath = "/app/admin/local"
         },
         {
           sourceVolume  = "efs-fl-api-net-1-startup"
-          containerPath = "/app/data/fl-api-net-1/startup"
+          containerPath = "/app/admin/startup"
         },
       ]
 
@@ -189,9 +193,9 @@ resource "aws_ecs_task_definition" "fl_server_net_1" {
 
   container_definitions = jsonencode([
     {
-      name  = "fl-server-net-1"
-      image = local.fl_server_image
-      cpu   = 1024
+      name              = "fl-server-net-1"
+      image             = local.fl_server_image
+      cpu               = 1024
       memoryReservation = 2048
 
       portMappings = [
@@ -206,26 +210,36 @@ resource "aws_ecs_task_definition" "fl_server_net_1" {
         { name = k, value = v }
       ]
 
+      # INTERNAL_SERVICE_KEY is sourced from the FLIP_API Secrets Manager
+      # secret rather than passed as a plain env, so the raw key never lands
+      # in the task definition JSON or CloudFormation describe output. The
+      # JSON-key syntax (`:internal_service_key::`) extracts that single
+      # field from the multi-field secret payload.
+      secrets = [
+        {
+          name      = "INTERNAL_SERVICE_KEY"
+          valueFrom = "${module.flip_api_secret.secret_arn}:internal_service_key::"
+        },
+      ]
+
+      # Container paths must match what the fl-server image expects (mirrors
+      # compose.production.nvflare.yml: /app/{local,startup,transfer}). The
+      # entrypoint chmods scripts in /app/startup and reads
+      # /app/local/log_config.template.json - wrong paths -> crash loop.
+      # certs and keys live inside /app/local (NVFLARE puts them under
+      # site-1/ssl-key, ssl-cert), so no separate mount is needed.
       mountPoints = [
         {
           sourceVolume  = "efs-fl-server-net-1-local"
-          containerPath = "/app/data/fl-server-net-1/local"
+          containerPath = "/app/local"
         },
         {
           sourceVolume  = "efs-fl-server-net-1-startup"
-          containerPath = "/app/data/fl-server-net-1/startup"
+          containerPath = "/app/startup"
         },
         {
           sourceVolume  = "efs-fl-server-net-1-transfer"
-          containerPath = "/app/data/fl-server-net-1/transfer"
-        },
-        {
-          sourceVolume  = "efs-fl-server-net-1-certs"
-          containerPath = "/app/data/fl-server-net-1/certs"
-        },
-        {
-          sourceVolume  = "efs-fl-server-net-1-keys"
-          containerPath = "/app/data/fl-server-net-1/keys"
+          containerPath = "/app/transfer"
         },
       ]
 
@@ -285,35 +299,11 @@ resource "aws_ecs_task_definition" "fl_server_net_1" {
     }
   }
 
-  volume {
-    name = "efs-fl-server-net-1-certs"
-
-    efs_volume_configuration {
-      file_system_id     = aws_efs_file_system.flip_fl[0].id
-      root_directory     = "/"
-      transit_encryption = "ENABLED"
-
-      authorization_config {
-        access_point_id = aws_efs_access_point.flip_fl["fl_server_certs"].id
-        iam             = "ENABLED"
-      }
-    }
-  }
-
-  volume {
-    name = "efs-fl-server-net-1-keys"
-
-    efs_volume_configuration {
-      file_system_id     = aws_efs_file_system.flip_fl[0].id
-      root_directory     = "/"
-      transit_encryption = "ENABLED"
-
-      authorization_config {
-        access_point_id = aws_efs_access_point.flip_fl["fl_server_keys"].id
-        iam             = "ENABLED"
-      }
-    }
-  }
+  # NVFLARE keeps SSL key + cert under /app/local/site-1/ssl-* (i.e. inside
+  # the local volume), so no separate certs/keys mounts are needed. The
+  # corresponding fl_server_certs / fl_server_keys access points in efs.tf
+  # are left in place to avoid a destroy on this hot path - drop them in a
+  # follow-up cleanup PR once the cutover is stable.
 
   tags = {
     Name = "fl-server-net-1"

--- a/deploy/providers/AWS/ecs_tasks.tf
+++ b/deploy/providers/AWS/ecs_tasks.tf
@@ -90,7 +90,7 @@ resource "aws_ecs_task_definition" "flip_api" {
 ############################
 
 resource "aws_ecs_task_definition" "fl_api_net_1" {
-  count = var.enable_efs ? 1 : 0
+  count                    = var.enable_efs ? 1 : 0
   family                   = "fl-api-net-1"
   network_mode             = "awsvpc"
   requires_compatibilities = ["FARGATE"]
@@ -184,7 +184,7 @@ resource "aws_ecs_task_definition" "fl_api_net_1" {
 ############################
 
 resource "aws_ecs_task_definition" "fl_server_net_1" {
-  count = var.enable_efs ? 1 : 0
+  count                    = var.enable_efs ? 1 : 0
   family                   = "fl-server-net-1"
   network_mode             = "awsvpc"
   requires_compatibilities = ["FARGATE"]

--- a/deploy/providers/AWS/efs.tf
+++ b/deploy/providers/AWS/efs.tf
@@ -44,8 +44,7 @@ resource "aws_efs_file_system" "flip_fl" {
 #
 # Empty-by-design in PR 1. PR 2 adds standalone aws_security_group_rule
 # resources allowing ingress 2049 from the ecs_fl_api and ecs_fl_server SGs
-# (which PR 2 also creates). Until then, the file system is unreachable —
-# which is the intended state during PR 1.
+# (which PR 2 also creates).
 #
 # No egress rule by design: EFS mount targets terminate NFS traffic at the
 # ENI and never initiate outbound connections, so denying egress costs
@@ -128,4 +127,30 @@ resource "aws_efs_access_point" "flip_fl" {
   tags = {
     Name = "flip-fl-${each.key}"
   }
+}
+
+############################
+# SG ingress: NFS from ECS tasks
+############################
+
+resource "aws_security_group_rule" "efs_ingress_ecs_fl_api" {
+  count                    = var.enable_efs ? 1 : 0
+  type                     = "ingress"
+  description              = "NFS from ecs_fl_api tasks"
+  from_port                = 2049
+  to_port                  = 2049
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.efs_mount_target.id
+  source_security_group_id = aws_security_group.ecs_fl_api.id
+}
+
+resource "aws_security_group_rule" "efs_ingress_ecs_fl_server" {
+  count                    = var.enable_efs ? 1 : 0
+  type                     = "ingress"
+  description              = "NFS from ecs_fl_server tasks"
+  from_port                = 2049
+  to_port                  = 2049
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.efs_mount_target.id
+  source_security_group_id = aws_security_group.ecs_fl_server.id
 }

--- a/deploy/providers/AWS/iam_ecs.tf
+++ b/deploy/providers/AWS/iam_ecs.tf
@@ -205,6 +205,29 @@ data "aws_iam_policy_document" "ecs_fl_server_task" {
       values   = ["uploaded_federated_data/*", "uploaded_federated_data"]
     }
   }
+
+  # Read access to the NVFLARE participant kit on the AICENTRE bucket. Used
+  # by the one-shot efs-provision-certs task (which runs under this role and
+  # syncs the kit into EFS at boot). Runtime fl-server never reads from
+  # this prefix - the data lives on EFS by the time the service starts.
+  statement {
+    sid     = "S3ReadFlareKit"
+    actions = ["s3:GetObject", "s3:HeadObject"]
+    resources = [
+      "${aws_s3_bucket.aicentre_bucket.arn}/fl-flare-participant-kits/*",
+    ]
+  }
+
+  statement {
+    sid       = "S3ListAicentreBucketForKit"
+    actions   = ["s3:ListBucket", "s3:GetBucketLocation"]
+    resources = [aws_s3_bucket.aicentre_bucket.arn]
+    condition {
+      test     = "StringLike"
+      variable = "s3:prefix"
+      values   = ["fl-flare-participant-kits/*", "fl-flare-participant-kits"]
+    }
+  }
 }
 
 resource "aws_iam_role_policy" "ecs_fl_server_task" {

--- a/deploy/providers/AWS/locals.tf
+++ b/deploy/providers/AWS/locals.tf
@@ -12,11 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Centralised locals consumed by ECS task definitions in PR 2. Keeping the env
-# var maps here means that "what env vars does the task get?" lives in one file
-# next to the compose-file source of truth — making it harder to forget vars
-# like LOCAL_DEV=false or UPLOADED_FEDERATED_DATA_BUCKET when the task defs
-# are introduced.
+# Centralised locals consumed by ECS task definitions. Keeping the env-var maps
+# here means "what env vars does the task get?" lives in one file next to the
+# compose-file source of truth - making it harder to forget vars like
+# LOCAL_DEV=false or UPLOADED_FEDERATED_DATA_BUCKET when the task defs change.
+#
+# These maps mirror compose.production.yml + compose.production.nvflare.yml so
+# the running container sees the same env whether it runs on EC2+compose or
+# ECS Fargate.
 
 locals {
   flip_local_domain = "flip.local"
@@ -30,25 +33,55 @@ locals {
 
   # Container port for flip-api. On EC2 + Docker Compose, var.API_PORT is the
   # host-side port (8080) mapped to container port 8000. ECS Fargate has no
-  # host mapping — the container port IS the reachable port. Service Discovery
+  # host mapping - the container port IS the reachable port. Service Discovery
   # resolves to the task IP, so fl-server calls flip-api on port 8000.
   api_container_port = 8000
 
-  # Buckets and S3 paths used by the central hub services. Both reference
-  # the resource (not var.FLIP_BUCKET_NAME) so a future bucket rename only
-  # has to land in one place.
+  # Buckets and S3 paths used by the central hub services. References the
+  # resource (not var.FLIP_BUCKET_NAME) so a future bucket rename only has to
+  # land in one place. Paths mirror .env.stag values for the same env-var name.
+  flip_bucket_id              = aws_s3_bucket.flip_bucket.id
   flip_bucket_arn             = aws_s3_bucket.flip_bucket.arn
-  uploaded_federated_data_uri = "s3://${aws_s3_bucket.flip_bucket.id}/uploaded_federated_data"
+  uploaded_federated_data_uri = "s3://${local.flip_bucket_id}/uploaded_federated_data"
+  uploaded_model_files_uri    = "s3://${local.flip_bucket_id}/model_files/uploaded"
+  scanned_model_files_uri     = "s3://${local.flip_bucket_id}/model_files/uploaded"
+  fl_app_base_uri             = "s3://${local.flip_bucket_id}/base-application/${var.fl_backend}"
+  fl_app_destination_uri      = "s3://${local.flip_bucket_id}/app_destination_bucket"
+
+  # NET_ENDPOINTS tells flip-api how to reach each FL network's fl-api. On
+  # ECS the hostname differs from compose (compose uses Docker DNS:
+  # flip-fl-api-net-1; ECS uses Cloud Map: fl-api-net-1.flip.local), so we
+  # build it here from service discovery rather than passing through .env.
+  net_endpoints_json = jsonencode({
+    "net-1" = "http://${local.service_discovery_names.fl_api}:${local.api_container_port}"
+  })
 
   # Env vars per service. Mirrors compose.production.yml +
-  # compose.production.{nvflare,flower}.yml. PR 2 reads these into the ECS
-  # task definitions so the deploy-time and runtime view are kept in sync.
+  # compose.production.nvflare.yml. ECS task definitions in ecs_tasks.tf read
+  # these so the deploy-time and runtime view are kept in sync.
   ecs_task_env = {
     flip_api = {
       ENV                            = "production"
+      ENFORCE_MFA                    = var.ENFORCE_MFA
       AWS_REGION                     = var.AWS_REGION
+      AWS_COGNITO_USER_POOL_ID       = module.cognito.user_pool_id
+      AWS_COGNITO_APP_CLIENT_ID      = module.cognito.app_client_id
+      POSTGRES_USER                  = var.POSTGRES_USER
+      POSTGRES_DB                    = var.POSTGRES_DB
+      POSTGRES_SECRET_ARN            = module.flip_db.db_instance_master_user_secret_arn
+      TRUST_API_KEY_HEADER           = var.TRUST_API_KEY_HEADER
+      INTERNAL_SERVICE_KEY_HEADER    = var.INTERNAL_SERVICE_KEY_HEADER
       AWS_SECRET_NAME                = "FLIP_API" # pragma: allowlist secret
+      AWS_SES_ADMIN_EMAIL_ADDRESS    = var.SES_VERIFIED_EMAIL
+      AWS_SES_SENDER_EMAIL_ADDRESS   = var.SES_VERIFIED_EMAIL
+      UPLOADED_MODEL_FILES_BUCKET    = local.uploaded_model_files_uri
+      SCANNED_MODEL_FILES_BUCKET     = local.scanned_model_files_uri
       UPLOADED_FEDERATED_DATA_BUCKET = local.uploaded_federated_data_uri
+      FL_APP_BASE_BUCKET             = local.fl_app_base_uri
+      FL_APP_DESTINATION_BUCKET      = local.fl_app_destination_uri
+      NET_ENDPOINTS                  = local.net_endpoints_json
+      FL_BACKEND                     = var.fl_backend
+      TRUST_NAMES                    = var.TRUST_NAMES
     }
     fl_server = {
       LOCAL_DEV                      = "false"
@@ -57,10 +90,13 @@ locals {
       IMAGES_DIR                     = "/app/data/images"
       UPLOADED_FEDERATED_DATA_BUCKET = local.uploaded_federated_data_uri
       FLIP_API_INTERNAL_URL          = "http://${local.service_discovery_names.flip_api}:${local.api_container_port}/api"
+      INTERNAL_SERVICE_KEY_HEADER    = var.INTERNAL_SERVICE_KEY_HEADER
+      # INTERNAL_SERVICE_KEY is injected via the `secrets` block in
+      # ecs_tasks.tf (sourced from the FLIP_API Secrets Manager secret),
+      # never exposed as plain env in the task definition.
     }
     fl_api = {
-      # Filled in PR 2 once backend-specific (nvflare vs flower) ports are wired.
-      # Kept here as an explicit empty map so PR 2 can extend without restructuring.
+      FL_ADMIN_DIRECTORY = var.FL_ADMIN_DIRECTORY
     }
   }
 }

--- a/deploy/providers/AWS/main.tf
+++ b/deploy/providers/AWS/main.tf
@@ -490,44 +490,14 @@ module "alb" {
         protocol    = "HTTPS"
         status_code = "HTTP_301"
       }
-    },
-    "api-listener" = {
-      port     = var.API_PORT
-      protocol = "HTTP"
-      forward = {
-        target_group_key = "ec2-instance-api"
-      }
-    },
-    "fl-api-listener" = {
-      port     = var.FL_API_PORT
-      protocol = "HTTP"
-      forward = {
-        target_group_key = "ec2-instance-fl-api"
-      }
     }
   }
 
-  # UI is served from S3 + CloudFront; no ec2-instance-ui target group.
-  target_groups = {
-    ec2-instance-api = {
-      port      = var.API_PORT
-      protocol  = "HTTP"
-      target_id = aws_instance.ec2_instance.id
-
-      health_check = {
-        enabled  = true
-        protocol = "HTTP"
-        path     = "/api/health"
-        port     = "traffic-port"
-        matcher  = "200"
-      }
-    },
-    ec2-instance-fl-api = {
-      port      = var.FL_API_PORT
-      protocol  = "HTTP"
-      target_id = aws_instance.ec2_instance.id
-    }
-  }
+  # No EC2-instance target groups — the EC2 host no longer runs application
+  # containers (they run on ECS Fargate). Legacy `api-listener` and
+  # `fl-api-listener` listeners were removed in PR #452 review; the ALB
+  # only routes the https-listener /api/* path to the ECS target group.
+  target_groups = {}
 }
 
 # Network Load Balancer for FL server TCP/TLS pass-through

--- a/deploy/providers/AWS/main.tf
+++ b/deploy/providers/AWS/main.tf
@@ -562,33 +562,25 @@ module "fl_server_nlb" {
     }
   }
 
+  # Listener forwards directly to the ECS Fargate TG defined as a standalone
+  # aws_lb_target_group below. We bypass the module's target_groups map
+  # because that map only supports target_type=instance bound to an EC2 id;
+  # Fargate awsvpc requires target_type=ip with no pre-registered targets.
   listeners = {
     "fl-server-tcp-listener" = {
       port     = var.FL_SERVER_PORT
       protocol = "TCP"
       forward = {
-        target_group_key = "ec2-instance-fl-server-tcp"
+        target_group_arn = aws_lb_target_group.ecs_fl_server_tcp.arn
       }
     }
   }
 
-  target_groups = {
-    ec2-instance-fl-server-tcp = {
-      port        = var.FL_SERVER_PORT
-      protocol    = "TCP"
-      target_type = "instance"
-      target_id   = aws_instance.ec2_instance.id
-
-      health_check = {
-        enabled             = true
-        protocol            = "TCP"
-        port                = "traffic-port"
-        healthy_threshold   = 3
-        unhealthy_threshold = 3
-        interval            = 30
-      }
-    }
-  }
+  # No module-managed target groups - the ECS TG is the standalone resource
+  # below. Leaving the legacy `ec2-instance-fl-server-tcp` definition would
+  # keep the EC2 instance attached as an unhealthy target and contradict the
+  # post-cutover state.
+  target_groups = {}
 }
 
 data "aws_route53_zone" "subdomain" {
@@ -610,6 +602,32 @@ resource "aws_route53_record" "alb" {
   }
 }
 
+# Target group for the fl-server-net-1 ECS Fargate service. Registered by
+# the ECS service via the load_balancer block in ecs_services.tf - we never
+# attach instance/IP targets here. target_type=ip is required for awsvpc
+# Fargate tasks. NLB protocol must be TCP - HTTP/2 gRPC framing is opaque
+# to the NLB and forwarded as-is.
+resource "aws_lb_target_group" "ecs_fl_server_tcp" {
+  name        = "ecs-fl-server-tcp"
+  port        = var.FL_SERVER_PORT
+  protocol    = "TCP"
+  target_type = "ip"
+  vpc_id      = module.flip_vpc.vpc_id
+
+  health_check {
+    enabled             = true
+    protocol            = "TCP"
+    port                = "traffic-port"
+    healthy_threshold   = 3
+    unhealthy_threshold = 3
+    interval            = 30
+  }
+
+  # Match flip-api TG (30s) - long deregistration on rolling deploys would
+  # block training-round handshakes against a draining task.
+  deregistration_delay = 30
+}
+
 resource "aws_route53_record" "fl_server_nlb" {
   zone_id = data.aws_route53_zone.subdomain.zone_id
   name    = var.flip_nlb_subdomain
@@ -622,14 +640,43 @@ resource "aws_route53_record" "fl_server_nlb" {
   }
 }
 
-# Listener rule for path-based routing to the API namespace
+# Target group for the flip-api ECS Fargate service. Registered by the ECS
+# service itself via the load_balancer block in ecs_services.tf - we never
+# attach instance/IP targets here from terraform. target_type=ip is required
+# for awsvpc Fargate tasks (each task gets an ENI; the IP is what ECS
+# registers, not an instance id).
+resource "aws_lb_target_group" "ecs_flip_api" {
+  name        = "ecs-flip-api"
+  port        = local.api_container_port
+  protocol    = "HTTP"
+  target_type = "ip"
+  vpc_id      = module.flip_vpc.vpc_id
+
+  health_check {
+    enabled  = true
+    protocol = "HTTP"
+    path     = "/api/health"
+    port     = "traffic-port"
+    matcher  = "200"
+  }
+
+  # ECS rolling deploys briefly need both old + new tasks present; a long
+  # deregistration delay would stretch every cutover. 30s is enough for
+  # in-flight requests to drain without holding rollouts hostage.
+  deregistration_delay = 30
+}
+
+# Listener rule for path-based routing to the API namespace. Forwards /api/*
+# to the ECS Fargate target group above. The legacy `ec2-instance-api`
+# target group on the EC2 host is kept in module.alb for state continuity
+# but no longer wired to a listener rule.
 resource "aws_lb_listener_rule" "api_routing" {
   listener_arn = module.alb.listeners["https-listener"].arn
   priority     = 98
 
   action {
     type             = "forward"
-    target_group_arn = module.alb.target_groups["ec2-instance-api"].arn
+    target_group_arn = aws_lb_target_group.ecs_flip_api.arn
   }
 
   condition {

--- a/deploy/providers/AWS/main.tf
+++ b/deploy/providers/AWS/main.tf
@@ -112,6 +112,16 @@ module "rds_security_group" {
   block_all_outbound = true
 }
 
+resource "aws_security_group_rule" "rds_ingress_ecs_flip_api" {
+  type                     = "ingress"
+  from_port                = 5432
+  to_port                  = 5432
+  protocol                 = "tcp"
+  description              = "PostgreSQL from ECS flip-api"
+  source_security_group_id = aws_security_group.ecs_flip_api.id
+  security_group_id        = module.rds_security_group.security_group.id
+}
+
 ############################
 # RDS PostgreSQL Database
 ############################

--- a/deploy/providers/AWS/main.tf
+++ b/deploy/providers/AWS/main.tf
@@ -19,11 +19,18 @@ terraform {
       source  = "hashicorp/aws"
       version = "~> 6.0"
     }
+    null = {
+      source  = "hashicorp/null"
+      version = "~> 3.0"
+    }
   }
 }
 
 provider "aws" {
   region = var.AWS_REGION
+}
+
+provider "null" {
 }
 
 ############################

--- a/deploy/providers/AWS/modules/trust_ec2/main.tf
+++ b/deploy/providers/AWS/modules/trust_ec2/main.tf
@@ -27,7 +27,13 @@ resource "aws_instance" "trust_host" {
   iam_instance_profile = var.iam_instance_profile_name
 
   root_block_device {
-    volume_size           = 50
+    # 50 GB was too small once we added flare-fl-client (multi-GB torch
+    # dependencies) on top of XNAT (~4 GB), Orthanc, OMOP, and the
+    # trust-side application stack. Image extracts kept hitting "no
+    # space left on device" mid-pull. 100 GB leaves headroom for image
+    # archive growth on /opt/flip/xnat/xnat-data/archive too. Grows in
+    # place; no instance replacement.
+    volume_size           = 100
     volume_type           = "gp3"
     delete_on_termination = true
   }

--- a/deploy/providers/AWS/service_discovery.tf
+++ b/deploy/providers/AWS/service_discovery.tf
@@ -28,3 +28,61 @@ resource "aws_service_discovery_private_dns_namespace" "flip_local" {
   description = "Private DNS for ECS service-to-service resolution"
   vpc         = module.flip_vpc.vpc_id
 }
+
+############################
+# Per-service registries
+############################
+
+resource "aws_service_discovery_service" "flip_api" {
+  count = var.enable_service_discovery ? 1 : 0
+  name  = "flip-api"
+
+  dns_config {
+    namespace_id = aws_service_discovery_private_dns_namespace.flip_local[0].id
+    dns_records {
+      ttl  = 60
+      type = "A"
+    }
+    routing_policy = "MULTIVALUE"
+  }
+
+  health_check_custom_config {
+    failure_threshold = 1
+  }
+}
+
+resource "aws_service_discovery_service" "fl_api" {
+  count = var.enable_service_discovery ? 1 : 0
+  name  = "fl-api-net-1"
+
+  dns_config {
+    namespace_id = aws_service_discovery_private_dns_namespace.flip_local[0].id
+    dns_records {
+      ttl  = 60
+      type = "A"
+    }
+    routing_policy = "MULTIVALUE"
+  }
+
+  health_check_custom_config {
+    failure_threshold = 1
+  }
+}
+
+resource "aws_service_discovery_service" "fl_server" {
+  count = var.enable_service_discovery ? 1 : 0
+  name  = "fl-server-net-1"
+
+  dns_config {
+    namespace_id = aws_service_discovery_private_dns_namespace.flip_local[0].id
+    dns_records {
+      ttl  = 60
+      type = "A"
+    }
+    routing_policy = "MULTIVALUE"
+  }
+
+  health_check_custom_config {
+    failure_threshold = 1
+  }
+}

--- a/deploy/providers/AWS/site.yml
+++ b/deploy/providers/AWS/site.yml
@@ -278,10 +278,18 @@
       when: fl_backend == "nvflare"
 
     - name: sync NVFLARE Trust_1 participant kit from S3
+      # `aws s3 sync` skips files when source/dest size + mtime "look
+      # equivalent", so a freshly regenerated kit can leave stale
+      # rootCA.pem / client.crt / fed_client.json in place — the
+      # symptom is fl-client failing with CERTIFICATE_VERIFY_FAILED
+      # against a server cert signed by the new rootCA. Wipe the
+      # destination first to force a clean copy. Mirrors the
+      # ecs_efs_provision.tf fix on the central-hub side.
       shell: |
         set -euo pipefail
         dest="{{ trust_services_dir }}/Trust_1"
         mkdir -p "$dest"
+        find "$dest" -mindepth 1 -delete 2>/dev/null || true
         aws s3 sync \
           "{{ trust_s3_source }}" \
           "$dest"
@@ -308,9 +316,15 @@
       when: fl_backend == "flower"
 
     - name: sync Flower net-1 certificates and keys from S3
+      # See the NVFLARE sync above — same staleness trap. Flower's
+      # mTLS chain (rootCA.pem / server.pem / client.pem) is
+      # regenerated whenever the kit date changes; without a wipe
+      # `aws s3 sync` can leave a previous rootCA in place and the
+      # client fails the TLS handshake to fl-server.
       shell: |
         set -euo pipefail
         mkdir -p "{{ trust_services_dir }}/net-1"
+        find "{{ trust_services_dir }}/net-1" -mindepth 1 -delete 2>/dev/null || true
         aws s3 sync \
           "{{ trust_s3_source }}/" \
           "{{ trust_services_dir }}/net-1/"

--- a/deploy/providers/AWS/site.yml
+++ b/deploy/providers/AWS/site.yml
@@ -234,9 +234,19 @@
         mode: "0755"
       loop:
         - /opt/flip
-        # Data directory for Trust 1 (where XNAT images will be downloaded for the FL client to use)
-        # NOTE if this is not created here, it will be created later by Docker Compose but owned by root, and will cause permission issues
-        - /opt/flip/data/images
+        # Bind-mount sources for the imaging-api / fl-client images dir.
+        # Both compose projects (trust1-, trust2-) bind-mount one of these
+        # onto /app/data/images via BASE_IMAGES_DOWNLOAD_DIR_TRUST{1,2}, then
+        # imaging-api creates /app/data/images/net-1/ inside it as uid 1000
+        # (the `flip` user in the container).
+        # If we don't pre-create them here Docker creates the missing source
+        # path as root at first startup, leaving the container unable to
+        # mkdir net-1 inside it - imaging-api then 500s every download with
+        # `[Errno 13] Permission denied: '/app/data/images/net-1'`, and the
+        # FL training run fails downstream with `num_samples=0` because the
+        # whole cohort's image fetches errored out.
+        - /opt/flip/data/trust-1
+        - /opt/flip/data/trust-2
         # XNAT bind-mount directories (Docker Swarm does not auto-create them)
         - /opt/flip/xnat
         - /opt/flip/xnat/xnat-data/tomcat_logs

--- a/deploy/providers/AWS/variables.tf
+++ b/deploy/providers/AWS/variables.tf
@@ -89,9 +89,39 @@ variable "INTERNAL_SERVICE_KEY" {
 }
 
 variable "docker_image_tag" {
-  description = "Container image tag for ECS task definitions. Empty default — deploys must pass an explicit tag (Git SHA preferred). 'latest' is intentionally not the default to avoid the mutable-tag pitfalls flagged in the v1 review."
+  description = "Docker image tag for flip-api and flip-ui"
   type        = string
   default     = ""
+}
+
+variable "flip_fl_image_tag" {
+  description = "Docker image tag for FL services (fl-api, fl-server, fl-client)"
+  type        = string
+  default     = ""
+}
+
+variable "docker_registry" {
+  description = "Docker image registry prefix (e.g. ghcr.io/londonaicentre/)"
+  type        = string
+  default     = "ghcr.io/londonaicentre/"
+}
+
+variable "fl_api_name" {
+  description = "FL API Docker image name (backend-specific: flare-fl-api or flower-fl-api)"
+  type        = string
+  default     = "flare-fl-api"
+}
+
+variable "fl_server_name" {
+  description = "FL server Docker image name (backend-specific: flare-fl-server or flower-fl-server)"
+  type        = string
+  default     = "flare-fl-server"
+}
+
+variable "fl_client_name" {
+  description = "FL client Docker image name (backend-specific: flare-fl-client or flower-fl-client)"
+  type        = string
+  default     = "flare-fl-client"
 }
 
 variable "MIN_CLIENTS" {

--- a/deploy/providers/AWS/variables.tf
+++ b/deploy/providers/AWS/variables.tf
@@ -101,21 +101,21 @@ variable "MIN_CLIENTS" {
 }
 
 variable "enable_efs" {
-  description = "Enable EFS file system for FL task persistent storage. Gated to false until PR 2 adds ECS task definitions that mount EFS volumes — creating EFS without consumers is dead infra."
+  description = "Enable EFS file system for FL task persistent storage"
   type        = bool
-  default     = false
+  default     = true
 }
 
 variable "enable_ecs_endpoints" {
-  description = "Enable VPC interface endpoints (SSM, Secrets, Logs, ECR) for ECS Fargate. Gated to false until PR 2 adds ECS services that consume them — existing EC2 traffic uses the NAT gateway. Unconditionally creating endpoints before PR 2 incurs ~$73/month idle cost."
+  description = "Enable VPC interface endpoints (SSM, Secrets, Logs, ECR) for ECS Fargate"
   type        = bool
-  default     = false
+  default     = true
 }
 
 variable "enable_service_discovery" {
-  description = "Enable Cloud Map Service Discovery namespace. Gated to false until PR 2 adds ECS services that register — creating the namespace without registrants is dead infra."
+  description = "Enable Cloud Map Service Discovery namespace"
   type        = bool
-  default     = false
+  default     = true
 }
 
 variable "FLIP_BUCKET_NAME" {

--- a/deploy/providers/AWS/variables.tf
+++ b/deploy/providers/AWS/variables.tf
@@ -274,6 +274,35 @@ variable "PACS_UI_PORT" {
   type        = number
 }
 
+variable "TRUST_NAMES" {
+  description = "JSON-array string of registered trust names, e.g. [\"Trust_1\",\"Trust_2\"]. Consumed by flip-api to validate inbound trust API calls."
+  type        = string
+}
+
+variable "TRUST_API_KEY_HEADER" {
+  description = "HTTP header name carrying per-trust API keys on trust-to-hub calls. Compose default: Authorization."
+  type        = string
+  default     = "Authorization"
+}
+
+variable "INTERNAL_SERVICE_KEY_HEADER" {
+  description = "HTTP header name carrying the internal service key on fl-server-to-flip-api callbacks."
+  type        = string
+  default     = "X-Internal-Service-Key"
+}
+
+variable "FL_ADMIN_DIRECTORY" {
+  description = "Container path that fl-api looks at for NVFLARE admin secrets (local + startup subdirs)."
+  type        = string
+  default     = "/app/admin"
+}
+
+variable "ENFORCE_MFA" {
+  description = "Gate authenticated routes on TOTP enrolment. Defaults to true; flip-api Settings default also enforces this when unset."
+  type        = string
+  default     = "true"
+}
+
 variable "local_trust_public_ip" {
   description = "Public IP of an on-premises Trust host. When non-empty, AWS security group rules are created to allow consolidated FL communication on port 8002 from this IP to the Central Hub."
   type        = string

--- a/deploy/providers/AWS/variables.tf
+++ b/deploy/providers/AWS/variables.tf
@@ -124,6 +124,24 @@ variable "fl_client_name" {
   default     = "flare-fl-client"
 }
 
+variable "fl_backend" {
+  description = "FL backend: nvflare or flower"
+  type        = string
+  default     = "nvflare"
+}
+
+variable "flare_kit_date" {
+  description = "Date stamp for the NVFLARE provisioned kit (e.g. 20260429), used to construct the S3 path for cert syncing"
+  type        = string
+  default     = ""
+}
+
+variable "flower_kit_date" {
+  description = "Date stamp for the Flower provisioned kit"
+  type        = string
+  default     = ""
+}
+
 variable "MIN_CLIENTS" {
   description = "Minimum number of FL clients required before the server starts training"
   type        = number

--- a/flip-api/src/flip_api/fl_services/run_jobs.py
+++ b/flip-api/src/flip_api/fl_services/run_jobs.py
@@ -13,10 +13,12 @@
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, status
-from sqlmodel import Session
+from sqlmodel import Session, select
 
 from flip_api.auth.dependencies import verify_token
 from flip_api.db.database import engine, get_session
+from flip_api.db.models.main_models import FLJob, FLScheduler
+from flip_api.domain.schemas.status import NetStatus
 from flip_api.fl_services.services.fl_scheduler_service import (
     check_for_available_net,
     check_for_queued_jobs,
@@ -25,6 +27,26 @@ from flip_api.fl_services.services.fl_scheduler_service import (
 from flip_api.utils.logger import logger
 
 router = APIRouter(prefix="/fl", tags=["fl_services"])
+
+
+def _recover_stale_busy_schedulers(db: Session) -> int:
+    """Reset all FLScheduler rows stuck in BUSY to AVAILABLE.
+
+    BUSY schedulers with no associated job, or whose job has been deleted,
+    are unrecoverable unless cleaned up here. This prevents a single crash
+    from permanently starving a net of new training jobs.
+    """
+    stale = 0
+    rows = db.exec(select(FLScheduler).where(FLScheduler.status == NetStatus.BUSY)).all()
+    for s in rows:
+        if s.job_id is None or db.get(FLJob, s.job_id) is None:
+            s.status = NetStatus.AVAILABLE
+            s.job_id = None
+            stale += 1
+    if stale:
+        db.commit()
+        logger.info("Recovered %d stale BUSY scheduler(s)", stale)
+    return stale
 
 
 # [#114] ✅
@@ -44,20 +66,14 @@ def run_jobs(db: Session = Depends(get_session), user_id: UUID = Depends(verify_
 
 
 def run_jobs_core(db: Session) -> None:
-    """
-    Core logic to run FL jobs. This function is called by both the API endpoint and the scheduled task. It checks for
-    available nets, retrieves queued jobs, and starts training.
+    """Core logic to run FL jobs, with stale-BUSY scheduler recovery.
 
-    Args:
-        db (Session): Database session.
-
-    Returns:
-        None
-
-    Raises:
-        HTTPException: If there is an error while running jobs.
+    Resets any FLScheduler rows stuck in BUSY status (e.g. from a crashed
+    previous job run) before attempting to pick an available net.
     """
     try:
+        _recover_stale_busy_schedulers(db)
+
         # Step 1: Find an available net
         scheduler = check_for_available_net(db)
 

--- a/flip-api/src/flip_api/fl_services/run_jobs.py
+++ b/flip-api/src/flip_api/fl_services/run_jobs.py
@@ -13,7 +13,7 @@
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, status
-from sqlmodel import Session, select
+from sqlmodel import Session, select, update
 
 from flip_api.auth.dependencies import verify_token
 from flip_api.db.database import engine, get_session
@@ -32,21 +32,28 @@ router = APIRouter(prefix="/fl", tags=["fl_services"])
 def _recover_stale_busy_schedulers(db: Session) -> int:
     """Reset all FLScheduler rows stuck in BUSY to AVAILABLE.
 
+    Uses a single atomic UPDATE statement to avoid read-side races with
+    check_for_queued_jobs (which uses with_for_update) and eliminates the
+    N+1 query pattern of the previous row-by-row approach.
+
     BUSY schedulers with no associated job, or whose job has been deleted,
     are unrecoverable unless cleaned up here. This prevents a single crash
     from permanently starving a net of new training jobs.
     """
-    stale = 0
-    rows = db.exec(select(FLScheduler).where(FLScheduler.status == NetStatus.BUSY)).all()
-    for s in rows:
-        if s.job_id is None or db.get(FLJob, s.job_id) is None:
-            s.status = NetStatus.AVAILABLE
-            s.job_id = None
-            stale += 1
-    if stale:
+    stmt = (
+        update(FLScheduler)
+        .where(FLScheduler.status == NetStatus.BUSY)
+        .where(
+            (FLScheduler.job_id.is_(None))
+            | ~FLScheduler.job_id.in_(select(FLJob.id))
+        )
+        .values(status=NetStatus.AVAILABLE, job_id=None)
+    )
+    result = db.exec(stmt)
+    if result.rowcount:
         db.commit()
-        logger.info("Recovered %d stale BUSY scheduler(s)", stale)
-    return stale
+        logger.info("Recovered %d stale BUSY scheduler(s)", result.rowcount)
+    return result.rowcount
 
 
 # [#114] ✅

--- a/flip-api/src/flip_api/fl_services/run_jobs.py
+++ b/flip-api/src/flip_api/fl_services/run_jobs.py
@@ -13,11 +13,11 @@
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, status
-from sqlmodel import Session, select, update
+from sqlalchemy import text
+from sqlmodel import Session
 
 from flip_api.auth.dependencies import verify_token
 from flip_api.db.database import engine, get_session
-from flip_api.db.models.main_models import FLJob, FLScheduler
 from flip_api.domain.schemas.status import NetStatus
 from flip_api.fl_services.services.fl_scheduler_service import (
     check_for_available_net,
@@ -40,20 +40,23 @@ def _recover_stale_busy_schedulers(db: Session) -> int:
     are unrecoverable unless cleaned up here. This prevents a single crash
     from permanently starving a net of new training jobs.
     """
-    stmt = (
-        update(FLScheduler)
-        .where(FLScheduler.status == NetStatus.BUSY)
-        .where(
-            (FLScheduler.job_id.is_(None))
-            | ~FLScheduler.job_id.in_(select(FLJob.id))
-        )
-        .values(status=NetStatus.AVAILABLE, job_id=None)
+    stmt = text(
+        """
+        UPDATE fl_scheduler
+        SET status = :available, jobid = NULL
+        WHERE status = :busy
+          AND (jobid IS NULL OR jobid NOT IN (SELECT id FROM fl_job))
+        """
     )
-    result = db.exec(stmt)
-    if result.rowcount:
+    result = db.execute(
+        stmt,
+        {"available": NetStatus.AVAILABLE.value, "busy": NetStatus.BUSY.value},
+    )
+    recovered = result.rowcount  # type: ignore[attr-defined]
+    if recovered:
         db.commit()
-        logger.info("Recovered %d stale BUSY scheduler(s)", result.rowcount)
-    return result.rowcount
+        logger.info("Recovered %d stale BUSY scheduler(s)", recovered)
+    return recovered
 
 
 # [#114] ✅

--- a/flip-api/tests/unit/fl_services/test_run_jobs.py
+++ b/flip-api/tests/unit/fl_services/test_run_jobs.py
@@ -17,7 +17,7 @@ import pytest
 from fastapi import HTTPException
 
 from flip_api.domain.interfaces.fl import IJobResponse
-from flip_api.fl_services.run_jobs import run_jobs
+from flip_api.fl_services.run_jobs import _recover_stale_busy_schedulers, run_jobs
 
 
 @pytest.fixture
@@ -89,3 +89,57 @@ def test_run_jobs_failure(mock_db, mock_check_for_available_net, mock_check_for_
             run_jobs(mock_db)
         assert exc_info.value.status_code == 500
         assert "start error" in exc_info.value.detail
+
+
+# ── _recover_stale_busy_schedulers tests ────────────────────────────────────
+
+
+def _make_mock_session(rowcount: int) -> MagicMock:
+    """Create a mocked Session whose db.execute() returns a result with the given rowcount."""
+    session = MagicMock(name="mock_session")
+    mock_result = MagicMock(name="mock_result")
+    mock_result.rowcount = rowcount
+    session.execute.return_value = mock_result
+    return session
+
+
+def test_recover_stale_busy_no_busy_rows(caplog):
+    """No BUSY rows → 0 returned, no db.commit() called."""
+    session = _make_mock_session(rowcount=0)
+
+    result = _recover_stale_busy_schedulers(session)
+
+    assert result == 0
+    session.commit.assert_not_called()
+
+
+def test_recover_stale_busy_job_id_none(caplog):
+    """BUSY + job_id=None → reset, commit called, returns 1."""
+    session = _make_mock_session(rowcount=1)
+
+    result = _recover_stale_busy_schedulers(session)
+
+    assert result == 1
+    session.commit.assert_called_once()
+    assert "Recovered 1 stale BUSY scheduler(s)" in caplog.text
+
+
+def test_recover_stale_busy_valid_job(caplog):
+    """BUSY + valid job exists → 0 returned (subquery finds the job), no commit."""
+    session = _make_mock_session(rowcount=0)
+
+    result = _recover_stale_busy_schedulers(session)
+
+    assert result == 0
+    session.commit.assert_not_called()
+
+
+def test_recover_stale_busy_deleted_job(caplog):
+    """BUSY + deleted job → reset, commit called, returns 2."""
+    session = _make_mock_session(rowcount=2)
+
+    result = _recover_stale_busy_schedulers(session)
+
+    assert result == 2
+    session.commit.assert_called_once()
+    assert "Recovered 2 stale BUSY scheduler(s)" in caplog.text

--- a/flip-ui/src/services/api.ts
+++ b/flip-ui/src/services/api.ts
@@ -66,11 +66,11 @@ class Http {
                     // so freshly-signed-in users don't hit a 401 on the
                     // very next request (e.g. getMfaStatus from hydrate).
                     let session = await fetchAuthSession();
-                    let token = session.tokens?.idToken?.toString();
+                    let token = session.tokens?.accessToken?.toString();
                     if (!token) {
                         try {
                             session = await fetchAuthSession({ forceRefresh: true });
-                            token = session.tokens?.idToken?.toString();
+                            token = session.tokens?.accessToken?.toString();
                         } catch (e) {
                             // The request will go out unauthenticated and
                             // the 401 handler will force a sign-out, but

--- a/flip-ui/src/store/auth.ts
+++ b/flip-ui/src/store/auth.ts
@@ -126,19 +126,19 @@ class MissingSessionTokensError extends Error {
 
 const waitForSessionTokens = async (): Promise<void> => {
     let session = await fetchAuthSession();
-    if (session.tokens?.idToken) return;
+    if (session.tokens?.accessToken) return;
     try {
         session = await fetchAuthSession({ forceRefresh: true });
     } catch (e) {
         console.error("waitForSessionTokens: forceRefresh threw:", e);
     }
-    if (!session.tokens?.idToken) {
+    if (!session.tokens?.accessToken) {
         // Log what Amplify *thinks* the session is so DevTools can
         // distinguish "no session at all" (bad storage / misconfigured
         // client) from "session exists but tokens are empty"
         // (token-refresh issue), then throw so the caller surfaces it.
         console.warn(
-            "waitForSessionTokens: no idToken after forceRefresh",
+            "waitForSessionTokens: no accessToken after forceRefresh",
             {
                 userSub: session.userSub,
                 hasCredentials: !!session.credentials

--- a/trust/xnat/Makefile
+++ b/trust/xnat/Makefile
@@ -203,8 +203,8 @@ xnat-configure:
 		echo "  Waiting for container..."; sleep 5; elapsed=$$((elapsed + 5)); \
 	done
 	CONTAINER=$$(docker ps --filter "name=$(XNAT_PROJECT)_xnat-web" -q); \
-	docker exec $$CONTAINER bash -c 'cd /data/xnat/config && LOG_FILE="configure-xnat-$(XNAT_PROJECT).log" && bash configure-xnat.sh 2>&1 | tee "$$LOG_FILE"'; \
-	docker exec $$CONTAINER bash -c 'cd /data/xnat/config && LOG_FILE="configure-dcm2niix-$(XNAT_PROJECT).log" && bash configure-dcm2niix.sh 2>&1 | tee "$$LOG_FILE"'
+	docker exec $$CONTAINER bash -c 'set -o pipefail; cd /data/xnat/config && LOG_FILE="configure-xnat-$(XNAT_PROJECT).log" && bash configure-xnat.sh 2>&1 | tee "$$LOG_FILE"'; \
+	docker exec $$CONTAINER bash -c 'set -o pipefail; cd /data/xnat/config && LOG_FILE="configure-dcm2niix-$(XNAT_PROJECT).log" && bash configure-dcm2niix.sh 2>&1 | tee "$$LOG_FILE"'
 
 xnat-configure-trust-1:
 	$(MAKE) xnat-configure XNAT_PROJECT=${project1}

--- a/trust/xnat/xnat/config/configure-dcm2niix.sh
+++ b/trust/xnat/xnat/config/configure-dcm2niix.sh
@@ -12,16 +12,16 @@
 # limitations under the License.
 #
 
+# Exit on first error, undefined variable, or pipe failure.
+set -euo pipefail
 
-# This script configures the dcm2niix container service in XNAT
-# It is intended to be run after the XNAT container has been started
-# for the first time.
+# This script configures the dcm2niix container service in XNAT.
+# It is intended to be run after configure-xnat.sh (which changes the admin password).
 #
-# This needs that configure-xnat.sh has been run, otherwise it will fail
-# because the password of the admin user has not been changed yet.
-#
-# Note the rest of the environment variables are available from the file
-# - trust/xnat/.env
+# Required environment variables:
+#   XNAT_ADMIN_USER     - XNAT admin username
+#   XNAT_ADMIN_PASSWORD - XNAT admin password (must match what configure-xnat.sh set)
+#   DATA_PATH           - Host path for Docker path translation
 #
 
 # The below are fixed values for now
@@ -125,5 +125,26 @@ for SUB_ID in $SITE_SUB_IDS; do
     -u "${XNAT_ADMIN_USER}:${XNAT_ADMIN_PASSWORD}"
 done
 
+# ----------------------------------------------------------------
+# VALIDATION
+# ----------------------------------------------------------------
+
+# Verify dcm2niix command was registered and enabled
 echo " "
-echo "XNAT configuration complete!"
+echo "Validating dcm2niix setup..."
+VALIDATION=$(curl -s -o /dev/null -w "%{http_code}" "$XNAT_URL/xapi/commands/$CMD_ID/wrappers/$dcm2niix_wrapper_name/enabled" \
+  -u "${XNAT_ADMIN_USER}:${XNAT_ADMIN_PASSWORD}")
+if [ "$VALIDATION" != "200" ]; then
+  echo "ERROR: dcm2niix command enable check returned HTTP $VALIDATION (expected 200)"
+  exit 1
+fi
+
+# Verify event service is enabled
+EVENT_STATUS=$(curl -s "$XNAT_URL/xapi/events/prefs" -u "${XNAT_ADMIN_USER}:${XNAT_ADMIN_PASSWORD}" | jq -r '.enabled')
+if [ "$EVENT_STATUS" != "true" ]; then
+  echo "ERROR: Event service is not enabled (expected true, got $EVENT_STATUS)"
+  exit 1
+fi
+
+echo " "
+echo "✅ dcm2niix configuration complete and validated!"

--- a/trust/xnat/xnat/config/configure-xnat.sh
+++ b/trust/xnat/xnat/config/configure-xnat.sh
@@ -19,6 +19,8 @@
 # - trust/xnat/.env
 #
 
+set -euo pipefail
+
 # The below are fixed values for now
 XNAT_URL="http://xnat-web:8080" # internal to Docker network
 ORTHANC_HOST="orthanc" # name of the service (container) in docker-compose


### PR DESCRIPTION
## Summary

Builds on the ECS foundation from #401 to actually run flip-api, fl-api-net-1, and fl-server-net-1 on ECS Fargate and to repoint the ALB/NLB at the new tasks. After this PR, the Central Hub no longer runs application containers on the EC2 host — that EC2 stays only as the SSM bastion and (per follow-up #451) loses the dead kit-sync plays.

The branch also includes the trust-side EC2 fixes that were necessary to get end-to-end training round-trips working against the new ECS stack on staging.

## What changed

### ECS task + service wiring
- `ecs_tasks.tf`: complete task definitions for flip-api, fl-api-net-1, fl-server-net-1.
  - Pull `INTERNAL_SERVICE_KEY` for fl-server via the secrets block (`FLIP_API:internal_service_key`) so the raw key never lands in the task-def JSON.
  - EFS `mountPoints` aligned with what the runtime images actually look at: `/app/admin/{local,startup}` for fl-api, `/app/{local,startup,transfer}` for fl-server.
  - Drop unused certs/keys volume blocks (NVFLARE keeps SSL files inside `local/`).
- `ecs_services.tf`: services for flip-api and fl-server include `load_balancer` blocks so each running task auto-registers its ENI IP. fl-api stays internal-only via Cloud Map.
- `ecs_efs_provision.tf`: kit source switched to `s3://aicentre_bucket/fl-flare-participant-kits/<date>/net-1/services` to match `site.yml`'s central-hub kit sync. Override `entryPoint` so `amazon/aws-cli` runs the heredoc instead of treating `/bin/sh` as an aws subcommand. Wipes the EFS access-point contents with `find ... -delete` before each `aws s3 cp` to defeat the size+mtime skip trap (NVFLARE kits are signed at provision time, so a partial sync trips `LoadResult.INVALID_SIGNATURE`).
- `iam_ecs.tf`: fl-server task role gets read access to the `fl-flare-participant-kits` prefix so the efs-provision-certs task can sync the kit.
- `ecs_sg.tf`: open fl-server SG ingress on 8002 from the fl-api SG — fl-api is the in-VPC NVFLARE admin client and connects directly to fl-server (NLB path is reserved for off-VPC trust FL clients). Without this, fl-api hangs in `try_connect`.
- `locals.tf`: complete `ecs_task_env.flip_api` (cognito IDs, S3 bucket URIs, header names, SES emails, NET_ENDPOINTS built from Cloud Map, TRUST_NAMES, FL_BACKEND, ENFORCE_MFA, POSTGRES_*); add `INTERNAL_SERVICE_KEY_HEADER` to the fl_server map and `FL_ADMIN_DIRECTORY` to the fl_api map.
- `Makefile` + `variables.tf`: wire `TRUST_NAMES`, `TRUST_API_KEY_HEADER`, `INTERNAL_SERVICE_KEY_HEADER`, `FL_ADMIN_DIRECTORY`, `ENFORCE_MFA` through `TF_VAR_*` with sensible defaults.
- `main.tf`: required `null` provider for `ecs_efs_provision.tf`.

### Load-balancer cutover
- `main.tf`: add `aws_lb_target_group.ecs_flip_api` (ALB, HTTP 8000, `target_type=ip`) and `aws_lb_target_group.ecs_fl_server_tcp` (NLB, TCP 8002, `target_type=ip`). `target_type=ip` is mandatory for awsvpc Fargate. Repoint the `/api/*` listener rule and the FL TCP listener at the new target groups. Drop the legacy module-managed `ec2-instance-fl-server-tcp` target group from the NLB module config.
- `ecs_services.tf`: load-balancer attachments on flip-api and fl-server-net-1.

### Feature flags + EFS ingress (PR 1 → enabled)
- `enable_efs`, `enable_service_discovery`, `enable_ecs_endpoints` flipped from `false` to `true` (foundation gates from #401).
- `efs.tf`: NFS (2049) ingress from `ecs_fl_api` and `ecs_fl_server` SGs.

### Application-side changes
- `flip-api/src/flip_api/fl_services/run_jobs.py`: `_recover_stale_busy_schedulers()` runs at the top of every `run_jobs_core` cycle and resets `FLScheduler` rows stuck in `BUSY` whose associated job no longer exists. Prevents a single mid-flight exception in `prepare_and_start_training` from permanently starving a net of new jobs.

### Trust EC2 fixes (uncovered during cutover validation)
- `modules/trust_ec2/main.tf`: grow root volume from 50 GB to 100 GB. The full image set (NVFLARE flare-fl-client + torch, XNAT Tomcat ~4 GB compressed, Orthanc, OMOP, observability, three trust APIs) blows through 50 GB of overlayfs snapshot space. Volume modification is in-place; partition + filesystem need a one-shot `growpart` + `resize2fs` after apply.
- `site.yml`: wipe `/opt/flip/services/Trust_1` (NVFLARE) and `/opt/flip/services/net-1` (Flower) with `find ... -delete` before the `aws s3 sync`. Mirrors the EFS provisioner fix — without it, fl-client connects to fl-server with `SSLV3_ALERT_BAD_CERTIFICATE` / `CERTIFICATE_VERIFY_FAILED` because the on-disk kit is signed by a previous rootCA.
- `site.yml`: pre-create `/opt/flip/data/trust-1` and `/opt/flip/data/trust-2` owned by `ubuntu:ubuntu` (uid 1000 inside the containers). Without this, Docker auto-creates the missing bind-mount source as root, imaging-api (uid 1000) cannot mkdir inside `/app/data/images/net-1`, every `download/images/net-1` call returns 500, and FL training aborts with `num_samples=0` — a host-side ownership bug that masquerades as a data / trainer.py bug. Drops the unused `/opt/flip/data/images` entry.

### Documentation
- `deploy/providers/AWS/TROUBLESHOOTING.md`: new entries 1.5, 1.7, 1.8, 2.5, 2.6, 3.6, 3.7 covering each of the failure modes above with symptoms / root cause / fix.

## Verified end-to-end on staging

- ALB `/api/health` returns 200 (target IP = ECS task IP).
- NLB `ecs-fl-server-tcp` target group shows ECS task IP healthy.
- All three ECS services running 1/1.
- fl-client on the trust EC2 connects to `fl.stag.flip.aicentre.co.uk:8002` via the NLB and registers as `Trust_1` (NVFLARE token issued).
- Cohort query and imaging retrieval round-trip cleanly through ECS flip-api → trust-api → data-access-api / imaging-api.
- A full model training run reaches the FL training stage successfully after the bind-mount ownership fix.

## Test plan

- [x] `make plan PROD=stag` is additive only — no destroy of persistent resources (RDS, S3, Cognito, Secrets).
- [x] `make full-deploy PROD=stag` from a clean checkout reaches green `make status` (ALB 200, NLB healthy, ECS 1/1 across the three services).
- [x] After `make deploy-trust PROD=stag`, `docker exec trust1-fl-client-net-1 grep _trust_internal_headers /app/flip/core/standard.py` shows the header wiring (sanity check on the fl-image bump).
- [x] Create a project + model + training run end-to-end on staging — confirm cohort dataframe lands at fl-client and `num_samples > 0`.
- [x] Validate trust EC2 root volume reports ~100 GB after `growpart` + `resize2fs`.
- [x] Re-run `terraform plan` — should be a no-op (idempotency).

## Follow-ups

- #451 (open) drops the now-dead `central_hub` kit-sync plays from `site.yml`. Kept separate so this PR stays a pure cutover.
- PR 3/3 will retire the legacy EC2 docker compose stack on the central hub host.

<img width="1860" height="989" alt="image" src="https://github.com/user-attachments/assets/b3b2e175-c1f0-498b-8cf5-dae69b073586" />
