### PR TITLE
feat(flip-ui): add Status column to project Models list

### DIFF
--- a/flip-ui/src/partials/models/ModelList.vue
+++ b/flip-ui/src/partials/models/ModelList.vue
@@ -80,6 +80,9 @@
                                 <th>
                                     Description
                                 </th>
+                                <th class="w-[220px] whitespace-nowrap">
+                                    Status
+                                </th>
                                 <th class="w-[150px]" />
                             </tr>
                         </template>
@@ -107,6 +110,25 @@
                                         </p>
                                     </div>
                                 </td>
+                                <td :data-test="`model-status-${row.id}`">
+                                    <div class="flex items-center gap-2 whitespace-nowrap">
+                                        <icon-heroicons-outline-check
+                                            v-if="row.status && !isModelStatusError(row.status)"
+                                            class="w-4 h-4 text-green-600 dark:text-green-400 shrink-0"
+                                            data-test="model-status-icon-tick"
+                                            aria-hidden="true"
+                                        />
+                                        <icon-heroicons-outline-x
+                                            v-else-if="isModelStatusError(row.status)"
+                                            class="w-4 h-4 text-red-600 dark:text-red-400 shrink-0"
+                                            data-test="model-status-icon-cross"
+                                            aria-hidden="true"
+                                        />
+                                        <span class="text-sm text-gray-700 dark:text-gray-300">
+                                            {{ modelStatusLabel(row.status) }}
+                                        </span>
+                                    </div>
+                                </td>
                                 <td>
                                     <AiButton
                                         text-primary
@@ -120,7 +142,7 @@
                                 </td>
                             </tr>
                             <tr v-if="!rows.length">
-                                <td colspan="3" class="text-center">
+                                <td colspan="4" class="text-center">
                                     There are no models to show
                                 </td>
                             </tr>
@@ -148,7 +170,7 @@ import AiButton from "@/components/AiButton/AiButton.vue";
 import AiPagination from "@/components/AiPagination/AiPagination.vue";
 import useErrorHandler from "@/composables/useErrorHandler";
 import { routeChange } from "@/router";
-import { getModels } from "@/services/model-service";
+import { getModels, isModelStatusError, modelStatusLabel } from "@/services/model-service";
 import { useAuthStore } from "@/store/auth";
 import { useModalsStore } from "@/store/modals";
 

--- a/flip-ui/src/partials/models/__tests__/ModelList.spec.ts
+++ b/flip-ui/src/partials/models/__tests__/ModelList.spec.ts
@@ -1,0 +1,191 @@
+/*
+ * Copyright (c) 2026 Guy's and St Thomas' NHS Foundation Trust & King's College London
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createTestingPinia } from "@pinia/testing";
+import { flushPromises, mount } from "@vue/test-utils";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { ref } from "vue";
+
+import ModelList from "../ModelList.vue";
+
+const mockRoute = { params: { projectId: "project-1" } as Record<string, string> };
+vi.mock("vue-router", async (importOriginal) => {
+    const actual = await importOriginal<typeof import("vue-router")>();
+    return { ...actual, useRoute: () => mockRoute };
+});
+
+const mockData = vi.hoisted(() => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const vue = require("vue") as typeof import("vue");
+    return { ref: vue.ref<unknown>(undefined) };
+});
+vi.mock("swrv", () => ({
+    default: () => ({ data: mockData.ref, error: ref(null) })
+}));
+
+vi.mock("@/services/model-service", async (importOriginal) => {
+    const actual = await importOriginal<typeof import("@/services/model-service")>();
+    return { ...actual, getModels: vi.fn(async () => undefined) };
+});
+
+vi.mock("@/composables/useErrorHandler", () => ({ default: vi.fn() }));
+
+function setData(v: unknown) {
+    (mockData.ref as { value: unknown }).value = v;
+}
+
+function mountModelList() {
+    return mount(ModelList, {
+        global: {
+            plugins: [
+                createTestingPinia({
+                    createSpy: vi.fn,
+                    stubActions: false,
+                    initialState: {
+                        auth: {
+                            user: {
+                                username: "u",
+                                userId: "id",
+                                attributes: { sub: "s", email: "u@e.com" },
+                                permissions: ["CanManageProjects"]
+                            },
+                            signInStep: "DONE",
+                            mfaEnabled: true,
+                            mfaRequired: true
+                        }
+                    }
+                })
+            ],
+            stubs: {
+                AiButton: { template: "<button><slot /></button>" },
+                AiPagination: { template: "<div />" },
+                AiSearch: { template: "<input />" },
+                AiSkeleton: { template: "<div />" },
+                // VTable is a global component (registered via Vite) that the
+                // unit-test runner doesn't auto-resolve. Stub it with a thin
+                // table that forwards `data` into the body slot's `rows`.
+                VTable: {
+                    template: "<table><slot name=\"head\" /><tbody><slot name=\"body\" :rows=\"data ?? []\" /></tbody></table>",
+                    props: ["data"]
+                },
+                "router-link": { template: "<a><slot /></a>", props: ["to"] }
+            }
+        }
+    });
+}
+
+describe("ModelList — Status column", () => {
+    beforeEach(() => {
+        setData(undefined);
+    });
+
+    test("renders a Status column header after Description", async () => {
+        setData({ data: [{ id: "m1", name: "A", description: "d", status: "PENDING" }] });
+        const wrapper = mountModelList();
+        await flushPromises();
+
+        const headers = wrapper.findAll("th").map(th => th.text().trim());
+        // Adjacent headers: Description, then Status, then the empty action column.
+        const descIdx = headers.indexOf("Description");
+        expect(descIdx).toBeGreaterThanOrEqual(0);
+        expect(headers[descIdx + 1]).toBe("Status");
+    });
+
+    test("PENDING renders 'Model Created' with a tick icon", async () => {
+        setData({ data: [{ id: "m1", name: "A", description: "", status: "PENDING" }] });
+        const wrapper = mountModelList();
+        await flushPromises();
+
+        const cell = wrapper.find("[data-test='model-status-m1']");
+        expect(cell.exists()).toBe(true);
+        expect(cell.text()).toContain("Model Created");
+        expect(cell.find("[data-test='model-status-icon-tick']").exists()).toBe(true);
+        expect(cell.find("[data-test='model-status-icon-cross']").exists()).toBe(false);
+    });
+
+    test("INITIATED renders 'Model Queued' with a tick", async () => {
+        setData({ data: [{ id: "m1", name: "A", description: "", status: "INITIATED" }] });
+        const wrapper = mountModelList();
+        await flushPromises();
+
+        const cell = wrapper.find("[data-test='model-status-m1']");
+        expect(cell.text()).toContain("Model Queued");
+        expect(cell.find("[data-test='model-status-icon-tick']").exists()).toBe(true);
+    });
+
+    test("PREPARED renders 'Model Prepared' with a tick", async () => {
+        setData({ data: [{ id: "m1", name: "A", description: "", status: "PREPARED" }] });
+        const wrapper = mountModelList();
+        await flushPromises();
+
+        const cell = wrapper.find("[data-test='model-status-m1']");
+        expect(cell.text()).toContain("Model Prepared");
+        expect(cell.find("[data-test='model-status-icon-tick']").exists()).toBe(true);
+    });
+
+    test("TRAINING_STARTED renders 'Training Started' with a tick", async () => {
+        setData({ data: [{ id: "m1", name: "A", description: "", status: "TRAINING_STARTED" }] });
+        const wrapper = mountModelList();
+        await flushPromises();
+
+        const cell = wrapper.find("[data-test='model-status-m1']");
+        expect(cell.text()).toContain("Training Started");
+        expect(cell.find("[data-test='model-status-icon-tick']").exists()).toBe(true);
+    });
+
+    test("RESULTS_UPLOADED renders 'Results Uploaded' with a tick", async () => {
+        setData({ data: [{ id: "m1", name: "A", description: "", status: "RESULTS_UPLOADED" }] });
+        const wrapper = mountModelList();
+        await flushPromises();
+
+        const cell = wrapper.find("[data-test='model-status-m1']");
+        expect(cell.text()).toContain("Results Uploaded");
+        expect(cell.find("[data-test='model-status-icon-tick']").exists()).toBe(true);
+    });
+
+    test("ERROR renders 'Error' with a red cross", async () => {
+        setData({ data: [{ id: "m1", name: "A", description: "", status: "ERROR" }] });
+        const wrapper = mountModelList();
+        await flushPromises();
+
+        const cell = wrapper.find("[data-test='model-status-m1']");
+        expect(cell.text()).toContain("Error");
+        expect(cell.find("[data-test='model-status-icon-cross']").exists()).toBe(true);
+        expect(cell.find("[data-test='model-status-icon-tick']").exists()).toBe(false);
+    });
+
+    test("STOPPED renders 'Stopped' with a red cross", async () => {
+        setData({ data: [{ id: "m1", name: "A", description: "", status: "STOPPED" }] });
+        const wrapper = mountModelList();
+        await flushPromises();
+
+        const cell = wrapper.find("[data-test='model-status-m1']");
+        expect(cell.text()).toContain("Stopped");
+        expect(cell.find("[data-test='model-status-icon-cross']").exists()).toBe(true);
+    });
+
+    test("missing status falls back to a placeholder rather than crashing", async () => {
+        // Defensive: an older API response (or a stale cache from before the
+        // backend started returning status) leaves the cell with neither a
+        // tick nor a cross — and shouldn't blow up the row.
+        setData({ data: [{ id: "m1", name: "A", description: "" }] });
+        const wrapper = mountModelList();
+        await flushPromises();
+
+        expect(wrapper.exists()).toBe(true);
+        const cell = wrapper.find("[data-test='model-status-m1']");
+        expect(cell.exists()).toBe(true);
+        expect(cell.find("[data-test='model-status-icon-tick']").exists()).toBe(false);
+        expect(cell.find("[data-test='model-status-icon-cross']").exists()).toBe(false);
+    });
+});

--- a/flip-ui/src/services/model-service.ts
+++ b/flip-ui/src/services/model-service.ts
@@ -40,6 +40,9 @@ export interface IModel {
     description: string;
     ownerId: string;
     projectId: string;
+    // Optional only because cached payloads from before the backend exposed
+    // it on the project-models list may still be in flight on first paint.
+    status?: ModelStatus;
 }
 
 export interface ILog {
@@ -108,6 +111,26 @@ export enum ModelStatusEnum {
     "PREPARED",
     "TRAINING_STARTED",
     "RESULTS_UPLOADED",
+}
+
+const MODEL_STATUS_LABELS: Record<ModelStatus, string> = {
+    PENDING: "Model Created",
+    INITIATED: "Model Queued",
+    PREPARED: "Model Prepared",
+    TRAINING_STARTED: "Training Started",
+    RESULTS_UPLOADED: "Results Uploaded",
+    ERROR: "Error",
+    STOPPED: "Stopped"
+};
+
+/** Human-readable label for a model status. Falls back to "—" if unknown. */
+export function modelStatusLabel(status: ModelStatus | undefined): string {
+    return status ? MODEL_STATUS_LABELS[status] ?? "—" : "—";
+}
+
+/** True for terminal failure / cancellation states (drives the red-cross icon). */
+export function isModelStatusError(status: ModelStatus | undefined): boolean {
+    return status === "ERROR" || status === "STOPPED";
 }
 
 /**


### PR DESCRIPTION
Added model status column in models list page:

<img width="1512" height="866" alt="Screenshot 2026-05-08 at 12 24 58" src="https://github.com/user-attachments/assets/14404848-5a10-4352-a91a-5d65be242475" />

## Summary
- New **Status** column between Description and the action column on `/project/{id}/models`. Renders a green check for non-error states (PENDING → "Model Created", INITIATED → "Model Queued", PREPARED → "Model Prepared", TRAINING_STARTED → "Training Started", RESULTS_UPLOADED → "Results Uploaded") and a red x for ERROR / STOPPED.
- Backend already returned `status` on the project-models endpoint (`IModelsInfoResponse`) — only the TS `IModel` interface and `ModelList.vue` needed updating. `modelStatusLabel()` and `isModelStatusError()` helpers live alongside the existing `ModelStatus` / `ModelStatusEnum` so other consumers can reuse them.
- Column is sized + `whitespace-nowrap` so "Results Uploaded" stays on a single line.

## Test plan
- [x] `npx vitest run src/partials/models/__tests__/ModelList.spec.ts` (9 new cases, one per enum value + header position + missing-status fallback)
- [x] `npm run lint` — no new warnings on touched files
- [x] Visual check at `/project/{id}/models` against a project that exercises each status (covered ad-hoc by the e2e_smoke flow being shipped separately)