### PR TITLE
docs: trust-api README + return type annotations on flip-api / imaging-api

### DIFF
--- a/flip-api/src/flip_api/fl_services/run_jobs.py
+++ b/flip-api/src/flip_api/fl_services/run_jobs.py
@@ -99,7 +99,7 @@ def run_jobs_core(db: Session) -> None:
         )
 
 
-def run_jobs_scheduled_task():
+def run_jobs_scheduled_task() -> None:
     """
     Scheduled task to run jobs every minute.
     This function is called by the scheduler.

--- a/flip-api/src/flip_api/fl_services/services/fl_scheduler_service.py
+++ b/flip-api/src/flip_api/fl_services/services/fl_scheduler_service.py
@@ -49,7 +49,7 @@ from flip_api.utils.exceptions import DatabaseError, NotFoundError
 from flip_api.utils.logger import logger
 
 
-def remove_job(job_id: UUID, session: Session):
+def remove_job(job_id: UUID, session: Session) -> None:
     """
     Sets the job status to DELETED and clears the started timestamp.
 
@@ -84,7 +84,7 @@ def remove_job(job_id: UUID, session: Session):
         raise DatabaseError("Error reverting job pickup") from e
 
 
-def remove_job_from_queue(model_id: UUID, session: Session):
+def remove_job_from_queue(model_id: UUID, session: Session) -> None:
     """
     Sets the job status to DELETED for all jobs associated with the given model ID.
 
@@ -120,7 +120,7 @@ def remove_job_from_queue(model_id: UUID, session: Session):
         raise DatabaseError("Error removing job from queue") from e
 
 
-def revert_scheduler_pickup(scheduler_id: UUID, session: Session):
+def revert_scheduler_pickup(scheduler_id: UUID, session: Session) -> None:
     """
     Sets the scheduler status to AVAILABLE and clears the job_id.
 
@@ -360,7 +360,7 @@ def check_for_queued_jobs(scheduler_id: UUID, session: Session) -> IJobResponse 
         raise DatabaseError("Error checking for queued jobs") from e
 
 
-def prepare_and_start_training(model_id: UUID, fl_job_id: UUID, clients: list[str], session: Session):
+def prepare_and_start_training(model_id: UUID, fl_job_id: UUID, clients: list[str], session: Session) -> None:
     """
     Prepares and starts the training process for a given model.
 
@@ -475,7 +475,7 @@ def get_required_training_details(model_id: UUID, session: Session) -> IRequired
         raise DatabaseError("Error getting required training details") from e
 
 
-def update_fl_scheduler(model_id: UUID, session: Session):
+def update_fl_scheduler(model_id: UUID, session: Session) -> None:
     """
     Updates the FL job status to COMPLETED and sets the associated scheduler status to AVAILABLE.
 

--- a/flip-api/src/flip_api/main.py
+++ b/flip-api/src/flip_api/main.py
@@ -253,7 +253,7 @@ include_api_routers(app)
 
 # Root endpoint
 @app.get(API_PREFIX, response_model=dict[str, str])
-def root():
+def root() -> dict[str, str]:
     """Root endpoint to verify the API is running.
 
     Returns:
@@ -263,7 +263,7 @@ def root():
 
 
 @app.get(f"{API_PREFIX}/health", response_model=dict[str, str])
-def health_check():
+def health_check() -> dict[str, str]:
     """Health check endpoint to verify the API is running.
 
     Returns:
@@ -272,7 +272,7 @@ def health_check():
     return {"status": "ok", "message": "flip is running"}
 
 
-def main():
+def main() -> None:
     """Entry point for the application script"""
     uvicorn.run("flip_api.main:app", host="0.0.0.0", port=81, reload=True)
 

--- a/flip-api/src/flip_api/project_services/reimport_imaging_project_studies.py
+++ b/flip-api/src/flip_api/project_services/reimport_imaging_project_studies.py
@@ -57,7 +57,7 @@ def reimport_imaging_project_studies(db: Session) -> None:
     return
 
 
-def reimport_imaging_project_studies_scheduled_task():
+def reimport_imaging_project_studies_scheduled_task() -> None:
     """
     Scheduled task to reimport imaging project studies.
     This function is called by the scheduler.

--- a/flip-api/src/flip_api/scheduler/apscheduler_runner.py
+++ b/flip-api/src/flip_api/scheduler/apscheduler_runner.py
@@ -47,6 +47,6 @@ scheduler.add_job(
 )
 
 
-def start_scheduler():
+def start_scheduler() -> None:
     """Start the background scheduler to run periodic tasks."""
     scheduler.start()

--- a/flip-api/src/flip_api/user_services/access_request.py
+++ b/flip-api/src/flip_api/user_services/access_request.py
@@ -26,7 +26,7 @@ router = APIRouter(prefix="/users", tags=["user_services"])
 
 # [#114] ✅
 @router.post("/access", status_code=status.HTTP_204_NO_CONTENT, response_model=None)
-def request_access(request: IAccessRequest):
+def request_access(request: IAccessRequest) -> None:
     """
     Send an access request email to administrators.
 

--- a/trust/imaging-api/imaging_api/routers/health.py
+++ b/trust/imaging-api/imaging_api/routers/health.py
@@ -16,7 +16,7 @@ router = APIRouter(prefix="/health", tags=["Health"])
 
 
 @router.get("")
-async def health_check():
+async def health_check() -> dict[str, str]:
     """
     Health check endpoint for the Imaging API
 

--- a/trust/imaging-api/imaging_api/services/download.py
+++ b/trust/imaging-api/imaging_api/services/download.py
@@ -193,7 +193,7 @@ def format_download_url(
     )
 
 
-def download_file(url: str, destination_path: str, headers: dict[str, str]):
+def download_file(url: str, destination_path: str, headers: dict[str, str]) -> str:
     """
     Downloads a file from the given URL using an XNAT auth headers.
 
@@ -245,7 +245,7 @@ def download_file(url: str, destination_path: str, headers: dict[str, str]):
     return destination_path
 
 
-def unzip_file(zip_path: str, extract_dir: str, new_name: str):
+def unzip_file(zip_path: str, extract_dir: str, new_name: str) -> str:
     """
     Extracts a ZIP file and renames the directory.
 

--- a/trust/imaging-api/imaging_api/utils/exceptions.py
+++ b/trust/imaging-api/imaging_api/utils/exceptions.py
@@ -14,7 +14,7 @@
 class NotFoundError(Exception):
     """Exception raised when a resource is not found."""
 
-    def __init__(self, detail: str = "Resource not found", status_code: int = 404):
+    def __init__(self, detail: str = "Resource not found", status_code: int = 404) -> None:
         self.status_code = status_code
         self.detail = detail
         super().__init__(f"{status_code}: {detail}")
@@ -29,7 +29,7 @@ class AlreadyExistsError(Exception):
 class InternalServerError(Exception):
     """Exception raised for internal server errors."""
 
-    def __init__(self, detail: str = "Internal server error", status_code: int = 500):
+    def __init__(self, detail: str = "Internal server error", status_code: int = 500) -> None:
         self.status_code = status_code
         self.detail = detail
         super().__init__(f"{status_code}: {detail}")
@@ -44,7 +44,7 @@ class LocalStorageError(Exception):
     issue and should surface as 500, not 404.
     """
 
-    def __init__(self, detail: str = "Local storage error", status_code: int = 500):
+    def __init__(self, detail: str = "Local storage error", status_code: int = 500) -> None:
         self.status_code = status_code
         self.detail = detail
         super().__init__(f"{status_code}: {detail}")

--- a/trust/trust-api/README.md
+++ b/trust/trust-api/README.md
@@ -66,6 +66,17 @@ Key environment variables (set in [`.env.development.example`](../../.env.develo
 | `TRUST_API_KEY` | Per-trust API key for authenticating with the Central Hub. Keys are stored in `TRUST_API_KEYS` JSON dict; generate with `make generate-trust-api-keys` |
 | `AES_KEY_BASE64` | Base64-encoded AES-256 key shared with the hub, used to decrypt encrypted task payloads |
 | `POLL_INTERVAL_SECONDS` | Polling frequency in seconds (default: 5) |
+| `TRUST_INTERNAL_SERVICE_KEY_HEADER` | Header name for trust-internal service auth (default `X-Trust-Internal-Service-Key`) |
+| `TRUST_INTERNAL_SERVICE_KEY` | Per-trust plaintext key. Forwarded outbound on every call to imaging-api and data-access-api so those services can authenticate the caller. Generated alongside the other trust keys via `make generate-trust-internal-service-keys` (run from the repo root or `flip-api/`). |
+
+## Authentication
+
+trust-api authenticates **outbound** in two directions:
+
+- **To the Central Hub**: every request carries `TRUST_API_KEY` in the `TRUST_API_KEY_HEADER`. The hub validates against the SHA-256 hash stored in `TRUST_API_KEY_HASHES`.
+- **To sibling trust services** (imaging-api, data-access-api): every request carries `TRUST_INTERNAL_SERVICE_KEY` in the configured header. Receivers compare with `hmac.compare_digest` against their own copy of the same per-trust key. See the **Trust-internal Service Authentication** section in [`CLAUDE.md`](../../CLAUDE.md) for the threat model.
+
+trust-api itself does **not** receive inbound requests from the hub or any external caller — it only polls outbound — so it does not validate an inbound trust-internal header.
 
 ## Scaling Assumptions
 


### PR DESCRIPTION
> This is an automated scheduled weekly task by Alex's Claude Code.

## Summary

Routine sweep of READMEs / readthedocs vs code, plus docstring/type-annotation parity check. Two findings warranted action; everything else was already in sync.

### 1. `trust/trust-api/README.md` — document trust-internal service auth env vars

The Configuration table listed `TRUST_API_KEY` (hub-bound) but did **not** list `TRUST_INTERNAL_SERVICE_KEY` / `TRUST_INTERNAL_SERVICE_KEY_HEADER`, even though `trust_api/services/task_handlers.py::_trust_internal_headers` reads those settings and forwards the header on every outbound call to imaging-api and data-access-api.

`imaging-api/README.md` and `data-access-api/README.md` already document these vars; `trust-api/README.md` was the gap. Added the two rows and a short Authentication section consistent with the threat-model description in `CLAUDE.md`.

### 2. Missing return-type annotations on signatures whose docstrings already declared the return type

Pure annotation additions, no runtime behaviour change. Each function's docstring already stated `Returns: …`, so this is mechanical alignment between docstring and signature:

**flip-api**
- `src/flip_api/main.py`: `root` → `dict[str, str]`, `health_check` → `dict[str, str]`, `main` → `None`
- `src/flip_api/scheduler/apscheduler_runner.py`: `start_scheduler` → `None`
- `src/flip_api/fl_services/run_jobs.py`: `run_jobs_scheduled_task` → `None`
- `src/flip_api/project_services/reimport_imaging_project_studies.py`: `reimport_imaging_project_studies_scheduled_task` → `None`
- `src/flip_api/user_services/access_request.py`: `request_access` → `None`
- `src/flip_api/fl_services/services/fl_scheduler_service.py`: `remove_job`, `remove_job_from_queue`, `revert_scheduler_pickup`, `prepare_and_start_training`, `update_fl_scheduler` all → `None`

**imaging-api**
- `imaging_api/services/download.py`: `download_file` → `str`, `unzip_file` → `str`
- `imaging_api/routers/health.py`: `health_check` → `dict[str, str]`
- `imaging_api/utils/exceptions.py`: `NotFoundError.__init__`, `InternalServerError.__init__`, `LocalStorageError.__init__` all → `None`

### What was checked but is already correct

- `flip-api/README.md`, `trust/imaging-api/README.md`, `trust/data-access-api/README.md` — all describe trust-internal auth correctly.
- `docs/source/components/component-fl-nodes.rst` — covers both NVFLARE and Flower.
- `docs/source/5_api_reference.rst` — endpoints checked, no stale entries flagged.
- The Sphinx sys-admin guide (`admin-tre-deployment.rst`) does not yet describe `ENFORCE_MFA`, `FLIP_API_INTERNAL_URL`, or trust-internal auth env vars — these are documented in `deploy/README.md` and `CLAUDE.md`. Adding them to the Sphinx guide is a larger structural change (probably a new "Trust-internal auth" section) and is out of scope for this routine sweep; flagging here for a future PR.

## Test plan

- [x] `uv run ruff check` — passes on all modified files (flip-api + imaging-api)
- [x] `uv run mypy` — passes on all modified files (flip-api + imaging-api)
- [x] `uv run pytest tests/` (imaging-api) — 240 passed; one pre-existing failure (`TestDownloadFileLocalWriteFailure::test_unwritable_parent_raises_local_storage_error`) is unrelated — it relies on `chmod 500` blocking writes, but the sandbox runs as root, so chmod is not enforced. The function under test (`download_file`) only had a return-type annotation added.
- [ ] flip-api unit tests not run locally — they require DB / Cognito env vars typically supplied by `make unit_test` in Docker. CI will run them. Changes are pure annotations on functions with no behavioural change.

https://claude.ai/code/session_01FaK3RLWH6qnGfVKruSx1ih

---
_Generated by [Claude Code](https://claude.ai/code/session_01FaK3RLWH6qnGfVKruSx1ih)_