### PR TITLE
Fix select element styling and update copyright year to 2026

### DIFF
--- a/docs/source/_static/style.css
+++ b/docs/source/_static/style.css
@@ -167,10 +167,12 @@ body, .wy-body-for-nav,
     margin-bottom: 6px;
 }
 /* Default any interactive element in the search area to readable purple
-   so future additions (e.g. a language picker) don't fail contrast. */
+   so future additions (e.g. a language picker) don't fail contrast. The
+   !important is required to win against RTD's built-in white-text rule for
+   the version selector when it renders the <select> outside div.version. */
 .wy-side-nav-search select,
 .wy-side-nav-search button {
-    color: var(--flip-primary-400);
+    color: var(--flip-primary-400) !important;
 }
 .wy-side-nav-search > div.version,
 .wy-side-nav-search .wy-dropdown > a,

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -35,7 +35,7 @@ sys.path.insert(0, os.path.abspath("../../trust/trust-api"))
 
 # -- Project information -----------------------------------------------------
 project = "FLIP"
-copyright = "2025, The London AI Centre for Value-Based Healthcare"
+copyright = "2026, The London AI Centre for Value-Based Healthcare"
 author = "The London AI Centre for Value-Based Healthcare"
 
 # The full version of the documentation, including alpha/beta/rc tags


### PR DESCRIPTION
# Description

This PR makes two minor updates to the documentation configuration:

1. **CSS Fix**: Adds `!important` to the `.wy-side-nav-search select` and `button` color rule to ensure the purple text color takes precedence over Read the Docs' built-in white-text rule for the version selector when it renders outside the `div.version` container. This resolves a contrast issue with the version selector dropdown.

2. **Copyright Update**: Updates the copyright year from 2025 to 2026 in `conf.py`.

## Linked Issues

Fixes #

## Checklist

- [x] Follows the project's coding conventions and style guide
- [x] Updates documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Type of Change

- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] In-line docstrings updated.
- [x] Documentation updated, tested `make -C docs/ docs`.

## Testing

These are trivial changes (CSS specificity fix and copyright year update) that do not require additional testing. The CSS change can be visually verified by rendering the documentation and confirming the version selector text displays in the correct purple color with proper contrast.

## Additional Notes

The `!important` flag is necessary in this case to override Read the Docs' built-in styling rules that apply white text to the version selector when it renders outside the expected container structure.

https://claude.ai/code/session_01KjBeXA1yEaXJ25MBttzpmp