### PR TITLE
feat(deploy/aws): publish FLIP-Prod VPC + subnet IDs to SSM

### DIFF
--- a/deploy/providers/AWS/main.tf
+++ b/deploy/providers/AWS/main.tf
@@ -32,6 +32,11 @@ provider "aws" {
 
 data "aws_availability_zones" "available" {}
 
+# Cross-stack: aicentre-iac's network_account_flip module reads
+# /flip/networking/vpc_id and /flip/networking/private_subnet_ids from
+# this account's SSM (see parameter_store.tf) to back the cross-account
+# TGW VPC attachment. If you recreate or rename this VPC, plan against
+# aicentre-iac immediately afterwards.
 module "flip_vpc" {
   source               = "terraform-aws-modules/vpc/aws"
   version              = "~> 6.0"

--- a/deploy/providers/AWS/parameter_store.tf
+++ b/deploy/providers/AWS/parameter_store.tf
@@ -43,3 +43,22 @@ resource "aws_ssm_parameter" "internal_service_key_header" {
   type        = "String"
   value       = "X-Internal-Service-Key"
 }
+
+# Networking values published for cross-account consumers. aicentre-iac's
+# network_account_flip module reads these from the FLIP-Prod account to
+# back the cross-account TGW VPC attachment (single authoritative value
+# avoids tag-collision ambiguity during VPC migrations).
+
+resource "aws_ssm_parameter" "vpc_id" {
+  name        = "${local.ssm_prefix}/networking/vpc_id"
+  description = "FLIP-Prod VPC ID — consumed cross-account by aicentre-iac's TGW VPC attachment"
+  type        = "String"
+  value       = module.flip_vpc.vpc_id
+}
+
+resource "aws_ssm_parameter" "private_subnet_ids" {
+  name        = "${local.ssm_prefix}/networking/private_subnet_ids"
+  description = "FLIP-Prod private subnet IDs (comma-separated) — consumed cross-account by aicentre-iac's TGW VPC attachment"
+  type        = "StringList"
+  value       = join(",", module.flip_vpc.private_subnets)
+}


### PR DESCRIPTION
## Summary
- Publish `/flip/networking/vpc_id` (String) and `/flip/networking/private_subnet_ids` (StringList) from `module.flip_vpc`.
- Add a cross-stack-dependency comment above `module "flip_vpc"` so future operators see the consumer dependency before recreating the VPC.

## Why
`aicentre-iac`'s `network_account_flip` module hardcodes the FLIP-Prod VPC ID and one private subnet ID to back the cross-account TGW VPC attachment. Hardcoded IDs drift silently if the VPC is recreated; a tag-based filter fallback would ambiguate during a side-by-side VPC migration. SSM Parameter Store gives a single authoritative value per name with no migration brittleness.

## Merge / apply ordering
**This PR must merge and `make apply PROD=true` must complete before the companion `aicentre-iac` PR is applied** — otherwise its `data "aws_ssm_parameter"` lookups will fail with `ParameterNotFound`.

Companion PR: **londonaicentre/aicentre-iac#175** — switches `network_account_flip` to read from these SSM parameters.

## Test plan
- [x] `terraform plan` in `deploy/providers/AWS/` shows only two new `aws_ssm_parameter` resources to add; no changes to existing resources.
- [x] After apply, both parameters exist: `aws ssm get-parameter --name /flip/networking/vpc_id --profile prod` and `--name /flip/networking/private_subnet_ids --profile prod`.
- [x] The published `vpc_id` value matches `aws ec2 describe-vpcs --filters 'Name=tag:Name,Values=flip-vpc' --profile prod`.
- [x] The published `private_subnet_ids` value (comma-separated) matches the FLIP VPC's private subnets across all configured AZs.

Preparatory cleanup ahead of #53 (trust-to-hub VPN over TGW).