### PR TITLE
e2e_smoke to also work with Flower (use FL_BACKEND)

### DIFF
--- a/.env.development.example
+++ b/.env.development.example
@@ -284,6 +284,13 @@ DOCKER_TAG=stag
 # images to ensure compatibility between server, client, and API.
 DOCKER_REGISTRY=ghcr.io/londonaicentre/
 DOCKER_FL_TAG=stag
+# Override the FL registry independently of DOCKER_REGISTRY when iterating
+# on locally-built FL images (e.g. flower-superlink:dev). Leave unset to
+# inherit DOCKER_REGISTRY (default behaviour). Setting this empty (`=`)
+# resolves images as `flower-superlink:dev` instead of
+# `ghcr.io/londonaicentre/flower-superlink:dev`, leaving the non-FL images
+# (flip-api, trust-api, …) on the GHCR registry.
+# DOCKER_FL_REGISTRY=
 
 # DOCKER_FL_API_NAME / DOCKER_FL_SERVER_NAME / DOCKER_FL_CLIENT_NAME are
 # derived from FL_BACKEND in deploy/fl_backend.mk. Override here only if you

--- a/.env.development.example
+++ b/.env.development.example
@@ -129,7 +129,7 @@ VITE_LOCAL=false
 # Comma-separated list of filenames that should NOT appear in the model
 # file upload UI. These are framework internals (training scripts, event
 # handlers, validators) that users should never select for upload.
-BLACKLISTED_MODEL_FILES=flip.py,server_app.py
+BLACKLISTED_MODEL_FILES=flip.py,server_app.py,strategy.py
 
 # ── Trust Credentials ────────────────────────────────────────────────────
 

--- a/Makefile
+++ b/Makefile
@@ -269,12 +269,12 @@ integration_test:
 
 # Drives a fresh project end-to-end against a running `make up` stack:
 # create → approve → upload model → wait for image pull → start training.
-# Defaults to the xray classification tutorial in flip-fl-base (sibling repo)
-# for both model files and cohort query. Useful for sanity-checking PRs
-# without manually clicking through the UI. See flip-api/Makefile for
-# overrides (MODEL_FILES_DIR, QUERY_FILE, EXTRA_ARGS).
+# Defaults pick the chest-xray tutorial that matches FL_BACKEND (flower or
+# nvflare); both sit in sibling repos (flip-fl-base / flip-fl-base-flower).
+# Useful for sanity-checking PRs without manually clicking through the UI.
+# See flip-api/Makefile for overrides (MODEL_FILES_DIR, QUERY_FILE, EXTRA_ARGS).
 e2e_smoke:
-	$(MAKE) -C flip-api e2e_smoke $(if $(MODEL_FILES_DIR),MODEL_FILES_DIR=$(MODEL_FILES_DIR)) $(if $(QUERY_FILE),QUERY_FILE=$(QUERY_FILE)) $(if $(EXTRA_ARGS),EXTRA_ARGS="$(EXTRA_ARGS)")
+	$(MAKE) -C flip-api e2e_smoke $(if $(FL_BACKEND),FL_BACKEND=$(FL_BACKEND)) $(if $(MODEL_FILES_DIR),MODEL_FILES_DIR=$(MODEL_FILES_DIR)) $(if $(QUERY_FILE),QUERY_FILE=$(QUERY_FILE)) $(if $(EXTRA_ARGS),EXTRA_ARGS="$(EXTRA_ARGS)")
 
 generate-trust-api-keys:
 	$(MAKE) -C flip-api generate-trust-api-keys $(if $(ENV_FILE),ENV_FILE=$(ENV_FILE))

--- a/Makefile
+++ b/Makefile
@@ -66,10 +66,11 @@ DEBUG_OVERRIDE_COMPOSE_COMMAND=docker compose -f $(COMMON_COMPOSE_FILE) -f $(FL_
 SHOW_LOGS_CENTRAL_HUB=docker logs -f flip-api --tail 100 --timestamps --follow
 GENERIC_LOGS=docker logs -f --tail 100 --timestamps --follow
 
-# NOTE DOCKER_REGISTRY is set to empty when we use local FL images during development (e.g. flare-fl-server:dev). 
+# NOTE DOCKER_FL_REGISTRY is set to empty when we use local FL images during development (e.g. flare-fl-server:dev).
 # In that case, '--pull always' will error because docker won't be able to find the manifest for the dev image online,
-# so we need to remove the --pull always flag.
-ifneq ($(strip $(DOCKER_REGISTRY)),)
+# so we need to remove the --pull always flag. Non-FL images keep DOCKER_REGISTRY (always GHCR), so they're not the
+# constraint here — the check fires only when the FL registry is empty.
+ifneq ($(strip $(DOCKER_FL_REGISTRY)),)
 PULL_ALWAYS_FLAG=--pull always
 else
 PULL_ALWAYS_FLAG=

--- a/deploy/compose.development.flower.yml
+++ b/deploy/compose.development.flower.yml
@@ -115,10 +115,8 @@ services:
     volumes:
       - ${FL_PROVISIONED_DIR}/net-1/certificates:/certs:ro
       - ${FL_PROVISIONED_DIR}/net-1/keys:/keys:ro
-      # Dev-overlay: edit the script in the sibling repo and the change applies
-      # without a rebuild. The script is also baked into both fl-base / fl-server
-      # images, so removing the mount would still work — net-2's was previously
-      # missing entirely, hence the asymmetry.
+      # Dev-overlay: edits to the sibling-repo script apply without a rebuild.
+      # Same script is baked into the image, so removal still works.
       - ${FL_PROVISIONED_DIR}/../fl_services/register-supernode-keys.sh:/scripts/register-supernode-keys.sh:ro
     entrypoint: ["/bin/bash", "/scripts/register-supernode-keys.sh"]
     depends_on:
@@ -175,8 +173,7 @@ services:
     volumes:
       - ${FL_PROVISIONED_DIR}/net-2/certificates:/certs:ro
       - ${FL_PROVISIONED_DIR}/net-2/keys:/keys:ro
-      # Symmetric with net-1's dev-overlay; the script is also baked into the
-      # fl-server image, so this is for "edit in sibling repo, see effect now".
+      # See net-1 above — symmetric dev-overlay.
       - ${FL_PROVISIONED_DIR}/../fl_services/register-supernode-keys.sh:/scripts/register-supernode-keys.sh:ro
     entrypoint: ["/bin/bash", "/scripts/register-supernode-keys.sh"]
     depends_on:

--- a/deploy/compose.development.flower.yml
+++ b/deploy/compose.development.flower.yml
@@ -18,7 +18,7 @@ services:
 
   fl-api-net-1:
     container_name: flip-fl-api-net-1
-    image: ${DOCKER_REGISTRY}${DOCKER_FL_API_NAME}:${DOCKER_FL_TAG}
+    image: ${DOCKER_FL_REGISTRY}${DOCKER_FL_API_NAME}:${DOCKER_FL_TAG}
     volumes:
       - ${FL_PROVISIONED_DIR}/net-1/certificates:/certs:ro
     environment:
@@ -45,7 +45,7 @@ services:
 
   fl-api-net-2:
     container_name: flip-fl-api-net-2
-    image: ${DOCKER_REGISTRY}${DOCKER_FL_API_NAME}:${DOCKER_FL_TAG}
+    image: ${DOCKER_FL_REGISTRY}${DOCKER_FL_API_NAME}:${DOCKER_FL_TAG}
     volumes:
       - ${FL_PROVISIONED_DIR}/net-2/certificates:/certs:ro
     environment:
@@ -69,7 +69,7 @@ services:
 
   fl-server-net-1:
     container_name: fl-server-net-1
-    image: ${DOCKER_REGISTRY}${DOCKER_FL_SERVER_NAME}:${DOCKER_FL_TAG}
+    image: ${DOCKER_FL_REGISTRY}${DOCKER_FL_SERVER_NAME}:${DOCKER_FL_TAG}
     volumes:
       # Mount the AWS credentials (needed to upload model results to S3)
       - ~/.aws/config:/root/.aws/config:ro
@@ -107,7 +107,7 @@ services:
   register-supernode-keys-net-1:
     container_name: register-supernode-keys-net-1
     # It doesn't really matter if we use FL server or FL base image here since register-supernode-keys.sh is in both
-    image: ${DOCKER_REGISTRY}${DOCKER_FL_SERVER_NAME}:${DOCKER_FL_TAG}
+    image: ${DOCKER_FL_REGISTRY}${DOCKER_FL_SERVER_NAME}:${DOCKER_FL_TAG}
     environment:
       - SUPERLINK_ADDRESS=fl-server-net-1:9093
       - FL_API_ADDRESS=http://flip-fl-api-net-1:8000
@@ -129,7 +129,7 @@ services:
 
   fl-server-net-2:
     container_name: fl-server-net-2
-    image: ${DOCKER_REGISTRY}${DOCKER_FL_SERVER_NAME}:${DOCKER_FL_TAG}
+    image: ${DOCKER_FL_REGISTRY}${DOCKER_FL_SERVER_NAME}:${DOCKER_FL_TAG}
     volumes:
       # Mount the AWS credentials (needed to upload model results to S3)
       - ~/.aws/config:/root/.aws/config:ro
@@ -165,7 +165,7 @@ services:
   register-supernode-keys-net-2:
     container_name: register-supernode-keys-net-2
     # It doesn't really matter if we use FL server or FL base image here since register-supernode-keys.sh is in both
-    image: ${DOCKER_REGISTRY}${DOCKER_FL_SERVER_NAME}:${DOCKER_FL_TAG}
+    image: ${DOCKER_FL_REGISTRY}${DOCKER_FL_SERVER_NAME}:${DOCKER_FL_TAG}
     environment:
       - SUPERLINK_ADDRESS=fl-server-net-2:9093
       - FL_API_ADDRESS=http://flip-fl-api-net-2:8000

--- a/deploy/compose.development.flower.yml
+++ b/deploy/compose.development.flower.yml
@@ -71,9 +71,11 @@ services:
     container_name: fl-server-net-1
     image: ${DOCKER_FL_REGISTRY}${DOCKER_FL_SERVER_NAME}:${DOCKER_FL_TAG}
     volumes:
-      # Mount the AWS credentials (needed to upload model results to S3)
-      - ~/.aws/config:/root/.aws/config:ro
-      - ~/.aws/sso/cache:/root/.aws/sso/cache:rw
+      # Mount the AWS credentials (needed to upload model results to S3).
+      # The image runs as `app` (uid 49999) with HOME=/app, so the mount
+      # lands at /app/.aws/ — the SDK's default lookup path for that user.
+      - ~/.aws/config:/app/.aws/config:ro
+      - ~/.aws/sso/cache:/app/.aws/sso/cache:rw
       # Provisioned Flower secrets (only certificates are needed here)
       - ${FL_PROVISIONED_DIR}/net-1/certificates:/certs:ro
     environment:
@@ -131,9 +133,11 @@ services:
     container_name: fl-server-net-2
     image: ${DOCKER_FL_REGISTRY}${DOCKER_FL_SERVER_NAME}:${DOCKER_FL_TAG}
     volumes:
-      # Mount the AWS credentials (needed to upload model results to S3)
-      - ~/.aws/config:/root/.aws/config:ro
-      - ~/.aws/sso/cache:/root/.aws/sso/cache:rw
+      # Mount the AWS credentials (needed to upload model results to S3).
+      # The image runs as `app` (uid 49999) with HOME=/app, so the mount
+      # lands at /app/.aws/ — the SDK's default lookup path for that user.
+      - ~/.aws/config:/app/.aws/config:ro
+      - ~/.aws/sso/cache:/app/.aws/sso/cache:rw
       # Provisioned Flower secrets (only certificates are needed here)
       - ${FL_PROVISIONED_DIR}/net-2/certificates:/certs:ro
     environment:

--- a/deploy/compose.development.flower.yml
+++ b/deploy/compose.development.flower.yml
@@ -115,7 +115,11 @@ services:
     volumes:
       - ${FL_PROVISIONED_DIR}/net-1/certificates:/certs:ro
       - ${FL_PROVISIONED_DIR}/net-1/keys:/keys:ro
-      - ${FL_PROVISIONED_DIR}/../register-supernode-keys.sh:/scripts/register-supernode-keys.sh:ro
+      # Dev-overlay: edit the script in the sibling repo and the change applies
+      # without a rebuild. The script is also baked into both fl-base / fl-server
+      # images, so removing the mount would still work — net-2's was previously
+      # missing entirely, hence the asymmetry.
+      - ${FL_PROVISIONED_DIR}/../fl_services/register-supernode-keys.sh:/scripts/register-supernode-keys.sh:ro
     entrypoint: ["/bin/bash", "/scripts/register-supernode-keys.sh"]
     depends_on:
       fl-server-net-1:
@@ -171,6 +175,9 @@ services:
     volumes:
       - ${FL_PROVISIONED_DIR}/net-2/certificates:/certs:ro
       - ${FL_PROVISIONED_DIR}/net-2/keys:/keys:ro
+      # Symmetric with net-1's dev-overlay; the script is also baked into the
+      # fl-server image, so this is for "edit in sibling repo, see effect now".
+      - ${FL_PROVISIONED_DIR}/../fl_services/register-supernode-keys.sh:/scripts/register-supernode-keys.sh:ro
     entrypoint: ["/bin/bash", "/scripts/register-supernode-keys.sh"]
     depends_on:
       fl-server-net-2:

--- a/deploy/compose.development.nvflare.yml
+++ b/deploy/compose.development.nvflare.yml
@@ -18,7 +18,7 @@ services:
 
   fl-api-net-1:
     container_name: flip-fl-api-net-1
-    image: ${DOCKER_REGISTRY}${DOCKER_FL_API_NAME}:${DOCKER_FL_TAG}
+    image: ${DOCKER_FL_REGISTRY}${DOCKER_FL_API_NAME}:${DOCKER_FL_TAG}
     environment:
       - FL_ADMIN_DIRECTORY=${FL_ADMIN_DIRECTORY}
       - DEBUG=${DEBUG}
@@ -38,7 +38,7 @@ services:
 
   fl-api-net-2:
     container_name: flip-fl-api-net-2
-    image: ${DOCKER_REGISTRY}${DOCKER_FL_API_NAME}:${DOCKER_FL_TAG}
+    image: ${DOCKER_FL_REGISTRY}${DOCKER_FL_API_NAME}:${DOCKER_FL_TAG}
     environment:
       - FL_ADMIN_DIRECTORY=${FL_ADMIN_DIRECTORY}
       - DEBUG=${DEBUG}
@@ -55,7 +55,7 @@ services:
 
   fl-server-net-1:
     container_name: fl-server-net-1
-    image: ${DOCKER_REGISTRY}${DOCKER_FL_SERVER_NAME}:${DOCKER_FL_TAG}
+    image: ${DOCKER_FL_REGISTRY}${DOCKER_FL_SERVER_NAME}:${DOCKER_FL_TAG}
     volumes:
       # Provisioned NVFLARE secrets (certificates, fed_server.json)
       - ${FL_PROVISIONED_DIR}/net-1/services/fl-server-net-1/local:/app/local
@@ -81,7 +81,7 @@ services:
 
   fl-server-net-2:
     container_name: fl-server-net-2
-    image: ${DOCKER_REGISTRY}${DOCKER_FL_SERVER_NAME}:${DOCKER_FL_TAG}
+    image: ${DOCKER_FL_REGISTRY}${DOCKER_FL_SERVER_NAME}:${DOCKER_FL_TAG}
     volumes:
       # Provisioned NVFLARE secrets (certificates, fed_server.json)
       - ${FL_PROVISIONED_DIR}/net-2/services/fl-server-net-2/local:/app/local

--- a/deploy/compose.development.nvflare.yml
+++ b/deploy/compose.development.nvflare.yml
@@ -61,7 +61,9 @@ services:
       - ${FL_PROVISIONED_DIR}/net-1/services/fl-server-net-1/local:/app/local
       - ${FL_PROVISIONED_DIR}/net-1/services/fl-server-net-1/startup:/app/startup
       - ${FL_PROVISIONED_DIR}/net-1/services/fl-server-net-1/transfer:/app/transfer
-      # Mount the AWS credentials (needed to upload model results to S3)
+      # Mount the AWS credentials (needed to upload model results to S3).
+      # The image runs as root with HOME=/root, so the mount lands at
+      # /root/.aws/ — the SDK's default lookup path for that user.
       - ~/.aws/config:/root/.aws/config:ro
       - ~/.aws/sso/cache:/root/.aws/sso/cache:rw
     environment:
@@ -87,7 +89,9 @@ services:
       - ${FL_PROVISIONED_DIR}/net-2/services/fl-server-net-2/local:/app/local
       - ${FL_PROVISIONED_DIR}/net-2/services/fl-server-net-2/startup:/app/startup
       - ${FL_PROVISIONED_DIR}/net-2/services/fl-server-net-2/transfer:/app/transfer
-      # Mount the AWS credentials (needed to upload model results to S3)
+      # Mount the AWS credentials (needed to upload model results to S3).
+      # The image runs as root with HOME=/root, so the mount lands at
+      # /root/.aws/ — the SDK's default lookup path for that user.
       - ~/.aws/config:/root/.aws/config:ro
       - ~/.aws/sso/cache:/root/.aws/sso/cache:rw
     environment:

--- a/deploy/compose.production.flower.yml
+++ b/deploy/compose.production.flower.yml
@@ -18,7 +18,7 @@ services:
 
   fl-api-net-1:
     container_name: flip-fl-api-net-1
-    image: ${DOCKER_REGISTRY}${DOCKER_FL_API_NAME}:${DOCKER_FL_TAG}
+    image: ${DOCKER_FL_REGISTRY}${DOCKER_FL_API_NAME}:${DOCKER_FL_TAG}
     volumes:
       - /opt/flip/services/net-1/certificates:/certs:ro
     environment:
@@ -41,7 +41,7 @@ services:
 
   fl-server-net-1:
     container_name: fl-server-net-1
-    image: ${DOCKER_REGISTRY}${DOCKER_FL_SERVER_NAME}:${DOCKER_FL_TAG}
+    image: ${DOCKER_FL_REGISTRY}${DOCKER_FL_SERVER_NAME}:${DOCKER_FL_TAG}
     volumes:
       - /opt/flip/services/net-1/certificates:/certs:ro
     environment:
@@ -72,7 +72,7 @@ services:
   # One-shot service to register SuperNode public keys with the SuperLink
   register-supernode-keys-net-1:
     container_name: register-supernode-keys-net-1
-    image: ${DOCKER_REGISTRY}${DOCKER_FL_SERVER_NAME}:${DOCKER_FL_TAG}
+    image: ${DOCKER_FL_REGISTRY}${DOCKER_FL_SERVER_NAME}:${DOCKER_FL_TAG}
     environment:
       - SUPERLINK_ADDRESS=fl-server-net-1:9093
       - FL_API_ADDRESS=http://flip-fl-api-net-1:8000

--- a/deploy/compose.production.nvflare.yml
+++ b/deploy/compose.production.nvflare.yml
@@ -18,7 +18,7 @@ services:
 
   fl-api-net-1:
     container_name: flip-fl-api-net-1
-    image: ${DOCKER_REGISTRY}${DOCKER_FL_API_NAME}:${DOCKER_FL_TAG}
+    image: ${DOCKER_FL_REGISTRY}${DOCKER_FL_API_NAME}:${DOCKER_FL_TAG}
     environment:
       - FL_ADMIN_DIRECTORY=${FL_ADMIN_DIRECTORY}
     ports:
@@ -34,7 +34,7 @@ services:
   # TODO add second FL network when needed
   # fl-api-net-2:
   #   container_name: flip-fl-api-net-2
-  #   image: ${DOCKER_REGISTRY}${DOCKER_FL_API_NAME}:${DOCKER_FL_TAG}
+  #   image: ${DOCKER_FL_REGISTRY}${DOCKER_FL_API_NAME}:${DOCKER_FL_TAG}
   #   environment:
   #     - FL_ADMIN_DIRECTORY=${FL_ADMIN_DIRECTORY}
   #   volumes:
@@ -47,7 +47,7 @@ services:
 
   fl-server-net-1:
     container_name: fl-server-net-1
-    image: ${DOCKER_REGISTRY}${DOCKER_FL_SERVER_NAME}:${DOCKER_FL_TAG}
+    image: ${DOCKER_FL_REGISTRY}${DOCKER_FL_SERVER_NAME}:${DOCKER_FL_TAG}
     volumes:
       # Provisioned NVFLARE secrets (certificates, fed_server.json)
       - /opt/flip/services/fl-server-net-1/local:/app/local
@@ -71,7 +71,7 @@ services:
   # TODO add second FL network when needed
   # fl-server-net-2:
   #   container_name: fl-server-net-2
-  #   image: ${DOCKER_REGISTRY}${DOCKER_FL_SERVER_NAME}:${DOCKER_FL_TAG}
+  #   image: ${DOCKER_FL_REGISTRY}${DOCKER_FL_SERVER_NAME}:${DOCKER_FL_TAG}
   #   volumes:
   #     # Provisioned NVFLARE secrets (certificates, fed_server.json)
   #     - /opt/flip/services/fl-server-net-2/local:/app/local

--- a/deploy/fl_backend.mk
+++ b/deploy/fl_backend.mk
@@ -44,4 +44,11 @@ DOCKER_FL_CLIENT_NAME := flower-supernode
 FL_PROVISIONED_DIR    := ../flip-fl-base-flower/certs
 endif
 
-export DOCKER_FL_API_NAME DOCKER_FL_SERVER_NAME DOCKER_FL_CLIENT_NAME FL_PROVISIONED_DIR
+# DOCKER_FL_REGISTRY decouples the FL images' registry from DOCKER_REGISTRY so
+# you can iterate on locally-built FL images (DOCKER_FL_REGISTRY= DOCKER_FL_TAG=dev)
+# without flipping the rest of the stack to local images. Defaults to whatever
+# DOCKER_REGISTRY is — use `?=` so an explicit unset on the CLI (`make up
+# DOCKER_FL_REGISTRY=`) wins.
+DOCKER_FL_REGISTRY ?= $(DOCKER_REGISTRY)
+
+export DOCKER_FL_API_NAME DOCKER_FL_SERVER_NAME DOCKER_FL_CLIENT_NAME FL_PROVISIONED_DIR DOCKER_FL_REGISTRY

--- a/flip-api/Makefile
+++ b/flip-api/Makefile
@@ -83,15 +83,23 @@ delete_testing_projects:
 # waits for results, downloads them. Intended for PR sanity checks — replaces
 # the manual UI clickthrough.
 #
-# Defaults are pinned to the xray classification tutorial in flip-fl-base
-# (sibling repo to FLIP/): MODEL_FILES_DIR is its app_files/, and QUERY_FILE
-# is its query.sql (used as-is — the tutorial owns the LIMIT). Override either:
+# Defaults pick the chest-xray tutorial that matches FL_BACKEND so the same
+# `make e2e_smoke` invocation works against either stack. The Flower tutorial
+# is in flip-fl-base-flower; the NVFLARE one in flip-fl-base. Both reuse the
+# same query.sql against the trust mock OMOP data. Default backend matches
+# deploy/fl_backend.mk (flower). Override either path explicitly:
 #     make e2e_smoke MODEL_FILES_DIR=/path/to/app_files
 #     make e2e_smoke QUERY_FILE=/path/to/your_cohort.sql
 # Anything else passed via EXTRA_ARGS goes straight to the script:
 #     make e2e_smoke EXTRA_ARGS="--image-pull-threshold 0.5"
+FL_BACKEND ?= flower
+ifeq ($(FL_BACKEND),flower)
+MODEL_FILES_DIR ?= ../../flip-fl-base-flower/tutorials/image_classification/xray_classification/app
+QUERY_FILE ?= ../../flip-fl-base-flower/tutorials/image_classification/xray_classification/query.sql
+else
 MODEL_FILES_DIR ?= ../../flip-fl-base/tutorials/image_classification/xray_classification/app_files
 QUERY_FILE ?= $(MODEL_FILES_DIR)/../query.sql
+endif
 e2e_smoke:
 	@echo "🚀 Running e2e smoke (model files: $(MODEL_FILES_DIR), query: $(QUERY_FILE))..."
 	env DB_HOST=localhost uv run python -m tests.e2e_smoke --model-files-dir $(MODEL_FILES_DIR) --query-file $(QUERY_FILE) $(EXTRA_ARGS)

--- a/flip-api/Makefile
+++ b/flip-api/Makefile
@@ -94,8 +94,8 @@ delete_testing_projects:
 #     make e2e_smoke EXTRA_ARGS="--image-pull-threshold 0.5"
 FL_BACKEND ?= flower
 ifeq ($(FL_BACKEND),flower)
-MODEL_FILES_DIR ?= ../../flip-fl-base-flower/tutorials/image_classification/xray_classification/app
-QUERY_FILE ?= ../../flip-fl-base-flower/tutorials/image_classification/xray_classification/query.sql
+MODEL_FILES_DIR ?= ../../flip-fl-base-flower/tutorials/xray_classification/app
+QUERY_FILE ?= ../../flip-fl-base-flower/tutorials/xray_classification/query.sql
 else
 MODEL_FILES_DIR ?= ../../flip-fl-base/tutorials/image_classification/xray_classification/app_files
 QUERY_FILE ?= $(MODEL_FILES_DIR)/../query.sql

--- a/flip-api/tests/e2e_smoke.py
+++ b/flip-api/tests/e2e_smoke.py
@@ -32,8 +32,8 @@ Usage (preferred):
 Direct invocation:
     cd flip-api
     uv run python -m tests.e2e_smoke \\
-        --model-files-dir ../../flip-fl-base-flower/tutorials/image_classification/xray_classification/app \\
-        --query-file ../../flip-fl-base-flower/tutorials/image_classification/xray_classification/query.sql
+        --model-files-dir ../../flip-fl-base-flower/tutorials/xray_classification/app \\
+        --query-file ../../flip-fl-base-flower/tutorials/xray_classification/query.sql
 
 Run on a stack that already has trusts approved (`make up` plus the usual
 seeding) and non-empty XNAT data so image pull has something to do.
@@ -454,7 +454,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         type=Path,
         required=True,
         help="Directory whose files are uploaded to the model. Flower: "
-        "../../flip-fl-base-flower/tutorials/image_classification/xray_classification/app. "
+        "../../flip-fl-base-flower/tutorials/xray_classification/app. "
         "NVFLARE: ../../flip-fl-base/tutorials/image_classification/xray_classification/app_files.",
     )
     parser.add_argument(

--- a/flip-api/tests/e2e_smoke.py
+++ b/flip-api/tests/e2e_smoke.py
@@ -42,6 +42,7 @@ from __future__ import annotations
 
 import argparse
 import mimetypes
+import os
 import sys
 import tempfile
 import time
@@ -299,14 +300,26 @@ def create_model(client: requests.Session, headers: dict[str, str], project_id: 
     return model_id
 
 
+def _blacklisted_filenames() -> set[str]:
+    """Mirror flip-ui's BLACKLISTED_MODEL_FILES filter so the smoke doesn't upload
+    framework internals (server_app.py, strategy.py, flip.py, …) that the UI rejects."""
+    raw = os.environ.get("BLACKLISTED_MODEL_FILES", "")
+    return {name.strip() for name in raw.split(",") if name.strip()}
+
+
 def upload_files(
     client: requests.Session, headers: dict[str, str], model_id: str, files_dir: Path
 ) -> list[str]:
     if not files_dir.is_dir():
         raise SmokeFailure(f"--model-files-dir does not exist: {files_dir}")
-    paths = sorted(p for p in files_dir.iterdir() if p.is_file())
+    blacklist = _blacklisted_filenames()
+    all_paths = sorted(p for p in files_dir.iterdir() if p.is_file())
+    skipped = [p.name for p in all_paths if p.name in blacklist]
+    paths = [p for p in all_paths if p.name not in blacklist]
     if not paths:
         raise SmokeFailure(f"No files found under {files_dir}")
+    if skipped:
+        _log(f"⏭️  Skipping {len(skipped)} blacklisted file(s): {', '.join(skipped)}")
     _log(f"📤 Uploading {len(paths)} file(s) from {files_dir}")
     uploaded: list[str] = []
     for path in paths:
@@ -468,6 +481,13 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         default=None,
         help=f"Project name (default: '{DEFAULT_PROJECT_NAME_PREFIX} <epoch>')",
     )
+    parser.add_argument(
+        "--project-id",
+        default=None,
+        help="Reuse an existing approved project: skip cohort submission, approval, and image-pull "
+        "wait; jump straight to model creation + upload + training. Lets you iterate on training "
+        "code without re-pulling images for every retry.",
+    )
     parser.add_argument("--model-name", default=DEFAULT_MODEL_NAME)
     parser.add_argument(
         "--image-pull-threshold",
@@ -518,17 +538,26 @@ def main(argv: list[str] | None = None) -> int:
     results_dir = args.results_dir or Path(tempfile.mkdtemp(prefix="flip-e2e-results-"))
 
     try:
-        project_id, _query_id = create_project_with_query(client, headers, project_name, query)
-        trusts = stage_and_approve(client, headers, project_id)
+        if args.project_id:
+            project_id = args.project_id
+            _log(f"♻️  Reusing existing project_id={project_id} (skipping cohort + image pull)")
+            trusts = _ensure_ok(_get(client, "/trust/", headers), "list trusts").json()
+            if not trusts:
+                raise SmokeFailure("No trusts registered with the hub")
+            _log(f"  ✅ found {len(trusts)} trust(s): {[t['name'] for t in trusts]}")
+        else:
+            project_id, _query_id = create_project_with_query(client, headers, project_name, query)
+            trusts = stage_and_approve(client, headers, project_id)
         # Create the model and upload files before waiting for image pull. This
         # surfaces model-creation / upload errors immediately instead of after
         # 5–15 minutes of XNAT pulling, and the FL pipeline only consumes the
         # images at training time anyway.
         model_id = create_model(client, headers, project_id, args.model_name)
         upload_files(client, headers, model_id, args.model_files_dir)
-        wait_for_image_pull(
-            client, headers, project_id, args.image_pull_threshold, args.image_pull_timeout
-        )
+        if not args.project_id:
+            wait_for_image_pull(
+                client, headers, project_id, args.image_pull_threshold, args.image_pull_timeout
+            )
         initiate_training(client, headers, model_id, [t["name"] for t in trusts])
         wait_for_training_started(client, headers, model_id, args.training_start_timeout)
         final_status = wait_for_training_finished(

--- a/flip-api/tests/e2e_smoke.py
+++ b/flip-api/tests/e2e_smoke.py
@@ -17,19 +17,23 @@ training, wait for training to finish, download the FL results. Hits the same
 flip-api endpoints the UI does, so it covers the API + trust + FL integration
 paths without the fragility of UI selectors.
 
-The defaults are pinned to the xray classification tutorial in flip-fl-base
-(sibling repo to FLIP/): `--model-files-dir` points at its `app_files/`, and
-`make e2e_smoke` wires `--query-file` to its `query.sql` (used as-is). Other
-cohorts / tutorials work fine via `--model-files-dir` and `--query-file`.
+Backend-agnostic: the script uploads whatever files are in `--model-files-dir`,
+and the FL framework (Flower vs NVFLARE) is decided server-side by `FL_BACKEND`
+in flip-api's bundling code. `make e2e_smoke` picks the chest-xray tutorial
+that matches FL_BACKEND — the Flower tutorial lives in flip-fl-base-flower,
+the NVFLARE one in flip-fl-base. Both reuse the same `query.sql` against the
+trust mock OMOP data. Override either path with `--model-files-dir` and
+`--query-file`.
 
 Usage (preferred):
-    make e2e_smoke
+    make e2e_smoke                    # picks Flower tutorial (default)
+    FL_BACKEND=nvflare make e2e_smoke # picks NVFLARE tutorial
 
 Direct invocation:
     cd flip-api
     uv run python -m tests.e2e_smoke \\
-        --model-files-dir ../../flip-fl-base/tutorials/image_classification/xray_classification/app_files \\
-        --query-file /path/to/cohort.sql
+        --model-files-dir ../../flip-fl-base-flower/tutorials/image_classification/xray_classification/app \\
+        --query-file ../../flip-fl-base-flower/tutorials/image_classification/xray_classification/query.sql
 
 Run on a stack that already has trusts approved (`make up` plus the usual
 seeding) and non-empty XNAT data so image pull has something to do.
@@ -449,9 +453,9 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--model-files-dir",
         type=Path,
         required=True,
-        help="Directory whose files are uploaded to the model. "
-        "For the xray classification tutorial: "
-        "../../flip-fl-base/tutorials/image_classification/xray_classification/app_files",
+        help="Directory whose files are uploaded to the model. Flower: "
+        "../../flip-fl-base-flower/tutorials/image_classification/xray_classification/app. "
+        "NVFLARE: ../../flip-fl-base/tutorials/image_classification/xray_classification/app_files.",
     )
     parser.add_argument(
         "--query-file",

--- a/trust/Makefile
+++ b/trust/Makefile
@@ -56,10 +56,10 @@ ORTHANC_CMD=make -C ./orthanc
 DOCKER_COMPOSE_CMD=docker compose -f $(COMMON_COMPOSE_FILE) -f $(FL_BACKEND_COMPOSE_FILE)
 DEBUG_OVERRIDE_COMPOSE_COMMAND=docker compose -f $(COMMON_COMPOSE_FILE) -f $(FL_BACKEND_COMPOSE_FILE) -f compose_trust.debug.override.yml
 
-# NOTE DOCKER_REGISTRY is set to empty when we use local FL images during development (e.g. flare-fl-server:dev). 
+# NOTE DOCKER_FL_REGISTRY is set to empty when we use local FL images during development (e.g. flare-fl-client:dev).
 # In that case, '--pull always' will error because docker won't be able to find the manifest for the dev image online,
-# so we need to remove the --pull always flag.
-ifneq ($(strip $(DOCKER_REGISTRY)),)
+# so we need to remove the --pull always flag. Non-FL images keep DOCKER_REGISTRY (always GHCR).
+ifneq ($(strip $(DOCKER_FL_REGISTRY)),)
 PULL_ALWAYS_FLAG=--pull always
 else
 PULL_ALWAYS_FLAG=

--- a/trust/compose_trust.development.flower.yml
+++ b/trust/compose_trust.development.flower.yml
@@ -16,7 +16,7 @@
 services:
 
   fl-client-net-1:
-    image: ${DOCKER_REGISTRY}${DOCKER_FL_CLIENT_NAME}:${DOCKER_FL_TAG}
+    image: ${DOCKER_FL_REGISTRY}${DOCKER_FL_CLIENT_NAME}:${DOCKER_FL_TAG}
     volumes:
       # Mount the base images download directory to share images downloaded from XNAT with FL clients
       - ${BASE_IMAGES_DOWNLOAD_DIR}:/app/data/images
@@ -57,7 +57,7 @@ services:
     gpus: all
 
   fl-client-net-2:
-    image: ${DOCKER_REGISTRY}${DOCKER_FL_CLIENT_NAME}:${DOCKER_FL_TAG}
+    image: ${DOCKER_FL_REGISTRY}${DOCKER_FL_CLIENT_NAME}:${DOCKER_FL_TAG}
     volumes:
       # Mount the base images download directory to share images downloaded from XNAT with FL clients
       - ${BASE_IMAGES_DOWNLOAD_DIR}:/app/data/images

--- a/trust/compose_trust.development.nvflare.yml
+++ b/trust/compose_trust.development.nvflare.yml
@@ -16,7 +16,7 @@
 services:
 
   fl-client-net-1:
-    image: ${DOCKER_REGISTRY}${DOCKER_FL_CLIENT_NAME}:${DOCKER_FL_TAG}
+    image: ${DOCKER_FL_REGISTRY}${DOCKER_FL_CLIENT_NAME}:${DOCKER_FL_TAG}
     volumes:
       # Mount the base images download directory to share images downloaded from XNAT with FL clients
       - ${BASE_IMAGES_DOWNLOAD_DIR}:/app/data/images
@@ -48,7 +48,7 @@ services:
     gpus: all
 
   fl-client-net-2:
-    image: ${DOCKER_REGISTRY}${DOCKER_FL_CLIENT_NAME}:${DOCKER_FL_TAG}
+    image: ${DOCKER_FL_REGISTRY}${DOCKER_FL_CLIENT_NAME}:${DOCKER_FL_TAG}
     volumes:
       # Mount the base images download directory to share images downloaded from XNAT with FL clients
       - ${BASE_IMAGES_DOWNLOAD_DIR}:/app/data/images


### PR DESCRIPTION
Uses the new Flower xrays tutorial from https://github.com/londonaicentre/flip-fl-base-flower/pull/35. Merge that first.

end-to-end run:

<img width="1512" height="864" alt="Screenshot 2026-05-12 at 22 13 42" src="https://github.com/user-attachments/assets/e093bb13-ff57-4770-bc4e-f68f76aea0bb" />

## Summary

- `make e2e_smoke` is hard-coded to the NVFLARE chest-xray tutorial (`flip-fl-base/tutorials/image_classification/xray_classification/app_files/`); against a Flower stack the upload then fails the `required_files` check (Flower needs `client_app.py` + `models.py`, NVFLARE expects `trainer.py` + `validator.py`).
- Make the default chest-xray tutorial path FL_BACKEND-aware, defaulting to `flower` (matches `deploy/fl_backend.mk`). The smoke script itself is unchanged — it already uploads whatever's in `--model-files-dir`, and the FL-framework split happens server-side in `bundle_{flower,nvflare}_application`.
- Forward `FL_BACKEND` from the root Makefile's `e2e_smoke` target into the sub-make.
- Refresh the docstring + `--model-files-dir` help in `tests/e2e_smoke.py` to mention both backends.

The Flower chest-xray tutorial that backs the new default path is being added in a separate PR to [`flip-fl-base-flower`](https://github.com/londonaicentre/flip-fl-base-flower); both backends reuse the same `query.sql` against the trust mock OMOP data.

## Test plan

- [x] \`make -n e2e_smoke\` from repo root prints the Flower paths (default).
- [x] \`make -n e2e_smoke FL_BACKEND=nvflare\` prints the NVFLARE paths.
- [x] \`make -n e2e_smoke MODEL_FILES_DIR=/abs/path QUERY_FILE=/abs/cohort.sql\` honours overrides.
- [x] End-to-end smoke against a running Flower \`make up\` stack: project → cohort (300 rows × 2 trusts) → image pull → upload (8 files) → INITIATED → TRAINING_STARTED → RESULTS_UPLOADED → result zip downloaded.
- [ ] Re-run e2e smoke against an NVFLARE \`make up FL_BACKEND=nvflare\` stack to confirm no regression on the NVFLARE path (paths verified by \`make -n\`; expected to pass since the script logic is unchanged).