### PR TITLE
fix(flip-api): use job_id column name in scheduler atomic UPDATE

### DIFF
--- a/flip-api/src/flip_api/fl_services/run_jobs.py
+++ b/flip-api/src/flip_api/fl_services/run_jobs.py
@@ -40,12 +40,15 @@ def _recover_stale_busy_schedulers(db: Session) -> int:
     are unrecoverable unless cleaned up here. This prevents a single crash
     from permanently starving a net of new training jobs.
     """
+    # Raw column names: SQLModel `alias=` on the FLScheduler model only affects
+    # Pydantic API serialisation, not the SQLAlchemy column name — the actual
+    # DB column is `job_id` (the field name), not the `jobid` alias.
     stmt = text(
         """
         UPDATE fl_scheduler
-        SET status = :available, jobid = NULL
+        SET status = :available, job_id = NULL
         WHERE status = :busy
-          AND (jobid IS NULL OR jobid NOT IN (SELECT id FROM fl_job))
+          AND (job_id IS NULL OR job_id NOT IN (SELECT id FROM fl_job))
         """
     )
     result = db.execute(


### PR DESCRIPTION
## Summary

The raw SQL in `_recover_stale_busy_schedulers` references `jobid`, the Pydantic alias on `FLScheduler.job_id`. SQLModel's `alias=` parameter only affects API serialisation, not the SQLAlchemy column name — the actual DB column is `job_id`. Every scheduled `run_jobs` execution has been raising `psycopg2.errors.UndefinedColumn: column "jobid" does not exist` since the flip-api Fargate task started in prod on 2026-05-13.

## Context

Hotfix split out of #473 (the ALB private-subnet branch) so the `:stag` GHCR image rebuilds quickly when this lands. The parent infra PR has a larger review surface and can move at its own cadence; this one is a 3-line behavioural fix that needs to ship now.

## Why mocked tests didn't catch this

The existing `test_run_jobs.py` tests use `MagicMock` for the session, so the SQL string is never validated against a real schema. The bug only surfaces when the statement hits Postgres.

## Test plan

- [x] `uv run pytest tests/unit/fl_services/test_run_jobs.py` passes locally (no test changes — the existing tests are mock-based and remain green).
- [ ] After merge: `:stag` GHCR image rebuild kicks off via `docker_build_flip_api.yml`.
- [ ] After image is published: force a flip-api ECS rolling deploy and confirm `psycopg2.errors.UndefinedColumn` stops appearing in `/ecs/flip-api` CloudWatch logs. Quick check from a workstation:
  ```bash
  AWS_PROFILE=prod aws logs filter-log-events \
    --log-group-name /ecs/flip-api \
    --start-time $(($(date +%s) * 1000 - 600000)) \
    --filter-pattern 'jobid' --region eu-west-2 --max-items 1
  ```
  Expected: empty result set after the new task is healthy.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbPSBgXC4V7XGTrzLBKt1D)_