### PR TITLE
fix(deploy/aws): chmod +x NVFLARE startup scripts after S3 sync

### DIFF
--- a/deploy/providers/AWS/ecs_efs_provision.tf
+++ b/deploy/providers/AWS/ecs_efs_provision.tf
@@ -131,6 +131,15 @@ resource "aws_ecs_task_definition" "efs_provision" {
         aws s3 sync "$S3_BASE/fl-server-net-1/local/" /mnt/fl-server/local/
         aws s3 sync "$S3_BASE/fl-server-net-1/startup/" /mnt/fl-server/startup/
 
+        # `aws s3 sync` does not preserve POSIX execute bits — every file lands
+        # at mode 0644. NVFLARE's start.sh in startup/ then fails with
+        # `./sub_start.sh: Permission denied` on fl-server boot, crash-looping
+        # the container. Restore +x on the startup scripts and the `nvflare`
+        # CLI binary that the NVFLARE provisioner ships.
+        chmod +x /mnt/fl-api/startup/*.sh /mnt/fl-server/startup/*.sh 2>/dev/null || true
+        [ -f /mnt/fl-api/startup/nvflare ]    && chmod +x /mnt/fl-api/startup/nvflare    || true
+        [ -f /mnt/fl-server/startup/nvflare ] && chmod +x /mnt/fl-server/startup/nvflare || true
+
         echo "EFS provisioning complete."
         SCRIPT
       ]


### PR DESCRIPTION
## Summary

`aws s3 sync` does not preserve POSIX execute bits — every file lands at mode `0644` on EFS. NVFLARE's `start.sh` in `startup/` then fails with `./sub_start.sh: Permission denied` on fl-server boot, crash-looping the container.

Restore `+x` on the `*.sh` scripts in `startup/` for both fl-api and fl-server access points, plus the `nvflare` CLI binary that the NVFLARE provisioner ships (guarded with `-f` so the rule no-ops on kits that don't include it).

## How it surfaced

On prod (2026-05-13) post-ECS cutover:

- `aws ecs describe-services --service fl-server-net-1` → `failedTasks: 28`, `runningCount: 0`, `desiredCount: 1`.
- `/ecs/fl-server-net-1` log stream: `./start.sh: line 39: /app/startup/sub_start.sh: Permission denied`.
- Cascading failure on `fl-api-net-1`: can't establish the NVFLARE admin session because fl-server is never up, so `FLCommunicationError: cannot connect to server for 20.0 seconds` → `Application startup failed. Exiting.`
- User-visible: `/api/fl/status` returns 500 with `[Errno 111] Connection refused` (fl-api can't reach fl-server, flip-api can't reach fl-api).

## Test plan

- [ ] After merge: `:stag` rebuild not required (this is infra-only). Operator runs `make plan PROD=true` on the relevant infra branch — `null_resource.provision_efs_certs` triggers re-run because the task def hash changes.
- [ ] After `make apply`: `aws ecs describe-services --cluster flip-cluster --service fl-server-net-1` returns `runningCount: 1`, `failedTasks: 0`.
- [ ] `aws logs filter-log-events --log-group-name /ecs/fl-server-net-1 ...` no longer shows `Permission denied`.
- [ ] `curl -H "Authorization: Bearer <token>" https://app.flip.aicentre.co.uk/api/fl/status` returns 200.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbPSBgXC4V7XGTrzLBKt1D)_