### PR TITLE
Revert "fix: prevent fl-server crash loop with entryPoint override"

### DIFF
--- a/deploy/providers/AWS/ecs_tasks.tf
+++ b/deploy/providers/AWS/ecs_tasks.tf
@@ -200,19 +200,6 @@ resource "aws_ecs_task_definition" "fl_server_net_1" {
       cpu               = 1024
       memoryReservation = 2048
 
-      # CRITICAL: The image's /app/entrypoint.sh runs `./start.sh` which
-      # executes `./sub_start.sh &` -- but because start.sh is a *subshell*,
-      # its background jobs become orphaned when it exits. The entrypoint's
-      # `wait` returns immediately because it sees zero background jobs, so
-      # the container exits with code 0 in ~1 second.
-      #
-      # Workaround: source start.sh (`. ./start.sh`) so sub_start.sh & runs
-      # in the SAME shell as the entrypoint. `wait` then properly blocks on
-      # sub_start.sh's while-true loop, keeping the container alive.
-      # Trap is set BEFORE the blocking source so SIGTERM is caught and
-      # stop_fl.sh runs gracefully.
-      entryPoint = ["/bin/bash", "-c", "source /app/.venv/bin/activate && echo '[custom-ep] Starting...' && cd /app/startup && trap \"echo 'SIGTERM caught'; /app/startup/stop_fl.sh\" SIGTERM && . ./start.sh && wait"]
-
       portMappings = [
         {
           containerPort = 8002


### PR DESCRIPTION
Reverts #(commit) [\`33f6f393\`](https://github.com/londonaicentre/FLIP/commit/33f6f393ce8df9d3d499d97533382489a4953d78).

## Why revert

The custom \`entryPoint\` added by 33f6f393 (2026-05-12) overrode the fl-server image's default \`CMD ["/app/entrypoint.sh"]\`. The image's \`entrypoint.sh\` opens with:

\`\`\`bash
chmod +x /app/startup/start.sh
chmod +x /app/startup/sub_start.sh
chmod +x /app/startup/stop_fl.sh
\`\`\`

The kit on EFS is populated by \`aws s3 sync\` (see \`ecs_efs_provision.tf\`), which lands every file at mode 0644 because S3 does not preserve POSIX execute bits. EC2 docker-compose was fine because the image's entrypoint restored +x at runtime; the ECS override silently dropped that step, and fl-server then crashed with \`./sub_start.sh: Permission denied\` once the EFS contents existed (caught in prod on 2026-05-13 — \`failedTasks: 28\` on fl-server-net-1, cascading 500s on \`/api/fl/status\`).

The original diagnosis — *\"Container exits in ~1s because start.sh runs as a subshell — background jobs (sub_start.sh &) get orphaned\"* — does not match the current NVFLARE kit (\`start.sh\` ends with \`$DIR/sub_start.sh\` foreground, not \`&\`). The workaround likely papered over a different, transient cutover-debugging failure mode (kit not yet populated on EFS, env var missing, etc.) by side-effect.

## Diagnostic

Reverted both 33f6f393 and the related chmod fix in \`ecs_efs_provision.tf\` on a prod-matching branch, applied, and forced a fresh fl-server rolling deploy. With both reverted:

- \`fl-server-net-1\`: \`runningCount: 1, desiredCount: 1, failedTasks: 0, rolloutState: COMPLETED\`.
- \`/ecs/fl-server-net-1\` log on the new task: \`🔧 Generating log_config.json from template…\` → \`[entrypoint] Starting FL server with: LOG_LEVEL=INFO\` → \`WORKSPACE set to /app/startup/..\` → \`start fl because of no pid.fl\` → \`new pid 21\` → \`Server started\` → \`Got the primary sp: fl.app.flip.aicentre.co.uk fl_port: 8002 SSID: ebc6125d-0a56-4688-9b08-355fe9e4d61a. Turning to hot.\`

The \"~1s exit\" symptom does not reproduce. The image's default entrypoint handles the chmod + start.sh sequence correctly, and the NVFLARE server stays up.

## Relationship to #485

#485 (chmod +x in the EFS provisioning task) is still worth landing as defensive depth — it keeps the kit on EFS runnable regardless of any future entryPoint overrides — but with this revert it is no longer load-bearing. Either order of merge is fine; if #485 lands first, the image's chmod is redundant but harmless. If this revert lands first, the image's chmod handles it as it has since the open-source migration.

## Test plan

- [x] Revert applied to prod via a prod-matching branch; \`aws ecs describe-services --cluster flip-cluster --service fl-server-net-1\` shows steady-state running.
- [x] No \`Permission denied\` errors on the new task in \`/ecs/fl-server-net-1\` CloudWatch logs.
- [x] NVFLARE server logs reach \`Turning to hot.\` and \`added secure port at 0.0.0.0:8002\`.
- [ ] After merge: \`make deploy-centralhub\` is not required — the existing prod state already matches this branch's diff (the diagnostic apply put it there). On the next infra apply that touches \`ecs_tasks.tf\`, this PR's diff will be a no-op against state.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbPSBgXC4V7XGTrzLBKt1D)_