### PR TITLE
fix(flip-ui): wrap bare fetchAuthSession calls to absorb Amplify's refreshAuthTokens crash

### DIFF
--- a/flip-ui/src/services/__tests__/api.spec.ts
+++ b/flip-ui/src/services/__tests__/api.spec.ts
@@ -174,7 +174,7 @@ describe("api.ts Http client", () => {
 
             expect((out.headers as Record<string, string>).Authorization).toBeUndefined();
             expect(consoleWarn).toHaveBeenCalledWith(
-                "Token forceRefresh failed:",
+                "fetchAuthSession failed:",
                 expect.objectContaining({ name: "TooManyRequestsException" })
             );
             consoleWarn.mockRestore();

--- a/flip-ui/src/services/api.ts
+++ b/flip-ui/src/services/api.ts
@@ -66,21 +66,15 @@ class Http {
                     // so freshly-signed-in users don't hit a 401 on the
                     // very next request (e.g. getMfaStatus from hydrate).
                     //
-                    // Both fetchAuthSession calls are wrapped because the
-                    // bare call can transparently trigger an internal token
-                    // refresh, and that path crashes with
-                    // "Cannot read properties of undefined (reading 'payload')"
-                    // in @aws-amplify/auth's refreshAuthTokens.mjs when the
-                    // Cognito refresh-token response has no AccessToken
-                    // (refresh token expired / revoked / throttled) —
-                    // `decodeJWT(AuthenticationResult?.AccessToken ?? '')`
-                    // produces an object without `.payload` and the next
-                    // `accessToken.payload` access throws. Catching here
-                    // lets the request go out unauthenticated; the
-                    // response interceptor's 401 handler forces a clean
-                    // sign-out instead of an unhandled-promise console
-                    // error and a stuck page (observed on /connectionstatus
-                    // 2026-05-13).
+                    // fetchAuthSession can transparently trigger a token
+                    // refresh internally; that path throws "Cannot read
+                    // properties of undefined (reading 'payload')" in
+                    // @aws-amplify/auth's refreshAuthTokens.mjs when the
+                    // Cognito response has no AccessToken (refresh token
+                    // expired / revoked / throttled). Wrap both calls so
+                    // the request goes out unauthenticated and the
+                    // response interceptor's 401 handler takes over
+                    // instead of an unhandled rejection.
                     let token: string | undefined;
                     try {
                         let session = await fetchAuthSession();
@@ -90,10 +84,6 @@ class Http {
                             token = session.tokens?.accessToken?.toString();
                         }
                     } catch (e) {
-                        // Log the underlying Amplify error so DevTools
-                        // surfaces *why* (throttle, expired refresh token,
-                        // storage blocked, refreshAuthTokens bug) instead
-                        // of collapsing every cause to "signed out".
                         console.warn("fetchAuthSession failed:", e);
                     }
 

--- a/flip-ui/src/services/api.ts
+++ b/flip-ui/src/services/api.ts
@@ -65,21 +65,36 @@ class Http {
                     // session. If tokens aren't there yet, force a refresh
                     // so freshly-signed-in users don't hit a 401 on the
                     // very next request (e.g. getMfaStatus from hydrate).
-                    let session = await fetchAuthSession();
-                    let token = session.tokens?.accessToken?.toString();
-                    if (!token) {
-                        try {
+                    //
+                    // Both fetchAuthSession calls are wrapped because the
+                    // bare call can transparently trigger an internal token
+                    // refresh, and that path crashes with
+                    // "Cannot read properties of undefined (reading 'payload')"
+                    // in @aws-amplify/auth's refreshAuthTokens.mjs when the
+                    // Cognito refresh-token response has no AccessToken
+                    // (refresh token expired / revoked / throttled) —
+                    // `decodeJWT(AuthenticationResult?.AccessToken ?? '')`
+                    // produces an object without `.payload` and the next
+                    // `accessToken.payload` access throws. Catching here
+                    // lets the request go out unauthenticated; the
+                    // response interceptor's 401 handler forces a clean
+                    // sign-out instead of an unhandled-promise console
+                    // error and a stuck page (observed on /connectionstatus
+                    // 2026-05-13).
+                    let token: string | undefined;
+                    try {
+                        let session = await fetchAuthSession();
+                        token = session.tokens?.accessToken?.toString();
+                        if (!token) {
                             session = await fetchAuthSession({ forceRefresh: true });
                             token = session.tokens?.accessToken?.toString();
-                        } catch (e) {
-                            // The request will go out unauthenticated and
-                            // the 401 handler will force a sign-out, but
-                            // we log the underlying Amplify error so
-                            // DevTools surfaces *why* (throttle, expired
-                            // refresh token, storage blocked) instead of
-                            // collapsing every cause to "signed out".
-                            console.warn("Token forceRefresh failed:", e);
                         }
+                    } catch (e) {
+                        // Log the underlying Amplify error so DevTools
+                        // surfaces *why* (throttle, expired refresh token,
+                        // storage blocked, refreshAuthTokens bug) instead
+                        // of collapsing every cause to "signed out".
+                        console.warn("fetchAuthSession failed:", e);
                     }
 
                     if (token) {

--- a/flip-ui/src/store/__tests__/auth.spec.ts
+++ b/flip-ui/src/store/__tests__/auth.spec.ts
@@ -450,7 +450,7 @@ describe("authStore", () => {
             // helper had silently returned.
             expect(getCurrentUser).not.toHaveBeenCalled();
 
-            expect(consoleErrorSpy).toHaveBeenCalledWith(
+            expect(consoleWarnSpy).toHaveBeenCalledWith(
                 "waitForSessionTokens: forceRefresh threw:",
                 expect.objectContaining({ message: "Refresh token expired" })
             );

--- a/flip-ui/src/store/auth.ts
+++ b/flip-ui/src/store/auth.ts
@@ -11,7 +11,8 @@
  * limitations under the License.
  */
 
-import { confirmResetPassword,
+import { type AuthSession,
+    confirmResetPassword,
     confirmSignIn,
     fetchAuthSession,
     fetchUserAttributes,
@@ -125,24 +126,19 @@ class MissingSessionTokensError extends Error {
 }
 
 const waitForSessionTokens = async (): Promise<void> => {
-    // Both calls are wrapped because the bare fetchAuthSession() can
-    // transparently trigger an internal token refresh, and that path
-    // crashes with "Cannot read properties of undefined (reading 'payload')"
-    // in @aws-amplify/auth's refreshAuthTokens.mjs when the Cognito refresh
-    // response has no AccessToken (refresh token expired / revoked /
-    // throttled). See the matching catch in services/api.ts for the
-    // full rationale.
-    let session: Awaited<ReturnType<typeof fetchAuthSession>> | undefined;
+    // The bare fetchAuthSession() needs a try/catch — see services/api.ts
+    // for the Amplify-internals rationale.
+    let session: AuthSession | undefined;
     try {
         session = await fetchAuthSession();
     } catch (e) {
-        console.error("waitForSessionTokens: initial fetch threw:", e);
+        console.warn("waitForSessionTokens: initial fetch threw:", e);
     }
     if (session?.tokens?.accessToken) return;
     try {
         session = await fetchAuthSession({ forceRefresh: true });
     } catch (e) {
-        console.error("waitForSessionTokens: forceRefresh threw:", e);
+        console.warn("waitForSessionTokens: forceRefresh threw:", e);
     }
     if (!session?.tokens?.accessToken) {
         // Log what Amplify *thinks* the session is so DevTools can

--- a/flip-ui/src/store/auth.ts
+++ b/flip-ui/src/store/auth.ts
@@ -125,14 +125,26 @@ class MissingSessionTokensError extends Error {
 }
 
 const waitForSessionTokens = async (): Promise<void> => {
-    let session = await fetchAuthSession();
-    if (session.tokens?.accessToken) return;
+    // Both calls are wrapped because the bare fetchAuthSession() can
+    // transparently trigger an internal token refresh, and that path
+    // crashes with "Cannot read properties of undefined (reading 'payload')"
+    // in @aws-amplify/auth's refreshAuthTokens.mjs when the Cognito refresh
+    // response has no AccessToken (refresh token expired / revoked /
+    // throttled). See the matching catch in services/api.ts for the
+    // full rationale.
+    let session: Awaited<ReturnType<typeof fetchAuthSession>> | undefined;
+    try {
+        session = await fetchAuthSession();
+    } catch (e) {
+        console.error("waitForSessionTokens: initial fetch threw:", e);
+    }
+    if (session?.tokens?.accessToken) return;
     try {
         session = await fetchAuthSession({ forceRefresh: true });
     } catch (e) {
         console.error("waitForSessionTokens: forceRefresh threw:", e);
     }
-    if (!session.tokens?.accessToken) {
+    if (!session?.tokens?.accessToken) {
         // Log what Amplify *thinks* the session is so DevTools can
         // distinguish "no session at all" (bad storage / misconfigured
         // client) from "session exists but tokens are empty"
@@ -140,8 +152,8 @@ const waitForSessionTokens = async (): Promise<void> => {
         console.warn(
             "waitForSessionTokens: no accessToken after forceRefresh",
             {
-                userSub: session.userSub,
-                hasCredentials: !!session.credentials
+                userSub: session?.userSub,
+                hasCredentials: !!session?.credentials
             }
         );
         throw new MissingSessionTokensError(


### PR DESCRIPTION
## Summary

Two call sites in flip-ui (\`services/api.ts\` axios request interceptor and \`store/auth.ts\` \`waitForSessionTokens\`) had the \`fetchAuthSession({ forceRefresh: true })\` retry wrapped in try/catch but left the preceding bare \`fetchAuthSession()\` call unprotected. The bare call looks like a cheap cached read but Amplify v6's tokenOrchestrator transparently triggers a refresh when the access token is near expiry — and that refresh path crashes:

\`\`\`text
TypeError: Cannot read properties of undefined (reading 'payload')
    at refreshAuthTokens.mjs:38
\`\`\`

in \`node_modules/@aws-amplify/auth/dist/esm/providers/cognito/utils/refreshAuthTokens.mjs:38\` when the Cognito refresh-token call returns no AccessToken (expired / revoked / throttled refresh token):

\`\`\`js
const accessToken = decodeJWT(AuthenticationResult?.AccessToken ?? '');
...
const { iat } = accessToken.payload;   // <-- decodeJWT('') has no .payload
\`\`\`

The internal-refresh crash escaped as an unhandled-promise rejection, hung the request, and surfaced as a stuck \`/connectionstatus\` page (observed 2026-05-13 — the \"Cannot read properties of undefined (reading 'payload')\" console error with a \`core.js:297:N\` stack).

## Change

Wrap both \`fetchAuthSession\` invocations at each call site:

- **\`services/api.ts\`**: axios request interceptor — single try/catch around both calls. When either throws, the request goes out unauthenticated and the response interceptor's existing 401 handler forces a clean sign-out (the user sees the same \"Your session has expired\" snackbar they'd get on any other 401).
- **\`store/auth.ts\` \`waitForSessionTokens\`**: same pattern — falls through to the existing \`MissingSessionTokensError\` surface so callers get a clear signal.

Test update: \`api.spec.ts\` previously asserted on the \"Token forceRefresh failed:\" log prefix; now asserts on the consolidated \"fetchAuthSession failed:\" prefix.

## Test plan

- [x] \`npm run test:unit\` — 501 passed (was 500 passed + 1 failed on the now-renamed log prefix).
- [x] \`npm run lint\` — no new errors (6 pre-existing max-len warnings unrelated to this change).
- [ ] After merge: deploy via \`make deploy-ui PROD=true\` and confirm \`/connectionstatus\` no longer console-errors on a token-refresh failure. Easiest manual repro: leave the tab idle long enough for the access token to expire, then click into \`/connectionstatus\` — pre-fix, the page hangs with an uncaught \"payload\" TypeError; post-fix, the user is cleanly signed out with the existing snackbar.

## Upstream

This is a defensive catch around a real bug in \`@aws-amplify/auth@^6.x\`'s \`refreshAuthTokens\`. \`decodeJWT('')\` should not throw or should be guarded inside Amplify before the \`.payload\` access. A clean upstream fix is out of scope for this PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbPSBgXC4V7XGTrzLBKt1D)_