### PR TITLE
fix(xnat): make configure-dcm2niix.sh fail loudly on each curl + extract CMD_ID from POST

### DIFF
--- a/trust/xnat/Makefile
+++ b/trust/xnat/Makefile
@@ -212,6 +212,7 @@ xnat-configure:
 		echo "  Waiting for container..."; sleep 5; elapsed=$$((elapsed + 5)); \
 	done
 	CONTAINER=$$(docker ps --filter "name=$(XNAT_PROJECT)_xnat-web" -q); \
+	[ -n "$$CONTAINER" ] || { echo "❌ ERROR: $(XNAT_PROJECT)_xnat-web container not found at configure time"; exit 1; }; \
 	docker exec $$CONTAINER bash -c 'set -o pipefail; cd /data/xnat/config && LOG_FILE="configure-xnat-$(XNAT_PROJECT).log" && bash configure-xnat.sh 2>&1 | tee "$$LOG_FILE"' && \
 	docker exec $$CONTAINER bash -c 'set -o pipefail; cd /data/xnat/config && LOG_FILE="configure-dcm2niix-$(XNAT_PROJECT).log" && bash configure-dcm2niix.sh 2>&1 | tee "$$LOG_FILE"'
 

--- a/trust/xnat/Makefile
+++ b/trust/xnat/Makefile
@@ -212,7 +212,7 @@ xnat-configure:
 		echo "  Waiting for container..."; sleep 5; elapsed=$$((elapsed + 5)); \
 	done
 	CONTAINER=$$(docker ps --filter "name=$(XNAT_PROJECT)_xnat-web" -q); \
-	docker exec $$CONTAINER bash -c 'set -o pipefail; cd /data/xnat/config && LOG_FILE="configure-xnat-$(XNAT_PROJECT).log" && bash configure-xnat.sh 2>&1 | tee "$$LOG_FILE"'; \
+	docker exec $$CONTAINER bash -c 'set -o pipefail; cd /data/xnat/config && LOG_FILE="configure-xnat-$(XNAT_PROJECT).log" && bash configure-xnat.sh 2>&1 | tee "$$LOG_FILE"' && \
 	docker exec $$CONTAINER bash -c 'set -o pipefail; cd /data/xnat/config && LOG_FILE="configure-dcm2niix-$(XNAT_PROJECT).log" && bash configure-dcm2niix.sh 2>&1 | tee "$$LOG_FILE"'
 
 xnat-configure-trust-1:

--- a/trust/xnat/xnat/config/configure-dcm2niix.sh
+++ b/trust/xnat/xnat/config/configure-dcm2niix.sh
@@ -32,11 +32,12 @@ DCM2NIIX_NAME="dcm2niix"
 # its own timeout, so a dead or wedged XNAT fails the deploy loudly instead
 # of printing dots forever).
 echo "Waiting for XNAT to be available..."
-deadline=$((SECONDS + 900))
+wait_start=$SECONDS
+deadline=$((wait_start + 900))
 until curl --output /dev/null --silent --head --fail \
   --connect-timeout 5 --max-time 10 "$XNAT_URL/app/template/Login.vm"; do
   if [[ "$SECONDS" -ge "$deadline" ]]; then
-    echo "ERROR: XNAT did not become available within ${SECONDS}s" >&2
+    echo "ERROR: XNAT did not become available within $((SECONDS - wait_start))s" >&2
     exit 1
   fi
   printf '.'

--- a/trust/xnat/xnat/config/configure-dcm2niix.sh
+++ b/trust/xnat/xnat/config/configure-dcm2niix.sh
@@ -28,30 +28,31 @@ set -euo pipefail
 XNAT_URL="http://xnat-web:8080" # internal to Docker network
 DCM2NIIX_NAME="dcm2niix"
 
-# Wait for XNAT to be available (bounded so a dead XNAT fails the deploy
-# loudly instead of printing dots forever).
+# Wait for XNAT to be available (wall-clock bounded, and each probe carries
+# its own timeout, so a dead or wedged XNAT fails the deploy loudly instead
+# of printing dots forever).
 echo "Waiting for XNAT to be available..."
-elapsed=0
-until curl --output /dev/null --silent --head --fail "$XNAT_URL/app/template/Login.vm"; do
-  if [[ "$elapsed" -ge 900 ]]; then
-    echo "ERROR: XNAT did not become available within ${elapsed}s" >&2
+deadline=$((SECONDS + 900))
+until curl --output /dev/null --silent --head --fail \
+  --connect-timeout 5 --max-time 10 "$XNAT_URL/app/template/Login.vm"; do
+  if [[ "$SECONDS" -ge "$deadline" ]]; then
+    echo "ERROR: XNAT did not become available within ${SECONDS}s" >&2
     exit 1
   fi
   printf '.'
   sleep 1
-  elapsed=$((elapsed + 1))
 done
 echo "XNAT is up!"
 
 # Helper: curl wrapper for XNAT's REST API. On 2xx, emits the response body
 # on stdout for the caller to capture. On any other status — or a curl
-# transport failure — reports the request and body on stderr and returns
-# non-zero, which the script's `set -e` turns into an abort at the call
-# site (so don't call this inside `if`/`||` without handling the failure).
-# Use it for every request to XNAT's REST API, reads included: a silently
-# failed GET is exactly how the original empty-CMD_ID deploy failure arose
-# (bare `curl -s` discarded 4xx/5xx bodies and the script carried on with
-# empty state).
+# transport failure — reports the request (and, for HTTP failures, the
+# response body) on stderr and returns non-zero, which the script's
+# `set -e` turns into an abort at the call site (so don't call this inside
+# `if`/`||` without handling the failure). Use it for every request to
+# XNAT's REST API, reads included: an unnoticed bad GET response is how the
+# original empty-CMD_ID deploy failure slipped through — bare `curl -s`
+# surfaced neither HTTP errors nor unexpected bodies.
 xnat_curl() {
   local response
   local status
@@ -66,6 +67,11 @@ xnat_curl() {
   fi
   status=$(printf '%s' "$response" | tail -n1)
   body=$(printf '%s' "$response" | sed '$d')
+  # Strip CRs so a middlebox emitting \r\n line endings can't make the
+  # callers' numeric/boolean guards fail on an invisible character (a raw
+  # CR is not valid inside JSON strings, so this is lossless).
+  status=${status//$'\r'/}
+  body=${body//$'\r'/}
   # Fail closed: anything other than a literal 2xx status line (including
   # an empty or non-numeric one) is an error.
   if ! [[ "$status" =~ ^2[0-9]{2}$ ]]; then
@@ -107,13 +113,14 @@ fi
 
 # Add dcm2niix command from json. POST /xapi/commands returns the new
 # command's numeric id as the response body — a bare JSON number, not the
-# command object (container-service 3.7.3: CommandRestApi.createCommand
-# returns ResponseEntity<Long>). Read the id straight from the POST
-# response rather than re-GETting /xapi/commands?name=...: that GET has
-# been observed on prod to return an empty array even after a successful
-# POST (root cause undiagnosed), which left CMD_ID empty and broke the
-# enable/validation URLs downstream. The wrapper name is not in the POST
-# response at all, so take it from the command definition we just posted.
+# command object (container-service 3.7.3, pinned in trust/xnat/README.md's
+# plugin table: CommandRestApi.createCommand returns ResponseEntity<Long>).
+# Read the id straight from the POST response rather than re-GETting
+# /xapi/commands?name=...: on prod that GET came back with no usable
+# command even though the POST appeared to succeed (root cause
+# undiagnosed), which left CMD_ID unusable and broke the enable/validation
+# URLs downstream. The wrapper name is not in the POST response at all, so
+# take it from the command definition we just posted.
 echo "Adding dcm2niix command..."
 CMD_ID=$(xnat_curl -X POST "$XNAT_URL/xapi/commands" \
   -H "Content-Type: application/json" \

--- a/trust/xnat/xnat/config/configure-dcm2niix.sh
+++ b/trust/xnat/xnat/config/configure-dcm2niix.sh
@@ -28,31 +28,52 @@ set -euo pipefail
 XNAT_URL="http://xnat-web:8080" # internal to Docker network
 DCM2NIIX_NAME="dcm2niix"
 
-# Wait for XNAT to be available
+# Wait for XNAT to be available (bounded so a dead XNAT fails the deploy
+# loudly instead of printing dots forever).
 echo "Waiting for XNAT to be available..."
-until $(curl --output /dev/null --silent --head --fail $XNAT_URL/app/template/Login.vm); do
+elapsed=0
+until curl --output /dev/null --silent --head --fail "$XNAT_URL/app/template/Login.vm"; do
+  if [[ "$elapsed" -ge 900 ]]; then
+    echo "ERROR: XNAT did not become available within ${elapsed}s" >&2
+    exit 1
+  fi
   printf '.'
   sleep 1
+  elapsed=$((elapsed + 1))
 done
 echo "XNAT is up!"
 
-# Helper: curl that prints body, then exits with a clear error if the HTTP
-# status code is not 2xx. Solves the silent-failure problem where `curl -s`
-# discarded a 4xx/5xx body and the script kept going with empty state. Use
-# this for every write to XNAT's REST API.
+# Helper: curl wrapper for XNAT's REST API. On 2xx, emits the response body
+# on stdout for the caller to capture. On any other status — or a curl
+# transport failure — reports the request and body on stderr and returns
+# non-zero, which the script's `set -e` turns into an abort at the call
+# site (so don't call this inside `if`/`||` without handling the failure).
+# Use it for every request to XNAT's REST API, reads included: a silently
+# failed GET is exactly how the original empty-CMD_ID deploy failure arose
+# (bare `curl -s` discarded 4xx/5xx bodies and the script carried on with
+# empty state).
 xnat_curl() {
   local response
   local status
-  response=$(curl -sS -w '\n%{http_code}' "$@" -u "${XNAT_ADMIN_USER}:${XNAT_ADMIN_PASSWORD}")
+  local body
+  local curl_exit=0
+  response=$(curl -sS --connect-timeout 10 --max-time 120 -w '\n%{http_code}' "$@" \
+    -u "${XNAT_ADMIN_USER}:${XNAT_ADMIN_PASSWORD}") || curl_exit=$?
+  if [[ "$curl_exit" -ne 0 ]]; then
+    echo "ERROR: curl transport failure (exit $curl_exit)" >&2
+    echo "  args: $*" >&2
+    return 1
+  fi
   status=$(printf '%s' "$response" | tail -n1)
   body=$(printf '%s' "$response" | sed '$d')
-  if [[ "$status" -lt 200 || "$status" -ge 300 ]]; then
+  # Fail closed: anything other than a literal 2xx status line (including
+  # an empty or non-numeric one) is an error.
+  if ! [[ "$status" =~ ^2[0-9]{2}$ ]]; then
     echo "ERROR: XNAT request failed with HTTP $status" >&2
     echo "  args: $*" >&2
     echo "  body: $body" >&2
     return 1
   fi
-  # Body is exported on stdout for the caller to consume.
   printf '%s' "$body"
 }
 
@@ -60,7 +81,7 @@ xnat_curl() {
 # This is so that the container service can access the data
 echo "Adding path translation for container service..."
 
-# Replace ${DATA_PATH} in the file and store in a variable
+# Set path-translation-docker-prefix to $DATA_PATH in the backend config
 echo "Path translation with DATA_PATH=$DATA_PATH"
 backend_config=$(jq --arg data_path "$DATA_PATH" '.["path-translation-docker-prefix"] = $data_path' container-service-backend-configuration.json)
 
@@ -84,24 +105,29 @@ else
   echo "Command not found. Proceeding with addition."
 fi
 
-# Add dcm2niix command from json. POST /xapi/commands returns the created
-# command including its `id`; extract it directly to avoid the
-# eventual-consistency race the previous re-GET ran into (the GET could
-# return an empty array even after the POST succeeded, leaving the rest of
-# the script with empty CMD_ID and the validation curl 500ing on an
-# invalid URL).
+# Add dcm2niix command from json. POST /xapi/commands returns the new
+# command's numeric id as the response body — a bare JSON number, not the
+# command object (container-service 3.7.3: CommandRestApi.createCommand
+# returns ResponseEntity<Long>). Read the id straight from the POST
+# response rather than re-GETting /xapi/commands?name=...: that GET has
+# been observed on prod to return an empty array even after a successful
+# POST (root cause undiagnosed), which left CMD_ID empty and broke the
+# enable/validation URLs downstream. The wrapper name is not in the POST
+# response at all, so take it from the command definition we just posted.
 echo "Adding dcm2niix command..."
-POST_RESPONSE=$(xnat_curl -X POST "$XNAT_URL/xapi/commands" \
+CMD_ID=$(xnat_curl -X POST "$XNAT_URL/xapi/commands" \
   -H "Content-Type: application/json" \
   -d @dcm2niix_command.json)
-echo "POST response: $POST_RESPONSE"
 
-CMD_ID=$(echo "$POST_RESPONSE" | jq -r '.id // empty')
-dcm2niix_wrapper_name=$(echo "$POST_RESPONSE" | jq -r '.xnat[0].name // empty')
+if ! [[ "$CMD_ID" =~ ^[0-9]+$ ]]; then
+  echo "ERROR: POST /xapi/commands did not return a numeric command id." >&2
+  echo "  body: $CMD_ID" >&2
+  exit 1
+fi
 
-if [[ -z "$CMD_ID" || -z "$dcm2niix_wrapper_name" ]]; then
-  echo "ERROR: POST /xapi/commands did not return an id + xnat[0].name." >&2
-  echo "  body: $POST_RESPONSE" >&2
+dcm2niix_wrapper_name=$(jq -r '.xnat[0].name // empty' dcm2niix_command.json)
+if [[ -z "$dcm2niix_wrapper_name" ]]; then
+  echo "ERROR: no .xnat[0].name wrapper in dcm2niix_command.json." >&2
   exit 1
 fi
 
@@ -143,18 +169,25 @@ done
 # VALIDATION
 # ----------------------------------------------------------------
 
-# Verify dcm2niix command was registered and enabled. The xnat_curl helper
-# above already exits non-zero on any failure, so reaching this block means
-# the writes succeeded; this is a belt-and-braces check that the enable
-# state is queryable.
+# Every xnat_curl above aborts the script (via set -e) on a non-2xx
+# response, so reaching this block means every write was accepted; these
+# re-GETs check the resulting state actually persisted. The wrapper-enabled
+# endpoint returns a bare JSON boolean (container-service 3.7.3).
 echo " "
 echo "Validating dcm2niix setup..."
-xnat_curl "$XNAT_URL/xapi/commands/$CMD_ID/wrappers/$dcm2niix_wrapper_name/enabled" >/dev/null
+WRAPPER_ENABLED=$(xnat_curl "$XNAT_URL/xapi/commands/$CMD_ID/wrappers/$dcm2niix_wrapper_name/enabled")
+if [ "$WRAPPER_ENABLED" != "true" ]; then
+  echo "ERROR: dcm2niix wrapper is not enabled site-wide (expected true)" >&2
+  echo "  body: $WRAPPER_ENABLED" >&2
+  exit 1
+fi
 
 # Verify event service is enabled
-EVENT_STATUS=$(xnat_curl "$XNAT_URL/xapi/events/prefs" | jq -r '.enabled')
+EVENT_PREFS=$(xnat_curl "$XNAT_URL/xapi/events/prefs")
+EVENT_STATUS=$(echo "$EVENT_PREFS" | jq -r '.enabled // empty')
 if [ "$EVENT_STATUS" != "true" ]; then
-  echo "ERROR: Event service is not enabled (expected true, got $EVENT_STATUS)"
+  echo "ERROR: Event service is not enabled (expected true)" >&2
+  echo "  body: $EVENT_PREFS" >&2
   exit 1
 fi
 

--- a/trust/xnat/xnat/config/configure-dcm2niix.sh
+++ b/trust/xnat/xnat/config/configure-dcm2niix.sh
@@ -36,6 +36,26 @@ until $(curl --output /dev/null --silent --head --fail $XNAT_URL/app/template/Lo
 done
 echo "XNAT is up!"
 
+# Helper: curl that prints body, then exits with a clear error if the HTTP
+# status code is not 2xx. Solves the silent-failure problem where `curl -s`
+# discarded a 4xx/5xx body and the script kept going with empty state. Use
+# this for every write to XNAT's REST API.
+xnat_curl() {
+  local response
+  local status
+  response=$(curl -sS -w '\n%{http_code}' "$@" -u "${XNAT_ADMIN_USER}:${XNAT_ADMIN_PASSWORD}")
+  status=$(printf '%s' "$response" | tail -n1)
+  body=$(printf '%s' "$response" | sed '$d')
+  if [[ "$status" -lt 200 || "$status" -ge 300 ]]; then
+    echo "ERROR: XNAT request failed with HTTP $status" >&2
+    echo "  args: $*" >&2
+    echo "  body: $body" >&2
+    return 1
+  fi
+  # Body is exported on stdout for the caller to consume.
+  printf '%s' "$body"
+}
+
 # Path translation for container service plugin
 # This is so that the container service can access the data
 echo "Adding path translation for container service..."
@@ -45,56 +65,53 @@ echo "Path translation with DATA_PATH=$DATA_PATH"
 backend_config=$(jq --arg data_path "$DATA_PATH" '.["path-translation-docker-prefix"] = $data_path' container-service-backend-configuration.json)
 
 echo "backend_config: $backend_config"
-curl -s -X POST "$XNAT_URL/xapi/docker/server" \
-  -u "${XNAT_ADMIN_USER}:${XNAT_ADMIN_PASSWORD}" \
+xnat_curl -X POST "$XNAT_URL/xapi/docker/server" \
   -H "Content-Type: application/json" \
-  -d "$backend_config"
+  -d "$backend_config" >/dev/null
 
 # ----------------------------------------------------------------
 # CONTAINER SERVICE
 # ----------------------------------------------------------------
 
 echo "Checking if $DCM2NIIX_NAME command exists..."
-COMMAND_ID=$(curl -s "$XNAT_URL/xapi/commands?name=$DCM2NIIX_NAME" \
-  -u "${XNAT_ADMIN_USER}:${XNAT_ADMIN_PASSWORD}" | jq -r '.[0].id')
+COMMAND_ID=$(xnat_curl "$XNAT_URL/xapi/commands?name=$DCM2NIIX_NAME" | jq -r '.[0].id // empty')
 
-if [[ "$COMMAND_ID" != "null" && -n "$COMMAND_ID" ]]; then
+if [[ -n "$COMMAND_ID" ]]; then
   echo "Found existing command ID: $COMMAND_ID. Deleting..."
-  curl -s -X DELETE "$XNAT_URL/xapi/commands/$COMMAND_ID" \
-    -u "${XNAT_ADMIN_USER}:${XNAT_ADMIN_PASSWORD}"
+  xnat_curl -X DELETE "$XNAT_URL/xapi/commands/$COMMAND_ID" >/dev/null
   echo "Command deleted."
 else
   echo "Command not found. Proceeding with addition."
 fi
 
-# Add dcm2niix command from json
+# Add dcm2niix command from json. POST /xapi/commands returns the created
+# command including its `id`; extract it directly to avoid the
+# eventual-consistency race the previous re-GET ran into (the GET could
+# return an empty array even after the POST succeeded, leaving the rest of
+# the script with empty CMD_ID and the validation curl 500ing on an
+# invalid URL).
 echo "Adding dcm2niix command..."
-curl -s -X POST "$XNAT_URL/xapi/commands" \
-  -u "${XNAT_ADMIN_USER}:${XNAT_ADMIN_PASSWORD}" \
+POST_RESPONSE=$(xnat_curl -X POST "$XNAT_URL/xapi/commands" \
   -H "Content-Type: application/json" \
-  -d @dcm2niix_command.json
+  -d @dcm2niix_command.json)
+echo "POST response: $POST_RESPONSE"
 
-# Get the command ID for dcm2niix with improved extraction
-echo " "
-echo "Getting command ID for $DCM2NIIX_NAME..."
-RESPONSE=$(curl -s "$XNAT_URL/xapi/commands?name=$DCM2NIIX_NAME" \
-  -u "${XNAT_ADMIN_USER}:${XNAT_ADMIN_PASSWORD}")
+CMD_ID=$(echo "$POST_RESPONSE" | jq -r '.id // empty')
+dcm2niix_wrapper_name=$(echo "$POST_RESPONSE" | jq -r '.xnat[0].name // empty')
 
-echo "$RESPONSE"
+if [[ -z "$CMD_ID" || -z "$dcm2niix_wrapper_name" ]]; then
+  echo "ERROR: POST /xapi/commands did not return an id + xnat[0].name." >&2
+  echo "  body: $POST_RESPONSE" >&2
+  exit 1
+fi
 
-# Extract the id from the first element in the JSON array
-CMD_ID=$(echo "$RESPONSE" | jq -r '.[0].id')
 echo "Command ID: $CMD_ID"
-
-# Grab the event name e.g. "xnat":\[{"name":"dcm2niix-scan"\}
-dcm2niix_wrapper_name=$(echo "$RESPONSE" | jq -r '.[0].xnat[0].name')
 echo "Wrapper Name: $dcm2niix_wrapper_name"
 
 # Enable the dcm2niix command at the site level (makes it available for per-project use)
 # See https://wiki.xnat.org/container-service/container-service-api for more details
 echo "Enabling $DCM2NIIX_NAME command..."
-curl -s -X PUT "$XNAT_URL/xapi/commands/$CMD_ID/wrappers/$dcm2niix_wrapper_name/enabled" \
-  -u "${XNAT_ADMIN_USER}:${XNAT_ADMIN_PASSWORD}"
+xnat_curl -X PUT "$XNAT_URL/xapi/commands/$CMD_ID/wrappers/$dcm2niix_wrapper_name/enabled" >/dev/null
 
 # Note: this only enables the command site-wide so it can be used per-project.
 
@@ -104,10 +121,9 @@ curl -s -X PUT "$XNAT_URL/xapi/commands/$CMD_ID/wrappers/$dcm2niix_wrapper_name/
 
 # Enable Event Service (required for per-project event subscriptions to work)
 echo "Enabling event service..."
-curl -s -X PUT "$XNAT_URL/xapi/events/prefs" \
-  -u "${XNAT_ADMIN_USER}:${XNAT_ADMIN_PASSWORD}" \
+xnat_curl -X PUT "$XNAT_URL/xapi/events/prefs" \
   -H "Content-Type: application/json" \
-  -d '{"enabled": true}'
+  -d '{"enabled": true}' >/dev/null
 
 # Note: We intentionally do NOT create a site-wide event subscription here.
 # Per-project event subscriptions are created by the imaging-api during project creation,
@@ -116,31 +132,27 @@ curl -s -X PUT "$XNAT_URL/xapi/events/prefs" \
 
 # Clean up any legacy site-wide event subscriptions (from prior versions)
 echo "Cleaning up legacy site-wide event subscriptions..."
-SUBS=$(curl -s "$XNAT_URL/xapi/events/subscriptions" \
-  -u "${XNAT_ADMIN_USER}:${XNAT_ADMIN_PASSWORD}")
+SUBS=$(xnat_curl "$XNAT_URL/xapi/events/subscriptions")
 SITE_SUB_IDS=$(echo "$SUBS" | jq -r '.[] | select(.["project-id"] == null or .["project-id"] == "") | .id')
 for SUB_ID in $SITE_SUB_IDS; do
   echo "Deleting site-wide subscription $SUB_ID..."
-  curl -s -X DELETE "$XNAT_URL/xapi/events/subscription/$SUB_ID" \
-    -u "${XNAT_ADMIN_USER}:${XNAT_ADMIN_PASSWORD}"
+  xnat_curl -X DELETE "$XNAT_URL/xapi/events/subscription/$SUB_ID" >/dev/null
 done
 
 # ----------------------------------------------------------------
 # VALIDATION
 # ----------------------------------------------------------------
 
-# Verify dcm2niix command was registered and enabled
+# Verify dcm2niix command was registered and enabled. The xnat_curl helper
+# above already exits non-zero on any failure, so reaching this block means
+# the writes succeeded; this is a belt-and-braces check that the enable
+# state is queryable.
 echo " "
 echo "Validating dcm2niix setup..."
-VALIDATION=$(curl -s -o /dev/null -w "%{http_code}" "$XNAT_URL/xapi/commands/$CMD_ID/wrappers/$dcm2niix_wrapper_name/enabled" \
-  -u "${XNAT_ADMIN_USER}:${XNAT_ADMIN_PASSWORD}")
-if [ "$VALIDATION" != "200" ]; then
-  echo "ERROR: dcm2niix command enable check returned HTTP $VALIDATION (expected 200)"
-  exit 1
-fi
+xnat_curl "$XNAT_URL/xapi/commands/$CMD_ID/wrappers/$dcm2niix_wrapper_name/enabled" >/dev/null
 
 # Verify event service is enabled
-EVENT_STATUS=$(curl -s "$XNAT_URL/xapi/events/prefs" -u "${XNAT_ADMIN_USER}:${XNAT_ADMIN_PASSWORD}" | jq -r '.enabled')
+EVENT_STATUS=$(xnat_curl "$XNAT_URL/xapi/events/prefs" | jq -r '.enabled')
 if [ "$EVENT_STATUS" != "true" ]; then
   echo "ERROR: Event service is not enabled (expected true, got $EVENT_STATUS)"
   exit 1


### PR DESCRIPTION
## Summary

Two related issues observed on prod 2026-05-13 during `make deploy-trust`:

1. The script's `curl -s` calls discarded the HTTP status code and body on every call to XNAT's REST API. A 4xx/5xx response was indistinguishable from success; the script printed empty lines and marched on with empty state.
2. After `POST /xapi/commands` to add dcm2niix, the script re-GET'd `/xapi/commands?name=dcm2niix` to recover the new id. That round-trip returned an empty body on prod (root cause undiagnosed), so the script bound `CMD_ID=""` and `dcm2niix_wrapper_name=""`, called PUT on `commands//wrappers//enabled` (a malformed URL), and only the post-hoc validation at the bottom caught it as HTTP 500 — with no diagnostic about which step actually broke.

## Changes

- New `xnat_curl` helper wrapping `curl -sS --connect-timeout 10 --max-time 120 -w '\n%{http_code}'`. It checks curl's own exit code (transport failures are loud in every calling context; a truncated body under a 2xx status can't pass as success), fails closed unless the status line is a literal 2xx, and on failure prints the request args + response body to stderr and returns non-zero — `set -e` aborts the script at the failing call site. Used for every read and write of XNAT's REST API.
- `CMD_ID` is read **directly from the POST response body**. Per the vendored plugin (`container-service-3.7.3-fat.jar`; `CommandRestApi.createCommand` at source tag 3.7.3 returns `ResponseEntity<Long>`), the body is the created command's **bare numeric id** — not the command object. The id is validated as numeric; the wrapper name, which the POST response cannot supply, comes from the local `dcm2niix_command.json`. This drops the empty-re-GET race entirely.
- Validation now checks state, not just reachability: the wrapper-enabled GET (bare JSON boolean in 3.7.3) must return `true` — a 2xx PUT whose effect didn't persist previously passed validation — and the events/prefs body is printed on mismatch.
- The XNAT readiness wait is wall-clock bounded (900s) with per-probe `--connect-timeout`/`--max-time`, and the `until $(curl ...)` idiom is fixed — a dead *or wedged* (accepts TCP, never responds) XNAT fails the deploy loudly instead of printing dots forever.
- `xnat_curl` strips CRs from the status line and body, so `\r\n` line endings from a middlebox can't fail the numeric/boolean guards on an invisible character.
- `make xnat-configure` chains the two configure scripts with `&&` (a `configure-xnat.sh` failure previously vanished behind the `;` chain) and fails loudly if the xnat-web container lookup comes back empty.

## Test plan

- [x] `bash -n trust/xnat/xnat/config/configure-dcm2niix.sh` — syntax OK.
- [x] Verified end-to-end against a stub XNAT implementing the container-service 3.7.3 REST contract (`POST /xapi/commands` → `201` + bare `42`; wrapper-enabled GET → bare boolean): happy path and pre-existing-command path complete green; POST 500 exits at the POST with args + body; unpersisted enable state fails validation with the body shown; transport failure is loud + non-zero in direct, command-substitution, and pipeline contexts; bodies with `\r\n` line endings still complete green; an accept-but-never-respond XNAT trips the readiness bound with a clear error instead of hanging.
- [x] **Live deployment**: deployed an isolated XNAT stack (xnat-web `:stag` = XNAT 1.9.3 with the container-service 3.7.3 plugin) via `make -C trust/xnat up-xnat-local` from this branch. The full `configure-xnat.sh` → `configure-dcm2niix.sh` flow completed green: the command id was read from the live POST response (bare numeric body, confirming the 3.7.3 contract), the wrapper-enabled GET returned a bare `true`, and the script's own validation passed. A second run exercised the delete-existing → re-add path (id 1 → 2), also green; persisted state was independently confirmed via `/xapi/commands` and the wrapper-enabled endpoint.
- [ ] After merge: re-run `make deploy-trust PROD=true`. On the failing path the script now prints `ERROR: XNAT request failed with HTTP 4xx ... body: <reason>` and exits at the offending line. If the underlying XNAT issue is resolved, the deploy completes; if not, we get the diagnostic the original script swallowed.

## Out of scope

- Investigating *why* the prod `POST /xapi/commands` → `GET /xapi/commands?name=` round-trip returned empty. The proximate cause is likely a silent 4xx from the preceding `POST /xapi/docker/server` (which would leave the container-service backend uninitialised) — such failures are now loud, so a fresh failed deploy will carry the diagnostic.
