### PR TITLE
fix(flip-api): consume normalized FL job-metadata contract, fix stop-training (#490)

### DIFF
--- a/flip-api/src/flip_api/domain/interfaces/fl.py
+++ b/flip-api/src/flip_api/domain/interfaces/fl.py
@@ -18,7 +18,7 @@ from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, computed_field, field_validator
 
-from flip_api.domain.schemas.status import ClientStatus
+from flip_api.domain.schemas.status import ClientStatus, FLJobStatus
 from flip_api.domain.schemas.types import TrimStr
 from flip_api.utils.constants import JOB_TYPES_REQUIRED_FILES_FILE
 
@@ -70,13 +70,17 @@ class IJobResponse(BaseModel):
 
 
 class IJobMetaData(BaseModel):
-    """Defines the meta data of a job."""
+    """Job metadata as returned by an FL-API adapter's ``GET /list_jobs``.
+
+    The shared job-metadata contract (GitHub issue #490). flip-api correlates
+    ``model_id`` <-> ``job_id`` in its own ``fl_job`` table, so the contract carries
+    only ``job_id`` + ``status``.
+    """
 
     model_config = ConfigDict(extra="ignore")
 
     job_id: str
-    job_name: str
-    status: str
+    status: FLJobStatus
 
 
 class IRequiredTrainingInformation(BaseModel):

--- a/flip-api/src/flip_api/domain/schemas/status.py
+++ b/flip-api/src/flip_api/domain/schemas/status.py
@@ -10,7 +10,7 @@
 # limitations under the License.
 #
 
-from enum import Enum
+from enum import Enum, StrEnum
 
 # ---------------------------
 # Enums
@@ -168,3 +168,19 @@ class XNATImageStatus(str, Enum):
     RETRIEVE_ERROR = "RETRIEVE_ERROR"
     CREATED = "CREATED"
     DELETED = "DELETED"
+
+
+class FLJobStatus(StrEnum):
+    """Normalized FL-backend job lifecycle status.
+
+    The shared job-metadata contract (GitHub issue #490): every FL-API adapter
+    (fl-api-flower, fl-api-base) maps its native runtime status into one of these
+    values, and flip-api consumes only these. Distinct from ``JobStatus`` above,
+    which tracks the FL scheduler queue state.
+    """
+
+    PENDING = "PENDING"
+    RUNNING = "RUNNING"
+    FINISHED = "FINISHED"
+    FAILED = "FAILED"
+    STOPPED = "STOPPED"

--- a/flip-api/src/flip_api/fl_services/services/fl_service.py
+++ b/flip-api/src/flip_api/fl_services/services/fl_service.py
@@ -832,8 +832,7 @@ def abort_model_training(request: Request, model_id: UUID, session: Session) -> 
         session (Session): SQLModel session object
 
     Raises:
-        ValueError: If the FL server is not running, or if the job currently running on the
-            server does not correspond to ``model_id``, or if ``target`` is invalid.
+        ValueError: If the FL server is not running, or if ``target`` is invalid.
     """
     logger.debug(f"Checking if model {model_id} is currently running...")
 

--- a/flip-api/src/flip_api/fl_services/services/fl_service.py
+++ b/flip-api/src/flip_api/fl_services/services/fl_service.py
@@ -862,19 +862,14 @@ def abort_model_training(request: Request, model_id: UUID, session: Session) -> 
         logger.error(error_msg)
         raise ValueError(error_msg)
 
-    # Extracting current job data from the server status
-    current_job_data = extract_current_job_data(net_endpoint, fl_backend_job_id)
-
-    # Current server job name (i.e. app_name) must match the model_id in order to abort
-    current_app_name = current_job_data.job_name
-
-    if current_app_name != str(model_id):
-        error_msg = (
-            f"Requested model to abort ({model_id=}) does not match the current model running on the server "
-            f"({current_app_name=})."
+    # If there is no running job for this model, it is already terminal — abort is an
+    # idempotent no-op.
+    if extract_current_job_data(net_endpoint, fl_backend_job_id) is None:
+        logger.info(
+            f"No running FL job for model {model_id} (job ID {fl_backend_job_id}); "
+            f"already stopped — nothing to abort."
         )
-        logger.error(error_msg)
-        raise ValueError(error_msg)
+        return
 
     # Extracting target and clients from the request path parameters
     path_params = request.path_params

--- a/flip-api/src/flip_api/fl_services/services/fl_service.py
+++ b/flip-api/src/flip_api/fl_services/services/fl_service.py
@@ -784,6 +784,9 @@ def extract_current_job_data(net_endpoint: str, fl_backend_job_id: str) -> IJobM
     Raises:
         ValueError: If the FL server response is not a list, or more than one running
             job shares the same ID.
+        pydantic.ValidationError: If a returned item does not conform to ``IJobMetaData``
+            (e.g. an unknown status from a non-conforming FL-API adapter) — failing loudly
+            here is intentional.
     """
     url = f"{net_endpoint}/list_jobs"
     current_job_data = http_get(url)

--- a/flip-api/src/flip_api/fl_services/services/fl_service.py
+++ b/flip-api/src/flip_api/fl_services/services/fl_service.py
@@ -28,7 +28,7 @@ from flip_api.domain.interfaces.fl import (
     JobRequiredFiles,
     JobTypes,
 )
-from flip_api.domain.schemas.status import FLTargets
+from flip_api.domain.schemas.status import FLJobStatus, FLTargets
 from flip_api.utils.encryption import encrypt
 from flip_api.utils.http import http_delete, http_get, http_post
 from flip_api.utils.logger import logger
@@ -769,20 +769,21 @@ def get_bundle_urls(s3_path: str) -> list[str]:
         raise RuntimeError(error_msg)
 
 
-def extract_current_job_data(net_endpoint: str, fl_backend_job_id: str) -> IJobMetaData:
+def extract_current_job_data(net_endpoint: str, fl_backend_job_id: str) -> IJobMetaData | None:
     """
-    Extract the current job data from the FL server status response.
+    Extract the currently-running FL job matching ``fl_backend_job_id``.
 
     Args:
         net_endpoint (str): The endpoint of the FL API service.
         fl_backend_job_id (str): The FL job ID to look for.
 
     Returns:
-        IJobMetaData: The current job data if found.
+        IJobMetaData | None: The running job's metadata, or ``None`` if no running job
+            matches ``fl_backend_job_id`` (the job is already terminal or never started).
 
     Raises:
-        ValueError: If the FL server response is not a list, no running job matches
-            ``fl_backend_job_id``, or more than one running job shares the same ID.
+        ValueError: If the FL server response is not a list, or more than one running
+            job shares the same ID.
     """
     url = f"{net_endpoint}/list_jobs"
     current_job_data = http_get(url)
@@ -797,7 +798,7 @@ def extract_current_job_data(net_endpoint: str, fl_backend_job_id: str) -> IJobM
     current_job_data = [IJobMetaData.model_validate(j) for j in current_job_data]
 
     # Get the running jobs only
-    current_job_data = [j for j in current_job_data if j.status == "RUNNING"]
+    current_job_data = [j for j in current_job_data if j.status == FLJobStatus.RUNNING]
     logger.debug(f"Running jobs: {current_job_data}")
 
     # Filter the fl_backend_job_id
@@ -805,9 +806,11 @@ def extract_current_job_data(net_endpoint: str, fl_backend_job_id: str) -> IJobM
     logger.debug(f"Current job data for job ID {fl_backend_job_id}: {current_job_data}")
 
     if not current_job_data:
-        error_msg = f"Could not find job ID {fl_backend_job_id} on FL server {net_endpoint}."
-        logger.error(error_msg)
-        raise ValueError(error_msg)
+        logger.info(
+            f"No running job with ID {fl_backend_job_id} on FL server {net_endpoint}; "
+            f"it is already terminal or never started."
+        )
+        return None
 
     # assert that there is only 1 running job with the fl_backend_job_id
     # this should not happen, but just in case

--- a/flip-api/tests/e2e_smoke.py
+++ b/flip-api/tests/e2e_smoke.py
@@ -37,6 +37,11 @@ Direct invocation:
 
 Run on a stack that already has trusts approved (`make up` plus the usual
 seeding) and non-empty XNAT data so image pull has something to do.
+
+Pass --abort-midway to verify the FL "stop training" path (GitHub issue #490)
+instead of running to completion: once training is live, the smoke POSTs
+/fl/stop/{model_id} twice and asserts both return HTTP 204 — the first aborts
+the running job, the second is an idempotent no-op.
 """
 from __future__ import annotations
 
@@ -424,6 +429,62 @@ def wait_for_training_finished(
     )
 
 
+def wait_for_training_running(
+    client: requests.Session, headers: dict[str, str], model_id: str, timeout_s: int
+) -> str:
+    """Block until the model reports TRAINING_STARTED — a genuinely live FL job.
+
+    ``wait_for_training_started`` returns on the first status past INITIATED, which
+    can be the transient PREPARED. The --abort-midway stop test wants a running job,
+    so poll on for TRAINING_STARTED specifically. If training races to RESULTS_UPLOADED
+    first, return that — stopping an already-finished job is still a valid idempotency
+    check, the caller just notes it.
+    """
+    _log(f"⏳ Waiting for model to reach TRAINING_STARTED (timeout {timeout_s}s)")
+    deadline = time.monotonic() + timeout_s
+    last_status = ""
+    poll_interval = 5
+    while time.monotonic() < deadline:
+        resp = _try_request(_post, client, f"/step/model/{model_id}", {}, headers)
+        if resp is None or resp.status_code >= 300:
+            time.sleep(poll_interval)
+            continue
+        status = resp.json().get("status", "")
+        if status != last_status:
+            _log(f"  📊 status={status}")
+            last_status = status
+        if status == ModelStatus.ERROR.value:
+            raise SmokeFailure("Model entered ERROR state before training started — check fl-server logs")
+        if status in (ModelStatus.TRAINING_STARTED.value, ModelStatus.RESULTS_UPLOADED.value):
+            return status
+        time.sleep(poll_interval)
+    raise SmokeFailure(
+        f"Model did not reach TRAINING_STARTED within {timeout_s}s (last status: {last_status or 'unknown'})."
+    )
+
+
+def stop_training(client: requests.Session, headers: dict[str, str], model_id: str, *, attempt: int) -> None:
+    """POST /fl/stop/{model_id} and assert a clean HTTP 204 — the #490 contract."""
+    _log(f"🛑 Stop attempt #{attempt}: POST /fl/stop/{model_id}")
+    resp = _post(client, f"/fl/stop/{model_id}", {}, headers)
+    if resp.status_code != 204:
+        raise SmokeFailure(f"stop attempt #{attempt} expected HTTP 204, got {resp.status_code}: {resp.text}")
+    _log(f"  ✅ stop #{attempt} returned 204")
+
+
+def assert_model_stopped(client: requests.Session, headers: dict[str, str], model_id: str) -> None:
+    """After a successful stop the model should report STOPPED.
+
+    There is no GET /model/{id}; /step/model/{id} is the codebase's canonical
+    "current model status" call (it is what every wait_for_* helper polls).
+    """
+    resp = _ensure_ok(_post(client, f"/step/model/{model_id}", {}, headers), "fetch model status after stop")
+    status = resp.json().get("status", "")
+    if status != ModelStatus.STOPPED.value:
+        raise SmokeFailure(f"expected model status STOPPED after stop, got {status!r}")
+    _log(f"  ✅ model status is {status}")
+
+
 def download_results(
     client: requests.Session, headers: dict[str, str], model_id: str, dest_dir: Path
 ) -> list[Path]:
@@ -514,6 +575,13 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="Seconds to wait for the model to reach RESULTS_UPLOADED (default: %(default)s)",
     )
     parser.add_argument(
+        "--abort-midway",
+        action="store_true",
+        help="#490 stop-training check: once training is running, POST /fl/stop/{model_id} twice "
+        "(first aborts the live job, second is an idempotent no-op) instead of waiting for training "
+        "to finish + downloading results. Both stops must return HTTP 204.",
+    )
+    parser.add_argument(
         "--results-dir",
         type=Path,
         default=None,
@@ -534,8 +602,6 @@ def main(argv: list[str] | None = None) -> int:
     headers = authenticate()
     client = requests.Session()
     client.headers.update({"Content-Type": "application/json"})
-
-    results_dir = args.results_dir or Path(tempfile.mkdtemp(prefix="flip-e2e-results-"))
 
     try:
         if args.project_id:
@@ -560,10 +626,29 @@ def main(argv: list[str] | None = None) -> int:
             )
         initiate_training(client, headers, model_id, [t["name"] for t in trusts])
         wait_for_training_started(client, headers, model_id, args.training_start_timeout)
-        final_status = wait_for_training_finished(
-            client, headers, model_id, args.training_finish_timeout
-        )
-        downloaded = download_results(client, headers, model_id, results_dir)
+        if args.abort_midway:
+            # #490: exercise the FL "stop training" path instead of running to completion.
+            running_status = wait_for_training_running(
+                client, headers, model_id, args.training_start_timeout
+            )
+            if running_status == ModelStatus.RESULTS_UPLOADED.value:
+                _log("  ⚠️  training finished before the stop — both stops now exercise the "
+                     "idempotent (already-terminal) path only")
+            # Stop #1 aborts the running job; stop #2 is an idempotent no-op. Both must 204.
+            stop_training(client, headers, model_id, attempt=1)
+            assert_model_stopped(client, headers, model_id)
+            time.sleep(5)
+            stop_training(client, headers, model_id, attempt=2)
+            assert_model_stopped(client, headers, model_id)
+            final_status = ModelStatus.STOPPED.value
+            results_dir = None
+            downloaded = []
+        else:
+            results_dir = args.results_dir or Path(tempfile.mkdtemp(prefix="flip-e2e-results-"))
+            final_status = wait_for_training_finished(
+                client, headers, model_id, args.training_finish_timeout
+            )
+            downloaded = download_results(client, headers, model_id, results_dir)
     except SmokeFailure as exc:
         _log(f"\n❌ Smoke failed: {exc}")
         return 1
@@ -577,7 +662,10 @@ def main(argv: list[str] | None = None) -> int:
     _log(f"   project_id   = {project_id}")
     _log(f"   model_id     = {model_id}")
     _log(f"   final_status = {final_status}")
-    _log(f"   results_dir  = {results_dir} ({len(downloaded)} file(s))")
+    if args.abort_midway:
+        _log("   stop #1 (abort running job) + stop #2 (idempotent no-op) both returned 204")
+    else:
+        _log(f"   results_dir  = {results_dir} ({len(downloaded)} file(s))")
     _log("=" * 60)
     return 0
 

--- a/flip-api/tests/e2e_smoke.py
+++ b/flip-api/tests/e2e_smoke.py
@@ -67,6 +67,7 @@ from tests.integration.utils import admin_authentication
 DEFAULT_QUERY_FILE = Path(__file__).parent / "example_query.sql"
 DEFAULT_PROJECT_NAME_PREFIX = "Xrays E2E Smoke"
 DEFAULT_MODEL_NAME = "Xrays E2E Smoke Model"
+ABORT_MIDWAY_NAME_SUFFIX = " (abort-midway)"
 
 # Anything strictly past INITIATED. RESULTS_UPLOADED is included so a fast
 # finish short-circuits wait_for_training_finished cleanly on the first poll.
@@ -83,6 +84,26 @@ class SmokeFailure(RuntimeError):
 
 def _log(msg: str) -> None:
     print(msg, flush=True)
+
+
+def resolve_model_name(base_name: str, abort_midway: bool) -> str:
+    """Return ``base_name`` plus the abort-midway suffix when the flag is set.
+
+    The suffix lets the UI distinguish an abort-midway model from a full-train
+    model when the same project hosts both (the typical --project-id reuse flow).
+    Idempotent: a name that already ends with the suffix is returned unchanged.
+
+    Args:
+        base_name (str): The base model name (CLI default or --model-name override).
+        abort_midway (bool): Whether the smoke run will exercise the abort path.
+
+    Returns:
+        str: ``base_name`` with the abort suffix when ``abort_midway`` is true and
+        the suffix is not already present, otherwise ``base_name`` unchanged.
+    """
+    if not abort_midway or base_name.endswith(ABORT_MIDWAY_NAME_SUFFIX):
+        return base_name
+    return f"{base_name}{ABORT_MIDWAY_NAME_SUFFIX}"
 
 
 def _post(
@@ -619,7 +640,8 @@ def main(argv: list[str] | None = None) -> int:
         # surfaces model-creation / upload errors immediately instead of after
         # 5–15 minutes of XNAT pulling, and the FL pipeline only consumes the
         # images at training time anyway.
-        model_id = create_model(client, headers, project_id, args.model_name)
+        model_name = resolve_model_name(args.model_name, args.abort_midway)
+        model_id = create_model(client, headers, project_id, model_name)
         upload_files(client, headers, model_id, args.model_files_dir)
         # Always wait for image pull, including on --project-id reuse: a prior
         # run on this project may have left pulls in flight (aborted midway,

--- a/flip-api/tests/e2e_smoke.py
+++ b/flip-api/tests/e2e_smoke.py
@@ -545,9 +545,10 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument(
         "--project-id",
         default=None,
-        help="Reuse an existing approved project: skip cohort submission, approval, and image-pull "
-        "wait; jump straight to model creation + upload + training. Lets you iterate on training "
-        "code without re-pulling images for every retry.",
+        help="Reuse an existing approved project: skip cohort submission and approval; jump straight "
+        "to model creation + upload + training. Image-pull wait still runs (cheap when already at "
+        "100%, correct when a prior --abort-midway run left pulls in flight). Lets you iterate on "
+        "training code without re-creating the project for every retry.",
     )
     parser.add_argument("--model-name", default=DEFAULT_MODEL_NAME)
     parser.add_argument(
@@ -606,7 +607,7 @@ def main(argv: list[str] | None = None) -> int:
     try:
         if args.project_id:
             project_id = args.project_id
-            _log(f"♻️  Reusing existing project_id={project_id} (skipping cohort + image pull)")
+            _log(f"♻️  Reusing existing project_id={project_id} (skipping cohort + approval)")
             trusts = _ensure_ok(_get(client, "/trust/", headers), "list trusts").json()
             if not trusts:
                 raise SmokeFailure("No trusts registered with the hub")
@@ -620,10 +621,14 @@ def main(argv: list[str] | None = None) -> int:
         # images at training time anyway.
         model_id = create_model(client, headers, project_id, args.model_name)
         upload_files(client, headers, model_id, args.model_files_dir)
-        if not args.project_id:
-            wait_for_image_pull(
-                client, headers, project_id, args.image_pull_threshold, args.image_pull_timeout
-            )
+        # Always wait for image pull, including on --project-id reuse: a prior
+        # run on this project may have left pulls in flight (aborted midway,
+        # failed, or simply queued back-to-back before the first pull finished),
+        # in which case skipping the wait here would have wait_for_training_started
+        # sit blocked on the (still pulling) FL clients until it times out.
+        wait_for_image_pull(
+            client, headers, project_id, args.image_pull_threshold, args.image_pull_timeout
+        )
         initiate_training(client, headers, model_id, [t["name"] for t in trusts])
         wait_for_training_started(client, headers, model_id, args.training_start_timeout)
         if args.abort_midway:

--- a/flip-api/tests/unit/fl_services/services/test_fl_service.py
+++ b/flip-api/tests/unit/fl_services/services/test_fl_service.py
@@ -897,6 +897,36 @@ def test_abort_model_training_success(
     mock_abort.assert_called_once_with("http://fl-api-endpoint", "job123")
 
 
+@patch("flip_api.fl_services.services.fl_service.extract_current_job_data")
+@patch("flip_api.fl_services.services.fl_service.get_fl_backend_job_id_by_model_id")
+@patch("flip_api.fl_services.services.fl_service.fetch_server_status")
+@patch("flip_api.fl_services.services.fl_service.abort_job")
+@patch("flip_api.fl_services.services.fl_scheduler_service.get_net_by_model_id")
+@patch("flip_api.fl_services.services.fl_scheduler_service.remove_job_from_queue")
+def test_abort_model_training_idempotent_when_no_running_job(
+    mock_remove,
+    mock_get_net,
+    mock_abort,
+    mock_fetch_server_status,
+    mock_get_fl_backend_job_id_by_model_id,
+    mock_extract_current_job_data,
+    model_id,
+    fake_session,
+):
+    mock_get_fl_backend_job_id_by_model_id.return_value = "job123"
+    mock_get_net.return_value = MagicMock(endpoint="http://fl-api-endpoint", name="net1")
+    mock_fetch_server_status.return_value = {"status": "stopped"}
+    mock_extract_current_job_data.return_value = None
+
+    request = MagicMock()
+    request.scope = {"request_id": "req-id"}
+    request.path_params = {"target": "server", "clients": None}
+
+    # No running job -> idempotent no-op: must not raise and must not call abort_job.
+    fl_service.abort_model_training(request, model_id, fake_session)
+    mock_abort.assert_not_called()
+
+
 def test_add_fl_job_creates_job(model_id, fake_session):
     clients = ["client1", "client2"]
     fl_service.add_fl_job(model_id, clients, fake_session)

--- a/flip-api/tests/unit/fl_services/services/test_fl_service.py
+++ b/flip-api/tests/unit/fl_services/services/test_fl_service.py
@@ -842,15 +842,14 @@ def test_extract_current_job_data_success(mock_http_get):
 
 
 @patch("flip_api.fl_services.services.fl_service.http_get")
-def test_extract_current_job_data_not_found(mock_http_get):
+def test_extract_current_job_data_not_found_returns_none(mock_http_get):
     from flip_api.fl_services.services.fl_service import extract_current_job_data
 
     mock_http_get.return_value = [{"job_id": "other", "status": "RUNNING", "job_name": "otherjob"}]
     net_endpoint = "http://fl-api-endpoint"
     fl_backend_job_id = "missing-job"
 
-    with pytest.raises(ValueError, match=f"Could not find job ID {fl_backend_job_id}"):
-        extract_current_job_data(net_endpoint, fl_backend_job_id)
+    assert extract_current_job_data(net_endpoint, fl_backend_job_id) is None
 
 
 @patch("flip_api.fl_services.services.fl_service.http_get")

--- a/flip-api/tests/unit/fl_services/services/test_fl_service.py
+++ b/flip-api/tests/unit/fl_services/services/test_fl_service.py
@@ -827,8 +827,8 @@ def test_extract_current_job_data_success(mock_http_get):
 
     # Mock backend job list response
     mock_http_get.return_value = [
-        {"job_id": "job123", "status": "RUNNING", "job_name": "myjob"},
-        {"job_id": "job999", "status": "FINISHED", "job_name": "oldjob"},
+        {"job_id": "job123", "status": "RUNNING"},
+        {"job_id": "job999", "status": "FINISHED"},
     ]
 
     result = extract_current_job_data(net_endpoint, fl_backend_job_id)
@@ -845,7 +845,7 @@ def test_extract_current_job_data_success(mock_http_get):
 def test_extract_current_job_data_not_found_returns_none(mock_http_get):
     from flip_api.fl_services.services.fl_service import extract_current_job_data
 
-    mock_http_get.return_value = [{"job_id": "other", "status": "RUNNING", "job_name": "otherjob"}]
+    mock_http_get.return_value = [{"job_id": "other", "status": "RUNNING"}]
     net_endpoint = "http://fl-api-endpoint"
     fl_backend_job_id = "missing-job"
 
@@ -860,8 +860,8 @@ def test_extract_current_job_data_multiple_found(mock_http_get):
     fl_backend_job_id = "duplicate-job"
 
     mock_http_get.return_value = [
-        {"job_id": "duplicate-job", "status": "RUNNING", "job_name": "duplicate-job"},
-        {"job_id": "duplicate-job", "status": "RUNNING", "job_name": "duplicate-job"},
+        {"job_id": "duplicate-job", "status": "RUNNING"},
+        {"job_id": "duplicate-job", "status": "RUNNING"},
     ]
 
     with pytest.raises(ValueError, match="Multiple running jobs found"):
@@ -887,7 +887,7 @@ def test_abort_model_training_success(
     mock_get_fl_backend_job_id_by_model_id.return_value = "job123"
     mock_get_net.return_value = MagicMock(endpoint="http://fl-api-endpoint", name="net1")
     mock_fetch_server_status.return_value = {"status": "stopped"}
-    mock_extract_current_job_data.return_value = IJobMetaData(job_id="job123", job_name=str(model_id), status="RUNNING")
+    mock_extract_current_job_data.return_value = IJobMetaData(job_id="job123", status="RUNNING")
 
     request = MagicMock()
     request.scope = {"request_id": "req-id"}

--- a/flip-api/tests/unit/fl_services/services/test_job_metadata_contract.py
+++ b/flip-api/tests/unit/fl_services/services/test_job_metadata_contract.py
@@ -10,8 +10,33 @@
 # limitations under the License.
 #
 
+import pytest
+from pydantic import ValidationError
+
+from flip_api.domain.interfaces.fl import IJobMetaData
 from flip_api.domain.schemas.status import FLJobStatus
 
 
 def test_fl_job_status_has_exactly_five_contract_values():
     assert {s.value for s in FLJobStatus} == {"PENDING", "RUNNING", "FINISHED", "FAILED", "STOPPED"}
+
+
+def test_job_metadata_has_exactly_job_id_and_status():
+    assert set(IJobMetaData.model_fields) == {"job_id", "status"}
+
+
+@pytest.mark.parametrize("job_status", ["PENDING", "RUNNING", "FINISHED", "FAILED", "STOPPED"])
+def test_job_metadata_accepts_every_contract_status(job_status):
+    job = IJobMetaData.model_validate({"job_id": "abc", "status": job_status})
+    assert job.status == FLJobStatus(job_status)
+
+
+def test_job_metadata_rejects_unknown_status():
+    with pytest.raises(ValidationError):
+        IJobMetaData.model_validate({"job_id": "abc", "status": "running"})
+
+
+def test_job_metadata_ignores_extra_fields():
+    job = IJobMetaData.model_validate({"job_id": "abc", "status": "RUNNING", "job_name": "legacy"})
+    assert job.job_id == "abc"
+    assert not hasattr(job, "job_name")

--- a/flip-api/tests/unit/fl_services/services/test_job_metadata_contract.py
+++ b/flip-api/tests/unit/fl_services/services/test_job_metadata_contract.py
@@ -1,0 +1,17 @@
+# Copyright (c) Guy's and St Thomas' NHS Foundation Trust & King's College London
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from flip_api.domain.schemas.status import FLJobStatus
+
+
+def test_fl_job_status_has_exactly_five_contract_values():
+    assert {s.value for s in FLJobStatus} == {"PENDING", "RUNNING", "FINISHED", "FAILED", "STOPPED"}

--- a/trust/.gitignore
+++ b/trust/.gitignore
@@ -44,5 +44,5 @@ orthanc/orthanc-storage-local
 xnat/plugins/*.jar
 
 # Image data folder
-data/trust-*/**/*.nii.gz
-data/trust-*/**/*.dcm
+data/**/*.dcm
+data/**/*.nii.gz


### PR DESCRIPTION
## Summary

Consumer side of the 3-repo FL-backend job-metadata contract convergence — closes londonaicentre/FLIP#490.

Clicking "Stop training" in the UI currently 500s for both FL backends: `extract_current_job_data` validates `GET /list_jobs` against `IJobMetaData`, whose `{job_id, job_name, status}` shape matched **neither** adapter's real output. This PR slims `IJobMetaData` to the shared contract and makes the stop path idempotent:

- New `FLJobStatus` `StrEnum` (`PENDING`/`RUNNING`/`FINISHED`/`FAILED`/`STOPPED`) in `domain/schemas/status.py` — named `FLJobStatus` (not `JobStatus`) to avoid the existing FL-scheduler `JobStatus` enum.
- `IJobMetaData` slimmed to `{job_id: str, status: FLJobStatus}` — drops `job_name`; matches what both adapters now produce.
- `extract_current_job_data` returns `None` (instead of raising) when no running job matches — the "already terminal" case.
- `abort_model_training` drops the broken `job_name == model_id` check and is now an idempotent no-op when there is no running job — so a re-stop no longer 500s.

## Coordination — must merge + deploy together

This is **1 of 3 coordinated PRs**. The contract change is breaking in both directions, but the stop-training path is **already broken**, so there is no working state to protect. Sequence: merge the two adapter PRs first → CI rebuilds the FL images → merge this PR → deploy together.

- Flower adapter PR: londonaicentre/flip-fl-base-flower#42
- NVFLARE adapter PR: londonaicentre/flip-fl-base#120

## Test plan

- [x] `make local_test` green — ruff, mypy (312 files), 1066 tests pass
- [x] New `tests/unit/fl_services/services/test_job_metadata_contract.py` — `FLJobStatus` + `IJobMetaData` contract shape, unknown-status rejection, extra-field tolerance
- [x] `test_fl_service.py` updated — `extract_current_job_data` returns `None`, `abort_model_training` idempotent no-op
- [x] `test_stop_training.py` still green (unchanged)
- [ ] End-to-end: run a training, stop it, re-stop it (idempotent, no 500) — after all 3 PRs merge + deploy together