### PR TITLE
fix(security): in-session password change and token revocation

### DIFF
--- a/flip-api/src/flip_api/main.py
+++ b/flip-api/src/flip_api/main.py
@@ -88,6 +88,7 @@ from flip_api.trusts_services import (
 )
 from flip_api.user_services import (
     access_request,
+    change_password,
     delete_user,
     get_user,
     get_users,
@@ -226,6 +227,7 @@ ROUTERS: tuple[APIRouter, ...] = (
     update_trust_status.router,
     # User services
     access_request.router,
+    change_password.router,
     delete_user.router,
     get_user.router,
     get_users.router,

--- a/flip-api/src/flip_api/user_services/change_password.py
+++ b/flip-api/src/flip_api/user_services/change_password.py
@@ -34,6 +34,12 @@ class ChangePasswordRequest(BaseModel):
     new_password: str = Field(..., min_length=8)
 
 
+class RevokeTokenRequest(BaseModel):
+    """Request body for revoking a Cognito refresh token."""
+
+    refresh_token: str = Field(..., min_length=1)
+
+
 class ChangePasswordResponse(BaseModel):
     """Response body after a successful password change."""
 
@@ -98,6 +104,12 @@ def change_own_password(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="Current password is incorrect.",
             ) from e
+        if error_code == "InvalidPasswordException":
+            logger.warning(f"Invalid new password for user {token_id}")
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="The new password does not meet the requirements.",
+            ) from e
         logger.exception(f"Failed to change password for user {token_id}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
@@ -108,7 +120,7 @@ def change_own_password(
     # refresh token in the X-Refresh-Token header; if absent we
     # still succeed — Cognito's admin_user_global_sign_out is not
     # available to non-admin callers, and the frontend will call
-    # PUT /users/revoke/{refresh_token} separately.
+    # PUT /users/revoke separately.
     refresh_token = request.headers.get("X-Refresh-Token", "")
     if refresh_token:
         try:
@@ -124,7 +136,7 @@ def change_own_password(
 
 
 @router.put(
-    "/revoke/{refresh_token}",
+    "/revoke",
     status_code=status.HTTP_204_NO_CONTENT,
     summary="Revoke a refresh token",
     description=(
@@ -134,7 +146,7 @@ def change_own_password(
     ),
 )
 def revoke_own_token(
-    refresh_token: str,
+    body: RevokeTokenRequest,
     token_id: UUID = Depends(verify_token),
 ) -> None:
     """
@@ -144,10 +156,10 @@ def revoke_own_token(
     invalidate the session server-side.
 
     Args:
-        refresh_token: The Cognito refresh token to revoke.
+        body: Request body containing the Cognito refresh token to revoke.
         token_id: The authenticated user's UUID (from ``verify_token``).
 
     Raises:
         HTTPException: 500 if the Cognito revoke_token call fails.
     """
-    revoke_token(refresh_token, get_settings().AWS_COGNITO_APP_CLIENT_ID)
+    revoke_token(body.refresh_token, get_settings().AWS_COGNITO_APP_CLIENT_ID)

--- a/flip-api/src/flip_api/user_services/change_password.py
+++ b/flip-api/src/flip_api/user_services/change_password.py
@@ -1,0 +1,153 @@
+# Copyright (c) Guy's and St Thomas' NHS Foundation Trust & King's College London
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from uuid import UUID
+
+from botocore.exceptions import ClientError
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from pydantic import BaseModel, Field
+
+from flip_api.auth.dependencies import verify_token
+from flip_api.config import get_settings
+from flip_api.utils.cognito_helpers import _cognito_client, revoke_token
+from flip_api.utils.logger import logger
+
+security = HTTPBearer()
+
+router = APIRouter(prefix="/users", tags=["user_services"])
+
+
+class ChangePasswordRequest(BaseModel):
+    """Request body for changing the authenticated user's password."""
+
+    current_password: str = Field(..., min_length=1)
+    new_password: str = Field(..., min_length=8)
+
+
+class ChangePasswordResponse(BaseModel):
+    """Response body after a successful password change."""
+
+    detail: str
+
+
+@router.post(
+    "/me/password",
+    response_model=ChangePasswordResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Change own password",
+    description=(
+        "Change the authenticated user's password and revoke all "
+        "existing sessions. Requires the current password for "
+        "verification. After success the user must sign in again."
+    ),
+)
+def change_own_password(
+    body: ChangePasswordRequest,
+    request: Request,
+    credentials: HTTPAuthorizationCredentials = Depends(security),
+    token_id: UUID = Depends(verify_token),
+) -> dict[str, str]:
+    """
+    Change the authenticated user's password via Cognito and revoke
+    all active refresh tokens.
+
+    Cognito's ``change_password`` verifies the current password and
+    updates the credential; it does **not** invalidate active tokens,
+    so this endpoint explicitly revokes the user's refresh token to
+    force re-authentication with the new password.
+
+    Args:
+        body: The current and new password.
+        request: FastAPI request object, used to read the optional
+            ``X-Refresh-Token`` header for best-effort revocation.
+        credentials: The Bearer token (used as Cognito's ``AccessToken``
+            for the ``change_password`` call).
+        token_id: The authenticated user's UUID (from ``verify_token``).
+
+    Returns:
+        dict[str, str]: A success message indicating the password was
+        changed and the user should sign in again.
+
+    Raises:
+        HTTPException: 400 if the current password is wrong (Cognito
+            ``NotAuthorizedException``), 500 on other Cognito errors.
+    """
+    cognito_client = _cognito_client()
+
+    try:
+        cognito_client.change_password(
+            PreviousPassword=body.current_password,
+            ProposedPassword=body.new_password,
+            AccessToken=credentials.credentials,
+        )
+    except ClientError as e:
+        error_code = e.response.get("Error", {}).get("Code", "")
+        if error_code == "NotAuthorizedException":
+            logger.warning(f"Wrong current password for user {token_id}")
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Current password is incorrect.",
+            ) from e
+        logger.exception(f"Failed to change password for user {token_id}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to change password.",
+        ) from e
+
+    # Best-effort token revocation. The user may or may not send their
+    # refresh token in the X-Refresh-Token header; if absent we
+    # still succeed — Cognito's admin_user_global_sign_out is not
+    # available to non-admin callers, and the frontend will call
+    # PUT /users/revoke/{refresh_token} separately.
+    refresh_token = request.headers.get("X-Refresh-Token", "")
+    if refresh_token:
+        try:
+            revoke_token(refresh_token, get_settings().AWS_COGNITO_APP_CLIENT_ID)
+        except HTTPException:
+            logger.warning(
+                f"Password changed for user {token_id} but token "
+                f"revocation failed — user should sign out manually."
+            )
+
+    logger.info(f"Password changed successfully for user {token_id}")
+    return {"detail": "Password changed successfully. Please sign in again."}
+
+
+@router.put(
+    "/revoke/{refresh_token}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    summary="Revoke a refresh token",
+    description=(
+        "Revoke a specific Cognito refresh token, invalidating its "
+        "associated session. Used after password change or explicit "
+        "sign-out to force re-authentication."
+    ),
+)
+def revoke_own_token(
+    refresh_token: str,
+    token_id: UUID = Depends(verify_token),
+) -> None:
+    """
+    Revoke a specific refresh token in Cognito.
+
+    Used by the frontend after a password change or sign-out to
+    invalidate the session server-side.
+
+    Args:
+        refresh_token: The Cognito refresh token to revoke.
+        token_id: The authenticated user's UUID (from ``verify_token``).
+
+    Raises:
+        HTTPException: 500 if the Cognito revoke_token call fails.
+    """
+    revoke_token(refresh_token, get_settings().AWS_COGNITO_APP_CLIENT_ID)

--- a/flip-api/tests/unit/user_services/test_change_password.py
+++ b/flip-api/tests/unit/user_services/test_change_password.py
@@ -20,6 +20,7 @@ from fastapi.security import HTTPAuthorizationCredentials
 
 from flip_api.user_services.change_password import (
     ChangePasswordRequest,
+    RevokeTokenRequest,
     change_own_password,
     revoke_own_token,
 )
@@ -54,7 +55,7 @@ def _make_client_error(code: str, message: str = "An error occurred") -> ClientE
             "Message": message,
         },
     }
-    return ClientError(error_response, "change_password")
+    return ClientError(error_response, "change_password")  # type: ignore[arg-type]
 
 
 class TestChangeOwnPassword:
@@ -209,14 +210,16 @@ class TestChangeOwnPassword:
                     token_id=token_id,
                 )
 
-            assert exc_info.value.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+            assert exc_info.value.status_code == status.HTTP_400_BAD_REQUEST
+            assert "does not meet the requirements" in exc_info.value.detail
 
 
 class TestRevokeOwnToken:
-    """Tests for PUT /users/revoke/{refresh_token}."""
+    """Tests for PUT /users/revoke."""
 
     def test_success_returns_204(self, token_id):
         """Valid refresh token → revoke_token called, no body returned."""
+        body = RevokeTokenRequest(refresh_token="test-refresh-token")
         with (
             patch("flip_api.user_services.change_password.revoke_token") as mock_revoke,
             patch("flip_api.user_services.change_password.verify_token") as mock_verify,
@@ -224,7 +227,7 @@ class TestRevokeOwnToken:
             mock_verify.return_value = token_id
 
             result = revoke_own_token(
-                refresh_token="test-refresh-token",
+                body=body,
                 token_id=token_id,
             )
 
@@ -233,6 +236,7 @@ class TestRevokeOwnToken:
 
     def test_cognito_failure_raises_500(self, token_id):
         """Invalid or expired token → revoke_token raises → 500 propagates."""
+        body = RevokeTokenRequest(refresh_token="bad-token")
         with (
             patch("flip_api.user_services.change_password.revoke_token") as mock_revoke,
             patch("flip_api.user_services.change_password.verify_token") as mock_verify,
@@ -245,7 +249,7 @@ class TestRevokeOwnToken:
 
             with pytest.raises(HTTPException) as exc_info:
                 revoke_own_token(
-                    refresh_token="bad-token",
+                    body=body,
                     token_id=token_id,
                 )
 

--- a/flip-api/tests/unit/user_services/test_change_password.py
+++ b/flip-api/tests/unit/user_services/test_change_password.py
@@ -1,0 +1,253 @@
+# Copyright (c) Guy's and St Thomas' NHS Foundation Trust & King's College London
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import uuid
+from unittest.mock import MagicMock, patch
+
+import pytest
+from botocore.exceptions import ClientError
+from fastapi import HTTPException, status
+from fastapi.security import HTTPAuthorizationCredentials
+
+from flip_api.user_services.change_password import (
+    ChangePasswordRequest,
+    change_own_password,
+    revoke_own_token,
+)
+
+
+@pytest.fixture
+def token_id():
+    return uuid.uuid4()
+
+
+@pytest.fixture
+def mock_credentials():
+    return HTTPAuthorizationCredentials(
+        scheme="Bearer",
+        credentials="test-access-token",  # pragma: allowlist secret
+    )
+
+
+@pytest.fixture
+def valid_body():
+    return ChangePasswordRequest(
+        current_password="OldPass1!",  # pragma: allowlist secret
+        new_password="NewPass1!",  # pragma: allowlist secret
+    )
+
+
+def _make_client_error(code: str, message: str = "An error occurred") -> ClientError:
+    """Build a minimal ClientError to simulate a Cognito failure."""
+    error_response = {
+        "Error": {
+            "Code": code,
+            "Message": message,
+        },
+    }
+    return ClientError(error_response, "change_password")
+
+
+class TestChangeOwnPassword:
+    """Tests for POST /users/me/password."""
+
+    def test_success_with_refresh_token(self, mock_request, token_id, mock_credentials, valid_body):
+        """Happy path: correct password + refresh token → Cognito change_password + revoke_token called."""
+        mock_request.headers = {"X-Refresh-Token": "test-refresh-token"}
+
+        with (
+            patch("flip_api.user_services.change_password._cognito_client") as mock_client_factory,
+            patch("flip_api.user_services.change_password.revoke_token") as mock_revoke,
+            patch("flip_api.user_services.change_password.verify_token") as mock_verify,
+        ):
+            mock_client = MagicMock()
+            mock_client_factory.return_value = mock_client
+            mock_verify.return_value = token_id
+
+            result = change_own_password(
+                body=valid_body,
+                request=mock_request,
+                credentials=mock_credentials,
+                token_id=token_id,
+            )
+
+            mock_client.change_password.assert_called_once_with(
+                PreviousPassword="OldPass1!",  # pragma: allowlist secret
+                ProposedPassword="NewPass1!",  # pragma: allowlist secret
+                AccessToken="test-access-token",
+            )
+            mock_revoke.assert_called_once()
+            assert result == {"detail": "Password changed successfully. Please sign in again."}
+
+    def test_success_without_refresh_token(self, mock_request, token_id, mock_credentials, valid_body):
+        """Missing X-Refresh-Token header → password changes, revocation skipped (best-effort)."""
+        mock_request.headers = {}  # no refresh token header
+
+        with (
+            patch("flip_api.user_services.change_password._cognito_client") as mock_client_factory,
+            patch("flip_api.user_services.change_password.revoke_token") as mock_revoke,
+            patch("flip_api.user_services.change_password.verify_token") as mock_verify,
+        ):
+            mock_client = MagicMock()
+            mock_client_factory.return_value = mock_client
+            mock_verify.return_value = token_id
+
+            result = change_own_password(
+                body=valid_body,
+                request=mock_request,
+                credentials=mock_credentials,
+                token_id=token_id,
+            )
+
+            mock_client.change_password.assert_called_once()
+            mock_revoke.assert_not_called()
+            assert result == {"detail": "Password changed successfully. Please sign in again."}
+
+    def test_revoke_failure_still_succeeds(self, mock_request, token_id, mock_credentials, valid_body):
+        """Password change succeeds even if token revocation fails (best-effort)."""
+        mock_request.headers = {"X-Refresh-Token": "test-refresh-token"}
+
+        with (
+            patch("flip_api.user_services.change_password._cognito_client") as mock_client_factory,
+            patch("flip_api.user_services.change_password.revoke_token") as mock_revoke,
+            patch("flip_api.user_services.change_password.verify_token") as mock_verify,
+        ):
+            mock_client = MagicMock()
+            mock_client_factory.return_value = mock_client
+            mock_verify.return_value = token_id
+            mock_revoke.side_effect = HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Failed to revoke token",
+            )
+
+            result = change_own_password(
+                body=valid_body,
+                request=mock_request,
+                credentials=mock_credentials,
+                token_id=token_id,
+            )
+
+            mock_client.change_password.assert_called_once()
+            mock_revoke.assert_called_once()
+            assert result == {"detail": "Password changed successfully. Please sign in again."}
+
+    def test_wrong_current_password_raises_400(self, mock_request, token_id, mock_credentials, valid_body):
+        """Wrong current password → Cognito NotAuthorizedException → 400."""
+        mock_request.headers = {}
+
+        with (
+            patch("flip_api.user_services.change_password._cognito_client") as mock_client_factory,
+            patch("flip_api.user_services.change_password.verify_token") as mock_verify,
+        ):
+            mock_client = MagicMock()
+            mock_client.change_password.side_effect = _make_client_error("NotAuthorizedException")
+            mock_client_factory.return_value = mock_client
+            mock_verify.return_value = token_id
+
+            with pytest.raises(HTTPException) as exc_info:
+                change_own_password(
+                    body=valid_body,
+                    request=mock_request,
+                    credentials=mock_credentials,
+                    token_id=token_id,
+                )
+
+            assert exc_info.value.status_code == status.HTTP_400_BAD_REQUEST
+            assert "Current password is incorrect" in exc_info.value.detail
+
+    def test_cognito_limit_exceeded_raises_500(self, mock_request, token_id, mock_credentials, valid_body):
+        """Cognito throttling or other errors → 500."""
+        mock_request.headers = {}
+
+        with (
+            patch("flip_api.user_services.change_password._cognito_client") as mock_client_factory,
+            patch("flip_api.user_services.change_password.verify_token") as mock_verify,
+        ):
+            mock_client = MagicMock()
+            mock_client.change_password.side_effect = _make_client_error("LimitExceededException")
+            mock_client_factory.return_value = mock_client
+            mock_verify.return_value = token_id
+
+            with pytest.raises(HTTPException) as exc_info:
+                change_own_password(
+                    body=valid_body,
+                    request=mock_request,
+                    credentials=mock_credentials,
+                    token_id=token_id,
+                )
+
+            assert exc_info.value.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+            assert "Failed to change password" in exc_info.value.detail
+
+    def test_invalid_new_password_raises_400(self, mock_request, token_id, mock_credentials, valid_body):
+        """Cognito InvalidPasswordException → 400."""
+        mock_request.headers = {}
+
+        with (
+            patch("flip_api.user_services.change_password._cognito_client") as mock_client_factory,
+            patch("flip_api.user_services.change_password.verify_token") as mock_verify,
+        ):
+            mock_client = MagicMock()
+            mock_client.change_password.side_effect = _make_client_error("InvalidPasswordException")
+            mock_client_factory.return_value = mock_client
+            mock_verify.return_value = token_id
+
+            with pytest.raises(HTTPException) as exc_info:
+                change_own_password(
+                    body=valid_body,
+                    request=mock_request,
+                    credentials=mock_credentials,
+                    token_id=token_id,
+                )
+
+            assert exc_info.value.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+
+
+class TestRevokeOwnToken:
+    """Tests for PUT /users/revoke/{refresh_token}."""
+
+    def test_success_returns_204(self, token_id):
+        """Valid refresh token → revoke_token called, no body returned."""
+        with (
+            patch("flip_api.user_services.change_password.revoke_token") as mock_revoke,
+            patch("flip_api.user_services.change_password.verify_token") as mock_verify,
+        ):
+            mock_verify.return_value = token_id
+
+            result = revoke_own_token(
+                refresh_token="test-refresh-token",
+                token_id=token_id,
+            )
+
+            mock_revoke.assert_called_once()
+            assert result is None
+
+    def test_cognito_failure_raises_500(self, token_id):
+        """Invalid or expired token → revoke_token raises → 500 propagates."""
+        with (
+            patch("flip_api.user_services.change_password.revoke_token") as mock_revoke,
+            patch("flip_api.user_services.change_password.verify_token") as mock_verify,
+        ):
+            mock_verify.return_value = token_id
+            mock_revoke.side_effect = HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Failed to revoke token",
+            )
+
+            with pytest.raises(HTTPException) as exc_info:
+                revoke_own_token(
+                    refresh_token="bad-token",
+                    token_id=token_id,
+                )
+
+            assert exc_info.value.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+            assert "Failed to revoke token" in exc_info.value.detail

--- a/flip-ui/src/components/AiUserDropdown/AiUserDropdown.vue
+++ b/flip-ui/src/components/AiUserDropdown/AiUserDropdown.vue
@@ -87,14 +87,32 @@
                                 active ? 'bg-gray-100 dark:bg-gray-800' : 'text-gray-600 dark:text-gray-400',
                                 'group flex rounded-md items-center w-full px-3 py-2 text-sm transition font-semibold',
                             ]"
-                            data-test="change-password-btn"
-                            @click="changePassword"
+                            data-test="update-password-btn"
+                            @click="updatePassword"
                         >
                             <icon-ph-lock-duotone
                                 class="w-5 h-5 mr-3 text-gray-500 transition group-hover:text-gray-600 dark:group-hover:text-gray-400"
                                 aria-hidden="true"
                             />
-                            Change Password
+                            Update Password
+                        </button>
+                    </MenuItem>
+                </div>
+                <div class="px-1 py-1">
+                    <MenuItem v-slot="{ active }">
+                        <button
+                            :class="[
+                                active ? 'bg-gray-100 dark:bg-gray-800' : 'text-gray-600 dark:text-gray-400',
+                                'group flex rounded-md items-center w-full px-3 py-2 text-sm transition font-semibold',
+                            ]"
+                            data-test="change-password-btn"
+                            @click="changePassword"
+                        >
+                            <icon-ph-lock-key-open-duotone
+                                class="w-5 h-5 mr-3 text-gray-500 transition group-hover:text-gray-600 dark:group-hover:text-gray-400"
+                                aria-hidden="true"
+                            />
+                            Forgot Password?
                         </button>
                     </MenuItem>
                 </div>
@@ -147,6 +165,10 @@ const signOut = () => {
 
 const changePassword = () => {
     routeChange.changePassword(props.emailAddress);
+};
+
+const updatePassword = () => {
+    routeChange.updatePassword();
 };
 
 const appVersion = window.RELEASE_VERSION;

--- a/flip-ui/src/pages/auth/update-password.vue
+++ b/flip-ui/src/pages/auth/update-password.vue
@@ -1,0 +1,159 @@
+<!--
+    Copyright (c) 2026 Guy's and St Thomas' NHS Foundation Trust & King's College London
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+        http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+
+<route lang="yaml">
+meta:
+    layout: AuthLayout
+</route>
+
+<template>
+    <section class="flex flex-col h-full">
+        <h1 class="mb-3 text-xl font-heading md:text-2xl">
+            Update Password
+        </h1>
+        <p class="mb-4 text-sm">
+            Enter your current password and choose a new one. After
+            updating, you will be signed out and need to log in with
+            your new password.
+        </p>
+        <Form
+            :validation-schema="schema"
+            class="flex flex-col flex-grow p-0 space-y-4"
+            @submit="submit"
+        >
+            <AiInput
+                name="currentPassword"
+                type="password"
+                data-test="current-password"
+                label="Current password"
+                :pre-icon="LockOutline"
+            />
+            <AiInput
+                name="newPassword"
+                type="password"
+                data-test="new-password"
+                label="New password"
+                :pre-icon="LockOutline"
+            />
+            <AiInput
+                name="confirmPassword"
+                type="password"
+                data-test="confirm-password"
+                label="Confirm new password"
+                :pre-icon="LockOutline"
+            />
+            <div class="flex-grow" />
+            <div class="flex flex-row">
+                <AiButton
+                    data-test="cancel-btn"
+                    light
+                    class="mr-2"
+                    @click="cancel"
+                >
+                    Cancel
+                </AiButton>
+                <div class="flex-grow" />
+                <AiButton
+                    primary
+                    data-test="update-password-btn"
+                    :loading="loading"
+                    type="submit"
+                >
+                    Update Password
+                </AiButton>
+            </div>
+        </Form>
+    </section>
+</template>
+
+<script setup lang="ts">
+import { Form } from "vee-validate";
+import { ref } from "vue";
+import { object, ref as yupRef, string } from "yup";
+
+import AiButton from "@/components/AiButton/AiButton.vue";
+import AiInput from "@/components/AiInput/AiInput.vue";
+import { routeChange } from "@/router";
+import { useAuthStore } from "@/store/auth";
+import { passwordValidation } from "@/utils/forms/validation";
+import { Snackbar } from "@/utils/snackbar";
+import LockOutline from "~icons/mdi/lock-outline";
+
+const authStore = useAuthStore();
+const loading = ref(false);
+
+interface IUpdatePasswordForm {
+    currentPassword: string;
+    newPassword: string;
+    confirmPassword: string;
+}
+
+const schema = object().shape({
+    currentPassword: string()
+        .required("Current password is required"),
+    newPassword: passwordValidation,
+    confirmPassword: string()
+        .required("Please confirm your new password")
+        .oneOf([yupRef("newPassword")], "Passwords must match"),
+});
+
+const cancel = () => {
+    routeChange.viewProjects();
+};
+
+const submit = async (v: unknown): Promise<void> => {
+    const { currentPassword, newPassword } = v as IUpdatePasswordForm;
+
+    if (loading.value) {
+        return;
+    }
+
+    loading.value = true;
+
+    try {
+        await authStore.updatePassword({ currentPassword, newPassword });
+        // `updatePassword` calls signOut({global: true}) on success,
+        // so we only reach here if signOut throws.
+        Snackbar.success({
+            title: "Password changed",
+            text: "Your password has been updated. Please sign in again.",
+        });
+        routeChange.gotoLogin();
+    } catch (e) {
+        console.error("Password update failed:", e);
+        const err = e as { name?: string; message?: string };
+        const isWrongPassword =
+            err.name === "NotAuthorizedException" ||
+            /wrong.*password|incorrect.*password/i.test(err.message ?? "");
+
+        if (isWrongPassword) {
+            Snackbar.error({
+                title: "Invalid current password",
+                text: "The current password you entered is incorrect. Please try again.",
+            });
+        } else if (err.name === "InvalidPasswordException") {
+            Snackbar.error({
+                title: "Invalid new password",
+                text: "The new password does not meet the requirements. Please choose a different one.",
+            });
+        } else {
+            Snackbar.error({
+                title: "Password update failed",
+                text: err.message ?? "Something went wrong. Please try again.",
+            });
+        }
+    } finally {
+        loading.value = false;
+    }
+};
+</script>

--- a/flip-ui/src/router/index.ts
+++ b/flip-ui/src/router/index.ts
@@ -93,6 +93,9 @@ export const routeChange = {
     notAllowed: (): void => {
         router.push({ path: "/403" });
     },
+    updatePassword: (): void => {
+        router.push({ path: "/auth/update-password" });
+    },
     changePassword: (email: string): void => {
         router.push({
             name: "ChangePassword",

--- a/flip-ui/src/services/__tests__/user-service.spec.ts
+++ b/flip-ui/src/services/__tests__/user-service.spec.ts
@@ -239,12 +239,12 @@ describe("user-service", () => {
     });
 
     describe("revokeToken", () => {
-        it("PUTs to /users/revoke/{refreshToken}", async () => {
+        it("PUTs to /users/revoke with refresh_token in body", async () => {
             vi.mocked(_http.put).mockResolvedValue({ data: undefined } as never);
 
             await revokeToken("rt-abc");
 
-            expect(_http.put).toHaveBeenCalledWith("/users/revoke/rt-abc");
+            expect(_http.put).toHaveBeenCalledWith("/users/revoke", { refresh_token: "rt-abc" });
         });
     });
 

--- a/flip-ui/src/services/user-service.ts
+++ b/flip-ui/src/services/user-service.ts
@@ -109,7 +109,7 @@ export async function validateUser(email: string): Promise<IProjectUser> {
 }
 
 export async function revokeToken(refreshToken: string): Promise<void> {
-    await _http.put(`/users/revoke/${refreshToken}`);
+    await _http.put("/users/revoke", { refresh_token: refreshToken });
 }
 
 export async function resetUserMfa(userId: string): Promise<void> {

--- a/flip-ui/src/store/auth.ts
+++ b/flip-ui/src/store/auth.ts
@@ -21,12 +21,13 @@ import { confirmResetPassword,
     signIn,
     signOut,
     updateMFAPreference,
+    updatePassword,
     verifyTOTPSetup } from "aws-amplify/auth";
 import { defineStore } from "pinia";
 
 import { IChangePassword } from "@/interfaces/auth/interfaces";
 import { routeChange } from "@/router";
-import { getMfaStatus, getUserPermissions } from "@/services/user-service";
+import { getMfaStatus, getUserPermissions, revokeToken } from "@/services/user-service";
 import { Snackbar } from "@/utils/snackbar";
 
 /**
@@ -565,6 +566,23 @@ export const useAuthStore = defineStore("auth", {
             });
 
             return response;
+        },
+
+                async updatePassword(details: { currentPassword: string; newPassword: string }) {
+            await updatePassword({
+                oldPassword: details.currentPassword,
+                newPassword: details.newPassword
+            });
+            try {
+                const session = await fetchAuthSession();
+                const refreshToken = session.tokens?.refreshToken?.toString();
+                if (refreshToken) {
+                    await revokeToken(refreshToken);
+                }
+            } catch (e) {
+                console.warn("Refresh token revocation after password change failed:", e);
+            }
+            await signOut({ global: true });
         },
 
         hasPermissions(permissions: UserPermissions[]) {

--- a/flip-ui/src/store/auth.ts
+++ b/flip-ui/src/store/auth.ts
@@ -568,7 +568,7 @@ export const useAuthStore = defineStore("auth", {
             return response;
         },
 
-                async updatePassword(details: { currentPassword: string; newPassword: string }) {
+        async updatePassword(details: { currentPassword: string; newPassword: string }) {
             await updatePassword({
                 oldPassword: details.currentPassword,
                 newPassword: details.newPassword


### PR DESCRIPTION
Closes GHSA-jpx3-8pqg-3qxf (CVE-2026-33880). Adds POST /users/me/password endpoint, wires PUT /users/revoke/{refreshToken} to existing revoke_token() helper, and adds frontend UI for in-session password change.