### PR TITLE
docs: sync READMEs and ReadTheDocs with code; tighten Python type hints

### DIFF
--- a/DEBUG.md
+++ b/DEBUG.md
@@ -1,14 +1,21 @@
 # Debugging across services in FLIP [VScode guide]
 
-Before running the debug command, ensure that you have the services up and running. You can do this by executing:
+Before running the debug command, ensure that the services are up. Start the full stack normally with:
 
 ```bash
 make up
 ```
 
-This will run all API services in debug mode.
+then bring up the API services in debug mode with either:
+
+```bash
+make debug-all                      # all API services in debug mode
+make debug SERVICE=<service-name>   # one service in debug mode
+```
+
 When in debug mode, the services will wait for a debugger to attach before proceeding.
 You can attach a debugger using your IDE or by using `pdb` in the terminal.
+To leave debug mode use `make debug-off SERVICE=<service-name>` or `make debug-off-all`.
 
 ## Debugging with VSCode
 

--- a/README.md
+++ b/README.md
@@ -202,13 +202,12 @@ docker compose -f deploy/compose.development.yml run --rm < service name >
 
 The project supports [NVIDIA FLARE](https://developer.nvidia.com/flare) and [Flower Framework](https://flower.ai/) for federated learning. FLARE requires provisioned certificates and configuration files that are generated in the separate repository [flip-fl-base](https://github.com/londonaicentre/flip-fl-base) (see that repository for instructions on how to provision the workspace).
 
-1. **Path Resolution**: While `.env.development` defines `FL_PROVISIONED_DIR` as a relative path (`../flip-fl-base/workspace`), the Makefile automatically converts this to an absolute path using:
+1. **Path Resolution**: `FL_PROVISIONED_DIR` is derived from the `FL_BACKEND` selection inside [`deploy/fl_backend.mk`](deploy/fl_backend.mk) (no longer set in `.env.development`):
 
-   ```makefile
-   override FL_PROVISIONED_DIR := $(shell realpath $(dir $(lastword $(MAKEFILE_LIST)))/../flip-fl-base/workspace)
-   ```
+   - `FL_BACKEND=flower` → `../flip-fl-base-flower/certs`
+   - `FL_BACKEND=nvflare` → `../flip-fl-base/workspace`
 
-   This ensures Docker volume mounts work correctly (Docker requires absolute paths) while maintaining portability across different machines.
+   The Makefile then converts the relative value to an absolute path so Docker volume mounts work correctly. You can override the resolved path at the command line for a one-off, e.g. `make up FL_PROVISIONED_DIR=/tmp/my-workspace`.
 
 2. **Why This Matters**: Docker Compose cannot resolve relative paths for volume mounts, so the absolute path conversion is essential for FL services to access their provisioned certificates and configuration files.
 

--- a/deploy/providers/AWS/README.md
+++ b/deploy/providers/AWS/README.md
@@ -619,7 +619,7 @@ the direction of the request flow.
 - **EFS**: Shared file systems and access points used by the FL services for workspace volumes (configs, certs, transfer dir). Mount targets live in the **private subnets**.
 - **Cloud Map (Service Discovery)**: Private DNS namespace `flip.local` used for ECS task-to-task resolution (e.g. `fl-api-net-1.flip.local`).
 - **VPC endpoints**: Interface endpoints (Secrets Manager, SSM, CloudWatch Logs, ECR API + DKR) in the **private subnets** plus an S3 gateway endpoint. Allow Fargate tasks to reach AWS APIs without traversing the NAT Gateway.
-- **RDS**: PostgreSQL 15 managed database (EOL: October 2027), in the **private subnets**. Subnet group + security group ingress restricted to the Central Hub EC2 SG and the `flip-api` ECS task SG.
+- **RDS**: PostgreSQL 17 managed database (Terraform default, see `var.postgres_version`), in the **private subnets**. Subnet group + security group ingress restricted to the Central Hub EC2 SG and the `flip-api` ECS task SG.
 - **CloudWatch**: Logging and monitoring for ECS tasks, both EC2 instances, the WAFv2 ACL, and VPC endpoints.
 - **Secrets Manager**: Secure storage for API secrets and database credentials (`FLIP_API` secret).
 - **SSM Parameter Store**: Configuration values read by ECS tasks at startup — bucket URIs, internal service URL, internal-service-key header name.

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,9 +15,17 @@
 
 Uses [sphinx-autoapi](https://sphinx-autoapi.readthedocs.io/en/latest/) to generate API documentation from docstrings in the codebase.
 
-To generate the documentation, run:
+To generate the documentation, run (from the repository root):
 
 ```bash
+make -C docs clean
+make -C docs docs
+```
+
+Or, from inside the `docs/` directory:
+
+```bash
+cd docs
 make clean
 make docs
 ```

--- a/docs/source/components/component-logging-stack.rst
+++ b/docs/source/components/component-logging-stack.rst
@@ -98,8 +98,9 @@ The relevant setting is:
      - Description
    * - ``LOG_LEVEL``
      - ``INFO``
-     - Python log level applied uniformly to all trust services. Set to
-       ``DEBUG`` in development, ``INFO`` in staging/production.
+     - Python log level applied uniformly to all trust services. The Pydantic
+       ``Settings`` default is ``INFO``; the example ``.env.development``
+       overrides this to ``DEBUG`` for local development.
 
 This is set via environment variables or ``.env.*`` files and read through
 each service's Pydantic ``Settings`` class.
@@ -234,8 +235,10 @@ override.
      - Description
    * - ``TRUST_LOG_LEVEL``
      - All APIs (mapped to ``LOG_LEVEL`` inside each container)
-     - Sets the Python log level uniformly across all trust services.
-       Defaults to ``DEBUG`` in development, ``INFO`` in staging/production.
+     - Sets the Python log level uniformly across all trust services. The
+       Pydantic ``Settings`` default is ``INFO``; the example
+       ``.env.development`` sets ``TRUST_LOG_LEVEL=DEBUG`` for local
+       development.
    * - ``GRAFANA_PORT``
      - Grafana
      - Host port for the Grafana UI (default ``3000``)

--- a/docs/source/components/component-xnat.rst
+++ b/docs/source/components/component-xnat.rst
@@ -256,16 +256,7 @@ The following methods are available to be used in training, located in the `flip
 - ``get_dataframe(self, project_id: str, query: str) -> DataFrame``
     This retrieves data in the form of a Dataframe containing, at the minimum, accession IDs. The method takes in the project ID and the project query as parameters. These values are already passed in as parameters to the trainer to be used.
 
-- ``get_by_accession_number(self, project_id: str, accession_id: str) -> Path``
-    This downloads scans and places them in a directory made available for NVIDIA FLARE to utilise. The method takes in the project ID as a parameter as well as an accession ID, which can be  obtained from `get_dataframe`. It returns the path to where the scans are stored.
+- ``get_by_accession_number(project_id: str, accession_id: str, resource_type: ResourceType | list[ResourceType] = ResourceType.NIFTI) -> Path``
+    Downloads scans of the requested resource type (``NIFTI`` by default) and places them in a directory made available to the FL training script. Takes the project ID and an accession ID (which can be obtained from ``get_dataframe``) and an optional ``resource_type`` (single value or list). Returns the path to where the scans are stored.
 
-- ``add_resource(self, project_id: str, accession_id: str, scan_id: str, resource_id: str, files: List[str])``
-    This allows uploading scans to XNAT under the project that the model to. Scans are to be placed in the `uploads` directory. The method does not have a return type. It supports the following required parameters:
-
-    - project ID
-    - accession ID
-    - scan ID (ID/label of the directory at the scan level)
-    - resource ID (ID/label of the directory at the resource level)
-    - a list of files corresponding to the names of the files that reside within the `uploads` directory that you wish to upload, e.g. [`scan-1.dcm`, `scan-2.dcm`, ...].
-
-    The list of files could also point to locations in subfolders relative to the uploads directory, e.g. [`subfolder/scans/scan-1.dcm`, `scan-2.dcm`], where `scan-1` has the path `uploads/subfolder/scans/scan-1.dcm` and `scan-2` has the path `uploads/scan-2.dcm`.
+See the :doc:`/components/component-fl-nodes` documentation for the full list of ``flip.*`` calls available to user training code.

--- a/docs/source/deploy-flip/deploy-central-hub.rst
+++ b/docs/source/deploy-flip/deploy-central-hub.rst
@@ -122,9 +122,12 @@ For debugging or selective steps:
 
    make github-login
    make aws-login
-   make create-backend          # one-off bootstrap of the Terraform state bucket
+   make create-backend                          # one-off bootstrap of the Terraform state bucket
    make init
    make import-persistent
+   make generate-keys                           # trust API keys (idempotent)
+   make generate-internal-service-key           # fl-server → flip-api key
+   make generate-trust-internal-service-keys    # per-trust internal keys (idempotent)
    make plan
    make apply
    make ssh-config
@@ -141,8 +144,8 @@ The hub uses three separate authentication mechanisms (see :doc:`/sys-admin`
 for full details):
 
 - **Trust API keys** — per-trust plaintext key in ``TRUST_API_KEYS``; hub stores
-  only the SHA-256 hash in ``TRUST_API_KEY_HASHES``. Generated with
-  ``make generate-trust-api-keys``.
+  only the SHA-256 hash in ``TRUST_API_KEY_HASHES``. Generated from
+  ``deploy/providers/AWS`` with ``make generate-keys``.
 - **Internal service key** — single hub-internal key for fl-server → flip-api
   calls. Generated with ``make generate-internal-service-key``.
 - **Trust-internal service keys** — per-trust shared secret used inside each

--- a/docs/source/deploy-flip/deploy-flip-node-in-tre.rst
+++ b/docs/source/deploy-flip/deploy-flip-node-in-tre.rst
@@ -176,6 +176,10 @@ Key environment variables (set via ``.env`` or Docker secrets):
      - Per-trust authentication header used on every outbound request.
    * - ``AES_KEY_BASE64``
      - Symmetric key shared with the hub; used to decrypt task payloads.
+   * - ``TRUST_INTERNAL_SERVICE_KEY``
+     - Per-trust shared secret used inside the trust for calls between
+       trust-api / imaging-api / fl-client and imaging-api /
+       data-access-api. Never leaves the trust environment.
    * - ``POLL_INTERVAL_SECONDS``
      - Polling period in seconds (default: ``5``).
 

--- a/flip-api/src/flip_api/fl_services/services/fl_service.py
+++ b/flip-api/src/flip_api/fl_services/services/fl_service.py
@@ -138,7 +138,7 @@ def check_server_status(endpoint: str) -> IServerStatus | None:
         endpoint (str): The endpoint of the server to check the status from.
 
     Returns:
-        IServerStatus: The server status.
+        IServerStatus | None: The server status, or None if the FL API did not respond.
     """
     url = f"{endpoint}/check_server_status"
     logger.debug(f"Checking server status at '{url}'")

--- a/flip-api/src/flip_api/step_functions_services/cohort_query_step_function.py
+++ b/flip-api/src/flip_api/step_functions_services/cohort_query_step_function.py
@@ -47,9 +47,9 @@ def cohort_query_step_function_endpoint(
 
     Args:
         request (Request): The FastAPI request object.
-        cohort_query (flip.domain.schemas.cohort.CohortQueryInput): The input data for the cohort query.
+        cohort_query (flip_api.domain.schemas.cohort.CohortQueryInput): The input data for the cohort query.
         db (Session): The database session.
-        user_id (str): The ID of the current user.
+        user_id (UUID): The ID of the current user.
 
     Returns:
         SubmitCohortQueryOutput: A dictionary containing the result of the cohort query submission.

--- a/flip-api/src/flip_api/step_functions_services/retrieve_model_step_function.py
+++ b/flip-api/src/flip_api/step_functions_services/retrieve_model_step_function.py
@@ -41,7 +41,7 @@ def retrieve_model_step_function_endpoint(
         model_id (UUID): The ID of the model to retrieve.
         request (Request): The FastAPI request object.
         db (Session): The database session.
-        user_id (str): The ID of the current user.
+        user_id (UUID): The ID of the current user.
 
     Returns:
         IModelResponse: The response containing the model details.

--- a/flip-api/src/flip_api/utils/api_response.py
+++ b/flip-api/src/flip_api/utils/api_response.py
@@ -12,6 +12,7 @@
 
 import json
 import logging
+from typing import Any
 
 from fastapi import status
 
@@ -24,7 +25,7 @@ HEADERS = {
 }
 
 
-def success(status_code=status.HTTP_200_OK, data=None):
+def success(status_code: int = status.HTTP_200_OK, data: dict | None = None) -> dict:
     """
     Construct a successful API response with default CORS headers.
 
@@ -43,7 +44,7 @@ def success(status_code=status.HTTP_200_OK, data=None):
     return response
 
 
-def error(status_code, error):
+def error(status_code: int, error: Exception | Any) -> dict:
     """
     Construct an error response with logging and error message.
 
@@ -67,7 +68,7 @@ def error(status_code, error):
     return response
 
 
-def unhandled_error(status_code, error):
+def unhandled_error(status_code: int, error: Exception | Any) -> dict:
     """
     Construct an unhandled error response with logging and generic error message.
 
@@ -90,7 +91,7 @@ def unhandled_error(status_code, error):
     return response
 
 
-def api_response(status_code, body=None):
+def api_response(status_code: int, body: dict | None = None) -> dict:
     """
     Construct a generic API response with default CORS headers.
 

--- a/trust/imaging-api/README.md
+++ b/trust/imaging-api/README.md
@@ -50,8 +50,7 @@ It requires both [XNAT](../xnat/) and [Orthanc](../orthanc/) to be running.
 
 Download and unzip a XNAT dataset to a local folder.
 
-```bash
-net_id: net-1
+```json
 {
   "encrypted_central_hub_project_id": "string",
   "accession_id": "string"

--- a/trust/imaging-api/imaging_api/services/download.py
+++ b/trust/imaging-api/imaging_api/services/download.py
@@ -168,7 +168,7 @@ def format_download_url(
     experiment_id_or_label: str,
     assessor_type: str = "scan",
     resource_type: str = "NIFTI",
-):
+) -> str:
     """
     Formats the XNAT API URL to download experiment scan images.
 

--- a/trust/imaging-api/imaging_api/utils/xnat_token.py
+++ b/trust/imaging-api/imaging_api/utils/xnat_token.py
@@ -24,7 +24,7 @@ class XnatTokenFactory:
     Factory class for retrieving and caching XNAT authentication tokens.
     """
 
-    def __init__(self, url: str, username: str, password: str, expiry_hours: int = 24):
+    def __init__(self, url: str, username: str, password: str, expiry_hours: int = 24) -> None:
         self.url = url
         self.username = username
         self.password = password
@@ -35,9 +35,6 @@ class XnatTokenFactory:
         """
         Retrieves a new XNAT authentication token if expired or not set.
         Caches the token for reuse.
-
-        Args:
-            None
 
         Returns:
             str: A valid XNAT session token.

--- a/trust/omop-db/README.md
+++ b/trust/omop-db/README.md
@@ -24,13 +24,17 @@ creating the trust containers, and similarly they will be updated locally when t
 make update-omop-data
 ```
 
-Start the database container using:
+The OMOP database container is normally started as part of a full trust stack from the repository root:
 
 ```sh
-make up-test-omop-trust1
+make up-trusts                # both trusts
+make -C trust up-trust-1      # Trust_1 only
+make -C trust up-trust-2      # Trust_2 only
 ```
 
-This should not run any initialization scripts as the data volume already contains a populated database.
+For database-only debugging (without the rest of the trust stack), `make -C trust/omop-db up-test-omop-trust1` will start just the Trust_1 OMOP container.
+
+Bringing the container up should not run any initialization scripts — the data volume already contains a populated database.
 
 ## Further Reading
 

--- a/trust/orthanc/README.md
+++ b/trust/orthanc/README.md
@@ -17,7 +17,7 @@
 
 Orthanc username and password are set by `ORTHANC_USERNAME` and `ORTHANC_PASSWORD` environment variables in the .env.development file at the root of this repository (see example in [.env.development.example](../../.env.development.example)).
 
-You'll need to populate Orthanc with DICOM files in order to test FLIP locally. We have prepared mock DICOM data for each of the 2 dev trusts (Trust_1 and Trust_2) as Orthanc storage volumes on S3. In order to set up the storage locally, these data volumes need to be downloaded/extracted. This is handled automatically when bringing up the trust containers via `make up`, `make up-trusts`, `make up-trust-1`, or `make up-trust-2`, and similarly they will be updated locally when they are updated on S3 (note for devs: this is controlled by `.data_version` file in this directory).
+You'll need to populate Orthanc with DICOM files in order to test FLIP locally. We have prepared mock DICOM data for each of the 2 dev trusts (Trust_1 and Trust_2) as Orthanc storage volumes on S3. In order to set up the storage locally, these data volumes need to be downloaded/extracted. This is handled automatically when bringing up the trust containers via `make up` / `make up-trusts` (from the repository root) or `make -C trust up-trust-1` / `make -C trust up-trust-2` for a single trust, and similarly they will be updated locally when they are updated on S3 (note for devs: this is controlled by `.data_version` file in this directory).
 
 ```sh
 make update-orthanc-data

--- a/trust/trust-api/trust_api/utils/http.py
+++ b/trust/trust-api/trust_api/utils/http.py
@@ -10,6 +10,8 @@
 # limitations under the License.
 #
 
+from typing import Any
+
 import httpx
 from fastapi import HTTPException
 
@@ -25,7 +27,7 @@ async def make_request(
     headers: dict | None = None,
     timeout_seconds: float = 30.0,
     follow_redirects: bool = True,
-) -> dict[str, str]:
+) -> dict[str, Any]:
     """
     Utility function to help make HTTP requests to external APIs.
 
@@ -39,7 +41,7 @@ async def make_request(
         follow_redirects (bool): Whether to follow redirects
 
     Returns:
-        dict[str, str]: JSON response from the external API
+        dict[str, Any]: JSON response from the external API
 
     Raises:
         HTTPException: If there is an error during the request or if the response is not JSON


### PR DESCRIPTION
> **This is an automated scheduled weekly task by Alex's Claude Code.**
> It audits READMEs / ReadTheDocs / docstrings against the code and pushes only changes that match a real, verified drift in the source.

## Summary

A weekly documentation-and-typing sweep. Three parallel review passes were run; every claim that did not survive a second look at the source was discarded. The remaining fixes:

### READMEs

| File | Fix |
| --- | --- |
| `README.md` | `FL_PROVISIONED_DIR` is derived from `FL_BACKEND` in `deploy/fl_backend.mk` (it is no longer in `.env.development`). Updated the FL setup section accordingly and dropped the stale `realpath` Makefile snippet. |
| `DEBUG.md` | `make up` does **not** put services into debug mode; documented `make debug-all` and `make debug SERVICE=<name>` (matches `Makefile:191-194`). |
| `deploy/providers/AWS/README.md` | RDS now defaults to PostgreSQL **17** (`variables.tf:60` = `"17.9"`), not 15. |
| `trust/orthanc/README.md` | `make up-trust-1` / `make up-trust-2` are trust-side targets — qualified as `make -C trust up-trust-1` to match the actual Makefile. |
| `trust/omop-db/README.md` | Document the standard `make up-trusts` workflow and demote `make up-test-omop-trust1` to a database-only debugging fallback. |
| `trust/imaging-api/README.md` | Removed the spurious `net_id: net-1` line from the download endpoint example — it does not correspond to any router parameter. |
| `docs/README.md` | `make clean` / `make docs` only work from inside `docs/` (or via `make -C docs …` from root) — clarified both forms. |

### ReadTheDocs (`docs/source/`)

| File | Fix |
| --- | --- |
| `components/component-logging-stack.rst` | `LOG_LEVEL` / `TRUST_LOG_LEVEL` default to `INFO` (Pydantic `Settings` default); the example `.env.development` overrides this to `DEBUG`. The previous wording claimed `DEBUG` was the default in development. |
| `components/component-xnat.rst` | Replaced the stale `flip-utils` method list with the current `flip.*` surface (added `resource_type`, removed `add_resource`, cross-linked to `component-fl-nodes.rst`). |
| `deploy-flip/deploy-central-hub.rst` | Use the AWS Makefile's actual target name `make generate-keys` (not `make generate-trust-api-keys`), and add the three `make generate-*` steps that `full-deploy` runs in the step-by-step deploy list. |
| `deploy-flip/deploy-flip-node-in-tre.rst` | Added the now-required `TRUST_INTERNAL_SERVICE_KEY` to the env-var table (the on-prem doc already had it). |

### Python type hints / docstrings

| File | Fix |
| --- | --- |
| `flip-api/src/flip_api/utils/api_response.py` | All four public helpers (`success`, `error`, `unhandled_error`, `api_response`) were entirely untyped; added parameter and return annotations. |
| `flip-api/src/flip_api/fl_services/services/fl_service.py` | `check_server_status` docstring `Returns:` was `IServerStatus`; signature returns `IServerStatus | None`. |
| `flip-api/src/flip_api/step_functions_services/cohort_query_step_function.py` | Docstring claimed `user_id (str)` but signature is `UUID`. Also pinned the `CohortQueryInput` cross-reference to its fully-qualified `flip_api.domain.schemas.cohort.CohortQueryInput` form to keep Sphinx happy (autoapi otherwise sees an ambiguous target across three services). |
| `flip-api/src/flip_api/step_functions_services/retrieve_model_step_function.py` | Same `user_id (str)` → `(UUID)` docstring fix. |
| `trust/trust-api/trust_api/utils/http.py` | `make_request` was annotated as returning `dict[str, str]`, but it returns arbitrary JSON; widened to `dict[str, Any]`. |
| `trust/imaging-api/imaging_api/utils/xnat_token.py` | `__init__` was missing `-> None`; `get_xnat_cookie`'s `Args:` block listed a phantom `None` parameter. |
| `trust/imaging-api/imaging_api/services/download.py` | `format_download_url` was missing its `-> str` return annotation. |

## Items intentionally **not** changed

The first audit pass surfaced a couple of larger items that I left alone for a maintainer to weigh in on:

- `docs/source/sys-admin/admin-platform-support.rst` — the firewall-rules table includes Kibana / Kubernetes / port-22 inbound entries that contradict the SSM-only model described in the same section. The table is probably written for a legacy non-SSM trust install pattern, so the right call (delete vs. add a clarifying preamble vs. fold into a separate section) is a docs-content question rather than a drift fix.
- The doc filenames listed in `CLAUDE.md` and `docs/CLAUDE.md` (`1_overview.rst`, … `5_api_reference.rst`) do not match the actual unnumbered filenames in `docs/source/`. That's a CLAUDE-file rename, not source drift — left for a separate PR.

## Test plan

- [x] `cd flip-api && uv run mypy .` → ✅ `Success: no issues found in 311 source files`
- [x] `cd trust/trust-api && uv run mypy .` → ✅ `Success: no issues found in 27 source files`
- [x] `cd trust/imaging-api && uv run mypy .` → ✅ `Success: no issues found in 65 source files`
- [x] `cd flip-api && uv run ruff check src/flip_api/utils/api_response.py src/flip_api/fl_services/services/fl_service.py src/flip_api/step_functions_services/` → ✅ `All checks passed!`
- [x] `cd trust/trust-api && uv run ruff check trust_api/utils/http.py` → ✅ `All checks passed!`
- [x] `cd trust/imaging-api && uv run ruff check imaging_api/utils/xnat_token.py imaging_api/services/download.py` → ✅ `All checks passed!`
- [x] `cd docs && uv run sphinx-build -b html source build/html -q` → ✅ clean build, no warnings
- [ ] CI green on `develop` once merged


---
_Generated by [Claude Code](https://claude.ai/code/session_01XwemNsVRLpZ2erGJ4gZ21D)_