### PR TITLE
refactor(deploy/aws): allow multiple on-prem trusts on the FL NLB

### DIFF
--- a/deploy/providers/AWS/Makefile
+++ b/deploy/providers/AWS/Makefile
@@ -118,6 +118,11 @@ export TF_VAR_VPC_NAME=${VPC_NAME}
 export TF_VAR_ADMIN_USER_PASSWORD=${ADMIN_USER_PASSWORD}
 export TF_VAR_SES_VERIFIED_EMAIL=${SES_VERIFIED_EMAIL}
 export TF_VAR_flip_alb_subdomain=${ALB_SUBDOMAIN}
+# On-prem trust NLB allow-list. Stored in the env file as a JSON dict
+# (LOCAL_TRUST_PUBLIC_IPS='{"UCLH":"1.2.3.4","KCH":"5.6.7.8"}') so every plain
+# `make plan/apply` recreates the full set; `add-local-trust` merges its own
+# entry over this at apply time. Default to empty so unset envs validate.
+export TF_VAR_local_trust_public_ips=$(if $(LOCAL_TRUST_PUBLIC_IPS),$(LOCAL_TRUST_PUBLIC_IPS),{})
 export TF_VAR_flip_nlb_subdomain=${NLB_SUBDOMAIN}
 export TF_VAR_FLIP_UI_BUCKET_NAME=${FLIP_UI_BUCKET_NAME}
 # flip-api / fl-* env vars consumed by ECS task definitions (locals.tf).
@@ -514,11 +519,20 @@ else
 	  echo "✅ $(LOCAL_TRUST_NAME) Flower kit deployed"
 endif
 	@echo "🔐 Updating AWS security group rules..."
-	@TF_VAR_local_trust_public_ip=$(LOCAL_TRUST_IP) terraform plan \
-		-target=aws_security_group_rule.local_trust_fl_server_nlb \
-		-out=local-trust.tfplan
-	@TF_VAR_local_trust_public_ip=$(LOCAL_TRUST_IP) terraform apply local-trust.tfplan
+	@# Merge {LOCAL_TRUST_NAME: LOCAL_TRUST_IP} into the env-file map so this
+	@# apply adds (not replaces) the rule set. The operator is still responsible
+	@# for persisting the new entry into LOCAL_TRUST_PUBLIC_IPS in $(MAIN_ENV_FILE)
+	@# afterwards — otherwise the next plain `make apply` drops the rule.
+	@MERGED_IPS=$$(python3 -c 'import json,sys; d=json.loads(sys.argv[1] or "{}"); d[sys.argv[2]]=sys.argv[3]; print(json.dumps(d, separators=(",",":")))' "$$TF_VAR_local_trust_public_ips" "$(LOCAL_TRUST_NAME)" "$(LOCAL_TRUST_IP)") && \
+	  TF_VAR_local_trust_public_ips="$$MERGED_IPS" terraform plan \
+	    -target='aws_security_group_rule.local_trust_fl_server_nlb' \
+	    -out=local-trust.tfplan && \
+	  TF_VAR_local_trust_public_ips="$$MERGED_IPS" terraform apply local-trust.tfplan
 	@rm -f local-trust.tfplan
+	@echo ""
+	@echo "⚠️  Persist the new IP into $(MAIN_ENV_FILE):"
+	@echo "   LOCAL_TRUST_PUBLIC_IPS='<merged JSON dict including \"$(LOCAL_TRUST_NAME)\":\"$(LOCAL_TRUST_IP)\">'"
+	@echo "   …otherwise the next plain 'make apply' will drop the rule."
 	@echo ""
 	@echo "✅ On-premises Trust host provisioned!"
 	@echo ""

--- a/deploy/providers/AWS/README.md
+++ b/deploy/providers/AWS/README.md
@@ -572,7 +572,7 @@ the direction of the request flow.
                   │  eu-west-2 ACM cert          │    │  FL_SERVER_PORT               │
                   │  https-listener: default 404;│    │  SG ingress allow-listed to: │
                   │  /api/* → flip-api TG        │    │   FLIP VPC NAT public IP +   │
-                  │                              │    │   local_trust_public_ip      │
+                  │                              │    │   local_trust_public_ips     │
                   └──────────────┬──────────────┘    └──────────────┬───────────────┘
                                  │ → ip:8000                         │ → ip:FL_SERVER_PORT
                                  ▼                                   ▼
@@ -613,7 +613,7 @@ the direction of the request flow.
   - Automatic Docker network creation for inter-service communication
   - No inbound ports open — access via SSM (`ssh flip-trust`) and SSM port forwarding for XNAT/Orthanc debugging (`make forward-trust`)
 - **ALB (Application Load Balancer)**: HTTPS-only entrypoint for API traffic. **Internal** (`internal = true`), lives in the **private subnets** — it has no public IP and no internet-facing path. CloudFront reaches it via an `aws_cloudfront_vpc_origin` (AWS-managed ENI in this VPC). The ALB security group accepts HTTPS:443 only from the AWS-managed `CloudFront-VPCOrigins-Service-SG` (Option 2 in the AWS VPC origins docs — the documented most-restrictive pattern; a `vpc_cidr` rule would not work because AWS evaluates VPC-origin SG checks against the service-managed SG, not the ENI source IP). The `https-listener` returns 404 by default and routes `/api/*` to the `ecs-flip-api` target group (`target_type=ip`, port 8000). The legacy `http-redirect` listener on port 80 exists as a belt-and-braces fallback only — its SG has no port-80 ingress, so it is unreachable externally.
-- **NLB (Network Load Balancer)**: TCP pass-through entrypoint for FL server traffic. Lives in the **public subnets**. Listens on `FL_SERVER_PORT` and forwards to the `ecs-fl-server-tcp` target group (`target_type=ip`) so the `fl-server-net-1` Fargate task receives the connection. The NLB security group ingress is allow-listed: NAT Gateway public IP (so the AWS-resident Trust EC2 can reach the FL server) plus any `local_trust_public_ip` set in the env file (so an on-prem trust can reach it). HTTP/2 gRPC framing is opaque to the NLB and forwarded as-is.
+- **NLB (Network Load Balancer)**: TCP pass-through entrypoint for FL server traffic. Lives in the **public subnets**. Listens on `FL_SERVER_PORT` and forwards to the `ecs-fl-server-tcp` target group (`target_type=ip`) so the `fl-server-net-1` Fargate task receives the connection. The NLB security group ingress is allow-listed: NAT Gateway public IP (so the AWS-resident Trust EC2 can reach the FL server) plus one /32 ingress per entry in `local_trust_public_ips` (the `LOCAL_TRUST_PUBLIC_IPS` JSON dict in the env file, so each on-prem trust can reach it under its own rule). HTTP/2 gRPC framing is opaque to the NLB and forwarded as-is.
 - **CloudFront + WAFv2**: Edge distribution that serves the `flip-ui` static site from S3 and forwards `/api/*` to the internal ALB via an `aws_cloudfront_vpc_origin` (HTTPS-only). A WAFv2 WebACL is attached to the distribution for L7 protection; WAF logs are shipped to CloudWatch Logs.
 - **ACM**: Two certificates — one in `eu-west-2` for the ALB, one in `us-east-1` for the CloudFront viewer.
 - **Route53**: `A` alias records for the canonical subdomain (→ CloudFront) and for the FL-server NLB.
@@ -667,7 +667,7 @@ Ingress at the load balancers (not at any EC2 SG — both EC2 hosts are in priva
 | **22** | — | 🔴 **CLOSED everywhere** | n/a | SSH never exposed — remote access is via SSM Session Manager tunnel |
 | **443** | ALB (internal) | 🟢 **OPEN to VPC origin only** | `CloudFront-VPCOrigins-Service-SG` | `/api/*` HTTPS traffic from CloudFront via the VPC origin ENI. Not reachable from the internet (ALB has no public IP). Default action returns 404. |
 | **80** | ALB (internal) | 🟡 **DEFINED, UNREACHABLE** | (no ingress rule) | Legacy HTTP→HTTPS redirect listener. SG has no port-80 ingress and the ALB has no public IP anyway; CloudFront already redirects HTTP→HTTPS at the edge and dials the origin HTTPS-only. |
-| **`FL_SERVER_PORT`** | NLB | 🟡 **CONDITIONAL** | NAT Gateway public IP + `local_trust_public_ip` if set | TCP/gRPC pass-through to the `fl-server-net-1` Fargate task |
+| **`FL_SERVER_PORT`** | NLB | 🟡 **CONDITIONAL** | NAT Gateway public IP + one /32 per entry in `local_trust_public_ips` | TCP/gRPC pass-through to the `fl-server-net-1` Fargate task |
 
 Ports referenced internally only (no internet-facing ingress; reached only from inside the VPC or from the load balancers):
 
@@ -756,7 +756,7 @@ Both aliases resolve through the SSM tunnel — no public IP or open port 22 is 
 | `[ERROR] SessionManagerPlugin is not installed` | Session manager plugin is missing or outdated | Upgrade plugin: `brew upgrade session-manager-plugin` or download latest version |
 | `InvalidInstanceID.NotFound` | SSH attempts to connect but fails | Verify instance exists: `terraform output Ec2InstanceId` and `terraform output TrustEc2InstanceId` |
 | `AccessDeniedException` | `aws ssm start-session` returns access denied | Check EC2 instance IAM role has `ssm:StartSession` and `ec2messages:*` permissions (Terraform should have created this) |
-| `Connection timeout` (hanging) | SSM tunnel hangs without error | Check NLB security group allows ingress on `FL_SERVER_PORT` from the NAT Gateway public IP (and from `local_trust_public_ip` if a hybrid trust is configured); verify instances are running: `aws ec2 describe-instances` |
+| `Connection timeout` (hanging) | SSM tunnel hangs without error | Check NLB security group allows ingress on `FL_SERVER_PORT` from the NAT Gateway public IP (and from each entry in `local_trust_public_ips` for hybrid trusts); verify instances are running: `aws ec2 describe-instances` |
 | `Unable to connect to SSM endpoint` | Connection fails immediately | Verify AWS_REGION matches deployment region: `echo $AWS_REGION` should match `eu-west-2` (or your region) |
 | `Bad ProxyCommand` in ~/.ssh/config | SSH config syntax error | Re-generate config: `make ssh-config` and verify it looks like the example above |
 

--- a/deploy/providers/AWS/main.tf
+++ b/deploy/providers/AWS/main.tf
@@ -660,22 +660,23 @@ resource "aws_lb_listener_rule" "api_routing" {
 }
 
 ############################
-# On-Premises Trust (optional)
-# Activated by setting local_trust_public_ip in the env file or via
-# TF_VAR_local_trust_public_ip when running `make add-local-trust`.
+# On-Premises Trusts (optional)
+# Activated by setting local_trust_public_ips in the env file (LOCAL_TRUST_PUBLIC_IPS
+# JSON dict) or via TF_VAR_local_trust_public_ips when running `make add-local-trust`.
 ############################
 
-# Allow the local (on-prem) trust FL client to reach the FL server via the NLB.
-# Without this rule the NLB security group drops the connection before it reaches the EC2.
+# Allow each on-prem trust FL client to reach the FL server via the NLB. One rule
+# per trust so a CIDR rotation for trust A doesn't churn trust B's rule, and so
+# the AWS console shows the owning trust in the description.
 resource "aws_security_group_rule" "local_trust_fl_server_nlb" {
-  count             = var.local_trust_public_ip != "" ? 1 : 0
+  for_each          = var.local_trust_public_ips
   type              = "ingress"
   from_port         = var.FL_SERVER_PORT
   to_port           = var.FL_SERVER_PORT
   protocol          = "tcp"
-  cidr_blocks       = ["${var.local_trust_public_ip}/32"]
+  cidr_blocks       = ["${each.value}/32"]
   security_group_id = module.fl_server_nlb.security_group_id
-  description       = "FL Server/Admin NLB from on-prem Trust"
+  description       = "FL Server/Admin NLB from on-prem Trust ${each.key}"
 }
 
 # Outputs

--- a/deploy/providers/AWS/variables.tf
+++ b/deploy/providers/AWS/variables.tf
@@ -321,8 +321,22 @@ variable "ENFORCE_MFA" {
   default     = ""
 }
 
-variable "local_trust_public_ip" {
-  description = "Public IP of an on-premises Trust host. When non-empty, AWS security group rules are created to allow consolidated FL communication on port 8002 from this IP to the Central Hub."
-  type        = string
-  default     = ""
+variable "local_trust_public_ips" {
+  description = <<-EOT
+    Map of trust name → public IP for on-premises Trust hosts. One NLB ingress
+    rule (FL_SERVER_PORT/tcp, single-host /32) is created per entry, with the
+    trust name carried into the rule description so the AWS console / audit log
+    shows which trust owns which CIDR. Set in .env.stag / .env.production as a
+    JSON dict — `make add-local-trust` merges new entries into this map at
+    apply time.
+  EOT
+  type        = map(string)
+  default     = {}
+
+  validation {
+    # IPv4-only — we allow-list single hosts on a public NLB SG; CIDR ranges or
+    # IPv6 would silently widen the rule beyond what the operator typed.
+    condition     = alltrue([for ip in values(var.local_trust_public_ips) : can(regex("^([0-9]{1,3}\\.){3}[0-9]{1,3}$", ip))])
+    error_message = "Every value in local_trust_public_ips must be a bare IPv4 address (no CIDR suffix)."
+  }
 }

--- a/deploy/providers/local/README.md
+++ b/deploy/providers/local/README.md
@@ -192,10 +192,13 @@ uv run ansible-galaxy install -r deploy/providers/local/requirements.yml
 
 ### Dynamic Public IP
 
-The NLB security group allowlists the trust's public IP for FL traffic. If the public IP changes (common with residential broadband), update it:
+The NLB security group allowlists every on-prem trust's public IP for FL traffic via the `LOCAL_TRUST_PUBLIC_IPS` JSON dict in `.env.<env>` (one rule per entry). If a trust's public IP changes (common with residential broadband), update that trust's value in the dict and re-apply:
 
 ```bash
-TF_VAR_local_trust_public_ip=<new-ip> make -C deploy/providers/AWS plan apply
+# .env.stag / .env.production:
+# LOCAL_TRUST_PUBLIC_IPS='{"UCLH":"<new-ip>","KCH":"5.6.7.8"}'
+
+make -C deploy/providers/AWS plan apply
 ```
 
 ## Troubleshooting

--- a/docs/source/deploy-flip/deploy-flip-node-on-prem.rst
+++ b/docs/source/deploy-flip/deploy-flip-node-on-prem.rst
@@ -215,11 +215,15 @@ The trust host must be able to make outbound connections to:
 - The FL Server endpoint over gRPC or HTTP (configurable port; e.g. 8002).
 
 If the trust's public IP changes (common with residential broadband), update
-the NLB security group:
+the trust's entry in ``LOCAL_TRUST_PUBLIC_IPS`` in ``.env.<env>`` (the JSON
+dict that holds every on-prem trust's IP) and re-apply:
 
 .. code-block:: shell
 
-   TF_VAR_local_trust_public_ip=<new-ip> make -C deploy/providers/AWS plan apply
+   # .env.stag / .env.production:
+   # LOCAL_TRUST_PUBLIC_IPS='{"UCLH":"<new-ip>","KCH":"5.6.7.8"}'
+
+   make -C deploy/providers/AWS plan apply
 
 ***************
 Troubleshooting


### PR DESCRIPTION
## Summary

- Replace `var.local_trust_public_ip` (string) with `var.local_trust_public_ips` (`map(string)`); the SG rule becomes `for_each` over the map so each on-prem trust gets its own `/32` ingress, with the trust name carried in the rule description.
- `make add-local-trust` merges `{LOCAL_TRUST_NAME: LOCAL_TRUST_IP}` into the env-file `LOCAL_TRUST_PUBLIC_IPS` dict at apply time, so adding trust N+1 no longer overwrites trust N.

## Why

Today, `aws_security_group_rule.local_trust_fl_server_nlb` is a single-instance resource (`count = var.local_trust_public_ip != "" ? 1 : 0`) gated by one string variable. Calling `add-local-trust` for a second trust replaces the first trust's `cidr_blocks` on the next apply. That blocks the new admin-POST `/admin/trusts` onboarding flow (drafted on `506-connection-status-new`) from supporting more than one on-prem trust in prod.

## State migration

Existing state has `aws_security_group_rule.local_trust_fl_server_nlb[0]`; the new shape is `…[\"<trust>\"]`. Without a state move, the first apply destroys the old rule and creates a new one — a brief FL traffic interruption for that trust. Run before the first apply if any on-prem trust is live:

\`\`\`
terraform state mv \\
  'aws_security_group_rule.local_trust_fl_server_nlb[0]' \\
  'aws_security_group_rule.local_trust_fl_server_nlb[\"<trust>\"]'
\`\`\`

Then \`terraform plan\` should show zero changes.

## Test plan

- [x] \`terraform fmt -recursive -check -diff\` — clean.
- [x] \`terraform validate\` — \`Success! The configuration is valid\` (only pre-existing AWS provider deprecation warnings, unrelated).
- [x] Merge one-liner smoke-tested: append, empty start, in-place IP rotation all behave correctly.
- [ ] Stag: state-mv + \`make plan\` shows zero changes for the existing UCLH-like local trust entry.
- [ ] Stag: \`make add-local-trust LOCAL_TRUST_IP=<new> LOCAL_TRUST_NAME=<new-trust>\` adds a second rule without churning the first.

## Follow-ups (intentionally out of scope)

- Auto-persist the merged entry to \`.env.<env>\` via \`env_utils.update_or_append\` (currently the operator gets a reminder to hand-edit). Kept out so the diff stays scoped to the SG resource shape.
- Items 2 and 3 from the prior trust-onboarding gap analysis (ship the admin kit file from \`add-local-trust\` and follow \`FL_KIT_SLOT\` for the S3 kit path) are independent and not part of this PR.