### PR TITLE
fix(xnat): make `make up` idempotent so it can't corrupt its own mounts

### DIFF
--- a/trust/xnat/Makefile
+++ b/trust/xnat/Makefile
@@ -10,7 +10,7 @@
 # limitations under the License.
 #
 
-.PHONY: build up deploy down clean xnat-shell xnat-war-download xnat-plugins-download \
+.PHONY: build up deploy down xnat-stack-down clean xnat-shell xnat-war-download xnat-plugins-download \
 	xnat-reset xnat-configure xnat-configure-trust-1 xnat-configure-trust-2 xnat-configure-local \
 	create-network-trust-1 create-network-trust-2 create-network-trust-local \
 	up-xnat-1 up-xnat-2 up-xnat-local \
@@ -102,7 +102,13 @@ build:
 		nginx/
 	@echo "✅ XNAT Docker images built successfully!"
 
-up: xnat-reset up-xnat-1 up-xnat-2
+# `up` runs `down` before `xnat-reset`: `xnat-reset` does `sudo rm -rf` on the
+# bind-mounted host data dirs, and if a stack is still running its xnat-web
+# container keeps the deleted directory inode mounted — every archive write
+# then fails ("Source ... does not exist") and DICOM import silently breaks.
+# `down` removes the stacks and blocks until their containers are actually
+# gone, so the directories are safe to delete by the time `xnat-reset` runs.
+up: down xnat-reset up-xnat-1 up-xnat-2
 
 up-xnat-1: create-network-trust-1
 	XNAT_PATH=${XNAT_PATH} \
@@ -133,16 +139,35 @@ up-xnat-local: create-network-trust-local
 	docker stack deploy --with-registry-auth --detach=false ${STACK_FILES} ${project_local}
 	$(MAKE) xnat-configure-local
 
+# Remove a single XNAT Swarm stack and BLOCK until all its containers have
+# stopped. `docker stack rm` is asynchronous; callers that then delete the
+# stack's bind-mounted host directories (see `xnat-reset`) must wait for the
+# containers to release those mounts first.
+# Usage: $(MAKE) xnat-stack-down STACK=<stack-name>
+xnat-stack-down:
+	@[ -n "$(STACK)" ] || (echo "❌ STACK is required"; exit 1)
+	@echo "🧹 Removing XNAT stack $(STACK) if present..."
+	@docker stack rm $(STACK) 2>/dev/null || true
+	@elapsed=0; \
+	while [ -n "$$(docker ps -aq --filter label=com.docker.stack.namespace=$(STACK) 2>/dev/null)" ]; do \
+		if [ $$elapsed -ge 120 ]; then \
+			echo "❌ ERROR: $(STACK) containers still running after 120s"; exit 1; \
+		fi; \
+		echo "⏳ Waiting for $(STACK) containers to stop ($${elapsed}s)..."; \
+		sleep 2; elapsed=$$((elapsed + 2)); \
+	done
+	@echo "✅ $(STACK) fully removed."
+
 down-xnat-1:
-	docker stack rm ${project1}
+	$(MAKE) xnat-stack-down STACK=${project1}
 
 down-xnat-2:
-	docker stack rm ${project2}
+	$(MAKE) xnat-stack-down STACK=${project2}
 
 down: down-xnat-1 down-xnat-2
 
 down-xnat-local:
-	docker stack rm ${project_local}
+	$(MAKE) xnat-stack-down STACK=${project_local}
 
 # Stop and clean up images
 clean: down


### PR DESCRIPTION
_Note_: This is only an issue if you do `make up` twice and xnat starts twice without removing the previous stack.

## Problem

`trust/xnat`'s `make up` was not idempotent. `up` runs `xnat-reset` —
which `sudo rm -rf`s the bind-mounted host data dirs
(`<port>/xnat-data/{archive,build,cache,tomcat_logs}`) — **while the
previous run's `xnat-web` container is still running**. `docker stack
deploy` then leaves that container in place, still bound to the
now-deleted directory inode.

XNAT then writes to a dead inode: every archive write fails with
`Source '/data/xnat/archive/.../arc001/<accession>' does not exist`
(`xhbm_direct_archive_session.status = ERROR`), the C-STORE from Orthanc
returns DIMSE status `0xC000`, and image pull hangs at `0/N` until
`e2e_smoke` times out. XNAT application logging breaks too — `home/logs`
is on the same kind of now-stale mount.

`make up` once worked; `make up` twice broke it. Long-standing —
`up: xnat-reset …` has existed since the Makefile's first commit.

## Fix

- New parametrized `xnat-stack-down` target: `docker stack rm <stack>`,
  then poll until the stack's containers are actually gone (`docker
  stack rm` is asynchronous).
- `down-xnat-1` / `down-xnat-2` / `down-xnat-local` route through it.
- `up` now depends on `down`, so the data dirs are deleted only after
  the containers have released the mounts. `make up` is idempotent.

## Verification

- `make up` twice in a row → container/host archive inode match and
  writes propagate (before: inode mismatch + `No such file or
  directory`).
- `make e2e_smoke` image pull `0 → 300/300` on both trusts → threshold
  reached (before: stuck at `0/300`).
- XNAT application logging restored.

Related: #524 (XNAT import failures should surface in the flip UI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)