### PR TITLE
Release v0.2.0

### DIFF
--- a/flip-api/pyproject.toml
+++ b/flip-api/pyproject.toml
@@ -12,7 +12,7 @@
 
 [project]
 name = "flip-api"
-version = "0.1.3"
+version = "0.2.0"
 description = ""
 readme = "README.md"
 authors = [

--- a/flip-api/uv.lock
+++ b/flip-api/uv.lock
@@ -659,7 +659,7 @@ wheels = [
 
 [[package]]
 name = "flip-api"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },

--- a/flip-ui/package-lock.json
+++ b/flip-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "flip-ui",
-    "version": "0.0.7",
+    "version": "0.2.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "flip-ui",
-            "version": "0.0.7",
+            "version": "0.2.0",
             "dependencies": {
                 "echarts": "^5.2.2",
                 "husky": "^9.1.7",

--- a/flip-ui/package.json
+++ b/flip-ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "flip-ui",
-    "version": "0.1.3",
+    "version": "0.2.0",
     "engines": {
         "node": "^20.19.0 || >=22.12.0"
     },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@
 #
 [project]
 name = "flip"
-version = "0.1.3"
+version = "0.2.0"
 description = ""
 readme = "README.md"
 authors = [

--- a/trust/data-access-api/pyproject.toml
+++ b/trust/data-access-api/pyproject.toml
@@ -12,7 +12,7 @@
 
 [project]
 name = "data-access-api"
-version = "0.1.3"
+version = "0.2.0"
 description = "flip Trust Data Access API"
 readme = "README.md"
 authors = [

--- a/trust/imaging-api/pyproject.toml
+++ b/trust/imaging-api/pyproject.toml
@@ -12,7 +12,7 @@
 
 [project]
 name = "imaging-api"
-version = "0.1.3"
+version = "0.2.0"
 description = "flip Trust Imaging API"
 readme = "README.md"
 authors = [

--- a/trust/trust-api/pyproject.toml
+++ b/trust/trust-api/pyproject.toml
@@ -12,7 +12,7 @@
 
 [project]
 name = "trust-api"
-version = "0.1.3"
+version = "0.2.0"
 description = "flip Trust API"
 readme = "README.md"
 authors = [


### PR DESCRIPTION
## Release v0.2.0

Version bump for the **v0.2.0** release, following the [release process](CONTRIBUTING.md#cutting-a-release) added in #520.

### What this does
- Bumps the root `pyproject.toml` to `0.2.0` — the version `.github/workflows/release.yml` reads to create the `v0.2.0` tag on merge to `main`.
- Bumps all five service version files (`flip-api`, `flip-ui`, `trust-api`, `imaging-api`, `data-access-api`) to `0.2.0` — every service has user-visible changes since `v0.1.3`.
- Syncs `flip-api/uv.lock` and `flip-ui/package-lock.json`, whose self-version had drifted behind their manifests.

### Release scope
`v0.2.0` covers everything merged since the last tagged release `v0.1.3` (Apr 8) — ~130 PRs including the ECS migration, security hardening, the FL end-to-end smoke, and the documented release process itself. `main` had advanced past `v0.1.3` (via #460) without a tag because the version was never bumped; this release captures all of it.

Minor bump (`0.1.3` → `0.2.0`): SemVer minor for a `0.x` line that has gained new features.

### Next steps (per CONTRIBUTING.md)
1. Merge this PR into `develop`; confirm CI is green.
2. Open a `develop` → `main` PR.
3. On merge to `main`, `release.yml` creates the `v0.2.0` tag and the GitHub Release with auto-generated notes; the `docker_build_*.yml` workflows push `:prod` images to GHCR.
4. Verify the [Releases page](https://github.com/londonaicentre/FLIP/releases) and the `:prod` tags on GHCR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)