### PR TITLE
Add restart-fl make target for fast FL service restarts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@
 #
 
 .PHONY: build dev prod clean stop up down up-no-trust up-trusts central-fl central-hub \
-		restart restart-no-trust ci tests debug create-networks remove-networks recreate-networks consolidate-deps \
+		restart restart-fl restart-no-trust ci tests debug create-networks remove-networks recreate-networks consolidate-deps \
 		check-aws-access up-local-trust generate-trust-api-keys generate-internal-service-key \
 		generate-trust-internal-service-keys integration_test
 
@@ -160,6 +160,24 @@ clean:
 
 # Stop all services and remove the containers
 restart: down up
+
+# Restart only FL services (APIs, servers, and clients in trusts)
+# NOTE: Uses $(PULL_ALWAYS_FLAG) — pulls fresh FL images only when DOCKER_FL_REGISTRY is set
+#       (same logic as `up`); an empty registry keeps locally built flip-fl-base-flower images.
+# NOTE: Client keys must be re-registered before starting clients (Flower only)
+restart-fl:
+	@echo "🔄 Restarting FL services ($(FL_BACKEND))..."
+	@echo "🔄 Step 1: Stopping and removing old FL clients..."
+	$(MAKE) -C trust down-fl-clients
+	@echo "🔄 Step 2: Restarting FL APIs and servers..."
+	${DOCKER_COMMAND} up -d --force-recreate --no-deps $(PULL_ALWAYS_FLAG) fl-api-net-1 fl-api-net-2 fl-server-net-1 fl-server-net-2
+	@if [ "$(FL_BACKEND)" = "flower" ]; then \
+		echo "🔄 Step 3: Registering new client keys with FL servers (Flower only)..."; \
+		${DOCKER_COMMAND} up --force-recreate $(PULL_ALWAYS_FLAG) register-supernode-keys-net-1 register-supernode-keys-net-2; \
+	fi
+	@echo "🔄 Step 4: Starting new FL clients..."
+	$(MAKE) -C trust up-fl-clients
+	@echo "✅ FL services restarted successfully!"
 
 # Stop and start all services except the trust services related services
 restart-no-trust:

--- a/trust/Makefile
+++ b/trust/Makefile
@@ -10,7 +10,7 @@
 # limitations under the License.
 #
 
-.PHONY: build dev prod clean stop up down up-trust-1 up-trust-2 down-trust-1 down-trust-2 up-local-trust down-local-trust create-networks create-networks-local-trust remove-networks recreate-networks tests update-omop-data update-orthanc-data integration_test
+.PHONY: build dev prod clean stop up down up-trust-1 up-trust-2 down-trust-1 down-trust-2 up-fl-clients down-fl-clients up-local-trust down-local-trust create-networks create-networks-local-trust remove-networks recreate-networks tests update-omop-data update-orthanc-data integration_test
 # if tag PROD=true is passed, set PROD=true
 ifeq ($(PROD),true)
 MAIN_ENV_FILE=../.env.production
@@ -213,6 +213,18 @@ restart-trust-2: down-trust-2 up-trust-2
 up: create-networks up-trust-1 up-trust-2
 
 down: down-trust-1 down-trust-2
+
+# Start / stop only the FL client containers, leaving the rest of each trust stack up.
+# Each dev trust project (trust1, trust2) runs a client per FL net, hence both net-1 and net-2.
+up-fl-clients:
+	@echo "🚢 Starting FL clients..."
+	$(TRUST_1_VARS) DEBUG=${DEBUG} ${DOCKER_COMPOSE_CMD} -f deploy/compose_trust-1_override.yml -p ${trust1} up -d --no-deps $(PULL_ALWAYS_FLAG) fl-client-net-1 fl-client-net-2
+	$(TRUST_2_VARS) ${DOCKER_COMPOSE_CMD} -p ${trust2} up -d --no-deps $(PULL_ALWAYS_FLAG) fl-client-net-1 fl-client-net-2
+
+down-fl-clients:
+	@echo "🛑 Stopping and removing FL clients..."
+	$(TRUST_1_VARS) ${DOCKER_COMPOSE_CMD} -f deploy/compose_trust-1_override.yml -p ${trust1} rm -fs fl-client-net-1 fl-client-net-2
+	$(TRUST_2_VARS) ${DOCKER_COMPOSE_CMD} -p ${trust2} rm -fs fl-client-net-1 fl-client-net-2
 
 update-omop-data:
 	$(OMOP_DB_CMD) update-omop-data


### PR DESCRIPTION
## Summary

Adds `make restart-fl` to restart only the FL services — FL APIs, FL servers, and the trust-side FL clients — without cycling the whole stack:

1. Stops and removes the old FL clients (`make -C trust down-fl-clients`).
2. Recreates the FL APIs and servers (`--force-recreate --no-deps`).
3. Re-registers SuperNode keys with the FL servers (Flower backend only).
4. Starts fresh FL clients (`make -C trust up-fl-clients`).

Also adds the `up-fl-clients` / `down-fl-clients` targets to `trust/Makefile` that `restart-fl` drives — these did not previously exist anywhere in the repo, so `make restart-fl` would have failed immediately without them. They act only on the `fl-client-net-1` / `fl-client-net-2` containers in both dev trust projects.

The `docker compose up` calls use `$(PULL_ALWAYS_FLAG)` so fresh FL images are pulled only when `DOCKER_FL_REGISTRY` is set — matching `up` / `up-no-trust` and avoiding a manifest-not-found error when local `:dev` FL images are in use.

This is the restart-fl half of #523, split into its own PR; the model-checkpoints half is #532. #523 is superseded by the two and is being closed.

Closes #522

## Test plan

- [ ] `make restart-fl` cycles the FL services on the Flower backend without touching the rest of the stack.
- [ ] With local `:dev` FL images (`DOCKER_FL_REGISTRY` empty), `restart-fl` does not error on `--pull always`.
- [ ] `make -C trust up-fl-clients` / `down-fl-clients` start/stop only the fl-client containers.

https://claude.ai/code/session_01Y3mzC5zrNh7QGaHC2DghU1

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y3mzC5zrNh7QGaHC2DghU1)_

## Acceptance Criteria

*Imported from issue #522*

Is able to spin out containers with latest images. 
Folder `model_checkpoints` should be visible by FL-API and server.