### PR TITLE
Fold corrected restart-fl (PR #534) into the PR #523 branch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@
 #
 
 .PHONY: build dev prod clean stop up down up-no-trust up-trusts central-fl central-hub \
-		restart restart-no-trust ci tests debug create-networks remove-networks recreate-networks consolidate-deps \
+		restart restart-fl restart-no-trust ci tests debug create-networks remove-networks recreate-networks consolidate-deps \
 		check-aws-access up-local-trust generate-trust-api-keys generate-internal-service-key \
 		generate-trust-internal-service-keys integration_test
 
@@ -74,8 +74,9 @@ ifneq ($(strip $(DOCKER_FL_REGISTRY)),)
 PULL_ALWAYS_FLAG=--pull always
 else
 PULL_ALWAYS_FLAG=
-# Build the Docker images
 endif
+
+# Build the Docker images
 build:
 	@echo "🛠️ Building Docker images..."
 	@echo "UI_PORT = $(UI_PORT)"
@@ -161,17 +162,18 @@ clean:
 restart: down up
 
 # Restart only FL services (APIs, servers, and clients in trusts)
-# NOTE: This target does NOT use --pull to ensure locally built images (from flip-fl-base-flower) are used
+# NOTE: Uses $(PULL_ALWAYS_FLAG) — pulls fresh FL images only when DOCKER_FL_REGISTRY is set
+#       (same logic as `up`); an empty registry keeps locally built flip-fl-base-flower images.
 # NOTE: Client keys must be re-registered before starting clients (Flower only)
 restart-fl:
 	@echo "🔄 Restarting FL services ($(FL_BACKEND))..."
 	@echo "🔄 Step 1: Stopping and removing old FL clients..."
 	$(MAKE) -C trust down-fl-clients
 	@echo "🔄 Step 2: Restarting FL APIs and servers..."
-	${DOCKER_COMMAND} up -d --force-recreate --no-deps fl-api-net-1 fl-api-net-2 fl-server-net-1 fl-server-net-2
+	${DOCKER_COMMAND} up -d --force-recreate --no-deps $(PULL_ALWAYS_FLAG) fl-api-net-1 fl-api-net-2 fl-server-net-1 fl-server-net-2
 	@if [ "$(FL_BACKEND)" = "flower" ]; then \
 		echo "🔄 Step 3: Registering new client keys with FL servers (Flower only)..."; \
-		${DOCKER_COMMAND} up --force-recreate register-supernode-keys-net-1 register-supernode-keys-net-2; \
+		${DOCKER_COMMAND} up --force-recreate $(PULL_ALWAYS_FLAG) register-supernode-keys-net-1 register-supernode-keys-net-2; \
 	fi
 	@echo "🔄 Step 4: Starting new FL clients..."
 	$(MAKE) -C trust up-fl-clients

--- a/trust/Makefile
+++ b/trust/Makefile
@@ -10,7 +10,7 @@
 # limitations under the License.
 #
 
-.PHONY: build dev prod clean stop up down up-trust-1 up-trust-2 down-trust-1 down-trust-2 up-local-trust down-local-trust create-networks create-networks-local-trust remove-networks recreate-networks tests update-omop-data update-orthanc-data integration_test
+.PHONY: build dev prod clean stop up down up-trust-1 up-trust-2 down-trust-1 down-trust-2 up-fl-clients down-fl-clients up-local-trust down-local-trust create-networks create-networks-local-trust remove-networks recreate-networks tests update-omop-data update-orthanc-data integration_test
 # if tag PROD=true is passed, set PROD=true
 ifeq ($(PROD),true)
 MAIN_ENV_FILE=../.env.production
@@ -210,6 +210,18 @@ restart-trust-2: down-trust-2 up-trust-2
 up: create-networks up-trust-1 up-trust-2
 
 down: down-trust-1 down-trust-2
+
+# Start / stop only the FL client containers, leaving the rest of each trust stack up.
+# Each dev trust project (trust1, trust2) runs a client per FL net, hence both net-1 and net-2.
+up-fl-clients:
+	@echo "🚢 Starting FL clients..."
+	$(TRUST_1_VARS) DEBUG=${DEBUG} ${DOCKER_COMPOSE_CMD} -f compose_trust-1_override.yml -p ${trust1} up -d --no-deps $(PULL_ALWAYS_FLAG) fl-client-net-1 fl-client-net-2
+	$(TRUST_2_VARS) ${DOCKER_COMPOSE_CMD} -p ${trust2} up -d --no-deps $(PULL_ALWAYS_FLAG) fl-client-net-1 fl-client-net-2
+
+down-fl-clients:
+	@echo "🛑 Stopping and removing FL clients..."
+	$(TRUST_1_VARS) ${DOCKER_COMPOSE_CMD} -f compose_trust-1_override.yml -p ${trust1} rm -fs fl-client-net-1 fl-client-net-2
+	$(TRUST_2_VARS) ${DOCKER_COMPOSE_CMD} -p ${trust2} rm -fs fl-client-net-1 fl-client-net-2
 
 update-omop-data:
 	$(OMOP_DB_CMD) update-omop-data


### PR DESCRIPTION
Internal: brings the corrected restart-fl work from #534 onto PR #523's branch — `PULL_ALWAYS_FLAG`-gated `up` calls, `restart-fl` in `.PHONY`, the endif/comment fix, and the `up-fl-clients` / `down-fl-clients` trust targets (adapted to #523's pre-reorg `trust/` layout). To be merged into the #523 branch; #534 will then be closed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y3mzC5zrNh7QGaHC2DghU1)_