### PR TITLE
docs: automate user-guide GIFs + repair the 5 broken demo specs

### DIFF
--- a/.github/workflows/regenerate_docs_gifs.yml
+++ b/.github/workflows/regenerate_docs_gifs.yml
@@ -9,12 +9,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Re-record the admin user-action GIFs whenever the admin UI changes on main,
-# then open a PR against develop with the regenerated assets. Functional CI
+# Re-record the documentation GIFs whenever the UI changes on main, then open a
+# PR against develop with the regenerated assets. Functional CI
 # (test_flip_ui.yml) is untouched — video stays off there so the 6-shard PR
 # pipeline isn't slowed down.
 #
-# See flip-ui/test/cypress/docs/admin/ for the demo specs and
+# See flip-ui/test/cypress/docs/ for the demo specs and
 # flip-ui/scripts/videos-to-gifs.sh for the ffmpeg conversion.
 
 name: Regenerate docs GIFs
@@ -92,17 +92,20 @@ jobs:
         with:
           branch: bot/regenerate-docs-gifs
           base: develop
-          add-paths: docs/source/assets/admin/*.gif
+          add-paths: |
+            docs/source/assets/admin/*.gif
+            docs/source/assets/flip/*.gif
           commit-message: |
-            docs: regenerate admin user-action GIFs
+            docs: regenerate documentation GIFs
 
             Auto-regenerated from main by .github/workflows/regenerate_docs_gifs.yml.
 
             Signed-off-by: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
-          title: "docs: regenerate admin user-action GIFs"
+          title: "docs: regenerate documentation GIFs"
           body: |
             Auto-regenerated from `main` @ ${{ github.sha }} by `.github/workflows/regenerate_docs_gifs.yml`.
 
-            Review the rendered GIFs under `docs/source/assets/admin/` before merging.
+            Review the rendered GIFs under `docs/source/assets/admin/` and
+            `docs/source/assets/flip/` before merging.
           signoff: true
           delete-branch: true

--- a/flip-ui/scripts/videos-to-gifs.sh
+++ b/flip-ui/scripts/videos-to-gifs.sh
@@ -14,8 +14,8 @@
 # Demo specs live at test/cypress/docs/<category>/<name>.spec.ts and map 1:1 to
 # <name>.gif under docs/source/assets/<category>/ — the spec's folder selects
 # the asset subdirectory, the basename selects the GIF:
-#   docs/admin/reset-mfa.spec.ts     -> docs/source/assets/admin/reset-mfa.gif
-#   docs/flip/create-model.spec.ts   -> docs/source/assets/flip/create-model.gif
+#   test/cypress/docs/admin/reset-mfa.spec.ts    -> docs/source/assets/admin/reset-mfa.gif
+#   test/cypress/docs/flip/create-model.spec.ts  -> docs/source/assets/flip/create-model.gif
 
 set -euo pipefail
 
@@ -59,11 +59,21 @@ for spec in "${specs[@]}"; do
     category="$(basename "$(dirname "${spec}")")"
     name="$(basename "${spec}" .spec.ts)"
 
-    mp4="$(find "${videos_root}" -type f -name "${name}.spec.ts.mp4" -print -quit)"
-    if [[ -z "${mp4}" ]]; then
+    # Scope the search to the spec's category subdir so a same-named spec in a
+    # different category can't be picked up by mistake, and bail on >1 matches
+    # rather than silently pick a stale recording (e.g. left over from a run
+    # against a different Cypress version with a different video-path prefix).
+    mapfile -t mp4_matches < <(find "${videos_root}" -type f -path "*/${category}/${name}.spec.ts.mp4" | sort)
+    if (( ${#mp4_matches[@]} == 0 )); then
         echo "No video for ${spec}; skipping." >&2
         continue
     fi
+    if (( ${#mp4_matches[@]} > 1 )); then
+        echo "Multiple videos for ${spec} — clean ${videos_root} and re-record:" >&2
+        printf '  %s\n' "${mp4_matches[@]}" >&2
+        exit 1
+    fi
+    mp4="${mp4_matches[0]}"
 
     out_dir="${assets_root}/${category}"
     mkdir -p "${out_dir}"

--- a/flip-ui/scripts/videos-to-gifs.sh
+++ b/flip-ui/scripts/videos-to-gifs.sh
@@ -10,9 +10,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Convert each Cypress-recorded mp4 under test/cypress/videos/docs/admin/ into
-# a GIF in-place under docs/source/assets/admin/. Spec filenames map 1:1 to GIF
-# basenames (reset-mfa.spec.ts.mp4 → reset-mfa.gif).
+# Convert each Cypress-recorded demo mp4 into a GIF under docs/source/assets/.
+# Demo specs live at test/cypress/docs/<category>/<name>.spec.ts and map 1:1 to
+# <name>.gif under docs/source/assets/<category>/ — the spec's folder selects
+# the asset subdirectory, the basename selects the GIF:
+#   docs/admin/reset-mfa.spec.ts     -> docs/source/assets/admin/reset-mfa.gif
+#   docs/flip/create-model.spec.ts   -> docs/source/assets/flip/create-model.gif
 
 set -euo pipefail
 
@@ -20,8 +23,9 @@ script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ui_dir="$(cd "${script_dir}/.." && pwd)"
 repo_root="$(cd "${ui_dir}/.." && pwd)"
 
+specs_root="${ui_dir}/test/cypress/docs"
 videos_root="${ui_dir}/test/cypress/videos"
-out_dir="${repo_root}/docs/source/assets/admin"
+assets_root="${repo_root}/docs/source/assets"
 
 # ffmpeg crop window isolating the AUT iframe inside the recorded frame.
 # Must stay in lockstep with cypress.docs.config.ts:
@@ -39,27 +43,30 @@ if [[ ! -d "${videos_root}" ]]; then
     exit 0
 fi
 
-# Cypress writes each video to {videosFolder}/{specRelativePath}.mp4, but the
-# exact prefix varies by version and common-root inference — find any mp4 under
-# the videos root and key off the filename. Demo specs are named to match the
-# target GIF (reset-mfa.spec.ts → reset-mfa.gif), so the basename carries
-# everything we need.
-mapfile -t videos < <(find "${videos_root}" -type f -name "*.mp4" | sort)
-if (( ${#videos[@]} == 0 )); then
-    echo "No mp4 files under ${videos_root}; nothing to convert." >&2
+# Drive off the demo spec files, not the recorded videos: the spec path is
+# stable and authoritative for both the GIF basename and its category subdir,
+# whereas Cypress's video-path prefix varies by version and common-root
+# inference. Each spec's video is then located by its unique filename.
+mapfile -t specs < <(find "${specs_root}" -type f -name "*.spec.ts" | sort)
+if (( ${#specs[@]} == 0 )); then
+    echo "No demo specs under ${specs_root}; nothing to convert." >&2
     exit 0
 fi
 
-mkdir -p "${out_dir}"
+converted=0
+for spec in "${specs[@]}"; do
+    # test/cypress/docs/flip/create-model.spec.ts -> category=flip, name=create-model
+    category="$(basename "$(dirname "${spec}")")"
+    name="$(basename "${spec}" .spec.ts)"
 
-for mp4 in "${videos[@]}"; do
-    base="$(basename "${mp4}")"
-    # reset-mfa.spec.ts.mp4 → reset-mfa
-    name="${base%.spec.ts.mp4}"
-    if [[ "${name}" == "${base}" ]]; then
-        # Fallback for unexpected naming — strip a single trailing extension.
-        name="${base%.mp4}"
+    mp4="$(find "${videos_root}" -type f -name "${name}.spec.ts.mp4" -print -quit)"
+    if [[ -z "${mp4}" ]]; then
+        echo "No video for ${spec}; skipping." >&2
+        continue
     fi
+
+    out_dir="${assets_root}/${category}"
+    mkdir -p "${out_dir}"
     out="${out_dir}/${name}.gif"
     echo "→ ${out}"
     # cypress.docs.config.ts forces Chrome to --window-size=1920,1200 so the
@@ -72,6 +79,7 @@ for mp4 in "${videos[@]}"; do
     ffmpeg -y -hide_banner -loglevel error -i "${mp4}" \
         -vf "crop=${CROP_WIDTH}:${CROP_HEIGHT}:${CROP_X}:${CROP_Y},fps=15,scale=1200:-1:flags=lanczos,split[s0][s1];[s0]palettegen=stats_mode=full[p];[s1][p]paletteuse=dither=bayer:bayer_scale=5" \
         "${out}"
+    converted=$(( converted + 1 ))
 done
 
-echo "Converted ${#videos[@]} video(s) → ${out_dir}"
+echo "Converted ${converted} video(s) → ${assets_root}/{admin,flip}"

--- a/flip-ui/test/cypress/docs/flip/approve-project.spec.ts
+++ b/flip-ui/test/cypress/docs/flip/approve-project.spec.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2026 Guy's and St Thomas' NHS Foundation Trust & King's College London
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Records docs/source/assets/flip/approve-project.gif.
+// Mirrors the happy path in test/cypress/integration/group-5/view_project.spec.ts
+// ("Project Page: STAGED with only one trust" -> "successfully approves the project").
+
+describe("docs: approve project", () => {
+    it("approves a staged project", () => {
+        const projectId = "6fcbdd40-3675-45c9-899e-1a005e5245ba";
+
+        cy.login();
+        cy.intercept("GET", "/projects/*/image/status", { fixture: "project/getProjectStatus" });
+        cy.intercept("GET", "/projects/" + projectId, { fixture: "project/getStagedProjectOneTrust" }).as("getProject");
+        cy.intercept("POST", `/step/project/${projectId}/approve`, {
+            statusCode: 200,
+            body: [
+                {
+                    id: "SOMEIDFORKCH",
+                    name: "Kings College Hospital",
+                    endpoint: "localhost"
+                }
+            ]
+        }).as("approveProject");
+
+        cy.visit("/project/" + projectId);
+        cy.wait("@getProject");
+        cy.demoPause();
+
+        cy.getBySel("trust-staged-0").demoClick();
+        cy.demoPause();
+
+        cy.getBySel("approve-project-btn").demoClick();
+        cy.wait("@approveProject");
+
+        cy.contains("Project Approved").should("be.visible");
+        cy.demoPause(1200);
+    });
+});

--- a/flip-ui/test/cypress/docs/flip/change-password-user.spec.ts
+++ b/flip-ui/test/cypress/docs/flip/change-password-user.spec.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2026 Guy's and St Thomas' NHS Foundation Trust & King's College London
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Records docs/source/assets/flip/change-password-user.gif.
+// Mirrors the happy path in test/cypress/integration/group-3/auth/reset_password.spec.ts
+// (the account-menu "Change Password" item routes to the same change-password form).
+
+describe("docs: change password", () => {
+    it("changes your own password from the account menu", () => {
+        const cognitoUrl = "https://cognito-idp.eu-west-2.amazonaws.com/";
+        const email = "HasAdminRole@gmail.com";
+
+        cy.login();
+
+        cy.visit("/projects");
+        cy.demoPause();
+
+        cy.getBySel("account-menu-btn").demoClick();
+        cy.demoPause();
+
+        cy.getBySel("change-password-btn").demoClick();
+        cy.demoPause();
+
+        cy.intercept("POST", cognitoUrl, {
+            statusCode: 200,
+            fixture: "auth/cognitoForgotPassword"
+        }).as("requestCode");
+        cy.getBySel("requestCode-btn").demoClick();
+        cy.wait("@requestCode");
+        cy.demoPause();
+
+        cy.getBySel("confirmation-code").demoType("12345");
+        cy.demoPause();
+
+        cy.getBySel("password").demoType("NewPassword!1");
+        cy.demoPause();
+
+        cy.intercept("POST", cognitoUrl, {
+            statusCode: 200,
+            fixture: "auth/cognitoConfirmForgotPassword"
+        }).as("changePassword");
+        cy.getBySel("changePassword-btn").demoClick();
+        cy.wait("@changePassword");
+
+        cy.contains("You've updated your password. You can now log in using it.").should("be.visible");
+        cy.demoPause(1200);
+    });
+});

--- a/flip-ui/test/cypress/docs/flip/change-password-user.spec.ts
+++ b/flip-ui/test/cypress/docs/flip/change-password-user.spec.ts
@@ -31,12 +31,23 @@ describe("docs: change password", () => {
         cy.getBySel("change-password-btn").demoClick();
         cy.demoPause();
 
+        // The request-code form needs the email typed in: routeChange.changePassword
+        // pushes the route with both `path` and `params`, and Vue Router drops
+        // `params` when `path` is present, so the field never prefills.
+        cy.getBySel("email").demoType(email);
+        cy.demoPause();
+
         cy.intercept("POST", cognitoUrl, {
             statusCode: 200,
             fixture: "auth/cognitoForgotPassword"
         }).as("requestCode");
         cy.getBySel("requestCode-btn").demoClick();
         cy.wait("@requestCode");
+        cy.demoPause();
+
+        // The change-password form is a separate form with its own (empty)
+        // email field — re-enter it, mirroring reset_password.spec.ts.
+        cy.getBySel("email").demoType(email);
         cy.demoPause();
 
         cy.getBySel("confirmation-code").demoType("12345");

--- a/flip-ui/test/cypress/docs/flip/cohort-query.spec.ts
+++ b/flip-ui/test/cypress/docs/flip/cohort-query.spec.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2026 Guy's and St Thomas' NHS Foundation Trust & King's College London
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Records docs/source/assets/flip/cohort-query.gif.
+// Mirrors the happy path in test/cypress/integration/group-6/cohort/create_cohort.spec.ts
+// ("Should be able to create a Cohort and display it's results using OMOP").
+
+describe("docs: cohort query", () => {
+    it("builds and runs a cohort query", () => {
+        const projectId = "6fcbdd40-3675-45c9-899e-1a005e5245ba";
+
+        cy.login();
+        cy.intercept("POST", "/step/cohort", { fixture: "cohort/cohortQueryResponseOMOP" })
+            .as("submitCohortQuery");
+        cy.intercept("GET", "cohort/*", { fixture: "cohort/cohortQueryResultsOmop" })
+            .as("cohortResults");
+        cy.intercept("GET", "/projects/" + projectId, {
+            fixture: "project/getProjectWithQueryNotApprovedUnstagedEmpty"
+        }).as("getProject");
+
+        cy.visit(`/project/${projectId}/cohort-query`);
+        cy.wait("@getProject");
+        cy.demoPause();
+
+        cy.getBySel("cohort-query")
+            .first()
+            .demoType("SELECT accession_id, year_of_birth FROM omop.person WHERE year_of_birth < 1980");
+        cy.demoPause();
+
+        cy.getBySel("view-cohort-query-results-btn").demoClick();
+        cy.wait("@submitCohortQuery");
+        cy.wait("@cohortResults");
+
+        cy.contains("Cohort query has been sent to trusts and queued for processing").should("be.visible");
+        cy.demoPause(1200);
+    });
+});

--- a/flip-ui/test/cypress/docs/flip/cohort-query.spec.ts
+++ b/flip-ui/test/cypress/docs/flip/cohort-query.spec.ts
@@ -20,8 +20,21 @@ describe("docs: cohort query", () => {
         const projectId = "6fcbdd40-3675-45c9-899e-1a005e5245ba";
 
         cy.login();
-        cy.intercept("POST", "/step/cohort", { fixture: "cohort/cohortQueryResponseOMOP" })
-            .as("submitCohortQuery");
+        // sendQuery() returns the raw POST body and runCohortQuery() reads
+        // `response.trust` off it directly. The cohortQueryResponseOMOP fixture
+        // wraps that payload in a stringified `body` envelope, so the success
+        // branch would throw and surface an error snackbar instead. Mock the
+        // shape the app actually consumes (ICohortQueryResponse).
+        cy.intercept("POST", "/step/cohort", {
+            statusCode: 200,
+            body: {
+                trust: [
+                    { name: "UCLH", statusCode: 200 },
+                    { name: "KCH", statusCode: 200 }
+                ],
+                queryId: "c9453df9-d228-4c9c-80dd-9a2e3c2ecf11"
+            }
+        }).as("submitCohortQuery");
         cy.intercept("GET", "cohort/*", { fixture: "cohort/cohortQueryResultsOmop" })
             .as("cohortResults");
         cy.intercept("GET", "/projects/" + projectId, {
@@ -39,8 +52,9 @@ describe("docs: cohort query", () => {
 
         cy.getBySel("view-cohort-query-results-btn").demoClick();
         cy.wait("@submitCohortQuery");
-        cy.wait("@cohortResults");
 
+        // Assert the success snackbar before anything else — Snackbar.show
+        // auto-dismisses after 6s, so a later cy.wait could outlast it.
         cy.contains("Cohort query has been sent to trusts and queued for processing").should("be.visible");
         cy.demoPause(1200);
     });

--- a/flip-ui/test/cypress/docs/flip/create-model.spec.ts
+++ b/flip-ui/test/cypress/docs/flip/create-model.spec.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2026 Guy's and St Thomas' NHS Foundation Trust & King's College London
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Records docs/source/assets/flip/create-model.gif.
+// Mirrors the happy path in test/cypress/integration/group-2/model/create_model.spec.ts
+// ("when name and description are provided successfully, model is created").
+
+describe("docs: create model", () => {
+    it("creates a new model", () => {
+        const projectId = "6fcbdd40-3675-45c9-899e-1a005e5245ba";
+
+        cy.login();
+        cy.intercept("GET", `/projects/${projectId}`, { fixture: "project/getProjectWithQuery" });
+        cy.intercept("GET", `/projects/${projectId}/models*`, { fixture: "model/getModels" }).as("getModels");
+        cy.intercept("POST", "/model", {
+            statusCode: 200,
+            body: { id: projectId }
+        }).as("createModel");
+        cy.intercept("POST", `/step/model/${projectId}`, { fixture: "model/getModel" }).as("getModel");
+
+        cy.visit(`/project/${projectId}`);
+        cy.wait("@getModels");
+        cy.demoPause();
+
+        cy.getBySel("add-model-btn").first().demoClick();
+        cy.demoPause();
+
+        cy.getBySel("model-name").demoType("Stroke Detection Model");
+        cy.demoPause();
+
+        cy.getBySel("model-description").demoType("Detects acute stroke from CT head scans.");
+        cy.demoPause();
+
+        cy.getBySel("create-model-btn").first().demoClick();
+        cy.wait("@createModel");
+        cy.contains("Model created successfully").should("be.visible");
+        cy.demoPause(1200);
+    });
+});

--- a/flip-ui/test/cypress/docs/flip/create-project.spec.ts
+++ b/flip-ui/test/cypress/docs/flip/create-project.spec.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2026 Guy's and St Thomas' NHS Foundation Trust & King's College London
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Records docs/source/assets/flip/create-project.gif.
+// Mirrors the happy path in test/cypress/integration/group-3/project/create_project.spec.ts
+// ("successfully creates a new project when name and description is provided").
+
+describe("docs: create project", () => {
+    it("creates a new project", () => {
+        cy.login();
+        cy.intercept("POST", "/projects", {
+            statusCode: 200,
+            body: { id: "6fcbdd40-3675-45c9-899e-1a005e5245ba" }
+        }).as("createProject");
+        cy.intercept("GET", "/projects/6fcbdd40-3675-45c9-899e-1a005e5245ba", {
+            fixture: "project/getProjectWithQuery"
+        });
+
+        cy.visit("/projects");
+        cy.demoPause();
+
+        cy.getBySel("add-project-btn").demoClick();
+        cy.demoPause();
+
+        cy.getBySel("project-name").demoType("Stroke Detection Study");
+        cy.demoPause();
+
+        cy.getBySel("project-description").demoType("Federated training of a stroke detection model.");
+        cy.demoPause();
+
+        cy.getBySel("create-project-btn").demoClick();
+        cy.wait("@createProject");
+        cy.contains("Project created successfully").should("be.visible");
+        cy.demoPause(1200);
+    });
+});

--- a/flip-ui/test/cypress/docs/flip/create-project.spec.ts
+++ b/flip-ui/test/cypress/docs/flip/create-project.spec.ts
@@ -18,6 +18,12 @@
 describe("docs: create project", () => {
     it("creates a new project", () => {
         cy.login();
+        // Start from an empty project list (as create_project.spec.ts does):
+        // each project card also carries data-test="project-name", so the
+        // default non-empty list collides with the modal's name input.
+        cy.intercept("GET", "/projects?pageNumber=1&pageSize=20", {
+            fixture: "project/getProjectsEmpty"
+        }).as("getProjectsEmpty");
         cy.intercept("POST", "/projects", {
             statusCode: 200,
             body: { id: "6fcbdd40-3675-45c9-899e-1a005e5245ba" }

--- a/flip-ui/test/cypress/docs/flip/dark-mode.spec.ts
+++ b/flip-ui/test/cypress/docs/flip/dark-mode.spec.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2026 Guy's and St Thomas' NHS Foundation Trust & King's College London
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Records docs/source/assets/flip/dark-mode.gif.
+// No functional spec — the dark-mode toggle lives in the account menu
+// (AiUserDropdown.vue, opened via the "account-menu-btn" MenuButton).
+
+describe("docs: dark mode", () => {
+    it("toggles dark mode", () => {
+        cy.login();
+
+        cy.visit("/projects");
+        cy.demoPause();
+
+        cy.getBySel("account-menu-btn").demoClick();
+        cy.demoPause();
+
+        cy.contains("button", "Dark Mode").demoClick();
+        cy.demoPause(1200);
+    });
+});

--- a/flip-ui/test/cypress/docs/flip/delete-model.spec.ts
+++ b/flip-ui/test/cypress/docs/flip/delete-model.spec.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2026 Guy's and St Thomas' NHS Foundation Trust & King's College London
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Records docs/source/assets/flip/delete-model.gif.
+// Mirrors the happy path in test/cypress/integration/group-2/model/delete_model.spec.ts
+// ("Delete Model: With Permissions" -> "Allows the user to delete the model").
+
+describe("docs: delete model", () => {
+    it("deletes a model", () => {
+        const projectId = "6fcbdd40-3675-45c9-899e-1a005e5245ba";
+        const modelId = "6292d9ec-e821-4e4a-814e-3a315a4cb95e";
+        const modelName = "Test Model";
+
+        cy.login();
+        cy.intercept("GET", "/projects/*", { fixture: "project/getApprovedProject" });
+        cy.intercept("POST", `/step/model/${modelId}`, { fixture: "model/getModel" }).as("getModel");
+        cy.intercept("GET", `/model/${modelId}/logs`, []);
+        cy.intercept("GET", "/projects/*/models?pageSize=5", { fixture: "model/getLatestModels" });
+        cy.intercept("DELETE", `/model/${modelId}`, {
+            statusCode: 200,
+            body: {}
+        }).as("deleteModel");
+
+        cy.visit(`project/${projectId}/model/${modelId}`);
+        cy.wait("@getModel");
+        cy.demoPause();
+
+        cy.getBySel("edit-model-btn").demoClick();
+        cy.demoPause();
+
+        cy.getBySel("delete-model-btn").demoClick();
+        cy.demoPause();
+
+        cy.getBySel("confirmation-input").demoType(modelName);
+        cy.demoPause();
+
+        cy.getBySel("confirm-modal-btn").demoClick();
+        cy.wait("@deleteModel");
+        cy.contains("Model deleted").should("be.visible");
+        cy.demoPause(1200);
+    });
+});

--- a/flip-ui/test/cypress/docs/flip/delete-project.spec.ts
+++ b/flip-ui/test/cypress/docs/flip/delete-project.spec.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2026 Guy's and St Thomas' NHS Foundation Trust & King's College London
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Records docs/source/assets/flip/delete-project.gif.
+// Mirrors the happy path in test/cypress/integration/group-5/view_project.spec.ts
+// ("Allows the user to delete a staged project").
+
+describe("docs: delete project", () => {
+    it("deletes a project", () => {
+        cy.login();
+        cy.intercept("GET", "/projects/*", { fixture: "project/getProject" }).as("getProject");
+        cy.intercept("DELETE", "/projects/*", { statusCode: 200, body: {} }).as("deleteProject");
+
+        cy.visit("/project/6fcbdd40-3675-45c9-899e-1a005e5245ba");
+        cy.wait("@getProject");
+        cy.demoPause();
+
+        cy.getBySel("edit-project-btn").demoClick();
+        cy.demoPause();
+
+        cy.getBySel("delete-project-btn").demoClick();
+        cy.demoPause();
+
+        cy.getBySel("confirmation-input").demoType("Stroke Test Project");
+        cy.demoPause();
+
+        cy.getBySel("confirm-modal-btn").demoClick();
+        cy.wait("@deleteProject");
+        cy.contains("Project deleted").should("be.visible");
+        cy.demoPause(1200);
+    });
+});

--- a/flip-ui/test/cypress/docs/flip/download-results.spec.ts
+++ b/flip-ui/test/cypress/docs/flip/download-results.spec.ts
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2026 Guy's and St Thomas' NHS Foundation Trust & King's College London
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Records docs/source/assets/flip/download-results.gif.
+// Mirrors the happy path in test/cypress/integration/group-6/model_dashboard_post_training.spec.ts.
+
+describe("docs: download results", () => {
+    it("downloads the training results for a completed model", () => {
+        cy.login();
+
+        const projectId = "6fcbdd40-3675-45c9-899e-1a005e5245ba";
+        const modelId = "6292d9ec-e821-4e4a-814e-3a315a4cb95e";
+
+        cy.intercept("GET", `/projects/${projectId}`, { fixture: "project/getProjectWithQuery" }).as("getProject");
+        cy.intercept("POST", `/step/model/${modelId}`, {
+            body: {
+                modelId,
+                modelName: "CS Test",
+                modelDescription: "A Model to test with",
+                projectId,
+                status: "RESULTS_UPLOADED",
+                query: {
+                    id: "54af9df8-b28b-4db9-8591-11ddda59f9be",
+                    name: "A query",
+                    query: "*:*",
+                    results: []
+                },
+                files: [
+                    {
+                        id: "8c81bfe0-b6be-4067-9657-116d30c6d519",
+                        name: "trainer.py",
+                        status: "COMPLETED",
+                        size: 3751,
+                        type: "text/x-python",
+                        tag: null
+                    }
+                ]
+            }
+        }).as("getModel");
+        cy.intercept("GET", `/model/${modelId}/logs`, { fixture: "model/logsPostTraining" });
+        cy.intercept("GET", `/model/${modelId}/metrics`, { body: [] });
+        cy.intercept("GET", `/files/model/${modelId}/fl/results`, {
+            body: ["https://example.com/results/model-results.zip"]
+        }).as("getResults");
+
+        cy.visit(`/project/${projectId}/model/${modelId}`);
+        cy.wait("@getModel");
+        cy.demoPause();
+
+        cy.getBySel("user-btn").demoClick();
+        cy.demoPause();
+
+        cy.contains("Download Results").demoClick();
+        cy.wait("@getResults");
+        cy.demoPause(1200);
+    });
+});

--- a/flip-ui/test/cypress/docs/flip/edit-model.spec.ts
+++ b/flip-ui/test/cypress/docs/flip/edit-model.spec.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2026 Guy's and St Thomas' NHS Foundation Trust & King's College London
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Records docs/source/assets/flip/edit-model.gif.
+// Mirrors the happy path in test/cypress/integration/group-2/model/edit_model.spec.ts
+// ("Allows user to edit the model").
+
+describe("docs: edit model", () => {
+    it("edits an existing model", () => {
+        const projectId = "6fcbdd40-3675-45c9-899e-1a005e5245ba";
+        const modelId = "6292d9ec-e821-4e4a-814e-3a315a4cb95e";
+
+        cy.login();
+        cy.intercept("GET", "/projects/*", { fixture: "project/getApprovedProject" });
+        cy.intercept("POST", `/step/model/${modelId}`, { fixture: "model/getModel" }).as("getModel");
+        cy.intercept("GET", `/model/${modelId}/logs`, []);
+        cy.intercept("PUT", "/model/*", {
+            statusCode: 200,
+            body: {}
+        }).as("editModel");
+
+        cy.visit(`project/${projectId}/model/${modelId}`);
+        cy.wait("@getModel");
+        cy.demoPause();
+
+        cy.getBySel("edit-model-btn").demoClick();
+        cy.demoPause();
+
+        cy.getBySel("model-name").clear().demoType("Updated Stroke Model");
+        cy.demoPause();
+
+        cy.getBySel("model-description").clear().demoType("Updated model description.");
+        cy.demoPause();
+
+        cy.getBySel("update-model-btn").demoClick();
+        cy.wait("@editModel");
+        cy.contains("This model has been updated.").should("be.visible");
+        cy.demoPause(1200);
+    });
+});

--- a/flip-ui/test/cypress/docs/flip/edit-project.spec.ts
+++ b/flip-ui/test/cypress/docs/flip/edit-project.spec.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2026 Guy's and St Thomas' NHS Foundation Trust & King's College London
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Records docs/source/assets/flip/edit-project.gif.
+// Mirrors the happy path in test/cypress/integration/group-1/project/view_project.spec.ts
+// ("Editing Project" -> "Handles project editing", the name/description update step).
+
+describe("docs: edit project", () => {
+    it("edits an existing project's details", () => {
+        cy.login();
+        cy.intercept("GET", "/projects/*", { fixture: "project/getProject" }).as("getProject");
+        cy.intercept("PUT", "/projects/*", { statusCode: 200, body: {} }).as("updateProject");
+
+        cy.visit("/project/6fcbdd40-3675-45c9-899e-1a005e5245ba");
+        cy.wait("@getProject");
+        cy.demoPause();
+
+        cy.getBySel("edit-project-btn").demoClick();
+        cy.demoPause();
+
+        cy.getBySel("project-name").clear().demoType("Stroke Detection Study");
+        cy.demoPause();
+
+        cy.getBySel("project-description").clear().demoType("Updated federated stroke detection model.");
+        cy.demoPause();
+
+        cy.getBySel("update-project-btn").demoClick();
+        cy.wait("@updateProject");
+        cy.contains("This project has been updated").should("be.visible");
+        cy.demoPause(1200);
+    });
+});

--- a/flip-ui/test/cypress/docs/flip/filter-project.spec.ts
+++ b/flip-ui/test/cypress/docs/flip/filter-project.spec.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2026 Guy's and St Thomas' NHS Foundation Trust & King's College London
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Records docs/source/assets/flip/filter-project.gif.
+// Mirrors the happy path in test/cypress/integration/group-6/project_list.spec.ts
+// ("displays only the search results when a search term is entered").
+
+describe("docs: filter project list", () => {
+    it("filters the project list by a search term", () => {
+        cy.login();
+        cy.intercept("GET", "/projects?pageNumber=1&pageSize=20", { fixture: "project/getProjects" })
+            .as("getProjects");
+        cy.intercept("GET", "/projects?pageNumber=1&pageSize=20&search=Example", {
+            fixture: "project/getProjectsSearch"
+        }).as("getProjectsSearch");
+
+        cy.visit("/projects");
+        cy.wait("@getProjects");
+        cy.demoPause();
+
+        cy.getBySel("project-search").demoType("Example");
+        cy.wait("@getProjectsSearch");
+        cy.demoPause();
+
+        cy.contains("Example project").should("be.visible");
+        cy.demoPause(1200);
+    });
+});

--- a/flip-ui/test/cypress/docs/flip/fl-status.spec.ts
+++ b/flip-ui/test/cypress/docs/flip/fl-status.spec.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2026 Guy's and St Thomas' NHS Foundation Trust & King's College London
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Records docs/source/assets/flip/fl-status.gif.
+// Mirrors the happy path in test/cypress/integration/group-6/model_dashboard_post_training.spec.ts
+// (in-progress "PREPARED" model dashboard) — shows the per-trust FL training timeline.
+
+describe("docs: fl status", () => {
+    it("views the federated-learning training status for a model", () => {
+        const projectId = "6fcbdd40-3675-45c9-899e-1a005e5245ba";
+        const modelId = "6292d9ec-e821-4e4a-814e-3a315a4cb95e";
+
+        cy.login();
+        cy.intercept("GET", "/projects/" + projectId, { fixture: "project/getProjectWithQuery" });
+        cy.intercept("POST", `/step/model/${modelId}`, { fixture: "model/getModelPostTrainingPreparedStatus" })
+            .as("getModel");
+        cy.intercept("GET", `/model/${modelId}/logs`, { fixture: "model/logsPostTraining" }).as("getLogs");
+        cy.intercept("GET", `/model/${modelId}/metrics`, []).as("getMetrics");
+
+        cy.visit(`project/${projectId}/model/${modelId}`);
+        cy.wait("@getModel");
+        cy.wait("@getLogs");
+        cy.demoPause();
+
+        cy.contains("sending the training request...").scrollIntoView().should("be.visible");
+        cy.demoPause(1200);
+    });
+});

--- a/flip-ui/test/cypress/docs/flip/flip-first-login.spec.ts
+++ b/flip-ui/test/cypress/docs/flip/flip-first-login.spec.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2026 Guy's and St Thomas' NHS Foundation Trust & King's College London
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Records docs/source/assets/flip/flip-first-login.gif.
+// Mirrors the happy path in test/cypress/integration/group-3/auth/change_temporary_password.spec.ts.
+
+describe("docs: flip first login", () => {
+    it("sets a new password on first login", () => {
+        cy.intercept("POST", "https://cognito-idp.eu-west-2.amazonaws.com/", {
+            fixture: "auth/cognitoNewPasswordRequired"
+        });
+
+        cy.visit("/auth/login");
+        cy.demoPause();
+
+        cy.getBySel("username").demoType("HasResearcherRole@gmail.com");
+        cy.demoPause();
+
+        cy.getBySel("password").demoType("NewPassword!1");
+        cy.demoPause();
+
+        cy.getBySel("login-btn").demoClick();
+        cy.demoPause();
+
+        cy.getBySel("new-password").demoType("NewPassword!2");
+        cy.demoPause();
+
+        cy.getBySel("confirm-new-password").demoType("NewPassword!2");
+        cy.demoPause();
+
+        cy.intercept("POST", "https://cognito-idp.eu-west-2.amazonaws.com/", {
+            fixture: "auth/cognitoNewPasswordChanged"
+        }).as("newPassword");
+
+        cy.getBySel("change-password-btn").demoClick();
+        cy.wait("@newPassword");
+
+        cy.contains("Your password has been changed").should("be.visible");
+        cy.demoPause(1200);
+    });
+});

--- a/flip-ui/test/cypress/docs/flip/flip-login.spec.ts
+++ b/flip-ui/test/cypress/docs/flip/flip-login.spec.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2026 Guy's and St Thomas' NHS Foundation Trust & King's College London
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Records docs/source/assets/flip/flip-login.gif.
+// Mirrors the happy path in test/cypress/integration/group-3/auth/login.spec.ts.
+
+describe("docs: flip login", () => {
+    it("signs in with email and password", () => {
+        cy.intercept("POST", "https://cognito-idp.eu-west-2.amazonaws.com/", {
+            statusCode: 200,
+            fixture: "auth/cognitoAuth"
+        }).as("login");
+
+        cy.visit("/auth/login");
+        cy.demoPause();
+
+        cy.getBySel("username").demoType("HasAdminRole@gmail.com");
+        cy.demoPause();
+
+        cy.getBySel("password").demoType("NewPassword!1");
+        cy.demoPause();
+
+        cy.getBySel("login-btn").demoClick();
+        cy.wait("@login");
+
+        cy.url().should("include", "/projects");
+        cy.demoPause(1200);
+    });
+});

--- a/flip-ui/test/cypress/docs/flip/forgot-password.spec.ts
+++ b/flip-ui/test/cypress/docs/flip/forgot-password.spec.ts
@@ -33,6 +33,11 @@ describe("docs: forgot password", () => {
         cy.wait("@requestCode");
         cy.demoPause();
 
+        // The change-password form is a separate <Form> with its own (empty)
+        // email field — re-enter it, mirroring reset_password.spec.ts.
+        cy.getBySel("email").demoType(email);
+        cy.demoPause();
+
         cy.getBySel("confirmation-code").demoType("12345");
         cy.demoPause();
 

--- a/flip-ui/test/cypress/docs/flip/forgot-password.spec.ts
+++ b/flip-ui/test/cypress/docs/flip/forgot-password.spec.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2026 Guy's and St Thomas' NHS Foundation Trust & King's College London
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Records docs/source/assets/flip/forgot-password.gif.
+// Mirrors the happy path in test/cypress/integration/group-3/auth/reset_password.spec.ts.
+
+describe("docs: forgot password", () => {
+    it("resets a forgotten password", () => {
+        const cognitoUrl = "https://cognito-idp.eu-west-2.amazonaws.com/";
+        const email = "throwaway.user@kcl.ac.uk";
+
+        cy.visit("/auth/change-password");
+        cy.demoPause();
+
+        cy.getBySel("email").demoType(email);
+        cy.demoPause();
+
+        cy.intercept("POST", cognitoUrl, {
+            statusCode: 200,
+            fixture: "auth/cognitoForgotPassword"
+        }).as("requestCode");
+        cy.getBySel("requestCode-btn").demoClick();
+        cy.wait("@requestCode");
+        cy.demoPause();
+
+        cy.getBySel("confirmation-code").demoType("12345");
+        cy.demoPause();
+
+        cy.getBySel("password").demoType("NewPassword!1");
+        cy.demoPause();
+
+        cy.intercept("POST", cognitoUrl, {
+            statusCode: 200,
+            fixture: "auth/cognitoConfirmForgotPassword"
+        }).as("changePassword");
+        cy.getBySel("changePassword-btn").demoClick();
+        cy.wait("@changePassword");
+
+        cy.contains("You've updated your password. You can now log in using it.").should("be.visible");
+        cy.demoPause(1200);
+    });
+});

--- a/flip-ui/test/cypress/docs/flip/imaging-status-filter.spec.ts
+++ b/flip-ui/test/cypress/docs/flip/imaging-status-filter.spec.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2026 Guy's and St Thomas' NHS Foundation Trust & King's College London
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Records docs/source/assets/flip/imaging-status-filter.gif.
+// Mirrors the happy path in test/cypress/integration/group-5/view_project.spec.ts
+// ("shows the imaging status"). Reuses the globalIntercepts mock for
+// /projects/*/image/status (project/imagingProjectStatus: UCLH + KCH).
+
+describe("docs: imaging status filter", () => {
+    it("filters the imaging project status by trust", () => {
+        cy.login();
+
+        const projectId = "6fcbdd40-3675-45c9-899e-1a005e5245ba";
+
+        cy.intercept("GET", `/projects/${projectId}`, { fixture: "project/getApprovedProject" }).as("getProject");
+
+        cy.visit(`/project/${projectId}`);
+        cy.wait("@getProject");
+        cy.demoPause();
+
+        cy.getBySel("project-status-container").scrollIntoView();
+        cy.demoPause();
+
+        cy.getBySel("filter-project-status").demoType("UCLH", { force: true });
+        cy.demoPause();
+
+        cy.getBySel("trust-name-a9b4cbe9-5754-4b7c-b2ae-6de495610f1b").contains("UCLH").should("be.visible");
+        cy.demoPause(1200);
+    });
+});

--- a/flip-ui/test/cypress/docs/flip/initiate-training.spec.ts
+++ b/flip-ui/test/cypress/docs/flip/initiate-training.spec.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2026 Guy's and St Thomas' NHS Foundation Trust & King's College London
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Records docs/source/assets/flip/initiate-training.gif.
+// Mirrors the happy path in test/cypress/integration/group-6/model_dashboard_pre_training.spec.ts
+// ("enables user to initiate training given all criteria is met").
+
+describe("docs: initiate training", () => {
+    it("starts training a model", () => {
+        const projectId = "6fcbdd40-3675-45c9-899e-1a005e5245ba";
+        const modelId = "6292d9ec-e821-4e4a-814e-3a315a4cb95e";
+
+        cy.login();
+        cy.intercept("GET", "/projects/" + projectId, { fixture: "project/getProjectWithQuery" });
+        cy.intercept("POST", `/step/model/${modelId}`, { fixture: "model/getModelTrain" }).as("getModel");
+        cy.intercept("GET", `/model/${modelId}/logs`, []).as("getLogs");
+        cy.intercept("GET", `/model/${modelId}/metrics`, []).as("getMetrics");
+        cy.intercept("GET", `/files/model/${modelId}/config.json`, {
+            fixture: "model/configJsonStandard.json"
+        }).as("getConfigJson");
+        cy.intercept("GET", "/model/job-types", {
+            standard: ["trainer.py", "validator.py", "models.py", "config.json"]
+        }).as("getJobTypes");
+
+        cy.visit(`project/${projectId}/model/${modelId}`);
+        cy.wait("@getModel");
+        cy.demoPause();
+
+        cy.getBySel("data-enrichment-btn").demoClick();
+        cy.demoPause();
+
+        cy.getBySel("trust-selection-0").demoClick();
+        cy.getBySel("trust-selection-1").demoClick();
+        cy.demoPause();
+
+        cy.intercept("POST", `/fl/initiate/${modelId}`, { statusCode: 200 }).as("initiateTraining");
+        cy.getBySel("initiate-training-btn").demoClick();
+        cy.wait("@initiateTraining");
+
+        cy.contains("Any results generated during training will show here.").should("be.visible");
+        cy.demoPause(1200);
+    });
+});

--- a/flip-ui/test/cypress/docs/flip/manage-files.spec.ts
+++ b/flip-ui/test/cypress/docs/flip/manage-files.spec.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2026 Guy's and St Thomas' NHS Foundation Trust & King's College London
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Records docs/source/assets/flip/manage-files.gif.
+// Mirrors the happy path in test/cypress/integration/group-2/model/upload_model.spec.ts
+// ("displays uploaded status when model file is uploaded successfully").
+
+describe("docs: manage files", () => {
+    it("uploads a file to a model", () => {
+        const projectId = "6fcbdd40-3675-45c9-899e-1a005e5245ba";
+        const modelId = "6292d9ec-e821-4e4a-814e-3a315a4cb95e";
+        const uploadOrigin = "https://flip-uploaded-model-files-bucket-test.s3.eu-west-2.amazonaws.com";
+        const presignedPolicy = {
+            url: `${uploadOrigin}/`,
+            fields: {
+                "key": `${modelId}/trainer.py`,
+                "Content-Type": "text/x-python",
+                "policy": "stub-policy",
+                "x-amz-signature": "stub-signature"
+            },
+            maxBytes: 100 * 1024 * 1024
+        };
+
+        cy.login();
+        cy.intercept("GET", "/projects/" + projectId, { fixture: "project/getProjectWithQuery" });
+        cy.intercept("POST", `/step/model/${modelId}`, { fixture: "model/getModel" }).as("getModel");
+        cy.intercept("GET", `/model/${modelId}/logs`, []).as("getLogs");
+        cy.intercept("POST", `/files/preSignedUrl/model/${modelId}`, presignedPolicy).as("fileLambda");
+        cy.intercept("POST", `${uploadOrigin}/`, { statusCode: 204 }).as("fileUpload");
+
+        cy.visit(`project/${projectId}/model/${modelId}`);
+        cy.wait("@getModel");
+        cy.demoPause();
+
+        cy.getBySel("upload-file-btn").scrollIntoView();
+        cy.getBySel("upload-file-btn").selectFile("test/cypress/fixtures/files/trainer.py", { action: "drag-drop" });
+        cy.demoPause();
+
+        cy.getBySel("file-upload-status-scanning").should("be.visible");
+        cy.demoPause();
+
+        cy.intercept("POST", `/step/model/${modelId}`, { fixture: "model/getModelFileCompleted" })
+            .as("getModelFile");
+        cy.wait("@getModelFile", { requestTimeout: 20000 });
+
+        cy.getBySel("file-upload-status-completed").should("be.visible");
+        cy.demoPause(1200);
+    });
+});

--- a/flip-ui/test/cypress/docs/flip/metrics.spec.ts
+++ b/flip-ui/test/cypress/docs/flip/metrics.spec.ts
@@ -69,7 +69,12 @@ describe("docs: model metrics", () => {
         cy.wait("@getMetrics");
         cy.demoPause();
 
-        cy.contains("Accuracy").should("be.visible");
+        // AiModelMetricsChart paints the chart — title, axes, legend — onto an
+        // ECharts <canvas>, so "Accuracy" is never DOM text. Assert the charts
+        // rendered instead: the empty-state placeholder is gone and a chart
+        // canvas is visible.
+        cy.contains("Any results generated during training will show here.").should("not.exist");
+        cy.get("canvas").first().should("be.visible");
         cy.demoPause(1200);
     });
 });

--- a/flip-ui/test/cypress/docs/flip/metrics.spec.ts
+++ b/flip-ui/test/cypress/docs/flip/metrics.spec.ts
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2026 Guy's and St Thomas' NHS Foundation Trust & King's College London
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Records docs/source/assets/flip/metrics.gif.
+// Mirrors the happy path in test/cypress/integration/group-6/model_dashboard_post_training.spec.ts.
+
+describe("docs: model metrics", () => {
+    it("views the training metrics for a completed model", () => {
+        cy.login();
+
+        const projectId = "6fcbdd40-3675-45c9-899e-1a005e5245ba";
+        const modelId = "6292d9ec-e821-4e4a-814e-3a315a4cb95e";
+
+        cy.intercept("GET", `/projects/${projectId}`, { fixture: "project/getProjectWithQuery" }).as("getProject");
+        cy.intercept("POST", `/step/model/${modelId}`, { fixture: "model/getModelPostTrainingPreparedStatus" })
+            .as("getModel");
+        cy.intercept("GET", `/model/${modelId}/logs`, { fixture: "model/logsPostTraining" });
+        cy.intercept("GET", `/model/${modelId}/metrics`, {
+            body: [
+                {
+                    yLabel: "Loss",
+                    xLabel: "Round",
+                    metrics: [
+                        {
+                            seriesLabel: "Global model",
+                            data: [
+                                { xValue: 1, yValue: 0.91 },
+                                { xValue: 2, yValue: 0.62 },
+                                { xValue: 3, yValue: 0.41 },
+                                { xValue: 4, yValue: 0.27 },
+                                { xValue: 5, yValue: 0.19 }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    yLabel: "Accuracy",
+                    xLabel: "Round",
+                    metrics: [
+                        {
+                            seriesLabel: "Global model",
+                            data: [
+                                { xValue: 1, yValue: 0.54 },
+                                { xValue: 2, yValue: 0.71 },
+                                { xValue: 3, yValue: 0.83 },
+                                { xValue: 4, yValue: 0.89 },
+                                { xValue: 5, yValue: 0.93 }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }).as("getMetrics");
+
+        cy.visit(`/project/${projectId}/model/${modelId}`);
+        cy.wait("@getModel");
+        cy.demoPause();
+
+        cy.wait("@getMetrics");
+        cy.demoPause();
+
+        cy.contains("Accuracy").should("be.visible");
+        cy.demoPause(1200);
+    });
+});

--- a/flip-ui/test/cypress/docs/flip/stage-project.spec.ts
+++ b/flip-ui/test/cypress/docs/flip/stage-project.spec.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2026 Guy's and St Thomas' NHS Foundation Trust & King's College London
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Records docs/source/assets/flip/stage-project.gif.
+// Mirrors the happy path in test/cypress/integration/group-1/project/view_project.spec.ts
+// ("With cohort query" -> "can stage with only one trust associated with a project").
+
+describe("docs: stage project", () => {
+    it("stages a project for approval", () => {
+        const projectId = "6fcbdd40-3675-45c9-899e-1a005e5245ba";
+
+        cy.login();
+        cy.intercept("GET", "/users/*/permissions", { fixture: "user/getPermissionsResearcher" });
+        cy.intercept("GET", "/projects/" + projectId, {
+            fixture: "project/getProjectWithQueryNotApprovedUnstaged"
+        }).as("getProject");
+        cy.intercept("POST", `/projects/${projectId}/stage`, { statusCode: 200 }).as("stage");
+
+        cy.visit("/project/" + projectId);
+        cy.wait("@getProject");
+        cy.demoPause();
+
+        cy.getBySel("KCH-selector").demoClick();
+        cy.demoPause();
+
+        cy.getBySel("stage-project-btn").demoClick();
+        cy.wait("@stage");
+        cy.demoPause(1200);
+    });
+});

--- a/flip-ui/test/cypress/docs/flip/stop-training.spec.ts
+++ b/flip-ui/test/cypress/docs/flip/stop-training.spec.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2026 Guy's and St Thomas' NHS Foundation Trust & King's College London
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Records docs/source/assets/flip/stop-training.gif.
+// Mirrors the happy path in test/cypress/integration/group-6/model_dashboard_post_training.spec.ts
+// ("allows the user to stop training once it has the status of 'PREPARED'").
+
+describe("docs: stop training", () => {
+    it("stops an in-progress training run", () => {
+        const projectId = "6fcbdd40-3675-45c9-899e-1a005e5245ba";
+        const modelId = "6292d9ec-e821-4e4a-814e-3a315a4cb95e";
+
+        cy.login();
+        cy.intercept("GET", "/projects/" + projectId, { fixture: "project/getProjectWithQuery" });
+        cy.intercept("POST", `/step/model/${modelId}`, { fixture: "model/getModelPostTrainingPreparedStatus" })
+            .as("getModel");
+        cy.intercept("GET", `/model/${modelId}/logs`, { fixture: "model/logsPostTraining" }).as("getLogs");
+        cy.intercept("GET", `/model/${modelId}/metrics`, []).as("getMetrics");
+        cy.intercept("POST", `/fl/stop/${modelId}`, { statusCode: 200 }).as("stopTraining");
+
+        cy.visit(`project/${projectId}/model/${modelId}`);
+        cy.wait("@getModel");
+        cy.demoPause();
+
+        cy.getBySel("user-btn").demoClick();
+        cy.demoPause();
+
+        cy.getBySel("stop-training-btn").demoClick();
+        cy.demoPause();
+
+        cy.getBySel("confirm-modal-btn").demoClick();
+        cy.wait("@stopTraining");
+        cy.demoPause(1200);
+    });
+});

--- a/flip-ui/test/cypress/docs/flip/unstage-project.spec.ts
+++ b/flip-ui/test/cypress/docs/flip/unstage-project.spec.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2026 Guy's and St Thomas' NHS Foundation Trust & King's College London
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Records docs/source/assets/flip/unstage-project.gif.
+// Mirrors the happy path in test/cypress/integration/group-5/view_project.spec.ts
+// ("Project Page: STAGED" -> "can unstage a staged project").
+
+describe("docs: unstage project", () => {
+    it("unstages a staged project", () => {
+        const projectId = "6fcbdd40-3675-45c9-899e-1a005e5245ba";
+
+        cy.login();
+        cy.intercept("GET", "/projects/*/image/status", { fixture: "project/getProjectStatus" });
+        cy.intercept("GET", "/projects/" + projectId, { fixture: "project/getStagedProject" }).as("getProject");
+        cy.intercept("POST", "/projects/*/unstage", { statusCode: 200 }).as("unstageProject");
+
+        cy.visit("/project/" + projectId);
+        cy.wait("@getProject");
+        cy.demoPause();
+
+        cy.getBySel("unstage-project-btn").demoClick();
+        cy.demoPause();
+
+        cy.getBySel("confirm-modal-btn").demoClick();
+        cy.wait("@unstageProject");
+
+        cy.contains("The project has been unstaged.").should("be.visible");
+        cy.demoPause(1200);
+    });
+});

--- a/flip-ui/test/cypress/docs/flip/upload-file.spec.ts
+++ b/flip-ui/test/cypress/docs/flip/upload-file.spec.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2026 Guy's and St Thomas' NHS Foundation Trust & King's College London
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Records docs/source/assets/flip/upload-file.gif.
+// Mirrors the happy path in test/cypress/integration/group-2/model/upload_model.spec.ts
+// ("displays uploaded status when model file is uploaded successfully").
+
+describe("docs: upload model file", () => {
+    it("uploads a file to a model", () => {
+        const projectId = "6fcbdd40-3675-45c9-899e-1a005e5245ba";
+        const modelId = "6292d9ec-e821-4e4a-814e-3a315a4cb95e";
+        const uploadOrigin = "https://flip-uploaded-model-files-bucket-test.s3.eu-west-2.amazonaws.com";
+        const presignedPolicy = {
+            url: `${uploadOrigin}/`,
+            fields: {
+                "key": `${modelId}/trainer.py`,
+                "Content-Type": "text/x-python",
+                "policy": "stub-policy",
+                "x-amz-signature": "stub-signature"
+            },
+            maxBytes: 100 * 1024 * 1024
+        };
+
+        cy.login();
+        cy.intercept("GET", `/projects/${projectId}`, { fixture: "project/getProjectWithQuery" });
+        cy.intercept("POST", `/step/model/${modelId}`, { fixture: "model/getModel" }).as("getModel");
+        cy.intercept("GET", `/model/${modelId}/logs`, []);
+        cy.intercept("POST", `/files/preSignedUrl/model/${modelId}`, presignedPolicy).as("fileLambda");
+        cy.intercept("POST", `${uploadOrigin}/`, { statusCode: 204 }).as("fileUpload");
+
+        cy.visit(`project/${projectId}/model/${modelId}`);
+        cy.wait("@getModel");
+        cy.demoPause();
+
+        cy.getBySel("upload-file-btn").scrollIntoView();
+        cy.demoPause();
+
+        cy.getBySel("upload-file-btn").selectFile("test/cypress/fixtures/files/trainer.py", { action: "drag-drop" });
+        cy.demoPause();
+
+        cy.getBySel("file-upload-status-scanning").should("be.visible");
+
+        cy.intercept("POST", `/step/model/${modelId}`, { fixture: "model/getModelFileCompleted" })
+            .as("getModelFile");
+        cy.wait("@getModelFile", { requestTimeout: 20000 });
+
+        cy.getBySel("file-upload-status-completed").should("be.visible");
+        cy.demoPause(1200);
+    });
+});


### PR DESCRIPTION
## Summary

Completes the documentation-GIF automation. The branch adds the
`regenerate_docs_gifs.yml` workflow, a docs-only `cypress.docs.config.ts`,
the `videos-to-gifs.sh` ffmpeg converter, and 31 demo Cypress specs
(7 admin + 24 flip) that screen-record one happy-path user action each.

The 24 flip demo specs were ported from CI-verified functional specs but
had never been run. A full `cypress.docs.config.ts` recording was done to
verify them — **5 specs failed and are now fixed**; the other 26 pass
unchanged. All 31 specs now pass and produce GIFs.

## Specs fixed (demo specs only — functional specs untouched)

| Spec | Root cause | Fix |
|---|---|---|
| `change-password-user` | `routeChange.changePassword()` calls `router.push({path, params})` — Vue Router drops `params` when `path` is set, so the email field never prefills | Type the email in both the request-code and change-password forms, as `reset_password.spec.ts` does |
| `forgot-password` | The change-password step is a separate `<Form>` with its own empty email field | Re-enter the email before submitting that form |
| `create-project` | The default `/projects` list renders `data-test="project-name"` per card (22 elements collide with the modal input) | Intercept the list with `getProjectsEmpty`, as `create_project.spec.ts` does |
| `cohort-query` | `cohortQueryResponseOMOP` fixture wraps the payload in a stringified `body` envelope; `runCohortQuery` reads `response.trust` directly, so the success branch throws | Mock the real `ICohortQueryResponse` shape inline; assert the snackbar before any other `cy.wait` |
| `metrics` | ECharts paints titles/labels onto a `<canvas>`, so `cy.contains("Accuracy")` can never match | Assert the chart rendered (placeholder gone, canvas visible) instead |

## Verification

- Full `cypress.docs.config.ts` run: **31/31 pass** (Chrome, headless).
- `npm run docs:gifs`: 24 GIFs under `docs/source/assets/flip/`, 7 under
  `admin/`, all within the 200 KB–4 MB envelope.
- Spot-checked rendered GIFs — the recorded action is visible and the
  crop window frames the app correctly.

Regenerated GIFs are intentionally **not** committed here — the
`regenerate_docs_gifs.yml` workflow owns GIF regeneration via its bot PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)