### PR TITLE
docs: fix stale CLAUDE.md doc paths and add missing type annotations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,16 +165,16 @@ After changes, evaluate if docs need updating:
 
 | Change Type | Documentation to Review |
 |-------------|------------------------|
-| New service/component | `README.md`, `CONTRIBUTING.md`, `docs/source/2_components.rst` |
-| New API endpoints | `docs/source/5_api_reference.rst`, service `README.md` |
-| Changed env vars | `.env.development.example`, `CONTRIBUTING.md`, `docs/source/3_sys-admin.rst` |
+| New service/component | `README.md`, `CONTRIBUTING.md`, `docs/source/components.rst` |
+| New API endpoints | `docs/source/api-reference.rst`, service `README.md` |
+| Changed env vars | `.env.development.example`, `CONTRIBUTING.md`, `docs/source/sys-admin.rst` |
 | New dependencies | `CONTRIBUTING.md`, service `README.md` |
-| Changed deployment config | `deploy/README.md`, `docs/source/3_sys-admin.rst` |
+| Changed deployment config | `deploy/README.md`, `docs/source/sys-admin.rst` |
 | New Make targets | `README.md`, this file |
-| User-facing workflow changes | `docs/source/4_user-guides.rst` |
+| User-facing workflow changes | `docs/source/user-guides.rst` |
 | FL framework features | `docs/source/components/component-fl-nodes.rst` |
 | Trust service changes | `trust/README.md`, relevant `trust/*/README.md` |
-| Auth/role changes | `docs/source/components/component-user-roles.rst` |
+| Auth/role changes | `docs/source/sys-admin/admin-user-roles.rst` |
 
 ## Code Style & Conventions
 
@@ -301,8 +301,8 @@ The senders construct the header inline at call sites:
 ## Documentation Files
 
 Key docs (read on demand):
-- Auth/deployment: `docs/source/3_sys-admin.rst`
-- Components: `docs/source/2_components.rst`
-- API reference: `docs/source/5_api_reference.rst`
-- User guides: `docs/source/4_user-guides.rst`
+- Auth/deployment: `docs/source/sys-admin.rst`
+- Components: `docs/source/components.rst`
+- API reference: `docs/source/api-reference.rst`
+- User guides: `docs/source/user-guides.rst`
 - AWS deployment: `deploy/providers/AWS/README.md`

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -4,21 +4,26 @@
 
 | File | Topic |
 |------|-------|
-| `source/1_overview.rst` | Project overview, architecture, motivation |
-| `source/2_components.rst` | Component descriptions (API, UI, trust services, FL nodes) |
-| `source/3_sys-admin.rst` | System administration, deployment, auth configuration |
-| `source/4_user-guides.rst` | User-facing workflows and guides |
-| `source/5_api_reference.rst` | REST API endpoint reference |
-| `source/6_faqs.rst` | Frequently asked questions |
-| `source/7_glossary.rst` | Terminology definitions |
+| `source/overview.rst` | Project overview, architecture, motivation |
+| `source/components.rst` | Component descriptions (API, UI, trust services, FL nodes) |
+| `source/sys-admin.rst` | System administration, deployment, auth configuration |
+| `source/user-guides.rst` | User-facing workflows and guides |
+| `source/api-reference.rst` | REST API endpoint reference |
+| `source/deploy-flip.rst` | Deployment instructions (central hub, TRE, on-prem) |
+| `source/working-with-flip-apps.rst` | Building FL apps (NVFLARE / Flower) |
+| `source/flip-workflow.rst` | End-to-end FLIP workflow |
+| `source/faqs.rst` | Frequently asked questions |
+| `source/glossary.rst` | Terminology definitions |
 
 ## Sub-docs
 
-| File | Topic |
-|------|-------|
-| `source/components/component-fl-nodes.rst` | FL training nodes (NVFLARE/Flower) |
-| `source/components/component-user-roles.rst` | User roles and permissions |
+| Directory | Topic |
+|-----------|-------|
+| `source/components/` | Per-component deep dives (FL nodes, XNAT, OMOP, logging stack, architecture overview) |
+| `source/sys-admin/` | Admin tasks (user roles, project/user management, platform support) |
 | `source/user-guides/` | User guide files |
+| `source/deploy-flip/` | Per-target deployment guides (central hub, TRE, on-prem) |
+| `source/working-with-flip-apps/` | Step-by-step FLARE / Flower app authoring |
 
 ## How to Read
 

--- a/flip-api/src/flip_api/domain/interfaces/fl.py
+++ b/flip-api/src/flip_api/domain/interfaces/fl.py
@@ -93,7 +93,7 @@ class IInitiateTrainingInputPayload(BaseModel):
 
     @field_validator("trusts")
     @classmethod
-    def must_be_unique(cls, v):
+    def must_be_unique(cls, v: list[TrimStr]) -> list[TrimStr]:
         if len(set(v)) != len(v):
             raise ValueError("'trusts' must all be unique entries")
         return v
@@ -168,10 +168,10 @@ JobTypes = Enum("JobTypes", {job_type: job_type for job_type in _JOB_TYPES_CONFI
 class JobRequiredFiles(BaseModel):
     model_config = {"extra": "allow"}
 
-    def __init__(self, **data):
+    def __init__(self, **data: object) -> None:
         """Initialize with required files from JSON configuration."""
         super().__init__(**data)
-        config = self._load_job_types_config()
+        config = _load_job_types_config()
         for job_type, files in config.items():
             setattr(self, job_type, files)
 

--- a/flip-api/src/flip_api/domain/interfaces/model.py
+++ b/flip-api/src/flip_api/domain/interfaces/model.py
@@ -116,7 +116,7 @@ class IBuildImagesForModel(BaseModel):
     files: dict = Field(...)
 
     @validator("files")
-    def validate_files(cls, v):
+    def validate_files(cls, v: dict) -> dict:
         required_keys = {"opener", "algo", "model"}
         if not isinstance(v, dict):
             raise ValueError("'files' must be an object")

--- a/flip-api/src/flip_api/domain/interfaces/project.py
+++ b/flip-api/src/flip_api/domain/interfaces/project.py
@@ -121,7 +121,7 @@ class IEditProject(BaseModel):
 
     # Handles cases where no users are added when editing a project (in which case the input is '[null]')
     @validator("users", pre=True)
-    def replace_null_list(cls, value):
+    def replace_null_list(cls, value: list[UUID] | None) -> list[UUID]:
         if value is None:
             return []
         if isinstance(value, list) and all(v is None for v in value):

--- a/flip-api/src/flip_api/domain/schemas/private.py
+++ b/flip-api/src/flip_api/domain/schemas/private.py
@@ -38,7 +38,7 @@ class OmopCohortResults(BaseModel):
     data: list[OmopData]
 
     @validator("data", pre=True, always=True)
-    def ensure_data_is_list(cls, value):
+    def ensure_data_is_list(cls, value: Any) -> list[Any]:
         if value is None:
             return []
         return value

--- a/flip-api/src/flip_api/domain/schemas/projects.py
+++ b/flip-api/src/flip_api/domain/schemas/projects.py
@@ -109,7 +109,7 @@ class ProjectDetails(BaseModel, from_attributes=True):
 
     @field_validator("description")
     @classmethod
-    def strip_whitespace(cls, value: str):
+    def strip_whitespace(cls, value: str) -> str:
         if not isinstance(value, str):
             return ""
         return value.strip()

--- a/flip-api/src/flip_api/domain/schemas/users.py
+++ b/flip-api/src/flip_api/domain/schemas/users.py
@@ -37,7 +37,7 @@ class GetUserById(GetUser):
     """Model specifically for retrieving a user by UUID."""
 
     @field_validator("userId")
-    def validate_uuid(cls, v):
+    def validate_uuid(cls, v: str) -> str:
         try:
             UUID(v)
         except ValueError:

--- a/flip-api/src/flip_api/site_services/details.py
+++ b/flip-api/src/flip_api/site_services/details.py
@@ -28,7 +28,7 @@ router = APIRouter(prefix="/site", tags=["site_services"])
 
 # [#114] ✅
 @router.get("/details", response_model=ISiteDetails)
-def get_details(db: Session = Depends(get_session), user_id: UUID = Depends(verify_token)):
+def get_details(db: Session = Depends(get_session), user_id: UUID = Depends(verify_token)) -> ISiteDetails:
     """
     Fetch current site details.
 
@@ -56,7 +56,7 @@ def update_details(
     site_details: ISiteDetails,
     db: Session = Depends(get_session),
     user_id: UUID = Depends(verify_token),
-):
+) -> ISiteDetails:
     """
     Update site details.
 

--- a/flip-api/src/flip_api/utils/s3_client.py
+++ b/flip-api/src/flip_api/utils/s3_client.py
@@ -62,7 +62,7 @@ def hash_s3_key(key: str) -> str:
 class S3Client:
     """S3 client wrapper for S3 operations."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         """Initialize S3 client with AWS credentials."""
         self.client = boto3.client("s3", region_name=get_settings().AWS_REGION)
 

--- a/flip-api/tests/unit/domain/interfaces/test_fl_interfaces.py
+++ b/flip-api/tests/unit/domain/interfaces/test_fl_interfaces.py
@@ -1,4 +1,6 @@
-from flip_api.domain.interfaces.fl import ClientStatus, IClientStatus
+from unittest.mock import patch
+
+from flip_api.domain.interfaces.fl import ClientStatus, IClientStatus, JobRequiredFiles
 
 
 class TestIClientStatusSchema:
@@ -58,3 +60,24 @@ class TestIClientStatusSchema:
 
         client_status.status = ClientStatus.NO_REPLY.value
         assert client_status.online is False
+
+
+class TestJobRequiredFiles:
+    def test_init_does_not_raise(self):
+        # Regression: __init__ previously called self._load_job_types_config(), which doesn't exist
+        # on the class and would raise AttributeError if anything ever instantiated the model.
+        JobRequiredFiles()
+
+    def test_init_sets_attribute_per_job_type_from_config(self):
+        fake_config = {"standard": ["trainer.py", "config.json"], "evaluation": ["evaluator.py"]}
+        with patch("flip_api.domain.interfaces.fl._load_job_types_config", return_value=fake_config):
+            instance = JobRequiredFiles()
+
+        assert instance.standard == ["trainer.py", "config.json"]
+        assert instance.evaluation == ["evaluator.py"]
+
+    def test_init_with_empty_config_sets_no_job_type_attributes(self):
+        with patch("flip_api.domain.interfaces.fl._load_job_types_config", return_value={}):
+            instance = JobRequiredFiles()
+
+        assert not hasattr(instance, "standard")

--- a/trust/imaging-api/imaging_api/routers/schemas.py
+++ b/trust/imaging-api/imaging_api/routers/schemas.py
@@ -216,14 +216,14 @@ class ImportStudy(BaseModel):
     accession_number: str = Field(..., alias="accessionNumber")
     relabel_map: dict[str, str] = Field(default={}, alias="relabelMap")
 
-    def set_relabel_map(self):
+    def set_relabel_map(self) -> None:
         """Sets the relabel_map dictionary for subject and session."""
         self.relabel_map = {
             "Subject": str(uuid.uuid4()),  # Generate new UUID for Subject
             "Session": self.accession_number,
         }
 
-    def __init__(self, **data):
+    def __init__(self, **data: object) -> None:
         """Initializes the ImportStudy instance and sets the relabel_map."""
         super().__init__(**data)
         self.set_relabel_map()
@@ -241,7 +241,7 @@ class ImportStudyRequest(BaseModel):
 
     @model_validator(mode="before")
     @classmethod
-    def deduplicate_and_parse_studies(cls, data):
+    def deduplicate_and_parse_studies(cls, data: dict) -> dict:
         """Deduplicates and parses studies before validation.
 
         Args:


### PR DESCRIPTION
> _This is an automated scheduled weekly task by Alex's Claude Code._ It audits `develop` for documentation drift against the code (READMEs, CLAUDE.md files, ReadTheDocs/Sphinx sources) and for missing or mismatched Python type annotations.

## Summary

Two classes of fixes, all narrow and contained:

### 1. CLAUDE.md drift — stale `docs/source/*.rst` paths

`docs/source/*.rst` files were renamed at some point to drop their numeric prefix (`1_overview.rst` → `overview.rst`, `2_components.rst` → `components.rst`, etc.), but the two CLAUDE.md indexes that point at them were not updated. The "Documentation Check" table in the root `CLAUDE.md` and the entire "Documentation Index" in `docs/CLAUDE.md` send contributors to file paths that no longer exist.

Verified by listing `docs/source/`:

```
api-reference.rst  components.rst  deploy-flip.rst  faqs.rst  flip-workflow.rst
glossary.rst       index.rst       overview.rst     sys-admin.rst  user-guides.rst
working-with-flip-apps.rst
```

Fixed:
- Root `CLAUDE.md` Documentation Check table — 5 path corrections.
- Root `CLAUDE.md` Documentation Files section — 4 path corrections.
- `docs/CLAUDE.md` index — 7 numeric-prefix paths corrected, plus filled in the 3 sub-doc directories that the index was silent on (`deploy-flip/`, `sys-admin/`, `working-with-flip-apps/`).

The `Auth/role changes` row in the root CLAUDE.md pointed at `docs/source/components/component-user-roles.rst`, which doesn't exist. The actual user-roles doc is `docs/source/sys-admin/admin-user-roles.rst` (confirmed via `find docs/source -name "*user-role*"`). Same fix in `docs/CLAUDE.md`.

### 2. Python type annotations — missing `->` and Pydantic validator gaps

Found via AST scan (`ast.walk` over all `flip-api/src/`, `trust/*/`). After filtering false positives, the legitimate gaps were:

- **Pydantic validators in `flip-api`** (`domain/schemas/users.py`, `private.py`, `projects.py`, `domain/interfaces/fl.py`, `model.py`, `project.py`) — `cls`-receiver validators consistently lacked both the parameter and return type annotations.
- **`S3Client.__init__`** missing `-> None`.
- **`ImportStudy.__init__` / `set_relabel_map`** and **`ImportStudyRequest.deduplicate_and_parse_studies`** (imaging-api) missing annotations; the `deduplicate_and_parse_studies` docstring already promised `dict` in and `dict` out.
- **`/site/details` GET and PUT handlers** missing `-> ISiteDetails` despite the docstring `Returns:` block already promising it and the route declaring `response_model=ISiteDetails`.

While adding `-> None` to `JobRequiredFiles.__init__` (`domain/interfaces/fl.py`), mypy surfaced a latent bug in that constructor: `self._load_job_types_config()` — there is no such method on the class, only a module-level `_load_job_types_config()` function. The class is only ever used via classmethods (`JobRequiredFiles.get_required_files`, `get_all_job_types_with_files`) so the bug never executes at runtime, but the wrong receiver was masked by the missing annotation. Replaced `self._load_job_types_config()` with `_load_job_types_config()` to silence mypy and clear the latent bug.

## What was checked but left alone

- All sub-READMEs (root `README.md`, `flip-api/README.md`, `flip-ui/README.md`, `trust/*/README.md`, `deploy/`, `scripts/`, `docs/`) — Makefile targets, env vars, paths, and service references all matched the code.
- Sphinx `.rst` files under `docs/source/` — content matches current API endpoints, env vars, and component layout. No drift worth touching this round.
- Other CLAUDE.md files (`flip-api/CLAUDE.md`, `trust/CLAUDE.md`, `trust/*/CLAUDE.md`, `deploy/providers/AWS/CLAUDE.md`) — accurate.
- Docstring `Args:` / `Returns:` / `Raises:` blocks in the modules I touched — re-verified, no parameter name drift.

## Test plan

- [x] `uv run ruff check src/flip_api/` — passes.
- [x] `uv run mypy . --ignore-missing-imports` (full flip-api) — passes (312 source files, no errors).
- [x] `uv run pytest tests/unit/ --no-cov` (flip-api) — 987 passed, 7 skipped.
- [x] `uv run ruff check imaging_api/` + `mypy imaging_api/routers/schemas.py` — passes.
- [x] `pytest` on imaging-api schemas — the schema/relabel/import_study tests pass (one unrelated test on download-file local-write permissions fails the same way on `develop` when run as root — not caused by this PR).
- [ ] Re-review docs CLAUDE.md indexes after merge to confirm new contributors get the right paths.

---

Reviewers: @garciadias @virginiafdez
Assignees: @garciadias @virginiafdez @atriaybagur

---
_Generated by [Claude Code](https://claude.ai/code/session_01D1kTrB2wqtjhNaeVwPNy4y)_