### PR TITLE
feat(ci): pull GHCR images in dev by default, gate builds on tests

### DIFF
--- a/.github/workflows/docker_build_flip_api.yml
+++ b/.github/workflows/docker_build_flip_api.yml
@@ -52,8 +52,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v5
         with:
-          repository: ${{ github.event.workflow_run.head_repository.full_name }}
-          ref: ${{ github.event.workflow_run.head_sha }}
+          # workflow_run.* is empty on manual workflow_dispatch runs, so fall
+          # back to the dispatched ref so manual builds check out correctly.
+          repository: ${{ github.event.workflow_run.head_repository.full_name || github.repository }}
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
       - name: Determine tags
         id: tags

--- a/.github/workflows/docker_build_flip_api.yml
+++ b/.github/workflows/docker_build_flip_api.yml
@@ -14,17 +14,26 @@ name: Build and Push Docker Image for Central Hub API
 
 on:
   workflow_dispatch:
-  push:
+  # Publish only after the flip-api test suite ("FLIP API CI") completes on
+  # main/develop; the job-level `if` below gates on its success, so a red test
+  # run never publishes. workflow_run has no path filter, but the test workflow
+  # itself is path-filtered to flip-api/**, so the build still only fires when
+  # flip-api actually changed.
+  workflow_run:
+    workflows: ["FLIP API CI"]
+    types: [completed]
     branches: [main, develop]
-    paths:
-      - "flip-api/**"
-      - ".github/workflows/flip_api.yml"
 
 permissions:
   contents: read
 
 jobs:
   build-and-push:
+    # Only publish when the upstream test run passed. workflow_dispatch (manual)
+    # has no workflow_run context, so allow it through unconditionally.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     permissions: # override top-level read-only default to allow GHCR push
       contents: read
@@ -52,18 +61,32 @@ jobs:
           GH_REF_NAME: ${{ github.ref_name }}
           GH_EVENT_NAME: ${{ github.event_name }}
           GH_REF: ${{ github.ref }}
+          GH_SHA: ${{ github.sha }}
           GH_WR_BRANCH: ${{ github.event.workflow_run.head_branch }}
           GH_WR_EVENT: ${{ github.event.workflow_run.event }}
+          GH_WR_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
-          TAGS="${REGISTRY}/${IMAGE_NAME}:${{ github.sha }}"
+          # On a workflow_run trigger, github.sha / github.ref_name point at the
+          # default branch (where this workflow definition lives), NOT the commit
+          # that was tested and checked out. Use the triggering run's head_sha /
+          # head_branch so the :<sha> and :<branch> tags match the built code.
+          if [[ "$GH_EVENT_NAME" == "workflow_run" ]]; then
+            SHA="$GH_WR_SHA"
+            REF_NAME="$GH_WR_BRANCH"
+          else
+            SHA="$GH_SHA"
+            REF_NAME="$GH_REF_NAME"
+          fi
+
+          TAGS="${REGISTRY}/${IMAGE_NAME}:${SHA}"
 
           # Branch name sanitization
-          SAFE_REF_NAME=$(echo "$GH_REF_NAME" | sed 's/[^a-zA-Z0-9]/-/g')
+          SAFE_REF_NAME=$(echo "$REF_NAME" | sed 's/[^a-zA-Z0-9]/-/g')
           TAGS="${TAGS},${REGISTRY}/${IMAGE_NAME}:${SAFE_REF_NAME}"
 
           # Branch number (if starts with number)
-          if [[ "$GH_REF_NAME" =~ ^[0-9]+ ]]; then
-              BRANCH_NUM=$(echo "$GH_REF_NAME" | grep -oE '^[0-9]+')
+          if [[ "$REF_NAME" =~ ^[0-9]+ ]]; then
+              BRANCH_NUM=$(echo "$REF_NAME" | grep -oE '^[0-9]+')
               TAGS="${TAGS},${REGISTRY}/${IMAGE_NAME}:${BRANCH_NUM}"
           fi
 

--- a/.github/workflows/docker_build_trust_data_access_api.yml
+++ b/.github/workflows/docker_build_trust_data_access_api.yml
@@ -14,18 +14,25 @@ name: Build and Push Docker Image for Data Access API
 
 on:
   workflow_dispatch:
-  push:
+  # Publish only after the data-access-api test suite ("Trust - Data Access API
+  # CI") completes on main/develop; the job-level `if` below gates on its success.
+  # The test workflow is path-filtered to trust/data-access-api/**, so the build
+  # only fires when data-access-api actually changed.
+  workflow_run:
+    workflows: ["Trust - Data Access API CI"]
+    types: [completed]
     branches: [main, develop]
-    paths:
-      - "trust/data-access-api/**"
-      - "trust/observability/log_config/**"
-      - ".github/workflows/docker_build_trust_data_access_api.yml"
 
 permissions:
   contents: read
 
 jobs:
   build-and-push:
+    # Only publish when the upstream test run passed. workflow_dispatch (manual)
+    # has no workflow_run context, so allow it through unconditionally.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     permissions: # override top-level read-only default to allow GHCR push
       contents: read
@@ -53,18 +60,32 @@ jobs:
           GH_REF_NAME: ${{ github.ref_name }}
           GH_EVENT_NAME: ${{ github.event_name }}
           GH_REF: ${{ github.ref }}
+          GH_SHA: ${{ github.sha }}
           GH_WR_BRANCH: ${{ github.event.workflow_run.head_branch }}
           GH_WR_EVENT: ${{ github.event.workflow_run.event }}
+          GH_WR_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
-          TAGS="${REGISTRY}/${IMAGE_NAME}:${{ github.sha }}"
+          # On a workflow_run trigger, github.sha / github.ref_name point at the
+          # default branch (where this workflow definition lives), NOT the commit
+          # that was tested and checked out. Use the triggering run's head_sha /
+          # head_branch so the :<sha> and :<branch> tags match the built code.
+          if [[ "$GH_EVENT_NAME" == "workflow_run" ]]; then
+            SHA="$GH_WR_SHA"
+            REF_NAME="$GH_WR_BRANCH"
+          else
+            SHA="$GH_SHA"
+            REF_NAME="$GH_REF_NAME"
+          fi
+
+          TAGS="${REGISTRY}/${IMAGE_NAME}:${SHA}"
 
           # Branch name sanitization
-          SAFE_REF_NAME=$(echo "$GH_REF_NAME" | sed 's/[^a-zA-Z0-9]/-/g')
+          SAFE_REF_NAME=$(echo "$REF_NAME" | sed 's/[^a-zA-Z0-9]/-/g')
           TAGS="${TAGS},${REGISTRY}/${IMAGE_NAME}:${SAFE_REF_NAME}"
 
           # Branch number (if starts with number)
-          if [[ "$GH_REF_NAME" =~ ^[0-9]+ ]]; then
-              BRANCH_NUM=$(echo "$GH_REF_NAME" | grep -oE '^[0-9]+')
+          if [[ "$REF_NAME" =~ ^[0-9]+ ]]; then
+              BRANCH_NUM=$(echo "$REF_NAME" | grep -oE '^[0-9]+')
               TAGS="${TAGS},${REGISTRY}/${IMAGE_NAME}:${BRANCH_NUM}"
           fi
 

--- a/.github/workflows/docker_build_trust_data_access_api.yml
+++ b/.github/workflows/docker_build_trust_data_access_api.yml
@@ -16,8 +16,10 @@ on:
   workflow_dispatch:
   # Publish only after the data-access-api test suite ("Trust - Data Access API
   # CI") completes on main/develop; the job-level `if` below gates on its success.
-  # The test workflow is path-filtered to trust/data-access-api/**, so the build
-  # only fires when data-access-api actually changed.
+  # The test workflow is path-filtered, but to more than trust/data-access-api/**
+  # (it also runs on trust/trust-api/tests/integration/fixtures/**,
+  # trust/observability/**, etc.), so this build can republish the
+  # data-access-api image even when only those sibling paths changed.
   workflow_run:
     workflows: ["Trust - Data Access API CI"]
     types: [completed]
@@ -51,8 +53,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v5
         with:
-          repository: ${{ github.event.workflow_run.head_repository.full_name }}
-          ref: ${{ github.event.workflow_run.head_sha }}
+          # workflow_run.* is empty on manual workflow_dispatch runs, so fall
+          # back to the dispatched ref so manual builds check out correctly.
+          repository: ${{ github.event.workflow_run.head_repository.full_name || github.repository }}
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
       - name: Determine tags
         id: tags

--- a/.github/workflows/docker_build_trust_imaging_api.yml
+++ b/.github/workflows/docker_build_trust_imaging_api.yml
@@ -14,18 +14,25 @@ name: Build and Push Docker Image for Imaging API
 
 on:
   workflow_dispatch:
-  push:
+  # Publish only after the imaging-api test suite ("Trust - Imaging API CI")
+  # completes on main/develop; the job-level `if` below gates on its success.
+  # The test workflow is path-filtered to trust/imaging-api/**, so the build only
+  # fires when imaging-api actually changed.
+  workflow_run:
+    workflows: ["Trust - Imaging API CI"]
+    types: [completed]
     branches: [main, develop]
-    paths:
-      - "trust/imaging-api/**"
-      - "trust/observability/log_config/**"
-      - ".github/workflows/docker_build_trust_imaging_api.yml"
 
 permissions:
   contents: read
 
 jobs:
   build-and-push:
+    # Only publish when the upstream test run passed. workflow_dispatch (manual)
+    # has no workflow_run context, so allow it through unconditionally.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     permissions: # override top-level read-only default to allow GHCR push
       contents: read
@@ -53,18 +60,32 @@ jobs:
           GH_REF_NAME: ${{ github.ref_name }}
           GH_EVENT_NAME: ${{ github.event_name }}
           GH_REF: ${{ github.ref }}
+          GH_SHA: ${{ github.sha }}
           GH_WR_BRANCH: ${{ github.event.workflow_run.head_branch }}
           GH_WR_EVENT: ${{ github.event.workflow_run.event }}
+          GH_WR_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
-          TAGS="${REGISTRY}/${IMAGE_NAME}:${{ github.sha }}"
+          # On a workflow_run trigger, github.sha / github.ref_name point at the
+          # default branch (where this workflow definition lives), NOT the commit
+          # that was tested and checked out. Use the triggering run's head_sha /
+          # head_branch so the :<sha> and :<branch> tags match the built code.
+          if [[ "$GH_EVENT_NAME" == "workflow_run" ]]; then
+            SHA="$GH_WR_SHA"
+            REF_NAME="$GH_WR_BRANCH"
+          else
+            SHA="$GH_SHA"
+            REF_NAME="$GH_REF_NAME"
+          fi
+
+          TAGS="${REGISTRY}/${IMAGE_NAME}:${SHA}"
 
           # Branch name sanitization
-          SAFE_REF_NAME=$(echo "$GH_REF_NAME" | sed 's/[^a-zA-Z0-9]/-/g')
+          SAFE_REF_NAME=$(echo "$REF_NAME" | sed 's/[^a-zA-Z0-9]/-/g')
           TAGS="${TAGS},${REGISTRY}/${IMAGE_NAME}:${SAFE_REF_NAME}"
 
           # Branch number (if starts with number)
-          if [[ "$GH_REF_NAME" =~ ^[0-9]+ ]]; then
-              BRANCH_NUM=$(echo "$GH_REF_NAME" | grep -oE '^[0-9]+')
+          if [[ "$REF_NAME" =~ ^[0-9]+ ]]; then
+              BRANCH_NUM=$(echo "$REF_NAME" | grep -oE '^[0-9]+')
               TAGS="${TAGS},${REGISTRY}/${IMAGE_NAME}:${BRANCH_NUM}"
           fi
 

--- a/.github/workflows/docker_build_trust_imaging_api.yml
+++ b/.github/workflows/docker_build_trust_imaging_api.yml
@@ -51,8 +51,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v5
         with:
-          repository: ${{ github.event.workflow_run.head_repository.full_name }}
-          ref: ${{ github.event.workflow_run.head_sha }}
+          # workflow_run.* is empty on manual workflow_dispatch runs, so fall
+          # back to the dispatched ref so manual builds check out correctly.
+          repository: ${{ github.event.workflow_run.head_repository.full_name || github.repository }}
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
       - name: Determine tags
         id: tags

--- a/.github/workflows/docker_build_trust_trust_api.yml
+++ b/.github/workflows/docker_build_trust_trust_api.yml
@@ -14,18 +14,25 @@ name: Build and Push Docker Image for Trust API
 
 on:
   workflow_dispatch:
-  push:
+  # Publish only after the trust-api test suite ("Trust - Trust API CI") completes
+  # on main/develop; the job-level `if` below gates on its success. The test
+  # workflow is path-filtered to trust/trust-api/**, so the build only fires when
+  # trust-api actually changed.
+  workflow_run:
+    workflows: ["Trust - Trust API CI"]
+    types: [completed]
     branches: [main, develop]
-    paths:
-      - "trust/trust-api/**"
-      - "trust/observability/log_config/**"
-      - ".github/workflows/docker_build_trust_trust_api.yml"
 
 permissions:
   contents: read
 
 jobs:
   build-and-push:
+    # Only publish when the upstream test run passed. workflow_dispatch (manual)
+    # has no workflow_run context, so allow it through unconditionally.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     permissions: # override top-level read-only default to allow GHCR push
       contents: read
@@ -53,18 +60,32 @@ jobs:
           GH_REF_NAME: ${{ github.ref_name }}
           GH_EVENT_NAME: ${{ github.event_name }}
           GH_REF: ${{ github.ref }}
+          GH_SHA: ${{ github.sha }}
           GH_WR_BRANCH: ${{ github.event.workflow_run.head_branch }}
           GH_WR_EVENT: ${{ github.event.workflow_run.event }}
+          GH_WR_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
-          TAGS="${REGISTRY}/${IMAGE_NAME}:${{ github.sha }}"
+          # On a workflow_run trigger, github.sha / github.ref_name point at the
+          # default branch (where this workflow definition lives), NOT the commit
+          # that was tested and checked out. Use the triggering run's head_sha /
+          # head_branch so the :<sha> and :<branch> tags match the built code.
+          if [[ "$GH_EVENT_NAME" == "workflow_run" ]]; then
+            SHA="$GH_WR_SHA"
+            REF_NAME="$GH_WR_BRANCH"
+          else
+            SHA="$GH_SHA"
+            REF_NAME="$GH_REF_NAME"
+          fi
+
+          TAGS="${REGISTRY}/${IMAGE_NAME}:${SHA}"
 
           # Branch name sanitization
-          SAFE_REF_NAME=$(echo "$GH_REF_NAME" | sed 's/[^a-zA-Z0-9]/-/g')
+          SAFE_REF_NAME=$(echo "$REF_NAME" | sed 's/[^a-zA-Z0-9]/-/g')
           TAGS="${TAGS},${REGISTRY}/${IMAGE_NAME}:${SAFE_REF_NAME}"
 
           # Branch number (if starts with number)
-          if [[ "$GH_REF_NAME" =~ ^[0-9]+ ]]; then
-              BRANCH_NUM=$(echo "$GH_REF_NAME" | grep -oE '^[0-9]+')
+          if [[ "$REF_NAME" =~ ^[0-9]+ ]]; then
+              BRANCH_NUM=$(echo "$REF_NAME" | grep -oE '^[0-9]+')
               TAGS="${TAGS},${REGISTRY}/${IMAGE_NAME}:${BRANCH_NUM}"
           fi
 

--- a/.github/workflows/docker_build_trust_trust_api.yml
+++ b/.github/workflows/docker_build_trust_trust_api.yml
@@ -16,8 +16,9 @@ on:
   workflow_dispatch:
   # Publish only after the trust-api test suite ("Trust - Trust API CI") completes
   # on main/develop; the job-level `if` below gates on its success. The test
-  # workflow is path-filtered to trust/trust-api/**, so the build only fires when
-  # trust-api actually changed.
+  # workflow is path-filtered, but to more than trust/trust-api/** (it also runs
+  # on trust/data-access-api/**, trust/observability/**, etc.), so this build can
+  # republish the trust-api image even when only those sibling paths changed.
   workflow_run:
     workflows: ["Trust - Trust API CI"]
     types: [completed]
@@ -51,8 +52,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v5
         with:
-          repository: ${{ github.event.workflow_run.head_repository.full_name }}
-          ref: ${{ github.event.workflow_run.head_sha }}
+          # workflow_run.* is empty on manual workflow_dispatch runs, so fall
+          # back to the dispatched ref so manual builds check out correctly.
+          repository: ${{ github.event.workflow_run.head_repository.full_name || github.repository }}
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
       - name: Determine tags
         id: tags

--- a/.gitignore
+++ b/.gitignore
@@ -368,3 +368,4 @@ deploy/providers/AWS/email_previews/
 deploy/providers/AWS/dev/.terraform.lock.hcl
 
 .claude/scheduled_tasks.lock
+CONTEXT.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,12 +53,13 @@ Service-specific details are in `flip-api/CLAUDE.md`, `trust/CLAUDE.md`, `trust/
 ### Running Services
 
 ```bash
-make up                    # Start all services (requires AWS access)
+make up                    # Start all services (requires AWS access) — pulls images from GHCR
+make up BUILD=true         # Same, but rebuild repo-built services from local source instead of pulling
 make up-no-trust           # Start central hub only
 make up-trusts             # Start trust services only
 make down                  # Stop all services
 make restart               # Stop and restart all
-make build                 # Build all Docker images
+make build                 # Build all Docker images (standalone, --no-cache; does not start)
 make lock                  # Regenerate every uv.lock from its pyproject.toml
 make ui                    # Start UI only
 make clean                 # Remove all stopped containers, networks, and images
@@ -69,6 +70,24 @@ make debug-off SERVICE=<name>
 make debug-all             # Debug all API services
 make debug-off-all         # Remove all debug modes
 ```
+
+#### Dev image sourcing: pull-by-default
+
+In development (`PROD` unset), `make up` **pulls** the repo-built services
+(`flip-api`, `trust-api`, `imaging-api`, `data-access-api`, `orthanc`) from GHCR
+rather than building them — they carry `image:` + `pull_policy: always` in the dev
+compose, with local `src/` bind-mounted on top so live reload still runs your
+working copy. Pass `BUILD=true` (e.g. `make up BUILD=true`) to rebuild from source
+instead — required after a dependency (`uv.lock`/`pyproject.toml`) or Dockerfile
+change, since those live in the image layer, not the mounted `src/`.
+
+- **Prerequisite:** be logged into GHCR (`docker login ghcr.io`) and have the
+  `${DOCKER_TAG}` tag published (dev defaults to `:stag`, the `develop` build).
+  A failed pull no longer silently falls back to a build.
+- **`flip-ui` is the exception** — it has no published GHCR image, so it always
+  builds locally. `make build` remains the standalone `--no-cache` builder.
+- Stag/prod are unchanged: `PROD=stag|true` selects the prod compose (baked
+  `image:`-only services, no mounts).
 
 ### Testing
 
@@ -233,9 +252,13 @@ After changes, evaluate if docs need updating:
 
 GitHub Actions: `test_flip_api.yml`, `test_flip_ui.yml`, `test_trust_*.yml`, `docker_build_*.yml`, `validate_terraform.yml`, `secret-scanning.yml`, `docs.yml`, `pr_acceptance_criteria.yml`. Run locally: `make ci` (uses `act`).
 
-### Docker image builds: manual trigger required for branches
+### Docker image builds: gated on tests, manual trigger for branches
 
-**The `docker_build_*.yml` workflows only auto-publish to GHCR on merges to `develop` and `main`.** Branch pushes do NOT build images. If you pin a branch-named tag in a compose file (e.g. `ghcr.io/londonaicentre/flip-api:my-feature-branch`) for prod testing, you must manually trigger the relevant build workflow first via `workflow_dispatch`:
+**The application `docker_build_*.yml` workflows (`flip_api`, `trust_trust_api`, `trust_imaging_api`, `trust_data_access_api`) auto-publish to GHCR only after their service's test workflow passes on `develop` or `main`.** They trigger via `workflow_run` on the matching test workflow (`FLIP API CI`, `Trust - Trust API CI`, etc.) and a job-level `if` gates on `workflow_run.conclusion == 'success'` — a red test suite never publishes. Path filtering is inherited from the test workflow, so a build still only fires when that service changed. (`orthanc`, `xnat_*` keep their direct push trigger — they have no test suite to gate on; `flip-ui` is a CI smoke test that never publishes.)
+
+> **Note:** `workflow_run` triggers only take effect once these workflow files are on the repo's **default branch**. The first merge that introduces them won't retroactively publish; subsequent qualifying pushes will.
+
+Branch pushes do NOT build images. If you pin a branch-named tag in a compose file (e.g. `ghcr.io/londonaicentre/flip-api:my-feature-branch`) for prod testing, manually trigger the relevant build workflow via `workflow_dispatch` (which bypasses the test gate):
 
 ```bash
 gh workflow run docker_build_flip_api.yml --ref <branch-name>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,6 +76,11 @@ In addition to the [deployment prerequisites](README.md#prerequisites), you'll n
 - [Python 3.12+](https://www.python.org/downloads/)
 - [UV](https://docs.astral.sh/uv) - Python environment management tool (`curl -LsSf https://astral.sh/uv/install.sh | sh`)
 - [act](https://github.com/nektos/act) - Run GitHub Actions locally (install via [Homebrew](https://brew.sh/): `brew install act`)
+- **GHCR login** — `make up` pulls the repo-built service images from GitHub Container Registry by default, so authenticate once with a PAT that has `read:packages`:
+  ```bash
+  echo "$GHCR_PAT" | docker login ghcr.io -u <your-github-username> --password-stdin
+  ```
+  Building everything locally instead (no GHCR access needed) is `make up BUILD=true` — see [Running the stack](#running-the-stack-pull-vs-build) below.
 
 ### Recommended IDE Setup
 
@@ -259,6 +264,26 @@ make ci
 ```
 
 This runs all jobs defined in `.github/workflows/` locally.
+
+### Running the stack (pull vs. build)
+
+In development (`PROD` unset), `make up` **pulls** the repo-built service images
+(`flip-api`, `trust-api`, `imaging-api`, `data-access-api`, `orthanc`) from GHCR
+instead of building them — each carries `image:` + `pull_policy: always` in the dev
+compose, and your local `src/` is bind-mounted on top, so editing a `.py` still
+hot-reloads against the pulled image. Startup is fast and matches the published
+`:stag` artifact's environment.
+
+```bash
+make up                # pull GHCR images (default; requires `docker login ghcr.io`)
+make up BUILD=true     # rebuild the repo-built services from local source instead
+```
+
+Use `BUILD=true` when you've changed **dependencies** (`uv.lock`/`pyproject.toml`),
+system packages, or a `Dockerfile` — those live in the image layer, so a plain
+`make up` (which pulls) won't pick them up. `flip-ui` always builds locally (it has
+no GHCR image). Stag/prod (`PROD=stag|true`) are unaffected: they run the prod
+compose with baked images and no bind-mounts.
 
 ## The contribution process
 

--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,8 @@ build:
 	@echo "✅ Docker images built successfully!"
 
 # Run all services
-# Uses --pull always to ensure the latest FL images are used
+# Pull/build behaviour is governed by $(UP_PULL_FLAGS): pulls fresh FL images
+# when DOCKER_FL_REGISTRY is set, builds from source on BUILD=true, no-op otherwise.
 up: check-aws-access generate-internal-service-key create-networks
 	@echo "🚢 Starting all services..."
 	@echo "🚢 Starting central hub API services..."

--- a/Makefile
+++ b/Makefile
@@ -66,14 +66,25 @@ DEBUG_OVERRIDE_COMPOSE_COMMAND=docker compose -f $(COMMON_COMPOSE_FILE) -f $(FL_
 SHOW_LOGS_CENTRAL_HUB=docker logs -f flip-api --tail 100 --timestamps --follow
 GENERIC_LOGS=docker logs -f --tail 100 --timestamps --follow
 
-# NOTE DOCKER_FL_REGISTRY is set to empty when we use local FL images during development (e.g. flare-fl-server:dev).
-# In that case, '--pull always' will error because docker won't be able to find the manifest for the dev image online,
-# so we need to remove the --pull always flag. Non-FL images keep DOCKER_REGISTRY (always GHCR), so they're not the
-# constraint here — the check fires only when the FL registry is empty.
-ifneq ($(strip $(DOCKER_FL_REGISTRY)),)
-PULL_ALWAYS_FLAG=--pull always
+# UP_PULL_FLAGS controls the pull/build behaviour of the `up` targets.
+#
+# Default: repo-built services (flip-api + trust APIs + orthanc) carry
+# `pull_policy: always` in the dev compose, so they always pull from GHCR on
+# their own. This flag only adds the global `--pull always` that keeps FL images
+# fresh — and it's dropped when DOCKER_FL_REGISTRY is empty (local `:dev` FL
+# images, e.g. flare-fl-server:dev), because docker can't pull a manifest that
+# isn't published and `--pull always` would error.
+#
+# BUILD=true: rebuild the repo-built services from source instead of pulling.
+# `--build` forces the build; `--pull missing` overrides the per-service
+# `pull_policy: always` for this run so the fresh build isn't immediately
+# re-pulled away, while still fetching any absent FL/infra image.
+ifeq ($(BUILD),true)
+UP_PULL_FLAGS=--build --pull missing
+else ifneq ($(strip $(DOCKER_FL_REGISTRY)),)
+UP_PULL_FLAGS=--pull always
 else
-PULL_ALWAYS_FLAG=
+UP_PULL_FLAGS=
 endif
 
 # Build the Docker images
@@ -91,7 +102,7 @@ up: check-aws-access generate-internal-service-key create-networks
 	@echo "🚢 Starting all services..."
 	@echo "🚢 Starting central hub API services..."
 	@echo "🧠 FL_BACKEND=$(FL_BACKEND) ($(FL_BACKEND_COMPOSE_FILE))"
-	${DOCKER_COMMAND} up --remove-orphans -d $(PULL_ALWAYS_FLAG)
+	${DOCKER_COMMAND} up --remove-orphans -d $(UP_PULL_FLAGS)
 	@echo "🚢 Starting trust services..."
 	$(MAKE) -C trust up
 	@echo "🚢 Starting XNAT services..."
@@ -102,7 +113,7 @@ up: check-aws-access generate-internal-service-key create-networks
 up-no-trust: generate-internal-service-key create-networks
 	@echo "🚢 Starting central hub API services..."
 	@echo "🧠 FL_BACKEND=$(FL_BACKEND) ($(FL_BACKEND_COMPOSE_FILE))"
-	${DOCKER_COMMAND} up --remove-orphans -d $(PULL_ALWAYS_FLAG)
+	${DOCKER_COMMAND} up --remove-orphans -d $(UP_PULL_FLAGS)
 
 up-trusts: create-networks
 	@echo "🚢 Starting Trust services..."
@@ -162,7 +173,7 @@ clean:
 restart: down up
 
 # Restart only FL services (APIs, servers, and clients in trusts)
-# NOTE: Uses $(PULL_ALWAYS_FLAG) — pulls fresh FL images only when DOCKER_FL_REGISTRY is set
+# NOTE: Uses $(UP_PULL_FLAGS) — pulls fresh FL images only when DOCKER_FL_REGISTRY is set
 #       (same logic as `up`); an empty registry keeps locally built flip-fl-base-flower images.
 # NOTE: Client keys must be re-registered before starting clients (Flower only)
 restart-fl:
@@ -170,10 +181,10 @@ restart-fl:
 	@echo "🔄 Step 1: Stopping and removing old FL clients..."
 	$(MAKE) -C trust down-fl-clients
 	@echo "🔄 Step 2: Restarting FL APIs and servers..."
-	${DOCKER_COMMAND} up -d --force-recreate --no-deps $(PULL_ALWAYS_FLAG) fl-api-net-1 fl-api-net-2 fl-server-net-1 fl-server-net-2
+	${DOCKER_COMMAND} up -d --force-recreate --no-deps $(UP_PULL_FLAGS) fl-api-net-1 fl-api-net-2 fl-server-net-1 fl-server-net-2
 	@if [ "$(FL_BACKEND)" = "flower" ]; then \
 		echo "🔄 Step 3: Registering new client keys with FL servers (Flower only)..."; \
-		${DOCKER_COMMAND} up --force-recreate $(PULL_ALWAYS_FLAG) register-supernode-keys-net-1 register-supernode-keys-net-2; \
+		${DOCKER_COMMAND} up --force-recreate $(UP_PULL_FLAGS) register-supernode-keys-net-1 register-supernode-keys-net-2; \
 	fi
 	@echo "🔄 Step 4: Starting new FL clients..."
 	$(MAKE) -C trust up-fl-clients

--- a/deploy/compose.development.yml
+++ b/deploy/compose.development.yml
@@ -49,6 +49,13 @@ services:
 
   flip-api:
     platform: linux/x86_64
+    # Pull the pre-built GHCR image by default (pull_policy: always); the local
+    # src/ bind-mount below overlays it so live reload still runs your working
+    # copy. `make up BUILD=true` rebuilds from the build: block instead.
+    # flip-ui is intentionally NOT given an image/pull_policy — it has no GHCR
+    # image (its workflow is a CI smoke test; prod serves it from S3/CloudFront).
+    image: ${DOCKER_REGISTRY}flip-api:${DOCKER_TAG}
+    pull_policy: always
     build:
       args:
         UID: ${UID}

--- a/flip-ui/package-lock.json
+++ b/flip-ui/package-lock.json
@@ -453,7 +453,6 @@
             "integrity": "sha512-WHO6yYegmnZ+K3vnYzVwy+wnxYqSkdFakBIlgm4922QXHOQYWdIl/rrTcaagrpJEGT6YlTnqx1ANIoPojNxWmw==",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@aws-crypto/sha256-js": "5.2.0",
                 "@aws-sdk/types": "3.973.1",
@@ -2001,7 +2000,6 @@
             "integrity": "sha512-UlLAnTPrFdNGoFtbSXwcGFQBtQZJCNjaN6hQNP3UPvuNXT1i82N26KL3dZeIpNalWywr9IuQuncaAfUaS1g6sQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@ampproject/remapping": "^2.2.0",
                 "@babel/code-frame": "^7.27.1",
@@ -2477,6 +2475,7 @@
             "integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.8.0"
             },
@@ -2490,6 +2489,7 @@
             "integrity": "sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.8.0"
             },
@@ -2503,6 +2503,7 @@
             "integrity": "sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.12.13"
             },
@@ -2516,6 +2517,7 @@
             "integrity": "sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.14.5"
             },
@@ -2593,6 +2595,7 @@
             "integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.8.0"
             },
@@ -2622,6 +2625,7 @@
             "integrity": "sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.10.4"
             },
@@ -2635,6 +2639,7 @@
             "integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.8.0"
             },
@@ -2648,6 +2653,7 @@
             "integrity": "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.10.4"
             },
@@ -2661,6 +2667,7 @@
             "integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.8.0"
             },
@@ -2674,6 +2681,7 @@
             "integrity": "sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.8.0"
             },
@@ -2687,6 +2695,7 @@
             "integrity": "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.8.0"
             },
@@ -2700,6 +2709,7 @@
             "integrity": "sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.14.5"
             },
@@ -2716,6 +2726,7 @@
             "integrity": "sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.14.5"
             },
@@ -3968,7 +3979,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=20.19.0"
             },
@@ -3992,7 +4002,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=20.19.0"
             }
@@ -4119,6 +4128,31 @@
             "license": "MIT",
             "dependencies": {
                 "ms": "^2.1.1"
+            }
+        },
+        "node_modules/@emnapi/core": {
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+            "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@emnapi/wasi-threads": "1.2.1",
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@emnapi/runtime": {
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+            "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
             }
         },
         "node_modules/@emnapi/wasi-threads": {
@@ -4383,8 +4417,7 @@
             "resolved": "https://registry.npmjs.org/@iconify/json/-/json-1.1.461.tgz",
             "integrity": "sha512-9Y41Tk9s3LDt4WI20XySNhNX6qTJ/WOBeE3O2iyoV9LJ6gFEDjp0uTPzfRU9NUx7D6VkvQ/htJEuRe9LmyMqUA==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/@iconify/json-tools": {
             "version": "1.0.10",
@@ -4577,6 +4610,7 @@
             "integrity": "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==",
             "dev": true,
             "license": "ISC",
+            "peer": true,
             "dependencies": {
                 "camelcase": "^5.3.1",
                 "find-up": "^4.1.0",
@@ -4594,6 +4628,7 @@
             "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "locate-path": "^5.0.0",
                 "path-exists": "^4.0.0"
@@ -4608,6 +4643,7 @@
             "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "p-locate": "^4.1.0"
             },
@@ -4621,6 +4657,7 @@
             "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "p-try": "^2.0.0"
             },
@@ -4637,6 +4674,7 @@
             "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "p-limit": "^2.2.0"
             },
@@ -4650,6 +4688,7 @@
             "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -4670,6 +4709,7 @@
             "integrity": "sha512-PAwCvFJ4696XP2qZj+LAn1BWjZaJ6RjG6c7/lkMaUJnkyMS34ucuIsfqYvfskVNvUI27R/u4P1HMYFnlVXG/Ww==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/types": "30.3.0",
                 "@types/node": "*",
@@ -4688,6 +4728,7 @@
             "integrity": "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@sinclair/typebox": "^0.34.0"
             },
@@ -4701,6 +4742,7 @@
             "integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/pattern": "30.0.1",
                 "@jest/schemas": "30.0.5",
@@ -4719,7 +4761,8 @@
             "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.48.tgz",
             "integrity": "sha512-kKJTNuK3AQOrgjjotVxMrCn1sUJwM76wMszfq1kdU4uYVJjvEWuFQ6HgvLt4Xz3fSmZlTOxJ/Ie13KnIcWQXFA==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@jest/console/node_modules/ansi-styles": {
             "version": "5.2.0",
@@ -4727,6 +4770,7 @@
             "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=10"
             },
@@ -4740,6 +4784,7 @@
             "integrity": "sha512-Z/j4Bo+4ySJ+JPJN3b2Qbl9hDq3VrXmnjjGEWD/x0BCXeOXPTV1iZYYzl2X8c1MaCOL+ewMyNBcm88sboE6YWw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.27.1",
                 "@jest/types": "30.3.0",
@@ -4761,6 +4806,7 @@
             "integrity": "sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/types": "30.3.0",
                 "@types/node": "*",
@@ -4779,6 +4825,7 @@
             "integrity": "sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/schemas": "30.0.5",
                 "ansi-styles": "^5.2.0",
@@ -4794,6 +4841,7 @@
             "integrity": "sha512-U5mVPsBxLSO6xYbf+tgkymLx+iAhvZX43/xI1+ej2ZOPnPdkdO1CzDmFKh2mZBn2s4XZixszHeQnzp1gm/DIxw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/console": "30.3.0",
                 "@jest/pattern": "30.0.1",
@@ -4841,6 +4889,7 @@
             "integrity": "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@sinclair/typebox": "^0.34.0"
             },
@@ -4854,6 +4903,7 @@
             "integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/pattern": "30.0.1",
                 "@jest/schemas": "30.0.5",
@@ -4872,7 +4922,8 @@
             "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.48.tgz",
             "integrity": "sha512-kKJTNuK3AQOrgjjotVxMrCn1sUJwM76wMszfq1kdU4uYVJjvEWuFQ6HgvLt4Xz3fSmZlTOxJ/Ie13KnIcWQXFA==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@jest/core/node_modules/ansi-styles": {
             "version": "5.2.0",
@@ -4880,6 +4931,7 @@
             "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=10"
             },
@@ -4893,6 +4945,7 @@
             "integrity": "sha512-Z/j4Bo+4ySJ+JPJN3b2Qbl9hDq3VrXmnjjGEWD/x0BCXeOXPTV1iZYYzl2X8c1MaCOL+ewMyNBcm88sboE6YWw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.27.1",
                 "@jest/types": "30.3.0",
@@ -4914,6 +4967,7 @@
             "integrity": "sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/types": "30.3.0",
                 "@types/node": "*",
@@ -4932,6 +4986,7 @@
             "integrity": "sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/schemas": "30.0.5",
                 "ansi-styles": "^5.2.0",
@@ -4947,6 +5002,7 @@
             "integrity": "sha512-cG51MVnLq1ecVUaQ3fr6YuuAOitHK1S4WUJHnsPFE/quQr33ADUx1FfrTCpMCRxvy0Yr9BThKpDjSlcTi91tMA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
             }
@@ -4957,6 +5013,7 @@
             "integrity": "sha512-SlLSF4Be735yQXyh2+mctBOzNDx5s5uLv88/j8Qn1wH679PDcwy67+YdADn8NJnGjzlXtN62asGH/T4vWOkfaw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/fake-timers": "30.3.0",
                 "@jest/types": "30.3.0",
@@ -4973,6 +5030,7 @@
             "integrity": "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@sinclair/typebox": "^0.34.0"
             },
@@ -4986,6 +5044,7 @@
             "integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/pattern": "30.0.1",
                 "@jest/schemas": "30.0.5",
@@ -5004,7 +5063,8 @@
             "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.48.tgz",
             "integrity": "sha512-kKJTNuK3AQOrgjjotVxMrCn1sUJwM76wMszfq1kdU4uYVJjvEWuFQ6HgvLt4Xz3fSmZlTOxJ/Ie13KnIcWQXFA==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@jest/expect": {
             "version": "30.3.0",
@@ -5012,6 +5072,7 @@
             "integrity": "sha512-76Nlh4xJxk2D/9URCn3wFi98d2hb19uWE1idLsTt2ywhvdOldbw3S570hBgn25P4ICUZ/cBjybrBex2g17IDbg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "expect": "30.3.0",
                 "jest-snapshot": "30.3.0"
@@ -5039,6 +5100,7 @@
             "integrity": "sha512-j0+W5iQQ8hBh7tHZkTQv3q2Fh/M7Je72cIsYqC4OaktgtO7v1So9UTjp6uPBHIaB6beoF/RRsCgMJKvti0wADA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/get-type": "30.1.0"
             },
@@ -5052,6 +5114,7 @@
             "integrity": "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@sinclair/typebox": "^0.34.0"
             },
@@ -5065,6 +5128,7 @@
             "integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/pattern": "30.0.1",
                 "@jest/schemas": "30.0.5",
@@ -5083,7 +5147,8 @@
             "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.48.tgz",
             "integrity": "sha512-kKJTNuK3AQOrgjjotVxMrCn1sUJwM76wMszfq1kdU4uYVJjvEWuFQ6HgvLt4Xz3fSmZlTOxJ/Ie13KnIcWQXFA==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@jest/expect/node_modules/ansi-styles": {
             "version": "5.2.0",
@@ -5091,6 +5156,7 @@
             "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=10"
             },
@@ -5104,6 +5170,7 @@
             "integrity": "sha512-1zQrciTiQfRdo7qJM1uG4navm8DayFa2TgCSRlzUyNkhcJ6XUZF3hjnpkyr3VhAqPH7i/9GkG7Tv5abz6fqz0Q==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/expect-utils": "30.3.0",
                 "@jest/get-type": "30.1.0",
@@ -5122,6 +5189,7 @@
             "integrity": "sha512-n3q4PDQjS4LrKxfWB3Z5KNk1XjXtZTBwQp71OP0Jo03Z6V60x++K5L8k6ZrW8MY8pOFylZvHM0zsjS1RqlHJZQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/diff-sequences": "30.3.0",
                 "@jest/get-type": "30.1.0",
@@ -5138,6 +5206,7 @@
             "integrity": "sha512-HEtc9uFQgaUHkC7nLSlQL3Tph4Pjxt/yiPvkIrrDCt9jhoLIgxaubo1G+CFOnmHYMxHwwdaSN7mkIFs6ZK8OhA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/get-type": "30.1.0",
                 "chalk": "^4.1.2",
@@ -5154,6 +5223,7 @@
             "integrity": "sha512-Z/j4Bo+4ySJ+JPJN3b2Qbl9hDq3VrXmnjjGEWD/x0BCXeOXPTV1iZYYzl2X8c1MaCOL+ewMyNBcm88sboE6YWw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.27.1",
                 "@jest/types": "30.3.0",
@@ -5175,6 +5245,7 @@
             "integrity": "sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/types": "30.3.0",
                 "@types/node": "*",
@@ -5193,6 +5264,7 @@
             "integrity": "sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/schemas": "30.0.5",
                 "ansi-styles": "^5.2.0",
@@ -5208,6 +5280,7 @@
             "integrity": "sha512-WUQDs8SOP9URStX1DzhD425CqbN/HxUYCTwVrT8sTVBfMvFqYt/s61EK5T05qnHu0po6RitXIvP9otZxYDzTGQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/types": "30.3.0",
                 "@sinonjs/fake-timers": "^15.0.0",
@@ -5226,6 +5299,7 @@
             "integrity": "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@sinclair/typebox": "^0.34.0"
             },
@@ -5239,6 +5313,7 @@
             "integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/pattern": "30.0.1",
                 "@jest/schemas": "30.0.5",
@@ -5257,7 +5332,8 @@
             "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.48.tgz",
             "integrity": "sha512-kKJTNuK3AQOrgjjotVxMrCn1sUJwM76wMszfq1kdU4uYVJjvEWuFQ6HgvLt4Xz3fSmZlTOxJ/Ie13KnIcWQXFA==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@jest/fake-timers/node_modules/ansi-styles": {
             "version": "5.2.0",
@@ -5265,6 +5341,7 @@
             "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=10"
             },
@@ -5278,6 +5355,7 @@
             "integrity": "sha512-Z/j4Bo+4ySJ+JPJN3b2Qbl9hDq3VrXmnjjGEWD/x0BCXeOXPTV1iZYYzl2X8c1MaCOL+ewMyNBcm88sboE6YWw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.27.1",
                 "@jest/types": "30.3.0",
@@ -5299,6 +5377,7 @@
             "integrity": "sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/types": "30.3.0",
                 "@types/node": "*",
@@ -5317,6 +5396,7 @@
             "integrity": "sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/schemas": "30.0.5",
                 "ansi-styles": "^5.2.0",
@@ -5332,6 +5412,7 @@
             "integrity": "sha512-eMbZE2hUnx1WV0pmURZY9XoXPkUYjpc55mb0CrhtdWLtzMQPFvu/rZkTLZFTsdaVQa+Tr4eWAteqcUzoawq/uA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
             }
@@ -5342,6 +5423,7 @@
             "integrity": "sha512-+owLCBBdfpgL3HU+BD5etr1SvbXpSitJK0is1kiYjJxAAJggYMRQz5hSdd5pq1sSggfxPbw2ld71pt4x5wwViA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/environment": "30.3.0",
                 "@jest/expect": "30.3.0",
@@ -5358,6 +5440,7 @@
             "integrity": "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@sinclair/typebox": "^0.34.0"
             },
@@ -5371,6 +5454,7 @@
             "integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/pattern": "30.0.1",
                 "@jest/schemas": "30.0.5",
@@ -5389,7 +5473,8 @@
             "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.48.tgz",
             "integrity": "sha512-kKJTNuK3AQOrgjjotVxMrCn1sUJwM76wMszfq1kdU4uYVJjvEWuFQ6HgvLt4Xz3fSmZlTOxJ/Ie13KnIcWQXFA==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@jest/pattern": {
             "version": "30.0.1",
@@ -5397,6 +5482,7 @@
             "integrity": "sha512-gWp7NfQW27LaBQz3TITS8L7ZCQ0TLvtmI//4OwlQRx4rnWxcPNIYjxZpDcN4+UlGxgm3jS5QPz8IPTCkb59wZA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/node": "*",
                 "jest-regex-util": "30.0.1"
@@ -5411,6 +5497,7 @@
             "integrity": "sha512-a09z89S+PkQnL055bVj8+pe2Caed2PBOaczHcXCykW5ngxX9EWx/1uAwncxc/HiU0oZqfwseMjyhxgRjS49qPw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@bcoe/v8-coverage": "^0.2.3",
                 "@jest/console": "30.3.0",
@@ -5453,7 +5540,8 @@
             "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
             "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@jest/reporters/node_modules/@jest/schemas": {
             "version": "30.0.5",
@@ -5461,6 +5549,7 @@
             "integrity": "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@sinclair/typebox": "^0.34.0"
             },
@@ -5474,6 +5563,7 @@
             "integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/pattern": "30.0.1",
                 "@jest/schemas": "30.0.5",
@@ -5492,7 +5582,8 @@
             "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.48.tgz",
             "integrity": "sha512-kKJTNuK3AQOrgjjotVxMrCn1sUJwM76wMszfq1kdU4uYVJjvEWuFQ6HgvLt4Xz3fSmZlTOxJ/Ie13KnIcWQXFA==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@jest/reporters/node_modules/ansi-styles": {
             "version": "5.2.0",
@@ -5500,6 +5591,7 @@
             "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=10"
             },
@@ -5513,6 +5605,7 @@
             "integrity": "sha512-Z/j4Bo+4ySJ+JPJN3b2Qbl9hDq3VrXmnjjGEWD/x0BCXeOXPTV1iZYYzl2X8c1MaCOL+ewMyNBcm88sboE6YWw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.27.1",
                 "@jest/types": "30.3.0",
@@ -5534,6 +5627,7 @@
             "integrity": "sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/types": "30.3.0",
                 "@types/node": "*",
@@ -5552,6 +5646,7 @@
             "integrity": "sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/schemas": "30.0.5",
                 "ansi-styles": "^5.2.0",
@@ -5580,6 +5675,7 @@
             "integrity": "sha512-ORbRN9sf5PP82v3FXNSwmO1OTDR2vzR2YTaR+E3VkSBZ8zadQE6IqYdYEeFH1NIkeB2HIGdF02dapb6K0Mj05g==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/types": "30.3.0",
                 "chalk": "^4.1.2",
@@ -5596,6 +5692,7 @@
             "integrity": "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@sinclair/typebox": "^0.34.0"
             },
@@ -5609,6 +5706,7 @@
             "integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/pattern": "30.0.1",
                 "@jest/schemas": "30.0.5",
@@ -5627,7 +5725,8 @@
             "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.48.tgz",
             "integrity": "sha512-kKJTNuK3AQOrgjjotVxMrCn1sUJwM76wMszfq1kdU4uYVJjvEWuFQ6HgvLt4Xz3fSmZlTOxJ/Ie13KnIcWQXFA==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@jest/source-map": {
             "version": "30.0.1",
@@ -5635,6 +5734,7 @@
             "integrity": "sha512-MIRWMUUR3sdbP36oyNyhbThLHyJ2eEDClPCiHVbrYAe5g3CHRArIVpBw7cdSB5fr+ofSfIb2Tnsw8iEHL0PYQg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jridgewell/trace-mapping": "^0.3.25",
                 "callsites": "^3.1.0",
@@ -5650,6 +5750,7 @@
             "integrity": "sha512-e/52nJGuD74AKTSe0P4y5wFRlaXP0qmrS17rqOMHeSwm278VyNyXE3gFO/4DTGF9w+65ra3lo3VKj0LBrzmgdQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/console": "30.3.0",
                 "@jest/types": "30.3.0",
@@ -5666,6 +5767,7 @@
             "integrity": "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@sinclair/typebox": "^0.34.0"
             },
@@ -5679,6 +5781,7 @@
             "integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/pattern": "30.0.1",
                 "@jest/schemas": "30.0.5",
@@ -5697,7 +5800,8 @@
             "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.48.tgz",
             "integrity": "sha512-kKJTNuK3AQOrgjjotVxMrCn1sUJwM76wMszfq1kdU4uYVJjvEWuFQ6HgvLt4Xz3fSmZlTOxJ/Ie13KnIcWQXFA==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@jest/test-sequencer": {
             "version": "30.3.0",
@@ -5705,6 +5809,7 @@
             "integrity": "sha512-dgbWy9b8QDlQeRZcv7LNF+/jFiiYHTKho1xirauZ7kVwY7avjFF6uTT0RqlgudB5OuIPagFdVtfFMosjVbk1eA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/test-result": "30.3.0",
                 "graceful-fs": "^4.2.11",
@@ -5721,6 +5826,7 @@
             "integrity": "sha512-TLKY33fSLVd/lKB2YI1pH69ijyUblO/BQvCj566YvnwuzoTNr648iE0j22vRvVNk2HsPwByPxATg3MleS3gf5A==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/core": "^7.27.4",
                 "@jest/types": "30.3.0",
@@ -5747,6 +5853,7 @@
             "integrity": "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@sinclair/typebox": "^0.34.0"
             },
@@ -5760,6 +5867,7 @@
             "integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/pattern": "30.0.1",
                 "@jest/schemas": "30.0.5",
@@ -5778,7 +5886,8 @@
             "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.48.tgz",
             "integrity": "sha512-kKJTNuK3AQOrgjjotVxMrCn1sUJwM76wMszfq1kdU4uYVJjvEWuFQ6HgvLt4Xz3fSmZlTOxJ/Ie13KnIcWQXFA==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@jest/transform/node_modules/jest-util": {
             "version": "30.3.0",
@@ -5786,6 +5895,7 @@
             "integrity": "sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/types": "30.3.0",
                 "@types/node": "*",
@@ -5980,6 +6090,7 @@
             "integrity": "sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
             },
@@ -6322,6 +6433,7 @@
             "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
             "dev": true,
             "license": "BSD-3-Clause",
+            "peer": true,
             "dependencies": {
                 "type-detect": "4.0.8"
             }
@@ -6332,6 +6444,7 @@
             "integrity": "sha512-cO5W33JgAPbOh07tvZjUOJ7oWhtaqGHiZw+11DPbyqh2kHTBc3eF/CjJDeQ4205RLQsX6rxCuYOroFQwl7JDRw==",
             "dev": true,
             "license": "BSD-3-Clause",
+            "peer": true,
             "dependencies": {
                 "@sinonjs/commons": "^3.0.1"
             }
@@ -7917,6 +8030,7 @@
             "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/parser": "^7.20.7",
                 "@babel/types": "^7.20.7",
@@ -7931,6 +8045,7 @@
             "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/types": "^7.0.0"
             }
@@ -7941,6 +8056,7 @@
             "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/parser": "^7.1.0",
                 "@babel/types": "^7.0.0"
@@ -7952,6 +8068,7 @@
             "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/types": "^7.28.2"
             }
@@ -8077,7 +8194,6 @@
             "integrity": "sha512-cuVNgarYWZqxRJDQHEB58GEONhOK79QVR/qYx4S7kcUObQvUwvFnYxJuuHUKm2aieN9X3yZB4LZsuYNU1Qphsw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "undici-types": "~6.21.0"
             }
@@ -8200,7 +8316,6 @@
             "integrity": "sha512-30ScMRHIAD33JJQkgfGW1t8CURZtjc2JpTrq5n2HFhOefbAhb7ucc7xJwdWcrEtqUIYJ73Nybpsggii6GtAHjA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "8.57.2",
                 "@typescript-eslint/types": "8.57.2",
@@ -8528,7 +8643,8 @@
             "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
             "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
             "dev": true,
-            "license": "ISC"
+            "license": "ISC",
+            "peer": true
         },
         "node_modules/@unrs/resolver-binding-android-arm-eabi": {
             "version": "1.11.1",
@@ -8542,7 +8658,8 @@
             "optional": true,
             "os": [
                 "android"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@unrs/resolver-binding-android-arm64": {
             "version": "1.11.1",
@@ -8556,7 +8673,8 @@
             "optional": true,
             "os": [
                 "android"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@unrs/resolver-binding-darwin-arm64": {
             "version": "1.11.1",
@@ -8570,7 +8688,8 @@
             "optional": true,
             "os": [
                 "darwin"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@unrs/resolver-binding-darwin-x64": {
             "version": "1.11.1",
@@ -8584,7 +8703,8 @@
             "optional": true,
             "os": [
                 "darwin"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@unrs/resolver-binding-freebsd-x64": {
             "version": "1.11.1",
@@ -8598,7 +8718,8 @@
             "optional": true,
             "os": [
                 "freebsd"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@unrs/resolver-binding-linux-arm-gnueabihf": {
             "version": "1.11.1",
@@ -8612,7 +8733,8 @@
             "optional": true,
             "os": [
                 "linux"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@unrs/resolver-binding-linux-arm-musleabihf": {
             "version": "1.11.1",
@@ -8626,7 +8748,8 @@
             "optional": true,
             "os": [
                 "linux"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@unrs/resolver-binding-linux-arm64-gnu": {
             "version": "1.11.1",
@@ -8640,7 +8763,8 @@
             "optional": true,
             "os": [
                 "linux"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@unrs/resolver-binding-linux-arm64-musl": {
             "version": "1.11.1",
@@ -8654,7 +8778,8 @@
             "optional": true,
             "os": [
                 "linux"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@unrs/resolver-binding-linux-ppc64-gnu": {
             "version": "1.11.1",
@@ -8668,7 +8793,8 @@
             "optional": true,
             "os": [
                 "linux"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@unrs/resolver-binding-linux-riscv64-gnu": {
             "version": "1.11.1",
@@ -8682,7 +8808,8 @@
             "optional": true,
             "os": [
                 "linux"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@unrs/resolver-binding-linux-riscv64-musl": {
             "version": "1.11.1",
@@ -8696,7 +8823,8 @@
             "optional": true,
             "os": [
                 "linux"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@unrs/resolver-binding-linux-s390x-gnu": {
             "version": "1.11.1",
@@ -8710,7 +8838,8 @@
             "optional": true,
             "os": [
                 "linux"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@unrs/resolver-binding-linux-x64-gnu": {
             "version": "1.11.1",
@@ -8724,7 +8853,8 @@
             "optional": true,
             "os": [
                 "linux"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@unrs/resolver-binding-linux-x64-musl": {
             "version": "1.11.1",
@@ -8738,7 +8868,8 @@
             "optional": true,
             "os": [
                 "linux"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@unrs/resolver-binding-wasm32-wasi": {
             "version": "1.11.1",
@@ -8750,6 +8881,7 @@
             "dev": true,
             "license": "MIT",
             "optional": true,
+            "peer": true,
             "dependencies": {
                 "@napi-rs/wasm-runtime": "^0.2.11"
             },
@@ -8764,6 +8896,7 @@
             "dev": true,
             "license": "MIT",
             "optional": true,
+            "peer": true,
             "dependencies": {
                 "@emnapi/core": "^1.4.3",
                 "@emnapi/runtime": "^1.4.3",
@@ -8782,7 +8915,8 @@
             "optional": true,
             "os": [
                 "win32"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@unrs/resolver-binding-win32-ia32-msvc": {
             "version": "1.11.1",
@@ -8796,7 +8930,8 @@
             "optional": true,
             "os": [
                 "win32"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@unrs/resolver-binding-win32-x64-msvc": {
             "version": "1.11.1",
@@ -8810,7 +8945,8 @@
             "optional": true,
             "os": [
                 "win32"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@vitejs/plugin-vue": {
             "version": "6.0.5",
@@ -9070,7 +9206,6 @@
             "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.17.tgz",
             "integrity": "sha512-rQQxbRJMgTqwRugtjw0cnyQv9cP4/4BxWfTdRBkqsTfLOHWykLzbOc3C4GGzAmdMDxhzU/1Ija5bTjMVrddqww==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/parser": "^7.27.5",
                 "@vue/compiler-core": "3.5.17",
@@ -9385,7 +9520,6 @@
             "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -9572,6 +9706,7 @@
             "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "sprintf-js": "~1.0.2"
             }
@@ -9847,6 +9982,7 @@
             "integrity": "sha512-gRpauEU2KRrCox5Z296aeVHR4jQ98BCnu0IO332D/xpHNOsIH/bgSRk9k6GbKIbBw8vFeN6ctuu6tV8WOyVfYQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/transform": "30.3.0",
                 "@types/babel__core": "^7.20.5",
@@ -9869,6 +10005,7 @@
             "integrity": "sha512-D8Z6Qm8jCvVXtIRkBnqNHX0zJ37rQcFJ9u8WOS6tkYOsRdHBzypCstaxWiu5ZIlqQtviRYbgnRLSoCEvjqcqbA==",
             "dev": true,
             "license": "BSD-3-Clause",
+            "peer": true,
             "workspaces": [
                 "test/babel-8"
             ],
@@ -9889,6 +10026,7 @@
             "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -9901,6 +10039,7 @@
             "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
             "dev": true,
             "license": "ISC",
+            "peer": true,
             "dependencies": {
                 "fs.realpath": "^1.0.0",
                 "inflight": "^1.0.4",
@@ -9922,6 +10061,7 @@
             "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
             "dev": true,
             "license": "ISC",
+            "peer": true,
             "dependencies": {
                 "brace-expansion": "^1.1.7"
             },
@@ -9935,6 +10075,7 @@
             "integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
             "dev": true,
             "license": "ISC",
+            "peer": true,
             "dependencies": {
                 "@istanbuljs/schema": "^0.1.2",
                 "glob": "^7.1.4",
@@ -9950,6 +10091,7 @@
             "integrity": "sha512-+TRkByhsws6sfPjVaitzadk1I0F5sPvOVUH5tyTSzhePpsGIVrdeunHSw/C36QeocS95OOk8lunc4rlu5Anwsg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/babel__core": "^7.20.5"
             },
@@ -10005,6 +10147,7 @@
             "integrity": "sha512-E/VlAEzRrsLEb2+dv8yp3bo4scof3l9nR4lrld+Iy5NyVqgVYUJnDAmunkhPMisRI32Qc4iRiz425d8vM++2fg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/plugin-syntax-async-generators": "^7.8.4",
                 "@babel/plugin-syntax-bigint": "^7.8.3",
@@ -10032,6 +10175,7 @@
             "integrity": "sha512-6ZcUbWHC+dMz2vfzdNwi87Z1gQsLNK2uLuK1Q89R11xdvejcivlYYwDlEv0FHX3VwEXpbBQ9uufB/MUNpZGfhQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "babel-plugin-jest-hoist": "30.3.0",
                 "babel-preset-current-node-syntax": "^1.2.0"
@@ -10185,7 +10329,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "caniuse-lite": "^1.0.30001726",
                 "electron-to-chromium": "^1.5.173",
@@ -10218,6 +10361,7 @@
             "integrity": "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==",
             "dev": true,
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "node-int64": "^0.4.0"
             }
@@ -10439,6 +10583,7 @@
             "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=6"
             }
@@ -10536,6 +10681,7 @@
             "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=10"
             }
@@ -10609,7 +10755,8 @@
             "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz",
             "integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/clean-stack": {
             "version": "2.2.0",
@@ -10721,6 +10868,7 @@
             "integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "iojs": ">= 1.0.0",
                 "node": ">= 0.12.0"
@@ -10754,7 +10902,8 @@
             "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.3.tgz",
             "integrity": "sha512-1L5aqIkwPfiodaMgQunkF1zRhNqifHBmtbbbxcr6yVxxBnliw4TDOW6NxpO8DJLgJ16OT+Y4ztZqP6p/FtXnAw==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/color-convert": {
             "version": "2.0.1",
@@ -10837,7 +10986,8 @@
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
             "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/confbox": {
             "version": "0.1.8",
@@ -11061,7 +11211,6 @@
             "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@cypress/request": "^3.0.8",
                 "@cypress/xvfb": "^1.2.4",
@@ -11338,6 +11487,7 @@
             "integrity": "sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "peerDependencies": {
                 "babel-plugin-macros": "^3.1.0"
             },
@@ -11360,6 +11510,7 @@
             "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -11436,6 +11587,7 @@
             "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -11680,6 +11832,7 @@
             "integrity": "sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -11709,7 +11862,6 @@
             "integrity": "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "ansi-colors": "^4.1.1",
                 "strip-ansi": "^6.0.1"
@@ -11736,6 +11888,7 @@
             "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "is-arrayish": "^0.2.1"
             }
@@ -11919,7 +12072,6 @@
             "integrity": "sha512-S9jlY/ELKEUwwQnqWDO+f+m6sercqOPSqXM5Go94l7DOmxHVDgmSFGWEzeE/gwgTAr0W103BWt0QLe/7mabIvA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.8.0",
                 "@eslint-community/regexpp": "^4.12.2",
@@ -11986,7 +12138,6 @@
             "integrity": "sha512-f1J/tcbnrpgC8suPN5AtdJ5MQjuXbSU9pGRSSYAuF3SHoiYCOdEX6O22pLaRyLHXvDcOe+O5ENgc1owQ587agA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.4.0",
                 "natural-compare": "^1.4.0",
@@ -12388,6 +12539,7 @@
             "integrity": "sha512-+I6B/IkJc1o/2tiURyz/ivu/O0nKNEArIUB5O7zBrlDVJr22SCLH3xTeEry428LvFhRzIA1g8izguxJ/gbNcVQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">= 0.8.0"
             }
@@ -12591,6 +12743,7 @@
             "integrity": "sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==",
             "dev": true,
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "bser": "2.1.1"
             }
@@ -12864,7 +13017,8 @@
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
             "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
             "dev": true,
-            "license": "ISC"
+            "license": "ISC",
+            "peer": true
         },
         "node_modules/fsevents": {
             "version": "2.3.3",
@@ -12972,6 +13126,7 @@
             "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=8.0.0"
             }
@@ -13426,6 +13581,7 @@
             "integrity": "sha512-2SPlun1JUPWoM6t3F0dw0FkCF/jWY8kttcY4f599GLTSjh2OCuuhdTkJQsEcZzBqbXZGKMK2OqW1oZsjtf/gQA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "pkg-dir": "^4.2.0",
                 "resolve-cwd": "^3.0.0"
@@ -13446,6 +13602,7 @@
             "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "locate-path": "^5.0.0",
                 "path-exists": "^4.0.0"
@@ -13460,6 +13617,7 @@
             "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "p-locate": "^4.1.0"
             },
@@ -13473,6 +13631,7 @@
             "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "p-try": "^2.0.0"
             },
@@ -13489,6 +13648,7 @@
             "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "p-limit": "^2.2.0"
             },
@@ -13502,6 +13662,7 @@
             "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -13512,6 +13673,7 @@
             "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "find-up": "^4.0.0"
             },
@@ -13553,6 +13715,7 @@
             "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
             "dev": true,
             "license": "ISC",
+            "peer": true,
             "dependencies": {
                 "once": "^1.3.0",
                 "wrappy": "1"
@@ -13563,7 +13726,8 @@
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
             "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
             "dev": true,
-            "license": "ISC"
+            "license": "ISC",
+            "peer": true
         },
         "node_modules/ini": {
             "version": "2.0.0",
@@ -13613,7 +13777,8 @@
             "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
             "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/is-async-function": {
             "version": "2.1.1",
@@ -13786,6 +13951,7 @@
             "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=6"
             }
@@ -14160,6 +14326,7 @@
             "integrity": "sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==",
             "dev": true,
             "license": "BSD-3-Clause",
+            "peer": true,
             "dependencies": {
                 "@babel/core": "^7.23.9",
                 "@babel/parser": "^7.23.9",
@@ -14177,6 +14344,7 @@
             "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
             "dev": true,
             "license": "ISC",
+            "peer": true,
             "bin": {
                 "semver": "bin/semver.js"
             },
@@ -14247,6 +14415,7 @@
             "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
             "dev": true,
             "license": "BSD-3-Clause",
+            "peer": true,
             "dependencies": {
                 "@jridgewell/trace-mapping": "^0.3.23",
                 "debug": "^4.1.1",
@@ -14292,6 +14461,7 @@
             "integrity": "sha512-AkXIIFcaazymvey2i/+F94XRnM6TsVLZDhBMLsd1Sf/W0wzsvvpjeyUrCZD6HGG4SDYPgDJDBKeiJTBb10WzMg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/core": "30.3.0",
                 "@jest/types": "30.3.0",
@@ -14319,6 +14489,7 @@
             "integrity": "sha512-B/7Cny6cV5At6M25EWDgf9S617lHivamL8vl6KEpJqkStauzcG4e+WPfDgMMF+H4FVH4A2PLRyvgDJan4441QA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "execa": "^5.1.1",
                 "jest-util": "30.3.0",
@@ -14334,6 +14505,7 @@
             "integrity": "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@sinclair/typebox": "^0.34.0"
             },
@@ -14347,6 +14519,7 @@
             "integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/pattern": "30.0.1",
                 "@jest/schemas": "30.0.5",
@@ -14365,7 +14538,8 @@
             "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.48.tgz",
             "integrity": "sha512-kKJTNuK3AQOrgjjotVxMrCn1sUJwM76wMszfq1kdU4uYVJjvEWuFQ6HgvLt4Xz3fSmZlTOxJ/Ie13KnIcWQXFA==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/jest-changed-files/node_modules/execa": {
             "version": "5.1.1",
@@ -14373,6 +14547,7 @@
             "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "cross-spawn": "^7.0.3",
                 "get-stream": "^6.0.0",
@@ -14397,6 +14572,7 @@
             "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=10"
             },
@@ -14410,6 +14586,7 @@
             "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
             "dev": true,
             "license": "Apache-2.0",
+            "peer": true,
             "engines": {
                 "node": ">=10.17.0"
             }
@@ -14420,6 +14597,7 @@
             "integrity": "sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/types": "30.3.0",
                 "@types/node": "*",
@@ -14438,6 +14616,7 @@
             "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "yocto-queue": "^0.1.0"
             },
@@ -14454,6 +14633,7 @@
             "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=10"
             },
@@ -14467,6 +14647,7 @@
             "integrity": "sha512-PyXq5szeSfR/4f1lYqCmmQjh0vqDkURUYi9N6whnHjlRz4IUQfMcXkGLeEoiJtxtyPqgUaUUfyQlApXWBSN1RA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/environment": "30.3.0",
                 "@jest/expect": "30.3.0",
@@ -14499,6 +14680,7 @@
             "integrity": "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@sinclair/typebox": "^0.34.0"
             },
@@ -14512,6 +14694,7 @@
             "integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/pattern": "30.0.1",
                 "@jest/schemas": "30.0.5",
@@ -14530,7 +14713,8 @@
             "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.48.tgz",
             "integrity": "sha512-kKJTNuK3AQOrgjjotVxMrCn1sUJwM76wMszfq1kdU4uYVJjvEWuFQ6HgvLt4Xz3fSmZlTOxJ/Ie13KnIcWQXFA==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/jest-circus/node_modules/ansi-styles": {
             "version": "5.2.0",
@@ -14538,6 +14722,7 @@
             "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=10"
             },
@@ -14551,6 +14736,7 @@
             "integrity": "sha512-n3q4PDQjS4LrKxfWB3Z5KNk1XjXtZTBwQp71OP0Jo03Z6V60x++K5L8k6ZrW8MY8pOFylZvHM0zsjS1RqlHJZQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/diff-sequences": "30.3.0",
                 "@jest/get-type": "30.1.0",
@@ -14567,6 +14753,7 @@
             "integrity": "sha512-HEtc9uFQgaUHkC7nLSlQL3Tph4Pjxt/yiPvkIrrDCt9jhoLIgxaubo1G+CFOnmHYMxHwwdaSN7mkIFs6ZK8OhA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/get-type": "30.1.0",
                 "chalk": "^4.1.2",
@@ -14583,6 +14770,7 @@
             "integrity": "sha512-Z/j4Bo+4ySJ+JPJN3b2Qbl9hDq3VrXmnjjGEWD/x0BCXeOXPTV1iZYYzl2X8c1MaCOL+ewMyNBcm88sboE6YWw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.27.1",
                 "@jest/types": "30.3.0",
@@ -14604,6 +14792,7 @@
             "integrity": "sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/types": "30.3.0",
                 "@types/node": "*",
@@ -14622,6 +14811,7 @@
             "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "yocto-queue": "^0.1.0"
             },
@@ -14638,6 +14828,7 @@
             "integrity": "sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/schemas": "30.0.5",
                 "ansi-styles": "^5.2.0",
@@ -14653,6 +14844,7 @@
             "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=10"
             },
@@ -14666,6 +14858,7 @@
             "integrity": "sha512-l6Tqx+j1fDXJEW5bqYykDQQ7mQg+9mhWXtnj+tQZrTWYHyHoi6Be8HPumDSA+UiX2/2buEgjA58iJzdj146uCw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/core": "30.3.0",
                 "@jest/test-result": "30.3.0",
@@ -14699,6 +14892,7 @@
             "integrity": "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@sinclair/typebox": "^0.34.0"
             },
@@ -14712,6 +14906,7 @@
             "integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/pattern": "30.0.1",
                 "@jest/schemas": "30.0.5",
@@ -14730,7 +14925,8 @@
             "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.48.tgz",
             "integrity": "sha512-kKJTNuK3AQOrgjjotVxMrCn1sUJwM76wMszfq1kdU4uYVJjvEWuFQ6HgvLt4Xz3fSmZlTOxJ/Ie13KnIcWQXFA==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/jest-cli/node_modules/jest-util": {
             "version": "30.3.0",
@@ -14738,6 +14934,7 @@
             "integrity": "sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/types": "30.3.0",
                 "@types/node": "*",
@@ -14756,6 +14953,7 @@
             "integrity": "sha512-WPMAkMAtNDY9P/oKObtsRG/6KTrhtgPJoBTmk20uDn4Uy6/3EJnnaZJre/FMT1KVRx8cve1r7/FlMIOfRVWL4w==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/core": "^7.27.4",
                 "@jest/get-type": "30.1.0",
@@ -14807,6 +15005,7 @@
             "integrity": "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@sinclair/typebox": "^0.34.0"
             },
@@ -14820,6 +15019,7 @@
             "integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/pattern": "30.0.1",
                 "@jest/schemas": "30.0.5",
@@ -14838,7 +15038,8 @@
             "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.48.tgz",
             "integrity": "sha512-kKJTNuK3AQOrgjjotVxMrCn1sUJwM76wMszfq1kdU4uYVJjvEWuFQ6HgvLt4Xz3fSmZlTOxJ/Ie13KnIcWQXFA==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/jest-config/node_modules/ansi-styles": {
             "version": "5.2.0",
@@ -14846,6 +15047,7 @@
             "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=10"
             },
@@ -14859,6 +15061,7 @@
             "integrity": "sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/types": "30.3.0",
                 "@types/node": "*",
@@ -14877,6 +15080,7 @@
             "integrity": "sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/schemas": "30.0.5",
                 "ansi-styles": "^5.2.0",
@@ -14908,6 +15112,7 @@
             "integrity": "sha512-tR/FFgZKS1CXluOQzZvNH3+0z9jXr3ldGSD8bhyuxvlVUwbeLOGynkunvlTMxchC5urrKndYiwCFC0DLVjpOCA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "detect-newline": "^3.1.0"
             },
@@ -14921,6 +15126,7 @@
             "integrity": "sha512-V8eMndg/aZ+3LnCJgSm13IxS5XSBM22QSZc9BtPK8Dek6pm+hfUNfwBdvsB3d342bo1q7wnSkC38zjX259qZNA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/get-type": "30.1.0",
                 "@jest/types": "30.3.0",
@@ -14938,6 +15144,7 @@
             "integrity": "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@sinclair/typebox": "^0.34.0"
             },
@@ -14951,6 +15158,7 @@
             "integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/pattern": "30.0.1",
                 "@jest/schemas": "30.0.5",
@@ -14969,7 +15177,8 @@
             "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.48.tgz",
             "integrity": "sha512-kKJTNuK3AQOrgjjotVxMrCn1sUJwM76wMszfq1kdU4uYVJjvEWuFQ6HgvLt4Xz3fSmZlTOxJ/Ie13KnIcWQXFA==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/jest-each/node_modules/ansi-styles": {
             "version": "5.2.0",
@@ -14977,6 +15186,7 @@
             "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=10"
             },
@@ -14990,6 +15200,7 @@
             "integrity": "sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/types": "30.3.0",
                 "@types/node": "*",
@@ -15008,6 +15219,7 @@
             "integrity": "sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/schemas": "30.0.5",
                 "ansi-styles": "^5.2.0",
@@ -15023,6 +15235,7 @@
             "integrity": "sha512-4i6HItw/JSiJVsC5q0hnKIe/hbYfZLVG9YJ/0pU9Hz2n/9qZe3Rhn5s5CUZA5ORZlcdT/vmAXRMyONXJwPrmYQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/environment": "30.3.0",
                 "@jest/fake-timers": "30.3.0",
@@ -15042,6 +15255,7 @@
             "integrity": "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@sinclair/typebox": "^0.34.0"
             },
@@ -15055,6 +15269,7 @@
             "integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/pattern": "30.0.1",
                 "@jest/schemas": "30.0.5",
@@ -15073,7 +15288,8 @@
             "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.48.tgz",
             "integrity": "sha512-kKJTNuK3AQOrgjjotVxMrCn1sUJwM76wMszfq1kdU4uYVJjvEWuFQ6HgvLt4Xz3fSmZlTOxJ/Ie13KnIcWQXFA==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/jest-environment-node/node_modules/jest-util": {
             "version": "30.3.0",
@@ -15081,6 +15297,7 @@
             "integrity": "sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/types": "30.3.0",
                 "@types/node": "*",
@@ -15109,6 +15326,7 @@
             "integrity": "sha512-mMi2oqG4KRU0R9QEtscl87JzMXfUhbKaFqOxmjb2CKcbHcUGFrJCBWHmnTiUqi6JcnzoBlO4rWfpdl2k/RfLCA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/types": "30.3.0",
                 "@types/node": "*",
@@ -15134,6 +15352,7 @@
             "integrity": "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@sinclair/typebox": "^0.34.0"
             },
@@ -15147,6 +15366,7 @@
             "integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/pattern": "30.0.1",
                 "@jest/schemas": "30.0.5",
@@ -15165,7 +15385,8 @@
             "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.48.tgz",
             "integrity": "sha512-kKJTNuK3AQOrgjjotVxMrCn1sUJwM76wMszfq1kdU4uYVJjvEWuFQ6HgvLt4Xz3fSmZlTOxJ/Ie13KnIcWQXFA==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/jest-haste-map/node_modules/jest-util": {
             "version": "30.3.0",
@@ -15173,6 +15394,7 @@
             "integrity": "sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/types": "30.3.0",
                 "@types/node": "*",
@@ -15191,6 +15413,7 @@
             "integrity": "sha512-cuKmUUGIjfXZAiGJ7TbEMx0bcqNdPPI6P1V+7aF+m/FUJqFDxkFR4JqkTu8ZOiU5AaX/x0hZ20KaaIPXQzbMGQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/get-type": "30.1.0",
                 "pretty-format": "30.3.0"
@@ -15205,6 +15428,7 @@
             "integrity": "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@sinclair/typebox": "^0.34.0"
             },
@@ -15217,7 +15441,8 @@
             "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.48.tgz",
             "integrity": "sha512-kKJTNuK3AQOrgjjotVxMrCn1sUJwM76wMszfq1kdU4uYVJjvEWuFQ6HgvLt4Xz3fSmZlTOxJ/Ie13KnIcWQXFA==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/jest-leak-detector/node_modules/ansi-styles": {
             "version": "5.2.0",
@@ -15225,6 +15450,7 @@
             "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=10"
             },
@@ -15238,6 +15464,7 @@
             "integrity": "sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/schemas": "30.0.5",
                 "ansi-styles": "^5.2.0",
@@ -15290,6 +15517,7 @@
             "integrity": "sha512-OTzICK8CpE+t4ndhKrwlIdbM6Pn8j00lvmSmq5ejiO+KxukbLjgOflKWMn3KE34EZdQm5RqTuKj+5RIEniYhog==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/types": "30.3.0",
                 "@types/node": "*",
@@ -15305,6 +15533,7 @@
             "integrity": "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@sinclair/typebox": "^0.34.0"
             },
@@ -15318,6 +15547,7 @@
             "integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/pattern": "30.0.1",
                 "@jest/schemas": "30.0.5",
@@ -15336,7 +15566,8 @@
             "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.48.tgz",
             "integrity": "sha512-kKJTNuK3AQOrgjjotVxMrCn1sUJwM76wMszfq1kdU4uYVJjvEWuFQ6HgvLt4Xz3fSmZlTOxJ/Ie13KnIcWQXFA==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/jest-mock/node_modules/jest-util": {
             "version": "30.3.0",
@@ -15344,6 +15575,7 @@
             "integrity": "sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/types": "30.3.0",
                 "@types/node": "*",
@@ -15362,6 +15594,7 @@
             "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=6"
             },
@@ -15380,6 +15613,7 @@
             "integrity": "sha512-jHEQgBXAgc+Gh4g0p3bCevgRCVRkB4VB70zhoAE48gxeSr1hfUOsM/C2WoJgVL7Eyg//hudYENbm3Ne+/dRVVA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
             }
@@ -15390,6 +15624,7 @@
             "integrity": "sha512-NRtTAHQlpd15F9rUR36jqwelbrDV/dY4vzNte3S2kxCKUJRYNd5/6nTSbYiak1VX5g8IoFF23Uj5TURkUW8O5g==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "chalk": "^4.1.2",
                 "graceful-fs": "^4.2.11",
@@ -15410,6 +15645,7 @@
             "integrity": "sha512-9ev8s3YN6Hsyz9LV75XUwkCVFlwPbaFn6Wp75qnI0wzAINYWY8Fb3+6y59Rwd3QaS3kKXffHXsZMziMavfz/nw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "jest-regex-util": "30.0.1",
                 "jest-snapshot": "30.3.0"
@@ -15424,6 +15660,7 @@
             "integrity": "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@sinclair/typebox": "^0.34.0"
             },
@@ -15437,6 +15674,7 @@
             "integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/pattern": "30.0.1",
                 "@jest/schemas": "30.0.5",
@@ -15455,7 +15693,8 @@
             "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.48.tgz",
             "integrity": "sha512-kKJTNuK3AQOrgjjotVxMrCn1sUJwM76wMszfq1kdU4uYVJjvEWuFQ6HgvLt4Xz3fSmZlTOxJ/Ie13KnIcWQXFA==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/jest-resolve/node_modules/jest-util": {
             "version": "30.3.0",
@@ -15463,6 +15702,7 @@
             "integrity": "sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/types": "30.3.0",
                 "@types/node": "*",
@@ -15481,6 +15721,7 @@
             "integrity": "sha512-gDv6C9LGKWDPLia9TSzZwf4h3kMQCqyTpq+95PODnTRDO0g9os48XIYYkS6D236vjpBir2fF63YmJFtqkS5Duw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/console": "30.3.0",
                 "@jest/environment": "30.3.0",
@@ -15515,6 +15756,7 @@
             "integrity": "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@sinclair/typebox": "^0.34.0"
             },
@@ -15528,6 +15770,7 @@
             "integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/pattern": "30.0.1",
                 "@jest/schemas": "30.0.5",
@@ -15546,7 +15789,8 @@
             "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.48.tgz",
             "integrity": "sha512-kKJTNuK3AQOrgjjotVxMrCn1sUJwM76wMszfq1kdU4uYVJjvEWuFQ6HgvLt4Xz3fSmZlTOxJ/Ie13KnIcWQXFA==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/jest-runner/node_modules/ansi-styles": {
             "version": "5.2.0",
@@ -15554,6 +15798,7 @@
             "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=10"
             },
@@ -15567,6 +15812,7 @@
             "integrity": "sha512-Z/j4Bo+4ySJ+JPJN3b2Qbl9hDq3VrXmnjjGEWD/x0BCXeOXPTV1iZYYzl2X8c1MaCOL+ewMyNBcm88sboE6YWw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.27.1",
                 "@jest/types": "30.3.0",
@@ -15588,6 +15834,7 @@
             "integrity": "sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/types": "30.3.0",
                 "@types/node": "*",
@@ -15606,6 +15853,7 @@
             "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "yocto-queue": "^0.1.0"
             },
@@ -15622,6 +15870,7 @@
             "integrity": "sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/schemas": "30.0.5",
                 "ansi-styles": "^5.2.0",
@@ -15637,6 +15886,7 @@
             "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "buffer-from": "^1.0.0",
                 "source-map": "^0.6.0"
@@ -15648,6 +15898,7 @@
             "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=10"
             },
@@ -15661,6 +15912,7 @@
             "integrity": "sha512-CgC+hIBJbuh78HEffkhNKcbXAytQViplcl8xupqeIWyKQF50kCQA8J7GeJCkjisC6hpnC9Muf8jV5RdtdFbGng==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/environment": "30.3.0",
                 "@jest/fake-timers": "30.3.0",
@@ -15695,6 +15947,7 @@
             "integrity": "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@sinclair/typebox": "^0.34.0"
             },
@@ -15708,6 +15961,7 @@
             "integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/pattern": "30.0.1",
                 "@jest/schemas": "30.0.5",
@@ -15726,7 +15980,8 @@
             "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.48.tgz",
             "integrity": "sha512-kKJTNuK3AQOrgjjotVxMrCn1sUJwM76wMszfq1kdU4uYVJjvEWuFQ6HgvLt4Xz3fSmZlTOxJ/Ie13KnIcWQXFA==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/jest-runtime/node_modules/ansi-styles": {
             "version": "5.2.0",
@@ -15734,6 +15989,7 @@
             "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=10"
             },
@@ -15747,6 +16003,7 @@
             "integrity": "sha512-Z/j4Bo+4ySJ+JPJN3b2Qbl9hDq3VrXmnjjGEWD/x0BCXeOXPTV1iZYYzl2X8c1MaCOL+ewMyNBcm88sboE6YWw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.27.1",
                 "@jest/types": "30.3.0",
@@ -15768,6 +16025,7 @@
             "integrity": "sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/types": "30.3.0",
                 "@types/node": "*",
@@ -15786,6 +16044,7 @@
             "integrity": "sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/schemas": "30.0.5",
                 "ansi-styles": "^5.2.0",
@@ -15801,6 +16060,7 @@
             "integrity": "sha512-f14c7atpb4O2DeNhwcvS810Y63wEn8O1HqK/luJ4F6M4NjvxmAKQwBUWjbExUtMxWJQ0wVgmCKymeJK6NZMnfQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/core": "^7.27.4",
                 "@babel/generator": "^7.27.5",
@@ -15834,6 +16094,7 @@
             "integrity": "sha512-j0+W5iQQ8hBh7tHZkTQv3q2Fh/M7Je72cIsYqC4OaktgtO7v1So9UTjp6uPBHIaB6beoF/RRsCgMJKvti0wADA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/get-type": "30.1.0"
             },
@@ -15847,6 +16108,7 @@
             "integrity": "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@sinclair/typebox": "^0.34.0"
             },
@@ -15860,6 +16122,7 @@
             "integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/pattern": "30.0.1",
                 "@jest/schemas": "30.0.5",
@@ -15878,7 +16141,8 @@
             "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.48.tgz",
             "integrity": "sha512-kKJTNuK3AQOrgjjotVxMrCn1sUJwM76wMszfq1kdU4uYVJjvEWuFQ6HgvLt4Xz3fSmZlTOxJ/Ie13KnIcWQXFA==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/jest-snapshot/node_modules/ansi-styles": {
             "version": "5.2.0",
@@ -15886,6 +16150,7 @@
             "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=10"
             },
@@ -15899,6 +16164,7 @@
             "integrity": "sha512-1zQrciTiQfRdo7qJM1uG4navm8DayFa2TgCSRlzUyNkhcJ6XUZF3hjnpkyr3VhAqPH7i/9GkG7Tv5abz6fqz0Q==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/expect-utils": "30.3.0",
                 "@jest/get-type": "30.1.0",
@@ -15917,6 +16183,7 @@
             "integrity": "sha512-n3q4PDQjS4LrKxfWB3Z5KNk1XjXtZTBwQp71OP0Jo03Z6V60x++K5L8k6ZrW8MY8pOFylZvHM0zsjS1RqlHJZQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/diff-sequences": "30.3.0",
                 "@jest/get-type": "30.1.0",
@@ -15933,6 +16200,7 @@
             "integrity": "sha512-HEtc9uFQgaUHkC7nLSlQL3Tph4Pjxt/yiPvkIrrDCt9jhoLIgxaubo1G+CFOnmHYMxHwwdaSN7mkIFs6ZK8OhA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/get-type": "30.1.0",
                 "chalk": "^4.1.2",
@@ -15949,6 +16217,7 @@
             "integrity": "sha512-Z/j4Bo+4ySJ+JPJN3b2Qbl9hDq3VrXmnjjGEWD/x0BCXeOXPTV1iZYYzl2X8c1MaCOL+ewMyNBcm88sboE6YWw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.27.1",
                 "@jest/types": "30.3.0",
@@ -15970,6 +16239,7 @@
             "integrity": "sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/types": "30.3.0",
                 "@types/node": "*",
@@ -15988,6 +16258,7 @@
             "integrity": "sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/schemas": "30.0.5",
                 "ansi-styles": "^5.2.0",
@@ -16003,6 +16274,7 @@
             "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
             "dev": true,
             "license": "ISC",
+            "peer": true,
             "bin": {
                 "semver": "bin/semver.js"
             },
@@ -16063,6 +16335,7 @@
             "integrity": "sha512-I/xzC8h5G+SHCb2P2gWkJYrNiTbeL47KvKeW5EzplkyxzBRBw1ssSHlI/jXec0ukH2q7x2zAWQm7015iusg62Q==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/get-type": "30.1.0",
                 "@jest/types": "30.3.0",
@@ -16081,6 +16354,7 @@
             "integrity": "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@sinclair/typebox": "^0.34.0"
             },
@@ -16094,6 +16368,7 @@
             "integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/pattern": "30.0.1",
                 "@jest/schemas": "30.0.5",
@@ -16112,7 +16387,8 @@
             "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.48.tgz",
             "integrity": "sha512-kKJTNuK3AQOrgjjotVxMrCn1sUJwM76wMszfq1kdU4uYVJjvEWuFQ6HgvLt4Xz3fSmZlTOxJ/Ie13KnIcWQXFA==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/jest-validate/node_modules/ansi-styles": {
             "version": "5.2.0",
@@ -16120,6 +16396,7 @@
             "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=10"
             },
@@ -16133,6 +16410,7 @@
             "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=10"
             },
@@ -16146,6 +16424,7 @@
             "integrity": "sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/schemas": "30.0.5",
                 "ansi-styles": "^5.2.0",
@@ -16161,6 +16440,7 @@
             "integrity": "sha512-PJ1d9ThtTR8aMiBWUdcownq9mDdLXsQzJayTk4kmaBRHKvwNQn+ANveuhEBUyNI2hR1TVhvQ8D5kHubbzBHR/w==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/test-result": "30.3.0",
                 "@jest/types": "30.3.0",
@@ -16181,6 +16461,7 @@
             "integrity": "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@sinclair/typebox": "^0.34.0"
             },
@@ -16194,6 +16475,7 @@
             "integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/pattern": "30.0.1",
                 "@jest/schemas": "30.0.5",
@@ -16212,7 +16494,8 @@
             "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.48.tgz",
             "integrity": "sha512-kKJTNuK3AQOrgjjotVxMrCn1sUJwM76wMszfq1kdU4uYVJjvEWuFQ6HgvLt4Xz3fSmZlTOxJ/Ie13KnIcWQXFA==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/jest-watcher/node_modules/jest-util": {
             "version": "30.3.0",
@@ -16220,6 +16503,7 @@
             "integrity": "sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/types": "30.3.0",
                 "@types/node": "*",
@@ -16238,6 +16522,7 @@
             "integrity": "sha512-DrCKkaQwHexjRUFTmPzs7sHQe0TSj9nvDALKGdwmK5mW9v7j90BudWirKAJHt3QQ9Dhrg1F7DogPzhChppkJpQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/node": "*",
                 "@ungap/structured-clone": "^1.3.0",
@@ -16255,6 +16540,7 @@
             "integrity": "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@sinclair/typebox": "^0.34.0"
             },
@@ -16268,6 +16554,7 @@
             "integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/pattern": "30.0.1",
                 "@jest/schemas": "30.0.5",
@@ -16286,7 +16573,8 @@
             "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.48.tgz",
             "integrity": "sha512-kKJTNuK3AQOrgjjotVxMrCn1sUJwM76wMszfq1kdU4uYVJjvEWuFQ6HgvLt4Xz3fSmZlTOxJ/Ie13KnIcWQXFA==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/jest-worker/node_modules/jest-util": {
             "version": "30.3.0",
@@ -16294,6 +16582,7 @@
             "integrity": "sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/types": "30.3.0",
                 "@types/node": "*",
@@ -16312,6 +16601,7 @@
             "integrity": "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@sinclair/typebox": "^0.34.0"
             },
@@ -16325,6 +16615,7 @@
             "integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/pattern": "30.0.1",
                 "@jest/schemas": "30.0.5",
@@ -16343,7 +16634,8 @@
             "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.48.tgz",
             "integrity": "sha512-kKJTNuK3AQOrgjjotVxMrCn1sUJwM76wMszfq1kdU4uYVJjvEWuFQ6HgvLt4Xz3fSmZlTOxJ/Ie13KnIcWQXFA==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/jiti": {
             "version": "1.21.7",
@@ -16414,6 +16706,7 @@
             "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "argparse": "^1.0.7",
                 "esprima": "^4.0.0"
@@ -16501,7 +16794,6 @@
             "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "mdn-data": "2.27.1",
                 "source-map-js": "^1.2.1"
@@ -16595,7 +16887,8 @@
             "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
             "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/json-schema": {
             "version": "0.4.0",
@@ -16710,6 +17003,7 @@
             "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=6"
             }
@@ -17294,6 +17588,7 @@
             "integrity": "sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==",
             "dev": true,
             "license": "BSD-3-Clause",
+            "peer": true,
             "dependencies": {
                 "tmpl": "1.0.5"
             }
@@ -17557,6 +17852,7 @@
             "integrity": "sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "napi-postinstall": "lib/cli.js"
             },
@@ -17618,7 +17914,8 @@
             "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
             "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/node-releases": {
             "version": "2.0.19",
@@ -17942,6 +18239,7 @@
             "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.0.0",
                 "error-ex": "^1.3.1",
@@ -18030,6 +18328,7 @@
             "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -18151,7 +18450,6 @@
             "integrity": "sha512-khUlZSwt9xXCaTbbxFYBKDc/bWAGWJjOgvxETwkTN7KRm66EeT1ZdZj6i2ceh9sP2Pzqsbc704r2yngBrxBVug==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@vue/devtools-api": "^6.6.3",
                 "vue-demi": "^0.14.10"
@@ -18315,7 +18613,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "nanoid": "^3.3.11",
                 "picocolors": "^1.1.1",
@@ -18618,7 +18915,8 @@
                     "url": "https://opencollective.com/fast-check"
                 }
             ],
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/qrcode": {
             "version": "1.5.4",
@@ -19062,6 +19360,7 @@
             "integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "resolve-from": "^5.0.0"
             },
@@ -19075,6 +19374,7 @@
             "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -19587,7 +19887,8 @@
             "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
             "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
             "dev": true,
-            "license": "BSD-3-Clause"
+            "license": "BSD-3-Clause",
+            "peer": true
         },
         "node_modules/sshpk": {
             "version": "1.18.0",
@@ -19754,6 +20055,7 @@
             "integrity": "sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "char-regex": "^1.0.2",
                 "strip-ansi": "^6.0.0"
@@ -19883,6 +20185,7 @@
             "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -19903,6 +20206,7 @@
             "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=8"
             },
@@ -20120,6 +20424,7 @@
             "integrity": "sha512-Bh7QjT8/SuKUIfObSXNHNSK6WHo6J1tHCqJsuaFDP7gP0fkzSfTxI8y85JrppZ0h8l0maIgc2tfuZQ6/t3GtnQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@pkgr/core": "^0.2.9"
             },
@@ -20136,7 +20441,6 @@
             "integrity": "sha512-w33E2aCvSDP0tW9RZuNXadXlkHXqFzSkQew/aIa2i/Sj8fThxwovwlXHSPXTbAHwEIhBFXAedUhP2tueAKP8Og==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@alloc/quick-lru": "^5.2.0",
                 "arg": "^5.0.2",
@@ -20411,7 +20715,8 @@
             "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
             "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
             "dev": true,
-            "license": "BSD-3-Clause"
+            "license": "BSD-3-Clause",
+            "peer": true
         },
         "node_modules/to-regex-range": {
             "version": "5.0.1",
@@ -20561,7 +20866,6 @@
             "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@cspotcode/source-map-support": "^0.8.0",
                 "@tsconfig/node10": "^1.0.7",
@@ -20666,6 +20970,7 @@
             "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=4"
             }
@@ -20767,7 +21072,6 @@
             "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
             "devOptional": true,
             "license": "Apache-2.0",
-            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -21120,6 +21424,7 @@
             "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "napi-postinstall": "^0.3.0"
             },
@@ -21300,7 +21605,6 @@
             "integrity": "sha512-t7g7GVRpMXjNpa67HaVWI/8BWtdVIQPCL2WoozXXA7LBGEFK4AkkKkHx2hAQf5x1GZSlcmEDPkVLSGahxnEEZw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "lightningcss": "^1.32.0",
                 "picomatch": "^4.0.4",
@@ -21583,7 +21887,6 @@
             "integrity": "sha512-xjR1dMTVHlFLh98JE3i/f/WePqJsah4A0FK9cc8Ehp9Udk0AZk6ccpIZhh1qJ/yxVWRZ+Q54ocnD8TXmkhspGg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@vitest/expect": "4.1.2",
                 "@vitest/mocker": "4.1.2",
@@ -21716,7 +22019,6 @@
             "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.17.tgz",
             "integrity": "sha512-LbHV3xPN9BeljML+Xctq4lbz2lVHCR6DtbpTf5XIO6gugpXUN49j2QQPcMj086r9+AkJ0FfUT8xjulKKBkkr9g==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@vue/compiler-dom": "3.5.17",
                 "@vue/compiler-sfc": "3.5.17",
@@ -21780,7 +22082,6 @@
             "integrity": "sha512-Vxi9pJdbN3ZnVGLODVtZ7y4Y2kzAAE2Cm0CZ3ZDRvydVYxZ6VrnBhLikBsRS+dpwj4Jv4UCv21PTEwF5rQ9WXg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "debug": "^4.4.0",
                 "eslint-scope": "^8.2.0 || ^9.0.0",
@@ -21830,7 +22131,6 @@
             "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.5.1.tgz",
             "integrity": "sha512-ogAF3P97NPm8fJsE4by9dwSYtDwXIY1nFY9T6DyQnGHd1E2Da94w9JIolpe42LJGIl0DwOHBi8TcRPlPGwbTtw==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@vue/devtools-api": "^6.6.4"
             },
@@ -21986,6 +22286,7 @@
             "integrity": "sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==",
             "dev": true,
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "makeerror": "1.0.12"
             }
@@ -22301,6 +22602,7 @@
             "integrity": "sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==",
             "dev": true,
             "license": "ISC",
+            "peer": true,
             "dependencies": {
                 "imurmurhash": "^0.1.4",
                 "signal-exit": "^4.0.1"
@@ -22315,6 +22617,7 @@
             "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
             "dev": true,
             "license": "ISC",
+            "peer": true,
             "engines": {
                 "node": ">=14"
             },

--- a/trust/Makefile
+++ b/trust/Makefile
@@ -155,7 +155,8 @@ build:
 	$(TRUST_1_VARS) ${DOCKER_COMPOSE_CMD} -p ${trust1} build --no-cache
 	$(TRUST_2_VARS) ${DOCKER_COMPOSE_CMD} -p ${trust2} build
 
-# Uses --pull always to ensure the latest FL images and omop-db image are used
+# Pull/build behaviour is governed by $(UP_PULL_FLAGS): pulls fresh FL images
+# when DOCKER_FL_REGISTRY is set, builds from source on BUILD=true, no-op otherwise.
 # ensure omop and orthanc data are up to date before bringing up trust 1
 up-trust-1: update-omop-data update-orthanc-data
 	@echo "🚢 Starting Trust 1 services..."
@@ -207,7 +208,8 @@ down-local-trust:
 	$(LOCAL_TRUST_VARS) \
 		$(DOCKER_COMPOSE_CMD) -f deploy/compose_trust.local.yml -p $(trust_local) down --remove-orphans
 
-# Uses --pull always to ensure the latest FL images and omop-db image are used
+# Pull/build behaviour is governed by $(UP_PULL_FLAGS): pulls fresh FL images
+# when DOCKER_FL_REGISTRY is set, builds from source on BUILD=true, no-op otherwise.
 # ensure omop and orthanc data are up to date before bringing up trust 2
 up-trust-2: update-omop-data update-orthanc-data
 	@echo "🚢 Starting Trust 2 services..."

--- a/trust/Makefile
+++ b/trust/Makefile
@@ -59,13 +59,25 @@ ORTHANC_CMD=make -C ./orthanc
 DOCKER_COMPOSE_CMD=docker compose --project-directory . -f $(COMMON_COMPOSE_FILE) -f $(FL_BACKEND_COMPOSE_FILE)
 DEBUG_OVERRIDE_COMPOSE_COMMAND=docker compose --project-directory . -f $(COMMON_COMPOSE_FILE) -f $(FL_BACKEND_COMPOSE_FILE) -f deploy/compose_trust.debug.override.yml
 
-# NOTE DOCKER_FL_REGISTRY is set to empty when we use local FL images during development (e.g. flare-fl-client:dev).
-# In that case, '--pull always' will error because docker won't be able to find the manifest for the dev image online,
-# so we need to remove the --pull always flag. Non-FL images keep DOCKER_REGISTRY (always GHCR).
-ifneq ($(strip $(DOCKER_FL_REGISTRY)),)
-PULL_ALWAYS_FLAG=--pull always
+# UP_PULL_FLAGS controls the pull/build behaviour of the up-trust targets.
+#
+# Default: repo-built services (trust-api, imaging-api, data-access-api, orthanc)
+# carry `pull_policy: always` in compose_trust.development.yml, so they always
+# pull from GHCR on their own. This flag only adds the global `--pull always`
+# that keeps FL images fresh — dropped when DOCKER_FL_REGISTRY is empty (local
+# `:dev` FL images, e.g. flare-fl-client:dev), since docker can't pull an
+# unpublished manifest and `--pull always` would error.
+#
+# BUILD=true: rebuild the repo-built services from source instead of pulling.
+# `--build` forces the build; `--pull missing` overrides the per-service
+# `pull_policy: always` for this run so the fresh build isn't re-pulled away.
+# Propagated automatically from `make up BUILD=true` at the repo root.
+ifeq ($(BUILD),true)
+UP_PULL_FLAGS=--build --pull missing
+else ifneq ($(strip $(DOCKER_FL_REGISTRY)),)
+UP_PULL_FLAGS=--pull always
 else
-PULL_ALWAYS_FLAG=
+UP_PULL_FLAGS=
 endif
 
 TRUST_1_VARS = \
@@ -150,7 +162,7 @@ up-trust-1: update-omop-data update-orthanc-data
 	@echo "⚙️ Using environment file ${MAIN_ENV_FILE}"
 	@echo "🧠 FL_BACKEND=$(FL_BACKEND) ($(FL_BACKEND_COMPOSE_FILE))"
 	mkdir -p ${BASE_IMAGES_DOWNLOAD_DIR_TRUST1}
-	$(TRUST_1_VARS) DEBUG=${DEBUG} ${DOCKER_COMPOSE_CMD} -f deploy/compose_trust-1_override.yml -p ${trust1} up -d $(PULL_ALWAYS_FLAG)
+	$(TRUST_1_VARS) DEBUG=${DEBUG} ${DOCKER_COMPOSE_CMD} -f deploy/compose_trust-1_override.yml -p ${trust1} up -d $(UP_PULL_FLAGS)
 
 down-trust-1:
 	@echo "🛑 Stopping Trust 1 services..."
@@ -202,7 +214,7 @@ up-trust-2: update-omop-data update-orthanc-data
 	@echo "⚙️ Using environment file ${MAIN_ENV_FILE}"
 	@echo "🧠 FL_BACKEND=$(FL_BACKEND) ($(FL_BACKEND_COMPOSE_FILE))"
 	mkdir -p ${BASE_IMAGES_DOWNLOAD_DIR_TRUST2}
-	$(TRUST_2_VARS) ${DOCKER_COMPOSE_CMD} -p ${trust2} up -d $(PULL_ALWAYS_FLAG)
+	$(TRUST_2_VARS) ${DOCKER_COMPOSE_CMD} -p ${trust2} up -d $(UP_PULL_FLAGS)
 
 down-trust-2:
 	@echo "🛑 Stopping Trust 2 services..."
@@ -218,8 +230,8 @@ down: down-trust-1 down-trust-2
 # Each dev trust project (trust1, trust2) runs a client per FL net, hence both net-1 and net-2.
 up-fl-clients:
 	@echo "🚢 Starting FL clients..."
-	$(TRUST_1_VARS) DEBUG=${DEBUG} ${DOCKER_COMPOSE_CMD} -f deploy/compose_trust-1_override.yml -p ${trust1} up -d --no-deps $(PULL_ALWAYS_FLAG) fl-client-net-1 fl-client-net-2
-	$(TRUST_2_VARS) ${DOCKER_COMPOSE_CMD} -p ${trust2} up -d --no-deps $(PULL_ALWAYS_FLAG) fl-client-net-1 fl-client-net-2
+	$(TRUST_1_VARS) DEBUG=${DEBUG} ${DOCKER_COMPOSE_CMD} -f deploy/compose_trust-1_override.yml -p ${trust1} up -d --no-deps $(UP_PULL_FLAGS) fl-client-net-1 fl-client-net-2
+	$(TRUST_2_VARS) ${DOCKER_COMPOSE_CMD} -p ${trust2} up -d --no-deps $(UP_PULL_FLAGS) fl-client-net-1 fl-client-net-2
 
 down-fl-clients:
 	@echo "🛑 Stopping and removing FL clients..."
@@ -295,4 +307,3 @@ debug-trust-api-off:
 integration_test:
 	$(MAKE) -C data-access-api integration_test
 	$(MAKE) -C trust-api integration_test
-

--- a/trust/deploy/compose_trust.development.yml
+++ b/trust/deploy/compose_trust.development.yml
@@ -31,6 +31,9 @@ services:
       - ./omop-db/volumes/${TRUST_NAME}/db_data:/var/lib/postgresql/data
 
   orthanc:
+    # Pull from GHCR by default; `make up BUILD=true` rebuilds from build: below.
+    image: ghcr.io/londonaicentre/orthanc:${DOCKER_TAG}
+    pull_policy: always
     build:
       context: ./orthanc
       dockerfile: Dockerfile
@@ -47,6 +50,10 @@ services:
           {"XNAT": {"AET": "XNAT", "Host": "xnat-web", "Port": "${XNAT_PORT}"}}
 
   imaging-api:
+    # Pull from GHCR by default; local imaging_api/ bind-mount overlays it for
+    # live reload. `make up BUILD=true` rebuilds from the build: block instead.
+    image: ghcr.io/londonaicentre/imaging-api:${DOCKER_TAG}
+    pull_policy: always
     build:
       args:
         UID: ${UID}
@@ -82,6 +89,10 @@ services:
       - ./observability/log_config:/app/log_config:ro
 
   data-access-api:
+    # Pull from GHCR by default; local data_access_api/ bind-mount overlays it for
+    # live reload. `make up BUILD=true` rebuilds from the build: block instead.
+    image: ghcr.io/londonaicentre/data-access-api:${DOCKER_TAG}
+    pull_policy: always
     build:
       args:
         UID: ${UID}
@@ -111,6 +122,10 @@ services:
       - ./observability/log_config:/app/log_config:ro
 
   trust-api:
+    # Pull from GHCR by default; local trust_api/ bind-mount overlays it for live
+    # reload. `make up BUILD=true` rebuilds from the build: block instead.
+    image: ghcr.io/londonaicentre/trust-api:${DOCKER_TAG}
+    pull_policy: always
     build:
       args:
         UID: ${UID}


### PR DESCRIPTION
# Description

Two related CI/dev-workflow changes to stop the `--pull always` flag from silently building images, and to gate GHCR publishes on tests.

**1. Dev `make up` pulls from GHCR by default (was: built from source).**
The repo-built services (`flip-api`, `trust-api`, `imaging-api`, `data-access-api`, `orthanc`) now carry `image:` + `pull_policy: always` in the dev compose files, with local `src/` bind-mounted on top — so live reload still runs your working copy, but the environment comes from the published image instead of a local build. Root cause of the original symptom: `--pull always` is a no-op for a service that has `build:` and no `image:`, so Compose built them.
- `make up BUILD=true` opts back into a from-source rebuild (needed after `uv.lock`/`pyproject.toml`/`Dockerfile` changes). Implemented by replacing `PULL_ALWAYS_FLAG` with `UP_PULL_FLAGS` in both Makefiles.
- `flip-ui` is unchanged (no published GHCR image; it always builds locally).
- Stag/prod (`PROD=stag|true`) unchanged — `PROD` still controls source-mounting.

**2. Build workflows publish only after tests pass.**
The four application `docker_build_*.yml` workflows now trigger via `workflow_run` on their matching test suite (`FLIP API CI`, `Trust - Trust API CI`, `Trust - Imaging API CI`, `Trust - Data Access API CI`), gated on `conclusion == 'success'`. A red test run never publishes. Also fixed the tag derivation to use the **tested commit's** `head_sha`/`head_branch` rather than the default-branch ref (latent bug under `workflow_run`).
- Per-service gating (each image waits on its own suite).
- `orthanc`/`xnat_*` keep their direct push trigger (no test suite to gate on); `workflow_dispatch` still bypasses the gate for manual branch builds.
- **Deploy caveat:** `workflow_run` triggers only take effect once these files are on the default branch; the introducing merge won't retroactively publish.

## Linked Issues

Fixes #

## Checklist

- [x] Follows the project's coding conventions and style guide
- [x] Updates documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Type of Change

- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] In-line docstrings updated.
- [x] Documentation updated (CLAUDE.md, CONTRIBUTING.md).

## Testing

- Validated both dev compose files with `docker compose config` (exit 0); confirmed the five services render `image:` + `pull_policy: always` and `flip-ui` stays build-only.
- Verified `UP_PULL_FLAGS` resolves correctly across all branches (default / `BUILD=true` / empty `DOCKER_FL_REGISTRY`) in both Makefiles.
- YAML-parsed all four build workflows and confirmed `workflow_run.workflows` names exactly match the test workflows' `name:` fields.

## Additional Notes

CI workflow behaviour can only be fully verified once merged to the default branch (the `workflow_run` trigger constraint noted above).
