### PR TITLE
feat(xnat): upgrade XNAT to 1.10.0

### DIFF
--- a/.github/workflows/docker_build_xnat_web.yml
+++ b/.github/workflows/docker_build_xnat_web.yml
@@ -39,7 +39,7 @@ jobs:
       IMAGE_NAME: londonaicentre/xnat-web
       FLIP_ARTIFACTS_BUCKET_NAME: flipdev-artifacts
       BUILD_ARGS: |
-        --build-arg XNAT_VERSION=1.9.3
+        --build-arg XNAT_VERSION=1.10.0
         --build-arg XNAT_SMTP_ENABLED=false
         --build-arg XNAT_DATASOURCE_DRIVER=org.postgresql.Driver
         --build-arg XNAT_DATASOURCE_USERNAME=xnat
@@ -113,7 +113,7 @@ jobs:
         run: echo "$GH_TOKEN" | docker login $REGISTRY -u "$GH_ACTOR" --password-stdin
 
       - name: Download XNAT WAR
-        run: aws s3 cp s3://${{ env.FLIP_ARTIFACTS_BUCKET_NAME }}/xnat/xnat-web-1.9.3.war build-artifacts/xnat-web-1.9.3.war
+        run: aws s3 cp s3://${{ env.FLIP_ARTIFACTS_BUCKET_NAME }}/xnat/xnat-web-1.10.0.war build-artifacts/xnat-web-1.10.0.war
 
       - name: Download XNAT plugins
         run: aws s3 sync s3://${{ env.FLIP_ARTIFACTS_BUCKET_NAME }}/xnat/plugins/ plugins/

--- a/trust/xnat/.env
+++ b/trust/xnat/.env
@@ -6,7 +6,7 @@
 # Modifications Copyright (c) 2026,
 # Guy's and St Thomas' NHS Foundation Trust & King's College London
 
-XNAT_VERSION=1.9.3
+XNAT_VERSION=1.10.0
 XNAT_MIN_HEAP=1024m
 XNAT_MAX_HEAP=3072m
 XNAT_SMTP_ENABLED=false

--- a/trust/xnat/README.md
+++ b/trust/xnat/README.md
@@ -76,14 +76,14 @@ Plugins and the XNAT WAR are stored in S3 at `s3://<FLIP_ARTIFACTS_BUCKET_NAME>/
 
 Make sure to always use the correct version of the plugins that are compatible with the XNAT version specified. Check the plugin's compatibility matrix for more information (for example, see [DQR Plugin Compatibility Matrix](https://wiki.xnat.org/xnat-tools/dqr-plugin-compatibility-matrix)).
 
-The following table lists the compatible versions of the plugins for the XNAT version `1.9.3` used in this environment.
+The following table lists the compatible versions of the plugins for the XNAT version `1.10.0` used in this environment. XNAT 1.10.0 is the first release compiled against JDK 21, so every plugin in S3 must be rebuilt against the 1.10-compatible plugin release line — older 1.9-era JARs will not load. Check each plugin's compatibility matrix (e.g. [Container Service](https://wiki.xnat.org/container-service/container-service-compatibility-matrix), [DQR](https://wiki.xnat.org/xnat-tools/dqr-plugin-compatibility-matrix)) before uploading replacements to `s3://<FLIP_ARTIFACTS_BUCKET_NAME>/xnat/plugins/`.
 
-| Plugin                          | Version for XNAT 1.9.3  |
+| Plugin                          | Version for XNAT 1.10.0 |
 | ------------------------------- | ----------------------- |
-| Container Service Plugin        | 3.7.3                   |
-| Batch Launch Plugin             | 0.9.0                   |
-| DICOM Query-Retrieve Plugin     | 2.2.0                   |
-| OHIF Viewer Plugin              | 3.7.1                   |
+| Container Service Plugin        | TBD (1.10-compatible)   |
+| Batch Launch Plugin             | TBD (1.10-compatible)   |
+| DICOM Query-Retrieve Plugin     | TBD (1.10-compatible)   |
+| OHIF Viewer Plugin              | TBD (1.10-compatible)   |
 
 ### Adding or updating a plugin
 

--- a/trust/xnat/xnat/Dockerfile
+++ b/trust/xnat/xnat/Dockerfile
@@ -6,7 +6,7 @@
 # Modifications Copyright (c) 2026,
 # Guy's and St Thomas' NHS Foundation Trust & King's College London
 
-FROM tomcat:9.0.108-jdk8-temurin-noble AS development
+FROM tomcat:9.0.108-jdk21-temurin-noble AS development
 
 ARG XNAT_VERSION=${XNAT_VERSION}
 ARG XNAT_ROOT=${XNAT_ROOT}

--- a/trust/xnat/xnat/config/anon_script.das
+++ b/trust/xnat/xnat/config/anon_script.das
@@ -1,6 +1,6 @@
 version "6.3"
 // FLIP Site-Wide DICOM Anonymization Script
-// Compatible with XNAT 1.9.3 (DicomEdit 6.7.x)
+// Compatible with XNAT 1.10.0 (DicomEdit 6.x)
 //
 // This script is applied to all incoming DICOM data when anonymizationEnabled
 // is set to true on the SCP receiver. It removes Protected Health Information


### PR DESCRIPTION
## Summary

Bumps the mocked XNAT service from **1.9.3 → 1.10.0**. Closes #549.

XNAT 1.10 is the first release compiled against **JDK 21** ([release announcement](https://wiki.xnat.org/news/announcing-the-alpha-release-of-xnat-1-10-compiled), [1.10.0 tag](https://github.com/NrgXnat/xnat/tree/1.10.0)), so the Tomcat base image moves to a JDK 21 variant. Tomcat 9 itself is unchanged — XNAT 1.10 still targets Tomcat 9 to keep plugin breakage manageable.

## Release notes findings

From the XNAT 1.10.0 source (the wiki release-notes page is gated, so I read the tag directly):

- **Java**: JDK 21 required (was JDK 8). Confirmed in `1.10.0/README.md` and `gradle/libs.versions.toml`.
- **Tomcat**: Tomcat Embed 9.0.93 — still Tomcat 9.
- **PostgreSQL**: 12+ supported (no change for us — we run `postgres:12.2-alpine`).
- **WAR layout**: file naming unchanged (`xnat-web-1.10.0.war`).
- **Monorepo restructure**: XNAT consolidated 25 plugin/library repos into a single Gradle 9 monorepo. This is a **plugin-build** breaking change, not a runtime one for us — but every plugin JAR must be rebuilt against the 1.10 plugin release line. 1.9-era JARs will not load (different transitive deps, compiled against JDK 8). See the [1.10 plugin migration guide](https://github.com/NrgXnat/xnat/blob/1.10.0/docs/plugin-migration-guide.md).
- **Spring 5.3.39 / Hibernate 5.6.15 / PostgreSQL JDBC 42.7.3 / DCM4CHE 5.33.1** — bumps come baked into the WAR; no FLIP-side change.
- **DicomEdit**: still on the v6 line (`dicom-edit6` module). The anon script header is updated but the rule set is unchanged — the existing test pack still passes.

## Changes

- `trust/xnat/.env` — `XNAT_VERSION` 1.9.3 → 1.10.0
- `trust/xnat/xnat/Dockerfile` — base image `tomcat:9.0.108-jdk8-temurin-noble` → `tomcat:9.0.108-jdk21-temurin-noble`
- `.github/workflows/docker_build_xnat_web.yml` — `--build-arg XNAT_VERSION` and the WAR S3 path bumped
- `trust/xnat/xnat/config/anon_script.das` — comment header updated
- `trust/xnat/README.md` — plugin compatibility table updated; the specific plugin versions are left as `TBD (1.10-compatible)` because the wiki compatibility matrices are gated and the actual JARs need to be rebuilt against the 1.10 plugin line before we know the exact tags we'll publish. Operator picks the versions when uploading to S3.

## Operational follow-ups (outside this PR)

These have to happen before the image actually boots in CI/stag — the build will otherwise fail at the S3-download step.

- [ ] Upload `xnat-web-1.10.0.war` to `s3://<FLIP_ARTIFACTS_BUCKET_NAME>/xnat/`.
- [ ] Rebuild Container Service, Batch Launch, DQR, OHIF Viewer plugins against the XNAT 1.10 plugin release line and upload to `s3://<FLIP_ARTIFACTS_BUCKET_NAME>/xnat/plugins/`. Remove the 1.9-era JARs.
- [ ] Fill in the concrete plugin versions in `trust/xnat/README.md`.
- [ ] Trigger `docker_build_xnat_web.yml` via `workflow_dispatch` against this branch to validate the image build end-to-end.

## Test plan

- [x] `make unit_test` from `trust/xnat/tests` — 83 anonymization tests pass; ruff + mypy clean.
- [ ] `make build` against XNAT subdir after the WAR + plugins are in S3.
- [ ] `make up` from `trust/xnat/` — verify XNAT boots, admin login works, PACS registration succeeds.
- [ ] End-to-end smoke (`make e2e_smoke` from repo root) once the trust stack is up against XNAT 1.10.

https://claude.ai/code/session_01FxjEbUaMvLz9VaRPpW3jDB

---
_Generated by [Claude Code](https://claude.ai/code/session_01FxjEbUaMvLz9VaRPpW3jDB)_

## Acceptance Criteria

*Imported from issue #549*

-