### PR TITLE
fix(flip-ui): lint all of src/ instead of only shallow files

### DIFF
--- a/flip-ui/eslint.config.mjs
+++ b/flip-ui/eslint.config.mjs
@@ -102,6 +102,21 @@ export default defineConfigWithVueTs(
     },
 
     {
+        name: "flip-ui/legacy-single-word-components",
+        // Grandfathered single-word component names that predate the multi-word rule.
+        // Renaming them ripples across imports and templates app-wide, so the exception is
+        // scoped to these specific files; the rule still applies to every other partial.
+        files: [
+            "src/partials/models/Timeline.vue",
+            "src/partials/models/Training.vue",
+            "src/partials/projects/Filter.vue",
+        ],
+        rules: {
+            "vue/multi-word-component-names": "off",
+        },
+    },
+
+    {
         name: "flip-ui/tests",
         files: [
             "**/__tests__/**/*.{js,ts,jsx,tsx}",

--- a/flip-ui/package.json
+++ b/flip-ui/package.json
@@ -15,7 +15,7 @@
         "build:deploy": "vite build",
         "serve": "vite preview",
         "test:unit": "vitest run --silent --coverage",
-        "lint": "npx eslint ./src/**/*.vue ./src/**/*.ts",
+        "lint": "npx eslint \"./src/**/*.vue\" \"./src/**/*.ts\"",
         "prepare": "husky install",
         "test:unit:update": "vitest run -u --silent --coverage",
         "test:unit:watch": "vitest watch --silent",

--- a/flip-ui/src/components/AiAlert/__tests__/AiAlert.test.ts
+++ b/flip-ui/src/components/AiAlert/__tests__/AiAlert.test.ts
@@ -52,9 +52,7 @@ describe("Ai Alert", () => {
         const comp = mount(AiAlert, {
             global: { plugins: [createPinia()] },
             props: { variant: "info" },
-            slots: {
-                default: "<strong data-test=\"slot-marker\">authored content</strong>"
-            }
+            slots: { default: "<strong data-test=\"slot-marker\">authored content</strong>" }
         });
 
         const html = comp.html();

--- a/flip-ui/src/components/AiModal/confirmsTypedValue.ts
+++ b/flip-ui/src/components/AiModal/confirmsTypedValue.ts
@@ -29,5 +29,6 @@ export function confirmsTypedValue(
         return true;
     }
     const typedStr = (typed ?? "").toString();
+
     return typedStr.toUpperCase() === expected.toUpperCase();
 }

--- a/flip-ui/src/components/AiSelect/__tests__/AiChipSelect.spec.ts
+++ b/flip-ui/src/components/AiSelect/__tests__/AiChipSelect.spec.ts
@@ -31,15 +31,30 @@ describe("AI Chip Select", () => {
 });
 
 describe("AI Chip Select — script logic", () => {
-    const optionA: IOption = { id: "1", description: "Admin" };
-    const optionB: IOption = { id: "2", description: "Researcher" };
+    const optionA: IOption = {
+        id: "1",
+        description: "Admin"
+    };
+    const optionB: IOption = {
+        id: "2",
+        description: "Researcher"
+    };
 
     const fieldEntry = (option: IOption, key = option.id): FieldEntry =>
-        ({ key, value: option, isFirst: false, isLast: false } as FieldEntry);
+        ({
+            key,
+            value: option,
+            isFirst: false,
+            isLast: false
+        } as FieldEntry);
 
     it("emits push + validate when a new option is selected", async () => {
         const component = mountComponent(AiChipSelect, {
-            props: { options: [optionA, optionB], selectedOptions: [], defaultText: "Select role" },
+            props: {
+                options: [optionA, optionB],
+                selectedOptions: [],
+                defaultText: "Select role"
+            }
         });
 
         // Drive the internal ref directly. Headlessui Listbox doesn't open in
@@ -60,8 +75,8 @@ describe("AI Chip Select — script logic", () => {
             props: {
                 options: [optionA, optionB],
                 selectedOptions: [fieldEntry(optionA)],
-                defaultText: "Select role",
-            },
+                defaultText: "Select role"
+            }
         });
 
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -77,8 +92,8 @@ describe("AI Chip Select — script logic", () => {
             props: {
                 options: [optionA, optionB],
                 selectedOptions: [fieldEntry(optionA), fieldEntry(optionB)],
-                defaultText: "Select role",
-            },
+                defaultText: "Select role"
+            }
         });
 
         const chips = component.findAllComponents({ name: "AiButton" });
@@ -93,18 +108,18 @@ describe("AI Chip Select — script logic", () => {
             props: {
                 options: [optionA, optionB],
                 selectedOptions: [fieldEntry(optionA)],
-                defaultText: "Select role",
-            },
+                defaultText: "Select role"
+            }
         });
 
         // Open the Listbox so the v-for over options actually renders, which
         // is the only path that exercises selectedOptionsInclude(). Headlessui
         // requires a real click on its ListboxButton; trigger() on the
         // wrapper element does the job in jsdom once attachTo is set.
-        await component.get('[aria-haspopup="listbox"]').trigger("click");
+        await component.get("[aria-haspopup=\"listbox\"]").trigger("click");
         await nextTick();
 
-        const optionElements = component.findAll('[data-test="chip-select-option"]');
+        const optionElements = component.findAll("[data-test=\"chip-select-option\"]");
         expect(optionElements).toHaveLength(2);
         // The check icon renders as an inline <svg> only when
         // selectedOptionsInclude returns true. optionA is in selectedOptions
@@ -120,8 +135,8 @@ describe("AI Chip Select — script logic", () => {
             props: {
                 options: [optionA, optionB],
                 selectedOptions: [fieldEntry(optionA), fieldEntry(optionB)],
-                defaultText: "Select role",
-            },
+                defaultText: "Select role"
+            }
         });
 
         // The chips render via AiButton (a <button> wrapper) and the @click
@@ -141,8 +156,8 @@ describe("AI Chip Select — script logic", () => {
             props: {
                 options: [optionA, optionB],
                 selectedOptions: [fieldEntry(optionA)],
-                defaultText: "Select role",
-            },
+                defaultText: "Select role"
+            }
         });
 
         // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/flip-ui/src/env.d.ts
+++ b/flip-ui/src/env.d.ts
@@ -32,7 +32,7 @@ interface Window {
 
 declare module "*.vue" {
     import { DefineComponent } from "vue";
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/ban-types
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-empty-object-type
     const component: DefineComponent<{}, {}, any>;
     export default component;
 }

--- a/flip-ui/src/pages/__tests__/ConnectionStatus.spec.ts
+++ b/flip-ui/src/pages/__tests__/ConnectionStatus.spec.ts
@@ -45,7 +45,10 @@ const stubs = {
 function mountConnectionStatus() {
     return mount(ConnectionStatus, {
         global: {
-            plugins: [createTestingPinia({ createSpy: vi.fn, stubActions: false })],
+            plugins: [createTestingPinia({
+                createSpy: vi.fn,
+                stubActions: false
+            })],
             stubs,
             directives: { highlightjs: () => {} }
         }
@@ -64,7 +67,11 @@ describe("ConnectionStatus", () => {
 
     it("renders nvflare backend as 'NVFlare' next to the NET title", () => {
         mockSwrvData.value = [
-            { name: "net-1", fl_backend: "nvflare", clients: [] }
+            {
+                name: "net-1",
+                fl_backend: "nvflare",
+                clients: []
+            }
         ];
         const wrapper = mountConnectionStatus();
         const titles = wrapper.findAll("h3");
@@ -75,7 +82,11 @@ describe("ConnectionStatus", () => {
 
     it("renders flower backend as 'Flower' next to the NET title", () => {
         mockSwrvData.value = [
-            { name: "net-2", fl_backend: "flower", clients: [] }
+            {
+                name: "net-2",
+                fl_backend: "flower",
+                clients: []
+            }
         ];
         const wrapper = mountConnectionStatus();
         const titles = wrapper.findAll("h3");
@@ -86,7 +97,10 @@ describe("ConnectionStatus", () => {
 
     it("omits parentheses when fl_backend is absent", () => {
         mockSwrvData.value = [
-            { name: "net-1", clients: [] }
+            {
+                name: "net-1",
+                clients: []
+            }
         ];
         const wrapper = mountConnectionStatus();
         const titles = wrapper.findAll("h3");

--- a/flip-ui/src/pages/admin/users.vue
+++ b/flip-ui/src/pages/admin/users.vue
@@ -393,7 +393,7 @@ const saveUser = async () => {
             text: "The user's permissions have been updated.",
             title: "User updated"
         });
-    } catch (e) {
+    } catch {
         Snackbar.error({
             text: "The user could not be updated, please try again.",
             title: "Update failed"
@@ -424,7 +424,7 @@ const updateUserState = async (disabled: boolean) => {
         const state: IUserDisabledStateDto = { disabled: disabled };
         await updateUserDisabledState(selectedUser.value?.id as string, state);
         await refreshUsers();
-    } catch (e) {
+    } catch {
         Snackbar.error({
             text: "There was an error, please try again.",
             title: "User not updated"
@@ -456,7 +456,7 @@ const resetMfa = async () => {
             text: "The user's authenticator has been cleared. They will enrol a new one on next sign-in.",
             title: "MFA reset"
         });
-    } catch (e) {
+    } catch {
         Snackbar.error({
             text: "There was an error resetting MFA, please try again.",
             title: "MFA reset failed"

--- a/flip-ui/src/pages/auth/Login.vue
+++ b/flip-ui/src/pages/auth/Login.vue
@@ -154,7 +154,7 @@ const submit = async (v: unknown): Promise<void> => {
                     routeChange.viewProjects();
                 }
         }
-    } catch (e) {
+    } catch {
         Snackbar.show({
             type: "error",
             title: "Error",

--- a/flip-ui/src/pages/auth/change-password.vue
+++ b/flip-ui/src/pages/auth/change-password.vue
@@ -175,7 +175,7 @@ const requestCode = async (values: unknown) => {
 
     try {
         await authStore.resetPassword(email);
-    } catch (e) {
+    } catch {
         errorStore.setError();
 
         return;
@@ -195,7 +195,7 @@ const submitChangePassword = async (v: unknown): Promise<void> => {
 
     try {
         await authStore.updateForgottenPassword(values);
-    } catch (e) {
+    } catch {
         Snackbar.show({
             type: "error",
             title: "Error",

--- a/flip-ui/src/pages/auth/mfa-setup.vue
+++ b/flip-ui/src/pages/auth/mfa-setup.vue
@@ -32,10 +32,12 @@ meta:
                 alt="TOTP QR code"
                 class="w-48 h-48 border border-gray-200 rounded"
                 data-test="mfa-qr-code"
-            />
+            >
         </div>
         <details v-if="sharedSecret" class="mb-4 text-sm">
-            <summary class="cursor-pointer">Can't scan? Enter this secret manually</summary>
+            <summary class="cursor-pointer">
+                Can't scan? Enter this secret manually
+            </summary>
             <code
                 class="block px-2 py-1 mt-2 font-mono break-all bg-gray-100 rounded dark:bg-gray-800"
                 data-test="mfa-shared-secret"
@@ -120,7 +122,10 @@ const renderQr = async (uri: string) => {
             // Soft neutral grey (tailwind gray-200) instead of the default
             // solid white block — works on both the light and dark
             // AuthLayout cards without introducing a harsh contrast edge.
-            color: { dark: "#000000ff", light: "#e5e7ebff" }
+            color: {
+                dark: "#000000ff",
+                light: "#e5e7ebff"
+            }
         });
     } catch {
         qrDataUrl.value = null;
@@ -132,9 +137,11 @@ onMounted(async () => {
         // Sign-in-chain: data already populated by signIn/changePassword.
         if (!setupUri.value) {
             routeChange.gotoLogin();
+
             return;
         }
         await renderQr(setupUri.value);
+
         return;
     }
 
@@ -142,10 +149,12 @@ onMounted(async () => {
     // session — if we don't have one, bounce to login.
     if (authStore.mfaEnabled === true) {
         routeChange.viewProjects();
+
         return;
     }
     if (!authStore.user) {
         routeChange.gotoLogin();
+
         return;
     }
     try {

--- a/flip-ui/src/pages/auth/new-password.vue
+++ b/flip-ui/src/pages/auth/new-password.vue
@@ -144,7 +144,7 @@ const submit = async (v: unknown): Promise<void> => {
 
     try {
         await authStore.changePassword(values.password);
-    } catch (e) {
+    } catch {
         Snackbar.show({
             type: "error",
             title: "Error",
@@ -171,6 +171,7 @@ const submit = async (v: unknown): Promise<void> => {
     ) {
         buttonLoader.value = false;
         routeChange.mfaSetup();
+
         return;
     }
 

--- a/flip-ui/src/pages/project/[projectId]/index.vue
+++ b/flip-ui/src/pages/project/[projectId]/index.vue
@@ -350,7 +350,7 @@ const stageProject = async (trustIds: string[]) => {
     try {
         await stageProjectWithTrusts(`/projects/${project?.value?.id}/stage`, trustIds);
         emit("UpdateProject");
-    } catch (e) {
+    } catch {
         Snackbar.error({
             title: "Unable to stage project",
             text: "There was a problem staging this project, please try again."
@@ -379,7 +379,7 @@ const unstageCurrentProject = async () => {
             text: "The project has been unstaged."
         });
 
-    } catch (e) {
+    } catch {
         Snackbar.error({
             title: "Unable to unstage project",
             text: "There was a problem unstaging this project, please try again."

--- a/flip-ui/src/pages/project/[projectId]/model/[modelId]/__tests__/index.spec.ts
+++ b/flip-ui/src/pages/project/[projectId]/model/[modelId]/__tests__/index.spec.ts
@@ -13,8 +13,8 @@
 
 import { createTestingPinia } from "@pinia/testing";
 import { mount } from "@vue/test-utils";
-import { reactive, ref } from "vue";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { reactive, ref } from "vue";
 
 import { FileUploadStatus } from "@/interfaces/model/types";
 import type { IModelDashboard } from "@/services/model-service";
@@ -23,11 +23,15 @@ const mockRoute = reactive({
     name: "Model",
     fullPath: "/project/test-project/model/test-model",
     path: "/project/test-project/model/test-model",
-    params: { projectId: "test-project", modelId: "test-model" } as Record<string, string>
+    params: {
+        projectId: "test-project",
+        modelId: "test-model"
+    } as Record<string, string>
 });
 
 vi.mock("vue-router", async (importOriginal) => {
     const actual = await importOriginal<typeof import("vue-router")>();
+
     return {
         ...actual,
         useRoute: () => mockRoute
@@ -46,19 +50,13 @@ vi.mock("swrv", () => ({
     })
 }));
 
-vi.mock("@/composables/useErrorHandler", () => ({
-    default: vi.fn()
-}));
+vi.mock("@/composables/useErrorHandler", () => ({ default: vi.fn() }));
 
-vi.mock("@/router", () => ({
-    routeChange: { viewProject: vi.fn() }
-}));
+vi.mock("@/router", () => ({ routeChange: { viewProject: vi.fn() } }));
 
 const resolveModelConfigStateMock = vi.fn();
 
-vi.mock("@/services/file-service", () => ({
-    resolveModelConfigState: (...args: unknown[]) => resolveModelConfigStateMock(...args)
-}));
+vi.mock("@/services/file-service", () => ({ resolveModelConfigState: (...args: unknown[]) => resolveModelConfigStateMock(...args) }));
 
 const jobTypes = {
     standard: ["trainer.py", "config.json"],
@@ -67,6 +65,7 @@ const jobTypes = {
 
 vi.mock("@/services/model-service", async (importOriginal) => {
     const actual = await importOriginal<typeof import("@/services/model-service")>();
+
     return {
         ...actual,
         fetchJobTypes: vi.fn().mockResolvedValue(jobTypes),
@@ -99,7 +98,11 @@ function makeModel(files: { name: string; status: string }[]): IModelDashboard {
         modelName: "Test Model",
         modelDescription: "",
         status: "PENDING",
-        query: { name: "", query: "", results: [] },
+        query: {
+            name: "",
+            query: "",
+            results: []
+        },
         files: files as IModelDashboard["files"]
     };
 }
@@ -112,12 +115,26 @@ async function flushPromises(): Promise<void> {
 
 async function mountPage() {
     const ModelPage = (await import("@/pages/project/[projectId]/model/[modelId]/index.vue")).default;
-    const pinia = createTestingPinia({ createSpy: vi.fn, stubActions: false });
-    pinia.state.value.project = { project: { id: "test-project", name: "P", status: "APPROVED" } };
+    const pinia = createTestingPinia({
+        createSpy: vi.fn,
+        stubActions: false
+    });
+    pinia.state.value.project = {
+        project: {
+            id: "test-project",
+            name: "P",
+            status: "APPROVED"
+        }
+    };
     const wrapper = mount(ModelPage, {
-        global: { plugins: [pinia], stubs, directives: { tippy: () => {} } }
+        global: {
+            plugins: [pinia],
+            stubs,
+            directives: { tippy: () => {} }
+        }
     });
     await flushPromises();
+
     return wrapper;
 }
 
@@ -143,7 +160,10 @@ describe("pages/project/[projectId]/model/[modelId]", () => {
     it("invokes resolveModelConfigState with the current config.json status on each poll", async () => {
         const wrapper = await mountPage();
         mockSwrvData.value = makeModel([
-            { name: "config.json", status: FileUploadStatus.SCANNING }
+            {
+                name: "config.json",
+                status: FileUploadStatus.SCANNING
+            }
         ]);
         await flushPromises();
         await wrapper.vm.$nextTick();
@@ -151,7 +171,10 @@ describe("pages/project/[projectId]/model/[modelId]", () => {
 
         expect(resolveModelConfigStateMock).toHaveBeenCalled();
         const call = resolveModelConfigStateMock.mock.calls.at(-1);
-        expect(call?.[0]).toEqual([{ name: "config.json", status: FileUploadStatus.SCANNING }]);
+        expect(call?.[0]).toEqual([{
+            name: "config.json",
+            status: FileUploadStatus.SCANNING
+        }]);
         // previousStatus starts as null
         expect(call?.[1]).toBeNull();
         expect(call?.[2]).toEqual(jobTypes);
@@ -166,7 +189,10 @@ describe("pages/project/[projectId]/model/[modelId]", () => {
             requiredFiles: jobTypes.diffusion
         });
         mockSwrvData.value = makeModel([
-            { name: "config.json", status: FileUploadStatus.COMPLETED }
+            {
+                name: "config.json",
+                status: FileUploadStatus.COMPLETED
+            }
         ]);
         const wrapper = await mountPage();
         await flushPromises();
@@ -175,7 +201,10 @@ describe("pages/project/[projectId]/model/[modelId]", () => {
 
         // Trigger a second poll with a new object reference but unchanged content
         mockSwrvData.value = makeModel([
-            { name: "config.json", status: FileUploadStatus.COMPLETED }
+            {
+                name: "config.json",
+                status: FileUploadStatus.COMPLETED
+            }
         ]);
         await flushPromises();
         await wrapper.vm.$nextTick();
@@ -196,7 +225,10 @@ describe("pages/project/[projectId]/model/[modelId]", () => {
             requiredFiles: jobTypes.standard
         });
         mockSwrvData.value = makeModel([
-            { name: "config.json", status: FileUploadStatus.SCANNING }
+            {
+                name: "config.json",
+                status: FileUploadStatus.SCANNING
+            }
         ]);
         const wrapper = await mountPage();
         await flushPromises();
@@ -207,7 +239,10 @@ describe("pages/project/[projectId]/model/[modelId]", () => {
         // Tracker must stay at SCANNING regardless of how many times the watch fires.
         resolveModelConfigStateMock.mockResolvedValue({ changed: false });
         mockSwrvData.value = makeModel([
-            { name: "config.json", status: FileUploadStatus.COMPLETED }
+            {
+                name: "config.json",
+                status: FileUploadStatus.COMPLETED
+            }
         ]);
         await flushPromises();
         await wrapper.vm.$nextTick();
@@ -223,7 +258,10 @@ describe("pages/project/[projectId]/model/[modelId]", () => {
             requiredFiles: jobTypes.diffusion
         });
         mockSwrvData.value = makeModel([
-            { name: "config.json", status: FileUploadStatus.COMPLETED }
+            {
+                name: "config.json",
+                status: FileUploadStatus.COMPLETED
+            }
         ]);
         await flushPromises();
         await wrapper.vm.$nextTick();
@@ -242,7 +280,10 @@ describe("pages/project/[projectId]/model/[modelId]", () => {
             requiredFiles: jobTypes.standard
         });
         mockSwrvData.value = makeModel([
-            { name: "config.json", status: FileUploadStatus.COMPLETED }
+            {
+                name: "config.json",
+                status: FileUploadStatus.COMPLETED
+            }
         ]);
         const wrapper = await mountPage();
         await flushPromises();
@@ -262,7 +303,10 @@ describe("pages/project/[projectId]/model/[modelId]", () => {
 
         // Simulate the refreshed poll response; helper should see previousStatus=null again
         mockSwrvData.value = makeModel([
-            { name: "trainer.py", status: FileUploadStatus.COMPLETED }
+            {
+                name: "trainer.py",
+                status: FileUploadStatus.COMPLETED
+            }
         ]);
         await flushPromises();
         await wrapper.vm.$nextTick();

--- a/flip-ui/src/pages/project/[projectId]/model/[modelId]/index.vue
+++ b/flip-ui/src/pages/project/[projectId]/model/[modelId]/index.vue
@@ -199,7 +199,7 @@ function getStatusEnumValue(status: string | undefined): number {
     // Map string status (e.g. "PENDING") to ModelStatusEnum value
     if (!status || !(status in ModelStatusEnum)) return ModelStatusEnum.ERROR;
 
-    // @ts-ignore
+    // @ts-expect-error indexing the enum by a string key already guarded by the `status in ModelStatusEnum` check above
     return ModelStatusEnum[status];
 }
 

--- a/flip-ui/src/partials/admin/banner/__tests__/SiteBanner.spec.ts
+++ b/flip-ui/src/partials/admin/banner/__tests__/SiteBanner.spec.ts
@@ -16,17 +16,11 @@ import { describe, expect, it } from "vitest";
 
 import SiteBanner from "@/partials/admin/banner/SiteBanner.vue";
 
-const confirmModalStub = {
-    template: "<div data-test=\"confirm-modal-stub\"><slot name=\"confirmation\" /></div>"
-};
+const confirmModalStub = { template: "<div data-test=\"confirm-modal-stub\"><slot name=\"confirmation\" /></div>" };
 
 describe("SiteBanner", () => {
     it("wires the confirmation slot into AiConfirmModal with the site-banner warning", () => {
-        const wrapper = mountComponent(SiteBanner, {
-            global: {
-                stubs: { AiConfirmModal: confirmModalStub }
-            }
-        });
+        const wrapper = mountComponent(SiteBanner, { global: { stubs: { AiConfirmModal: confirmModalStub } } });
 
         const html = wrapper.html();
 

--- a/flip-ui/src/partials/admin/deployments/__tests__/DeploymentMode.spec.ts
+++ b/flip-ui/src/partials/admin/deployments/__tests__/DeploymentMode.spec.ts
@@ -16,17 +16,11 @@ import { describe, expect, it } from "vitest";
 
 import DeploymentMode from "@/partials/admin/deployments/DeploymentMode.vue";
 
-const confirmModalStub = {
-    template: "<div data-test=\"confirm-modal-stub\"><slot name=\"confirmation\" /></div>"
-};
+const confirmModalStub = { template: "<div data-test=\"confirm-modal-stub\"><slot name=\"confirmation\" /></div>" };
 
 describe("DeploymentMode", () => {
     it("wires the confirmation slot into AiConfirmModal with the deployment-mode warning", () => {
-        const wrapper = mountComponent(DeploymentMode, {
-            global: {
-                stubs: { AiConfirmModal: confirmModalStub }
-            }
-        });
+        const wrapper = mountComponent(DeploymentMode, { global: { stubs: { AiConfirmModal: confirmModalStub } } });
 
         const html = wrapper.html();
 

--- a/flip-ui/src/partials/models/CreateModelModal.vue
+++ b/flip-ui/src/partials/models/CreateModelModal.vue
@@ -170,7 +170,7 @@ const submitForm = async (v: unknown) => {
         });
 
         routeChange.viewModel(projectId, modelId);
-    } catch (e) {
+    } catch {
         modalStore.toggleCreateModel();
 
         Snackbar.show({

--- a/flip-ui/src/partials/models/__tests__/EditModelDrawer.confirm-slot.spec.ts
+++ b/flip-ui/src/partials/models/__tests__/EditModelDrawer.confirm-slot.spec.ts
@@ -21,21 +21,23 @@ vi.mock("vue-router", async (importOriginal) => {
 
     return {
         ...actual,
-        useRoute: () => ({ params: {}, query: {} })
+        useRoute: () => ({
+            params: {},
+            query: {}
+        })
     };
 });
 
 vi.mock("@/router", () => ({
-    default: { push: vi.fn(), replace: vi.fn() }
+    default: {
+        push: vi.fn(),
+        replace: vi.fn()
+    }
 }));
 
-vi.mock("@/services/model-service", () => ({
-    deleteModel: vi.fn()
-}));
+vi.mock("@/services/model-service", () => ({ deleteModel: vi.fn() }));
 
-const confirmModalStub = {
-    template: "<div data-test=\"confirm-modal-stub\"><slot name=\"confirmation\" /></div>"
-};
+const confirmModalStub = { template: "<div data-test=\"confirm-modal-stub\"><slot name=\"confirmation\" /></div>" };
 
 describe("EditModelDrawer delete-confirmation slot", () => {
     const baseProps = {
@@ -71,7 +73,10 @@ describe("EditModelDrawer delete-confirmation slot", () => {
                 renderStubDefaultSlot: true,
                 stubs: { AiConfirmModal: confirmModalStub }
             },
-            props: { ...baseProps, name: payload }
+            props: {
+                ...baseProps,
+                name: payload
+            }
         });
 
         const slot = wrapper.find("[data-test=confirm-modal-stub]");

--- a/flip-ui/src/partials/models/__tests__/FileUpload.spec.ts
+++ b/flip-ui/src/partials/models/__tests__/FileUpload.spec.ts
@@ -11,16 +11,14 @@
  * limitations under the License.
  */
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
+
 import { createTestingPinia } from "@pinia/testing";
 import { mount } from "@vue/test-utils";
 import { describe, expect, it, vi } from "vitest";
 
 import FileUpload from "@/partials/models/FileUpload.vue";
 
-const alertStub = {
-    template: "<div data-test=\"alert-stub\"><slot /></div>"
-};
+const alertStub = { template: "<div data-test=\"alert-stub\"><slot /></div>" };
 
 function mountFileUpload(options: {
     permissions?: string[];
@@ -44,7 +42,10 @@ function mountFileUpload(options: {
                             user: {
                                 username: "testuser",
                                 userId: "1",
-                                attributes: { sub: "1", email: "t@e.co" },
+                                attributes: {
+                                    sub: "1",
+                                    email: "t@e.co"
+                                },
                                 permissions
                             },
                             signInStep: "DONE"
@@ -55,7 +56,10 @@ function mountFileUpload(options: {
             renderStubDefaultSlot: true,
             stubs: { AiAlert: alertStub }
         },
-        props: { requiredFiles, jobType }
+        props: {
+            requiredFiles,
+            jobType
+        }
     });
 }
 
@@ -90,7 +94,10 @@ describe("FileUpload observer-aware rendering", () => {
     it("escapes job type and file names so user-controlled values cannot inject HTML", () => {
         const payload = "<img src=x onerror=alert(1)>";
 
-        const wrapper = mountFileUpload({ jobType: payload, requiredFiles: [payload] });
+        const wrapper = mountFileUpload({
+            jobType: payload,
+            requiredFiles: [payload]
+        });
         const slot = wrapper.find("[data-test=alert-stub]");
 
         expect(slot.find("img").exists()).toBe(false);

--- a/flip-ui/src/partials/models/__tests__/LatestModels.spec.ts
+++ b/flip-ui/src/partials/models/__tests__/LatestModels.spec.ts
@@ -24,7 +24,11 @@ import LatestModels from "../LatestModels.vue";
 const mockRoute = { params: { projectId: "project-1" } as Record<string, string> };
 vi.mock("vue-router", async (importOriginal) => {
     const actual = await importOriginal<typeof import("vue-router")>();
-    return { ...actual, useRoute: () => mockRoute };
+
+    return {
+        ...actual,
+        useRoute: () => mockRoute
+    };
 });
 
 // SWRV is the data source. We swap it for a controllable ref so each test
@@ -36,15 +40,17 @@ vi.mock("vue-router", async (importOriginal) => {
 const mockData = vi.hoisted(() => {
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     const vue = require("vue") as typeof import("vue");
+
     return { ref: vue.ref<unknown>(undefined) };
 });
 vi.mock("swrv", () => ({
-    default: () => ({ data: mockData.ref, error: ref(null) })
+    default: () => ({
+        data: mockData.ref,
+        error: ref(null)
+    })
 }));
 
-vi.mock("@/services/model-service", () => ({
-    getModels: vi.fn(async () => undefined)
-}));
+vi.mock("@/services/model-service", () => ({ getModels: vi.fn(async () => undefined) }));
 
 vi.mock("@/composables/useErrorHandler", () => ({ default: vi.fn() }));
 
@@ -76,7 +82,10 @@ function mountLatestModels({
                             user: {
                                 username: "u",
                                 userId: "id",
-                                attributes: { sub: "s", email: "u@e.com" },
+                                attributes: {
+                                    sub: "s",
+                                    email: "u@e.com"
+                                },
                                 permissions: isObserver ? [] : ["CanManageProjects"]
                             },
                             signInStep: "DONE",
@@ -153,8 +162,16 @@ describe("LatestModels — defensive data access", () => {
     test("lists models and shows the View All button when data.data is populated", async () => {
         setData({
             data: [
-                { id: "m1", name: "Alpha", description: "" },
-                { id: "m2", name: "Beta", description: "second model" }
+                {
+                    id: "m1",
+                    name: "Alpha",
+                    description: ""
+                },
+                {
+                    id: "m2",
+                    name: "Beta",
+                    description: "second model"
+                }
             ]
         });
         const wrapper = mountLatestModels();
@@ -170,7 +187,13 @@ describe("LatestModels — defensive data access", () => {
         // Drives the `!isObserver && projectStore.project?.status === 'APPROVED'
         // && data?.data?.length` v-if branch in the template — both halves
         // of the optional chain must short-circuit safely.
-        setData({ data: [{ id: "m1", name: "Alpha", description: "" }] });
+        setData({
+            data: [{
+                id: "m1",
+                name: "Alpha",
+                description: ""
+            }]
+        });
         const wrapper = mountLatestModels({ isObserver: false });
         await flushPromises();
 
@@ -183,7 +206,13 @@ describe("LatestModels — defensive data access", () => {
     });
 
     test("hides the header Create-Model button for observers", async () => {
-        setData({ data: [{ id: "m1", name: "Alpha", description: "" }] });
+        setData({
+            data: [{
+                id: "m1",
+                name: "Alpha",
+                description: ""
+            }]
+        });
         const wrapper = mountLatestModels({ isObserver: true });
         await flushPromises();
 
@@ -226,12 +255,21 @@ describe("LatestModels — defensive data access", () => {
                         createSpy: vi.fn,
                         initialState: {
                             auth: {
-                                user: { username: "u", userId: "id", attributes: {}, permissions: ["CanManageProjects"] },
+                                user: {
+                                    username: "u",
+                                    userId: "id",
+                                    attributes: {},
+                                    permissions: ["CanManageProjects"]
+                                },
                                 signInStep: "DONE",
                                 mfaEnabled: true
                             },
                             project: {
-                                project: { id: "project-1", name: "Test", status: "UNSTAGED" }
+                                project: {
+                                    id: "project-1",
+                                    name: "Test",
+                                    status: "UNSTAGED"
+                                }
                             }
                         }
                     })
@@ -241,7 +279,10 @@ describe("LatestModels — defensive data access", () => {
                     AiButton: { template: "<button><slot /></button>" },
                     AiAlert: { template: "<div><slot /></div>" },
                     AiLoader: { template: "<div data-test='ai-loader' />" },
-                    "router-link": { template: "<a><slot /></a>", props: ["to"] }
+                    "router-link": {
+                        template: "<a><slot /></a>",
+                        props: ["to"]
+                    }
                 }
             }
         });

--- a/flip-ui/src/partials/models/__tests__/ModelList.spec.ts
+++ b/flip-ui/src/partials/models/__tests__/ModelList.spec.ts
@@ -21,21 +21,33 @@ import ModelList from "../ModelList.vue";
 const mockRoute = { params: { projectId: "project-1" } as Record<string, string> };
 vi.mock("vue-router", async (importOriginal) => {
     const actual = await importOriginal<typeof import("vue-router")>();
-    return { ...actual, useRoute: () => mockRoute };
+
+    return {
+        ...actual,
+        useRoute: () => mockRoute
+    };
 });
 
 const mockData = vi.hoisted(() => {
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     const vue = require("vue") as typeof import("vue");
+
     return { ref: vue.ref<unknown>(undefined) };
 });
 vi.mock("swrv", () => ({
-    default: () => ({ data: mockData.ref, error: ref(null) })
+    default: () => ({
+        data: mockData.ref,
+        error: ref(null)
+    })
 }));
 
 vi.mock("@/services/model-service", async (importOriginal) => {
     const actual = await importOriginal<typeof import("@/services/model-service")>();
-    return { ...actual, getModels: vi.fn(async () => undefined) };
+
+    return {
+        ...actual,
+        getModels: vi.fn(async () => undefined)
+    };
 });
 
 vi.mock("@/composables/useErrorHandler", () => ({ default: vi.fn() }));
@@ -56,7 +68,10 @@ function mountModelList() {
                             user: {
                                 username: "u",
                                 userId: "id",
-                                attributes: { sub: "s", email: "u@e.com" },
+                                attributes: {
+                                    sub: "s",
+                                    email: "u@e.com"
+                                },
                                 permissions: ["CanManageProjects"]
                             },
                             signInStep: "DONE",
@@ -78,7 +93,10 @@ function mountModelList() {
                     template: "<table><slot name=\"head\" /><tbody><slot name=\"body\" :rows=\"data ?? []\" /></tbody></table>",
                     props: ["data"]
                 },
-                "router-link": { template: "<a><slot /></a>", props: ["to"] }
+                "router-link": {
+                    template: "<a><slot /></a>",
+                    props: ["to"]
+                }
             }
         }
     });
@@ -90,7 +108,14 @@ describe("ModelList — Status column", () => {
     });
 
     test("renders a Status column header after Description", async () => {
-        setData({ data: [{ id: "m1", name: "A", description: "d", status: "PENDING" }] });
+        setData({
+            data: [{
+                id: "m1",
+                name: "A",
+                description: "d",
+                status: "PENDING"
+            }]
+        });
         const wrapper = mountModelList();
         await flushPromises();
 
@@ -102,7 +127,14 @@ describe("ModelList — Status column", () => {
     });
 
     test("PENDING renders 'Model Created' with a tick icon", async () => {
-        setData({ data: [{ id: "m1", name: "A", description: "", status: "PENDING" }] });
+        setData({
+            data: [{
+                id: "m1",
+                name: "A",
+                description: "",
+                status: "PENDING"
+            }]
+        });
         const wrapper = mountModelList();
         await flushPromises();
 
@@ -114,7 +146,14 @@ describe("ModelList — Status column", () => {
     });
 
     test("INITIATED renders 'Model Queued' with a tick", async () => {
-        setData({ data: [{ id: "m1", name: "A", description: "", status: "INITIATED" }] });
+        setData({
+            data: [{
+                id: "m1",
+                name: "A",
+                description: "",
+                status: "INITIATED"
+            }]
+        });
         const wrapper = mountModelList();
         await flushPromises();
 
@@ -124,7 +163,14 @@ describe("ModelList — Status column", () => {
     });
 
     test("PREPARED renders 'Model Prepared' with a tick", async () => {
-        setData({ data: [{ id: "m1", name: "A", description: "", status: "PREPARED" }] });
+        setData({
+            data: [{
+                id: "m1",
+                name: "A",
+                description: "",
+                status: "PREPARED"
+            }]
+        });
         const wrapper = mountModelList();
         await flushPromises();
 
@@ -134,7 +180,14 @@ describe("ModelList — Status column", () => {
     });
 
     test("TRAINING_STARTED renders 'Training Started' with a tick", async () => {
-        setData({ data: [{ id: "m1", name: "A", description: "", status: "TRAINING_STARTED" }] });
+        setData({
+            data: [{
+                id: "m1",
+                name: "A",
+                description: "",
+                status: "TRAINING_STARTED"
+            }]
+        });
         const wrapper = mountModelList();
         await flushPromises();
 
@@ -144,7 +197,14 @@ describe("ModelList — Status column", () => {
     });
 
     test("RESULTS_UPLOADED renders 'Results Uploaded' with a tick", async () => {
-        setData({ data: [{ id: "m1", name: "A", description: "", status: "RESULTS_UPLOADED" }] });
+        setData({
+            data: [{
+                id: "m1",
+                name: "A",
+                description: "",
+                status: "RESULTS_UPLOADED"
+            }]
+        });
         const wrapper = mountModelList();
         await flushPromises();
 
@@ -154,7 +214,14 @@ describe("ModelList — Status column", () => {
     });
 
     test("ERROR renders 'Error' with a red cross", async () => {
-        setData({ data: [{ id: "m1", name: "A", description: "", status: "ERROR" }] });
+        setData({
+            data: [{
+                id: "m1",
+                name: "A",
+                description: "",
+                status: "ERROR"
+            }]
+        });
         const wrapper = mountModelList();
         await flushPromises();
 
@@ -165,7 +232,14 @@ describe("ModelList — Status column", () => {
     });
 
     test("STOPPED renders 'Stopped' with a red cross", async () => {
-        setData({ data: [{ id: "m1", name: "A", description: "", status: "STOPPED" }] });
+        setData({
+            data: [{
+                id: "m1",
+                name: "A",
+                description: "",
+                status: "STOPPED"
+            }]
+        });
         const wrapper = mountModelList();
         await flushPromises();
 
@@ -178,7 +252,13 @@ describe("ModelList — Status column", () => {
         // Defensive: an older API response (or a stale cache from before the
         // backend started returning status) leaves the cell with neither a
         // tick nor a cross — and shouldn't blow up the row.
-        setData({ data: [{ id: "m1", name: "A", description: "" }] });
+        setData({
+            data: [{
+                id: "m1",
+                name: "A",
+                description: ""
+            }]
+        });
         const wrapper = mountModelList();
         await flushPromises();
 

--- a/flip-ui/src/partials/models/__tests__/ModelUpload.confirm-slot.spec.ts
+++ b/flip-ui/src/partials/models/__tests__/ModelUpload.confirm-slot.spec.ts
@@ -22,7 +22,10 @@ vi.mock("vue-router", async (importOriginal) => {
 
     return {
         ...actual,
-        useRoute: () => ({ params: {}, query: {} })
+        useRoute: () => ({
+            params: {},
+            query: {}
+        })
     };
 });
 
@@ -32,16 +35,12 @@ vi.mock("@/services/file-service", () => ({
     processScannedFile: vi.fn()
 }));
 
-const confirmModalStub = {
-    template: "<div data-test=\"confirm-modal-stub\"><slot name=\"confirmation\" /></div>"
-};
+const confirmModalStub = { template: "<div data-test=\"confirm-modal-stub\"><slot name=\"confirmation\" /></div>" };
 
 describe("ModelUpload delete-confirm slot", () => {
     it("renders the file-deletion confirmation slot via AiConfirmModal", async () => {
         const wrapper = mountComponent(ModelUpload, {
-            global: {
-                stubs: { AiConfirmModal: confirmModalStub }
-            },
+            global: { stubs: { AiConfirmModal: confirmModalStub } },
             props: {
                 files: [],
                 loading: false,
@@ -61,9 +60,7 @@ describe("ModelUpload delete-confirm slot", () => {
 
     it("escapes file names in the confirmation slot", async () => {
         const wrapper = mountComponent(ModelUpload, {
-            global: {
-                stubs: { AiConfirmModal: confirmModalStub }
-            },
+            global: { stubs: { AiConfirmModal: confirmModalStub } },
             props: {
                 files: [],
                 loading: false,

--- a/flip-ui/src/partials/models/__tests__/Training.spec.ts
+++ b/flip-ui/src/partials/models/__tests__/Training.spec.ts
@@ -11,7 +11,7 @@
  * limitations under the License.
  */
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
+
 import { createTestingPinia } from "@pinia/testing";
 import { mount } from "@vue/test-utils";
 import { describe, expect, it, vi } from "vitest";
@@ -20,29 +20,28 @@ import Training from "@/partials/models/Training.vue";
 
 vi.mock("vue-router", async (importOriginal) => {
     const actual = await importOriginal<typeof import("vue-router")>();
+
     return {
         ...actual,
-        useRoute: () => ({ params: { modelId: "model-1" }, query: {} })
+        useRoute: () => ({
+            params: { modelId: "model-1" },
+            query: {}
+        })
     };
 });
 
 vi.mock("@/services/model-service", async (importOriginal) => {
     const actual = await importOriginal<typeof import("@/services/model-service")>();
+
     return {
         ...actual,
         initialiseTraining: vi.fn()
     };
 });
 
-const alertStub = {
-    template: "<div data-test=\"alert-stub\"><slot /></div>"
-};
-const buttonStub = {
-    template: "<button data-test=\"initiate-training-btn\"><slot /></button>"
-};
-const actionsMenuStub = {
-    template: "<div data-test=\"training-actions-menu\" />"
-};
+const alertStub = { template: "<div data-test=\"alert-stub\"><slot /></div>" };
+const buttonStub = { template: "<button data-test=\"initiate-training-btn\"><slot /></button>" };
+const actionsMenuStub = { template: "<div data-test=\"training-actions-menu\" />" };
 
 interface MountOpts {
     permissions?: string[];
@@ -74,7 +73,10 @@ function mountTraining(options: MountOpts = {}) {
                             user: {
                                 username: "testuser",
                                 userId: "1",
-                                attributes: { sub: "1", email: "t@e.co" },
+                                attributes: {
+                                    sub: "1",
+                                    email: "t@e.co"
+                                },
                                 permissions
                             },
                             signInStep: "DONE"

--- a/flip-ui/src/partials/models/__tests__/model-upload.spec.ts
+++ b/flip-ui/src/partials/models/__tests__/model-upload.spec.ts
@@ -54,6 +54,7 @@ const { FileTooLargeError } = vi.hoisted(() => {
             this.actualBytes = actualBytes;
         }
     }
+
     return { FileTooLargeError };
 });
 vi.mock("@/utils/file", () => ({

--- a/flip-ui/src/partials/projects/CreateProjectModal.vue
+++ b/flip-ui/src/partials/projects/CreateProjectModal.vue
@@ -203,7 +203,7 @@ const submitForm = async(v: unknown) => {
         });
 
         routeChange.viewProject(projectId);
-    } catch (e) {
+    } catch {
         modalStore.toggleCreateProject();
 
         Snackbar.show({

--- a/flip-ui/src/partials/projects/ProjectStatus.vue
+++ b/flip-ui/src/partials/projects/ProjectStatus.vue
@@ -234,7 +234,7 @@ import AiAlert from "@/components/AiAlert/AiAlert.vue";
 import AiSearch from "@/components/AiSearch/AiSearch.vue";
 import AiSkeleton from "@/components/AiSkeleton/AiSkeleton.vue";
 import useErrorHandler from "@/composables/useErrorHandler";
-import { getImagingProjectsStatus, IImagingProjectStatus } from "@/services/project-service";
+import { getImagingProjectsStatus } from "@/services/project-service";
 import { useSiteDetailsStore } from "@/store/siteDetailsStore";
 
 interface IImagingProjectStatusProps {

--- a/flip-ui/src/partials/projects/ProjectUsers.vue
+++ b/flip-ui/src/partials/projects/ProjectUsers.vue
@@ -130,7 +130,10 @@ interface IAddUser {
 
 const props = withDefaults(
     defineProps<IProjectUsersProps>(),
-    { readonly: false, users: () => [] }
+    {
+        readonly: false,
+        users: () => []
+    }
 );
 
 const authStore = useAuthStore();
@@ -197,7 +200,7 @@ const removeUser = async(id: string): Promise<void> => {
             emit("updatedUsers", userList.value);
         }
 
-    } catch (e) {
+    } catch {
         return handleError("Something went wrong when removing the user");
     } finally {
         formSubmit.value = false;

--- a/flip-ui/src/partials/projects/__tests__/EditProjectDrawer.confirm-slot.spec.ts
+++ b/flip-ui/src/partials/projects/__tests__/EditProjectDrawer.confirm-slot.spec.ts
@@ -21,21 +21,23 @@ vi.mock("vue-router", async (importOriginal) => {
 
     return {
         ...actual,
-        useRoute: () => ({ params: {}, query: {} })
+        useRoute: () => ({
+            params: {},
+            query: {}
+        })
     };
 });
 
 vi.mock("@/router", () => ({
-    default: { push: vi.fn(), replace: vi.fn() }
+    default: {
+        push: vi.fn(),
+        replace: vi.fn()
+    }
 }));
 
-vi.mock("@/services/project-service", () => ({
-    deleteProject: vi.fn()
-}));
+vi.mock("@/services/project-service", () => ({ deleteProject: vi.fn() }));
 
-const confirmModalStub = {
-    template: "<div data-test=\"confirm-modal-stub\"><slot name=\"confirmation\" /></div>"
-};
+const confirmModalStub = { template: "<div data-test=\"confirm-modal-stub\"><slot name=\"confirmation\" /></div>" };
 
 describe("EditProjectDrawer delete-confirmation slot", () => {
     const baseProps = {
@@ -72,7 +74,10 @@ describe("EditProjectDrawer delete-confirmation slot", () => {
                 renderStubDefaultSlot: true,
                 stubs: { AiConfirmModal: confirmModalStub }
             },
-            props: { ...baseProps, name: payload }
+            props: {
+                ...baseProps,
+                name: payload
+            }
         });
 
         const slot = wrapper.find("[data-test=confirm-modal-stub]");

--- a/flip-ui/src/partials/projects/__tests__/create-project-modal.spec.ts
+++ b/flip-ui/src/partials/projects/__tests__/create-project-modal.spec.ts
@@ -45,7 +45,7 @@ const stubs = {
 };
 
 describe("Create Project Modal", () => {
-    let component: any;
+    let component: ReturnType<typeof mount>;
 
     beforeEach(() => {
         mockCreateProject.mockClear();
@@ -107,6 +107,7 @@ describe("Create Project Modal", () => {
                         template: "<form @submit.prevent=\"$emit('submit', $attrs['initial-values'])\"><slot /></form>",
                         mounted() {
                             // Override initial-values to simulate unchecked toggle
+                            // eslint-disable-next-line @typescript-eslint/no-explicit-any
                             (this as any).$attrs["initial-values"].dicom_to_nifti = "";
                         }
                     }

--- a/flip-ui/src/partials/projects/__tests__/project-status.spec.ts
+++ b/flip-ui/src/partials/projects/__tests__/project-status.spec.ts
@@ -102,6 +102,7 @@ function mountProjectStatus(canLoad = true, ...maxOverride: [number | undefined]
     });
     const store = useSiteDetailsStore(pinia);
     store.maxReimportCount = maxReimportCount;
+
     return mount(ProjectStatus, {
         props: { canLoad },
         global: {

--- a/flip-ui/src/partials/projects/__tests__/project-users.spec.ts
+++ b/flip-ui/src/partials/projects/__tests__/project-users.spec.ts
@@ -22,7 +22,7 @@ import AddUser from "../ProjectUsers.vue";
 import { AddProjectUsers } from "../selectors";
 
 describe("Project Users Modal", () => {
-    let component: any;
+    let component: ReturnType<typeof mount>;
 
     beforeEach(() => {
         component = mount(AddUser, {

--- a/flip-ui/src/services/__tests__/api.spec.ts
+++ b/flip-ui/src/services/__tests__/api.spec.ts
@@ -19,19 +19,18 @@ import { _http } from "@/services/api";
 import { useAuthStore } from "@/store/auth";
 import { Snackbar } from "@/utils/snackbar";
 
-vi.mock("aws-amplify/auth", () => ({
-    fetchAuthSession: vi.fn()
-}));
+vi.mock("aws-amplify/auth", () => ({ fetchAuthSession: vi.fn() }));
 
 // utils/auth registers a Hub.listen at import time; stub it so pulling in
 // api.ts (which transitively imports utils/auth for NO_FORCED_SIGNOUT_PATHS)
 // stays side-effect-free.
-vi.mock("aws-amplify/utils", () => ({
-    Hub: { listen: vi.fn() }
-}));
+vi.mock("aws-amplify/utils", () => ({ Hub: { listen: vi.fn() } }));
 
 vi.mock("@/router", () => ({
-    default: { push: vi.fn(), currentRoute: { value: { fullPath: "/" } } },
+    default: {
+        push: vi.fn(),
+        currentRoute: { value: { fullPath: "/" } }
+    },
     routeChange: { gotoLogin: vi.fn() }
 }));
 
@@ -87,11 +86,7 @@ const fakeAxiosInstance = {
     delete: vi.fn()
 };
 
-vi.mock("axios", () => ({
-    default: {
-        create: vi.fn(() => fakeAxiosInstance)
-    }
-}));
+vi.mock("axios", () => ({ default: { create: vi.fn(() => fakeAxiosInstance) } }));
 
 describe("api.ts Http client", () => {
     beforeEach(() => {
@@ -125,9 +120,7 @@ describe("api.ts Http client", () => {
 
     describe("request interceptor", () => {
         it("attaches Bearer token from the current Amplify session", async () => {
-            vi.mocked(fetchAuthSession).mockResolvedValue({
-                tokens: { accessToken: { toString: () => "token-abc" } }
-            } as never);
+            vi.mocked(fetchAuthSession).mockResolvedValue({ tokens: { accessToken: { toString: () => "token-abc" } } } as never);
             primeHttp();
 
             const cfg = { headers: {} } as Record<string, unknown>;
@@ -190,7 +183,10 @@ describe("api.ts Http client", () => {
     describe("response interceptor", () => {
         it("passes successful responses through unchanged", () => {
             primeHttp();
-            const response = { status: 200, data: { ok: true } };
+            const response = {
+                status: 200,
+                data: { ok: true }
+            };
 
             expect(interceptors.responseOnFulfilled!(response)).toBe(response);
         });

--- a/flip-ui/src/store/__tests__/auth.spec.ts
+++ b/flip-ui/src/store/__tests__/auth.spec.ts
@@ -11,8 +11,7 @@
  * limitations under the License.
  */
 
-import {
-    confirmResetPassword,
+import { confirmResetPassword,
     confirmSignIn,
     fetchAuthSession,
     fetchUserAttributes,
@@ -22,8 +21,7 @@ import {
     signIn,
     signOut,
     updateMFAPreference,
-    verifyTOTPSetup
-} from "aws-amplify/auth";
+    verifyTOTPSetup } from "aws-amplify/auth";
 import { createPinia, setActivePinia } from "pinia";
 
 import { routeChange } from "@/router";
@@ -95,9 +93,7 @@ describe("authStore", () => {
         // Default: tokens are visible immediately so waitForSessionTokens
         // resolves without triggering the forceRefresh fallback. Tests that
         // exercise the race re-arm this with mockResolvedValueOnce.
-        vi.mocked(fetchAuthSession).mockResolvedValue({
-            tokens: { accessToken: { toString: () => "access-token" } as never }
-        } as never);
+        vi.mocked(fetchAuthSession).mockResolvedValue({ tokens: { accessToken: { toString: () => "access-token" } as never } } as never);
     });
 
     describe("initial state & getters", () => {
@@ -113,7 +109,10 @@ describe("authStore", () => {
             store.user = {
                 username: "u",
                 userId: "id",
-                attributes: { sub: "s", email: "e@f.com" },
+                attributes: {
+                    sub: "s",
+                    email: "e@f.com"
+                },
                 permissions: []
             };
             expect(store.getUser).toEqual(store.user);
@@ -126,7 +125,10 @@ describe("authStore", () => {
             store.user = {
                 username: "u",
                 userId: "id",
-                attributes: { sub: "s", email: "e@f.com" },
+                attributes: {
+                    sub: "s",
+                    email: "e@f.com"
+                },
                 permissions: []
             };
             // Stag/prod path: mfaRequired=true forces mfaEnabled=true gate.
@@ -175,14 +177,15 @@ describe("authStore", () => {
                 username: "u",
                 userId: "id"
             } as never);
-            vi.mocked(getMfaStatus).mockResolvedValue({ enabled: true, required: true });
+            vi.mocked(getMfaStatus).mockResolvedValue({
+                enabled: true,
+                required: true
+            });
             vi.mocked(fetchUserAttributes).mockResolvedValue({
                 sub: "s",
                 email: "e@f.com"
             } as never);
-            vi.mocked(getUserPermissions).mockResolvedValue({
-                permissions: ["CanManageUsers"]
-            });
+            vi.mocked(getUserPermissions).mockResolvedValue({ permissions: ["CanManageUsers"] });
 
             await store.hydrate();
 
@@ -191,7 +194,10 @@ describe("authStore", () => {
             expect(store.user).toEqual({
                 username: "u",
                 userId: "id",
-                attributes: { sub: "s", email: "e@f.com" },
+                attributes: {
+                    sub: "s",
+                    email: "e@f.com"
+                },
                 permissions: ["CanManageUsers"]
             });
             expect(getUserPermissions).toHaveBeenCalledWith("id");
@@ -203,7 +209,10 @@ describe("authStore", () => {
                 username: "u",
                 userId: "id"
             } as never);
-            vi.mocked(getMfaStatus).mockResolvedValue({ enabled: true, required: true });
+            vi.mocked(getMfaStatus).mockResolvedValue({
+                enabled: true,
+                required: true
+            });
             vi.mocked(fetchUserAttributes).mockResolvedValue({
                 sub: "s",
                 email: "e@f.com"
@@ -221,7 +230,10 @@ describe("authStore", () => {
                 username: "u",
                 userId: "id"
             } as never);
-            vi.mocked(getMfaStatus).mockResolvedValue({ enabled: false, required: true });
+            vi.mocked(getMfaStatus).mockResolvedValue({
+                enabled: false,
+                required: true
+            });
             vi.mocked(fetchUserAttributes).mockResolvedValue({
                 sub: "s",
                 email: "e@f.com"
@@ -234,7 +246,10 @@ describe("authStore", () => {
             expect(store.user).toEqual({
                 username: "u",
                 userId: "id",
-                attributes: { sub: "s", email: "e@f.com" },
+                attributes: {
+                    sub: "s",
+                    email: "e@f.com"
+                },
                 permissions: []
             });
             expect(getUserPermissions).not.toHaveBeenCalled();
@@ -251,7 +266,10 @@ describe("authStore", () => {
             } as never);
             vi.mocked(getUserPermissions).mockResolvedValue({ permissions: [] });
 
-            await store.hydrate({ enabled: true, required: true });
+            await store.hydrate({
+                enabled: true,
+                required: true
+            });
 
             expect(getMfaStatus).not.toHaveBeenCalled();
             expect(store.mfaEnabled).toBe(true);
@@ -267,14 +285,15 @@ describe("authStore", () => {
                 username: "u",
                 userId: "id"
             } as never);
-            vi.mocked(getMfaStatus).mockResolvedValue({ enabled: false, required: false });
+            vi.mocked(getMfaStatus).mockResolvedValue({
+                enabled: false,
+                required: false
+            });
             vi.mocked(fetchUserAttributes).mockResolvedValue({
                 sub: "s",
                 email: "e@f.com"
             } as never);
-            vi.mocked(getUserPermissions).mockResolvedValue({
-                permissions: ["CanManageUsers"]
-            });
+            vi.mocked(getUserPermissions).mockResolvedValue({ permissions: ["CanManageUsers"] });
 
             await store.hydrate();
 
@@ -291,7 +310,10 @@ describe("authStore", () => {
                 username: "u",
                 userId: "id"
             } as never);
-            vi.mocked(getMfaStatus).mockResolvedValue({ enabled: false, required: true });
+            vi.mocked(getMfaStatus).mockResolvedValue({
+                enabled: false,
+                required: true
+            });
             vi.mocked(fetchUserAttributes).mockResolvedValue({
                 sub: "s",
                 email: "e@f.com"
@@ -310,7 +332,10 @@ describe("authStore", () => {
                 username: "u",
                 userId: "id"
             } as never);
-            vi.mocked(getMfaStatus).mockResolvedValue({ enabled: true, required: true });
+            vi.mocked(getMfaStatus).mockResolvedValue({
+                enabled: true,
+                required: true
+            });
             vi.mocked(fetchUserAttributes).mockResolvedValue({
                 sub: "s",
                 email: "e@f.com"
@@ -330,7 +355,10 @@ describe("authStore", () => {
             store.user = {
                 username: "stale",
                 userId: "stale",
-                attributes: { sub: "", email: "" },
+                attributes: {
+                    sub: "",
+                    email: ""
+                },
                 permissions: []
             };
             store.signInStep = "DONE";
@@ -343,14 +371,20 @@ describe("authStore", () => {
                 username: "u",
                 userId: "id"
             } as never);
-            vi.mocked(getMfaStatus).mockResolvedValue({ enabled: true, required: true });
+            vi.mocked(getMfaStatus).mockResolvedValue({
+                enabled: true,
+                required: true
+            });
             vi.mocked(fetchUserAttributes).mockResolvedValue({
                 sub: "s",
                 email: "e@f.com"
             } as never);
             vi.mocked(getUserPermissions).mockResolvedValue({ permissions: [] });
 
-            await store.signIn({ username: "u", password: "p" });
+            await store.signIn({
+                username: "u",
+                password: "p"
+            });
 
             expect(signIn).toHaveBeenCalledWith({
                 username: "u",
@@ -375,7 +409,10 @@ describe("authStore", () => {
                 }
             } as never);
 
-            await store.signIn({ username: "u", password: "p" });
+            await store.signIn({
+                username: "u",
+                password: "p"
+            });
 
             expect(store.signInStep).toBe("CONTINUE_SIGN_IN_WITH_TOTP_SETUP");
             expect(store.totpSetup).toEqual({
@@ -389,12 +426,13 @@ describe("authStore", () => {
         it("returns early for new-password challenge without hydrating", async () => {
             vi.mocked(signIn).mockResolvedValue({
                 isSignedIn: false,
-                nextStep: {
-                    signInStep: "CONFIRM_SIGN_IN_WITH_NEW_PASSWORD_REQUIRED"
-                }
+                nextStep: { signInStep: "CONFIRM_SIGN_IN_WITH_NEW_PASSWORD_REQUIRED" }
             } as never);
 
-            await store.signIn({ username: "u", password: "p" });
+            await store.signIn({
+                username: "u",
+                password: "p"
+            });
 
             expect(store.signInStep).toBe("CONFIRM_SIGN_IN_WITH_NEW_PASSWORD_REQUIRED");
             expect(getCurrentUser).not.toHaveBeenCalled();
@@ -406,7 +444,10 @@ describe("authStore", () => {
                 nextStep: { signInStep: "CONFIRM_SIGN_IN_WITH_TOTP_CODE" }
             } as never);
 
-            await store.signIn({ username: "u", password: "p" });
+            await store.signIn({
+                username: "u",
+                password: "p"
+            });
 
             expect(store.signInStep).toBe("CONFIRM_SIGN_IN_WITH_TOTP_CODE");
             expect(getCurrentUser).not.toHaveBeenCalled();
@@ -418,7 +459,10 @@ describe("authStore", () => {
                 nextStep: undefined
             } as never);
 
-            await store.signIn({ username: "u", password: "p" });
+            await store.signIn({
+                username: "u",
+                password: "p"
+            });
 
             expect(store.signInStep).toBeNull();
             expect(getCurrentUser).not.toHaveBeenCalled();
@@ -441,9 +485,10 @@ describe("authStore", () => {
                 nextStep: { signInStep: "DONE" }
             } as never);
 
-            await expect(store.signIn({ username: "u", password: "p" })).rejects.toMatchObject({
-                name: "MissingSessionTokensError"
-            });
+            await expect(store.signIn({
+                username: "u",
+                password: "p"
+            })).rejects.toMatchObject({ name: "MissingSessionTokensError" });
 
             // hydrate must not have been attempted — `getCurrentUser` is
             // hydrate's first Amplify call and would proceed if the wait
@@ -473,9 +518,7 @@ describe("authStore", () => {
             vi.mocked(fetchAuthSession)
                 .mockReset()
                 .mockResolvedValueOnce({ tokens: undefined } as never)
-                .mockResolvedValueOnce({
-                    tokens: { accessToken: { toString: () => "access" } as never }
-                } as never);
+                .mockResolvedValueOnce({ tokens: { accessToken: { toString: () => "access" } as never } } as never);
             vi.mocked(signIn).mockResolvedValue({
                 isSignedIn: true,
                 nextStep: { signInStep: "DONE" }
@@ -484,14 +527,20 @@ describe("authStore", () => {
                 username: "u",
                 userId: "id"
             } as never);
-            vi.mocked(getMfaStatus).mockResolvedValue({ enabled: true, required: true });
+            vi.mocked(getMfaStatus).mockResolvedValue({
+                enabled: true,
+                required: true
+            });
             vi.mocked(fetchUserAttributes).mockResolvedValue({
                 sub: "s",
                 email: "e@f.com"
             } as never);
             vi.mocked(getUserPermissions).mockResolvedValue({ permissions: [] });
 
-            await store.signIn({ username: "u", password: "p" });
+            await store.signIn({
+                username: "u",
+                password: "p"
+            });
 
             expect(fetchAuthSession).toHaveBeenCalledTimes(2);
             expect(fetchAuthSession).toHaveBeenNthCalledWith(2, { forceRefresh: true });
@@ -504,9 +553,7 @@ describe("authStore", () => {
             // tab still has a live session. Recover by signing the stale
             // session out and retrying once, otherwise the user is stuck on
             // the login page until they clear storage by hand.
-            const stale = Object.assign(new Error("There is already a signed in user."), {
-                name: "UserAlreadyAuthenticatedException"
-            });
+            const stale = Object.assign(new Error("There is already a signed in user."), { name: "UserAlreadyAuthenticatedException" });
             vi.mocked(signIn)
                 .mockReset()
                 .mockRejectedValueOnce(stale)
@@ -519,14 +566,20 @@ describe("authStore", () => {
                 username: "u",
                 userId: "id"
             } as never);
-            vi.mocked(getMfaStatus).mockResolvedValue({ enabled: true, required: true });
+            vi.mocked(getMfaStatus).mockResolvedValue({
+                enabled: true,
+                required: true
+            });
             vi.mocked(fetchUserAttributes).mockResolvedValue({
                 sub: "s",
                 email: "e@f.com"
             } as never);
             vi.mocked(getUserPermissions).mockResolvedValue({ permissions: [] });
 
-            await store.signIn({ username: "u", password: "p" });
+            await store.signIn({
+                username: "u",
+                password: "p"
+            });
 
             expect(signIn).toHaveBeenCalledTimes(2);
             expect(signOut).toHaveBeenCalledTimes(1);
@@ -544,9 +597,7 @@ describe("authStore", () => {
             // UserAlreadyAuthenticatedException (token write hadn't settled,
             // another tab racing), the store must let the error bubble
             // instead of retrying again. Two attempts max, no infinite loop.
-            const stale = Object.assign(new Error("There is already a signed in user."), {
-                name: "UserAlreadyAuthenticatedException"
-            });
+            const stale = Object.assign(new Error("There is already a signed in user."), { name: "UserAlreadyAuthenticatedException" });
             vi.mocked(signIn)
                 .mockReset()
                 .mockRejectedValueOnce(stale)
@@ -554,10 +605,11 @@ describe("authStore", () => {
             vi.mocked(signOut).mockResolvedValue(undefined as never);
 
             await expect(
-                store.signIn({ username: "u", password: "p" })
-            ).rejects.toMatchObject({
-                name: "UserAlreadyAuthenticatedException"
-            });
+                store.signIn({
+                    username: "u",
+                    password: "p"
+                })
+            ).rejects.toMatchObject({ name: "UserAlreadyAuthenticatedException" });
 
             expect(signIn).toHaveBeenCalledTimes(2);
             expect(signOut).toHaveBeenCalledTimes(1);
@@ -567,13 +619,14 @@ describe("authStore", () => {
         });
 
         it("does not retry on errors other than UserAlreadyAuthenticatedException", async () => {
-            const wrongPassword = Object.assign(new Error("Incorrect username or password."), {
-                name: "NotAuthorizedException"
-            });
+            const wrongPassword = Object.assign(new Error("Incorrect username or password."), { name: "NotAuthorizedException" });
             vi.mocked(signIn).mockReset().mockRejectedValue(wrongPassword);
 
             await expect(
-                store.signIn({ username: "u", password: "p" })
+                store.signIn({
+                    username: "u",
+                    password: "p"
+                })
             ).rejects.toThrow("Incorrect username or password.");
 
             expect(signIn).toHaveBeenCalledTimes(1);
@@ -600,7 +653,10 @@ describe("authStore", () => {
             const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
             await expect(
-                store.signIn({ username: "u", password: "p" })
+                store.signIn({
+                    username: "u",
+                    password: "p"
+                })
             ).rejects.toThrow("Request failed with status code 401");
 
             expect(consoleSpy).toHaveBeenCalledWith(
@@ -622,7 +678,10 @@ describe("authStore", () => {
                 username: "u",
                 userId: "id"
             } as never);
-            vi.mocked(getMfaStatus).mockResolvedValue({ enabled: false, required: true });
+            vi.mocked(getMfaStatus).mockResolvedValue({
+                enabled: false,
+                required: true
+            });
             vi.mocked(fetchUserAttributes).mockResolvedValue({
                 sub: "s",
                 email: "e@f.com"
@@ -630,9 +689,7 @@ describe("authStore", () => {
 
             await store.changePassword("newPassword123!");
 
-            expect(confirmSignIn).toHaveBeenCalledWith({
-                challengeResponse: "newPassword123!"
-            });
+            expect(confirmSignIn).toHaveBeenCalledWith({ challengeResponse: "newPassword123!" });
             expect(store.signInStep).toBe("DONE");
             expect(store.mfaEnabled).toBe(false);
         });
@@ -741,9 +798,7 @@ describe("authStore", () => {
             await store.confirmTotpChallenge("123456");
 
             expect(Snackbar.show).toHaveBeenCalledWith(
-                expect.objectContaining({
-                    type: "warning"
-                })
+                expect.objectContaining({ type: "warning" })
             );
             consoleSpy.mockRestore();
         });
@@ -763,7 +818,10 @@ describe("authStore", () => {
         });
 
         it("sets MFA preference, clears totpSetup, then hydrates with known-true MFA", async () => {
-            store.totpSetup = { sharedSecret: "ABC", setupUri: "otpauth://..." };
+            store.totpSetup = {
+                sharedSecret: "ABC",
+                setupUri: "otpauth://..."
+            };
             vi.mocked(confirmSignIn).mockResolvedValue({
                 isSignedIn: true,
                 nextStep: undefined
@@ -850,7 +908,10 @@ describe("authStore", () => {
             const getSetupUri = vi.fn(() => url);
             store.pendingUsername = "u@e.com";
             store.captureTotpSetupDetails({
-                totpSetupDetails: { sharedSecret: "SEC", getSetupUri }
+                totpSetupDetails: {
+                    sharedSecret: "SEC",
+                    getSetupUri
+                }
             });
 
             expect(getSetupUri).toHaveBeenCalledWith("FLIP", "u@e.com");
@@ -865,7 +926,10 @@ describe("authStore", () => {
             const getSetupUri = vi.fn(() => url);
             store.pendingUsername = null;
             store.captureTotpSetupDetails({
-                totpSetupDetails: { sharedSecret: "SEC", getSetupUri }
+                totpSetupDetails: {
+                    sharedSecret: "SEC",
+                    getSetupUri
+                }
             });
 
             expect(getSetupUri).toHaveBeenCalledWith("FLIP", undefined);
@@ -891,7 +955,10 @@ describe("authStore", () => {
             store.user = {
                 username: "u",
                 userId: "id",
-                attributes: { sub: "s", email: "e@f.com" },
+                attributes: {
+                    sub: "s",
+                    email: "e@f.com"
+                },
                 permissions: []
             };
 
@@ -920,7 +987,10 @@ describe("authStore", () => {
 
     describe("completeMfaEnrolment", () => {
         it("verifies code, sets MFA preference, clears setup, and hydrates known-true", async () => {
-            store.totpSetup = { sharedSecret: "ABC", setupUri: "otpauth://..." };
+            store.totpSetup = {
+                sharedSecret: "ABC",
+                setupUri: "otpauth://..."
+            };
             vi.mocked(verifyTOTPSetup).mockResolvedValue(undefined as never);
             vi.mocked(updateMFAPreference).mockResolvedValue(undefined as never);
             vi.mocked(getCurrentUser).mockResolvedValue({
@@ -997,7 +1067,10 @@ describe("authStore", () => {
             store.user = {
                 username: "u",
                 userId: "id",
-                attributes: { sub: "s", email: "e@f.com" },
+                attributes: {
+                    sub: "s",
+                    email: "e@f.com"
+                },
                 permissions: []
             };
             store.signInStep = "DONE";
@@ -1019,7 +1092,10 @@ describe("authStore", () => {
             store.user = {
                 username: "u",
                 userId: "id",
-                attributes: { sub: "s", email: "e@f.com" },
+                attributes: {
+                    sub: "s",
+                    email: "e@f.com"
+                },
                 permissions: []
             };
 
@@ -1031,9 +1107,7 @@ describe("authStore", () => {
             );
             expect(store.user).toBeNull();
             expect(routeChange.gotoLogin).toHaveBeenCalledTimes(1);
-            expect(Snackbar.error).toHaveBeenCalledWith(expect.objectContaining({
-                title: "Sign-out incomplete"
-            }));
+            expect(Snackbar.error).toHaveBeenCalledWith(expect.objectContaining({ title: "Sign-out incomplete" }));
             consoleSpy.mockRestore();
         });
 
@@ -1043,15 +1117,16 @@ describe("authStore", () => {
             // with NotAuthorizedException as expected. Surfacing any
             // snackbar here would stack on top of the interceptor's
             // "Not Authorised" message every time the session expires.
-            const expected = Object.assign(new Error("Access Token has been revoked"), {
-                name: "NotAuthorizedException"
-            });
+            const expected = Object.assign(new Error("Access Token has been revoked"), { name: "NotAuthorizedException" });
             vi.mocked(signOut).mockRejectedValue(expected);
             const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
             store.user = {
                 username: "u",
                 userId: "id",
-                attributes: { sub: "s", email: "e@f.com" },
+                attributes: {
+                    sub: "s",
+                    email: "e@f.com"
+                },
                 permissions: []
             };
 
@@ -1070,15 +1145,16 @@ describe("authStore", () => {
             // current code blanket-suppresses NotAuthorizedException so the
             // user gets no signal about the remote revocation. For
             // user-initiated sign-out, show an info-level message either way.
-            const expected = Object.assign(new Error("Access Token has been revoked"), {
-                name: "NotAuthorizedException"
-            });
+            const expected = Object.assign(new Error("Access Token has been revoked"), { name: "NotAuthorizedException" });
             vi.mocked(signOut).mockRejectedValue(expected);
             const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
             store.user = {
                 username: "u",
                 userId: "id",
-                attributes: { sub: "s", email: "e@f.com" },
+                attributes: {
+                    sub: "s",
+                    email: "e@f.com"
+                },
                 permissions: []
             };
 
@@ -1137,7 +1213,10 @@ describe("authStore", () => {
             store.user = {
                 username: "u",
                 userId: "id",
-                attributes: { sub: "s", email: "e@f.com" },
+                attributes: {
+                    sub: "s",
+                    email: "e@f.com"
+                },
                 permissions: ["CanManageUsers", "CanManageProjects"]
             };
 
@@ -1151,7 +1230,10 @@ describe("authStore", () => {
             store.user = {
                 username: "u",
                 userId: "id",
-                attributes: { sub: "s", email: "e@f.com" },
+                attributes: {
+                    sub: "s",
+                    email: "e@f.com"
+                },
                 permissions: ["CanManageUsers"]
             };
 
@@ -1165,7 +1247,10 @@ describe("authStore", () => {
             store.user = {
                 username: "u",
                 userId: "id",
-                attributes: { sub: "s", email: "e@f.com" },
+                attributes: {
+                    sub: "s",
+                    email: "e@f.com"
+                },
                 permissions: []
             };
 

--- a/flip-ui/src/unit-tests/layouts/__tests__/AuthLayout.spec.ts
+++ b/flip-ui/src/unit-tests/layouts/__tests__/AuthLayout.spec.ts
@@ -15,16 +15,19 @@ import { createTestingPinia } from "@pinia/testing";
 import { flushPromises, mount, VueWrapper } from "@vue/test-utils";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
-import { useAuthStore } from "@/store/auth";
-
 import AuthLayout from "@/layouts/AuthLayout.vue";
+import { useAuthStore } from "@/store/auth";
 
 // The layout uses useRoute() to pick the current page — mock it per test so
 // we can simulate navigation to Login, mfa-verify, mfa-setup etc.
-const currentRoute = { name: "", path: "" };
+const currentRoute = {
+    name: "",
+    path: ""
+};
 
 vi.mock("vue-router", async (importOriginal) => {
     const actual = await importOriginal<typeof import("vue-router")>();
+
     return {
         ...actual,
         useRoute: () => currentRoute
@@ -41,9 +44,7 @@ vi.mock("@/router", () => ({
 
 const mockAmplifySignOut = vi.fn();
 
-vi.mock("aws-amplify/auth", () => ({
-    signOut: (...args: unknown[]) => mockAmplifySignOut(...args)
-}));
+vi.mock("aws-amplify/auth", () => ({ signOut: (...args: unknown[]) => mockAmplifySignOut(...args) }));
 
 function mountLayout(route: { name: string; path: string }): VueWrapper {
     currentRoute.name = route.name;
@@ -78,7 +79,10 @@ describe("AuthLayout — Back to log in button", () => {
         locationAssign = vi.fn();
         Object.defineProperty(window, "location", {
             configurable: true,
-            value: { ...window.location, assign: locationAssign }
+            value: {
+                ...window.location,
+                assign: locationAssign
+            }
         });
     });
 
@@ -90,19 +94,28 @@ describe("AuthLayout — Back to log in button", () => {
     });
 
     test("is hidden on the Login page itself (already there)", () => {
-        const wrapper = mountLayout({ name: "auth-Login", path: "/auth/login" });
+        const wrapper = mountLayout({
+            name: "auth-Login",
+            path: "/auth/login"
+        });
 
         expect(wrapper.find("[data-test='back-to-login']").exists()).toBe(false);
     });
 
     test("is rendered on the MFA-verify page", () => {
-        const wrapper = mountLayout({ name: "auth-mfa-verify", path: "/auth/mfa-verify" });
+        const wrapper = mountLayout({
+            name: "auth-mfa-verify",
+            path: "/auth/mfa-verify"
+        });
 
         expect(wrapper.find("[data-test='back-to-login']").exists()).toBe(true);
     });
 
     test("is rendered on the MFA-setup page", () => {
-        const wrapper = mountLayout({ name: "auth-mfa-setup", path: "/auth/mfa-setup" });
+        const wrapper = mountLayout({
+            name: "auth-mfa-setup",
+            path: "/auth/mfa-setup"
+        });
 
         expect(wrapper.find("[data-test='back-to-login']").exists()).toBe(true);
     });
@@ -112,7 +125,10 @@ describe("AuthLayout — Back to log in button", () => {
         // after a failed MFA attempt (Amplify + router-guard could bounce
         // the user straight back). The handler must do a hard navigation
         // so nothing can short-circuit it.
-        const wrapper = mountLayout({ name: "auth-mfa-verify", path: "/auth/mfa-verify" });
+        const wrapper = mountLayout({
+            name: "auth-mfa-verify",
+            path: "/auth/mfa-verify"
+        });
         const authStore = useAuthStore();
         authStore.signInStep = "CONFIRM_SIGN_IN_WITH_TOTP_CODE";
         const localStorageClear = vi.spyOn(Storage.prototype, "clear");
@@ -136,7 +152,10 @@ describe("AuthLayout — Back to log in button", () => {
             () => new Promise<void>(resolve => { resolveSignOut = resolve; })
         );
 
-        const wrapper = mountLayout({ name: "auth-mfa-verify", path: "/auth/mfa-verify" });
+        const wrapper = mountLayout({
+            name: "auth-mfa-verify",
+            path: "/auth/mfa-verify"
+        });
         const authStore = useAuthStore();
 
         await wrapper.find("[data-test='back-to-login']").trigger("click");

--- a/flip-ui/src/unit-tests/pages/auth/__tests__/Login.spec.ts
+++ b/flip-ui/src/unit-tests/pages/auth/__tests__/Login.spec.ts
@@ -15,9 +15,8 @@ import { createTestingPinia } from "@pinia/testing";
 import { flushPromises, mount, VueWrapper } from "@vue/test-utils";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
-import { useAuthStore } from "@/store/auth";
-
 import Login from "@/pages/auth/Login.vue";
+import { useAuthStore } from "@/store/auth";
 
 // Router is imported at module-scope by the page, so it has to be mocked
 // before any Login import resolves. The spies here let us assert which
@@ -55,9 +54,7 @@ vi.mock("@/utils/snackbar", () => ({
 // short-circuit straight to /projects. Default is "no session" — each
 // suite re-arms it if we want to exercise the short-circuit path.
 const mockFetchAuthSession = vi.fn();
-vi.mock("aws-amplify/auth", () => ({
-    fetchAuthSession: (...args: unknown[]) => mockFetchAuthSession(...args)
-}));
+vi.mock("aws-amplify/auth", () => ({ fetchAuthSession: (...args: unknown[]) => mockFetchAuthSession(...args) }));
 
 interface AuthStoreState {
     signInStep: string | null;
@@ -135,7 +132,12 @@ describe("Login page", () => {
     describe("onBeforeMount short-circuit", () => {
         test("redirects to /projects when the user already has an access token", async () => {
             mockFetchAuthSession.mockResolvedValueOnce({
-                tokens: { accessToken: { payload: {}, toString: () => "tok" } }
+                tokens: {
+                    accessToken: {
+                        payload: {},
+                        toString: () => "tok"
+                    }
+                }
             });
 
             mountLogin();
@@ -232,7 +234,10 @@ describe("Login page", () => {
             // set that explicitly — the default mfaRequired=null would
             // prevent the enrolment redirect from firing even with
             // mfaEnabled=false.
-            const wrapper = mountLogin({ mfaEnabled: false, mfaRequired: true });
+            const wrapper = mountLogin({
+                mfaEnabled: false,
+                mfaRequired: true
+            });
             await flushPromises();
             const authStore = useAuthStore();
             (authStore.signIn as unknown as ReturnType<typeof vi.fn>).mockImplementationOnce(
@@ -262,7 +267,10 @@ describe("Login page", () => {
                     authStore.user = {
                         username: "u",
                         userId: "u",
-                        attributes: { sub: "s", email: "u@e.com" },
+                        attributes: {
+                            sub: "s",
+                            email: "u@e.com"
+                        },
                         permissions: []
                     };
                 }
@@ -290,7 +298,10 @@ describe("Login page", () => {
                     authStore.user = {
                         username: "u",
                         userId: "u",
-                        attributes: { sub: "s", email: "u@e.com" },
+                        attributes: {
+                            sub: "s",
+                            email: "u@e.com"
+                        },
                         permissions: []
                     };
                 }
@@ -316,7 +327,10 @@ describe("Login page", () => {
 
             expect(mockSnackbarShow).toHaveBeenCalledTimes(1);
             const [payload] = mockSnackbarShow.mock.calls[0];
-            expect(payload).toMatchObject({ type: "error", title: "Error" });
+            expect(payload).toMatchObject({
+                type: "error",
+                title: "Error"
+            });
             expect(mockViewProjects).not.toHaveBeenCalled();
             expect(mockMfaSetup).not.toHaveBeenCalled();
             expect(mockMfaVerify).not.toHaveBeenCalled();

--- a/flip-ui/src/unit-tests/pages/auth/__tests__/mfa-setup.spec.ts
+++ b/flip-ui/src/unit-tests/pages/auth/__tests__/mfa-setup.spec.ts
@@ -13,12 +13,11 @@
 
 import { createTestingPinia } from "@pinia/testing";
 import { flushPromises, mount, VueWrapper } from "@vue/test-utils";
-import { nextTick } from "vue";
 import { beforeEach, describe, expect, test, vi } from "vitest";
-
-import { useAuthStore } from "@/store/auth";
+import { nextTick } from "vue";
 
 import MfaSetup from "@/pages/auth/mfa-setup.vue";
+import { useAuthStore } from "@/store/auth";
 
 // Route/router mocks — the page calls routeChange.* and we need to assert
 // on which navigation target it picked.
@@ -46,9 +45,7 @@ vi.mock("@/utils/snackbar", () => ({
 // QR rendering is a canvas side-effect; stub it so we can verify the URI
 // passed in without running anything in jsdom.
 const mockToDataURL = vi.fn().mockResolvedValue("data:image/png;base64,STUB");
-vi.mock("qrcode", () => ({
-    default: { toDataURL: (...args: unknown[]) => mockToDataURL(...args) }
-}));
+vi.mock("qrcode", () => ({ default: { toDataURL: (...args: unknown[]) => mockToDataURL(...args) } }));
 
 const SIGN_IN_CHAIN_STEP = "CONTINUE_SIGN_IN_WITH_TOTP_SETUP";
 
@@ -126,11 +123,14 @@ describe("mfa-setup page", () => {
         expect(wrapper.find("[data-test='mfa-setup-signout-btn']").exists()).toBe(false);
     });
 
-describe("Sign-in-chain flow (signInStep = CONTINUE_SIGN_IN_WITH_TOTP_SETUP)", () => {
+    describe("Sign-in-chain flow (signInStep = CONTINUE_SIGN_IN_WITH_TOTP_SETUP)", () => {
         test("does not call beginMfaEnrolment — the setup details are already in the store", async () => {
             const wrapper = mountMfaSetup({
                 signInStep: SIGN_IN_CHAIN_STEP,
-                totpSetup: { sharedSecret: "ABCD1234", setupUri: "otpauth://totp/FLIP" }
+                totpSetup: {
+                    sharedSecret: "ABCD1234",
+                    setupUri: "otpauth://totp/FLIP"
+                }
             });
             await flushPromises();
             const authStore = useAuthStore();
@@ -144,7 +144,10 @@ describe("Sign-in-chain flow (signInStep = CONTINUE_SIGN_IN_WITH_TOTP_SETUP)", (
             // If we somehow reach the page mid-sign-in-chain with no
             // totpSetupDetails in the store, there's nothing to render;
             // sending the user back to login is the only safe recovery.
-            mountMfaSetup({ signInStep: SIGN_IN_CHAIN_STEP, totpSetup: null });
+            mountMfaSetup({
+                signInStep: SIGN_IN_CHAIN_STEP,
+                totpSetup: null
+            });
             await flushPromises();
 
             expect(mockGotoLogin).toHaveBeenCalledTimes(1);
@@ -155,7 +158,10 @@ describe("Sign-in-chain flow (signInStep = CONTINUE_SIGN_IN_WITH_TOTP_SETUP)", (
         test("submit routes through confirmTotpSetup (not completeMfaEnrolment)", async () => {
             const wrapper = mountMfaSetup({
                 signInStep: SIGN_IN_CHAIN_STEP,
-                totpSetup: { sharedSecret: "ABCD1234", setupUri: "otpauth://totp/FLIP" }
+                totpSetup: {
+                    sharedSecret: "ABCD1234",
+                    setupUri: "otpauth://totp/FLIP"
+                }
             });
             await flushPromises();
             const authStore = useAuthStore();
@@ -173,7 +179,10 @@ describe("Sign-in-chain flow (signInStep = CONTINUE_SIGN_IN_WITH_TOTP_SETUP)", (
         const signedInUser = {
             username: "u",
             userId: "u",
-            attributes: { sub: "s", email: "u@e.com" },
+            attributes: {
+                sub: "s",
+                email: "u@e.com"
+            },
             permissions: []
         };
 
@@ -221,7 +230,10 @@ describe("Sign-in-chain flow (signInStep = CONTINUE_SIGN_IN_WITH_TOTP_SETUP)", (
                 signInStep: "DONE",
                 user: signedInUser,
                 mfaEnabled: false,
-                totpSetup: { sharedSecret: "ABCD1234", setupUri: "otpauth://totp/FLIP" }
+                totpSetup: {
+                    sharedSecret: "ABCD1234",
+                    setupUri: "otpauth://totp/FLIP"
+                }
             });
             await flushPromises();
             const authStore = useAuthStore();
@@ -297,10 +309,14 @@ describe("Sign-in-chain flow (signInStep = CONTINUE_SIGN_IN_WITH_TOTP_SETUP)", (
                             inheritAttrs: false,
                             emits: ["submit"]
                         },
-                        AiInput: { template: "<input />",
-                            props: ["name", "type", "label", "preIcon", "inputProps"] },
-                        AiButton: { template: "<button><slot /></button>",
-                            props: ["primary", "clear", "block", "loading", "disabled"] }
+                        AiInput: {
+                            template: "<input />",
+                            props: ["name", "type", "label", "preIcon", "inputProps"]
+                        },
+                        AiButton: {
+                            template: "<button><slot /></button>",
+                            props: ["primary", "clear", "block", "loading", "disabled"]
+                        }
                     }
                 }
             });
@@ -318,12 +334,19 @@ describe("Sign-in-chain flow (signInStep = CONTINUE_SIGN_IN_WITH_TOTP_SETUP)", (
             mount(MfaSetup, {
                 global: {
                     stubs: {
-                        Form: { template: "<form><slot /></form>",
-                            inheritAttrs: false, emits: ["submit"] },
-                        AiInput: { template: "<input />",
-                            props: ["name", "type", "label", "preIcon", "inputProps"] },
-                        AiButton: { template: "<button><slot /></button>",
-                            props: ["primary", "clear", "block", "loading", "disabled"] }
+                        Form: {
+                            template: "<form><slot /></form>",
+                            inheritAttrs: false,
+                            emits: ["submit"]
+                        },
+                        AiInput: {
+                            template: "<input />",
+                            props: ["name", "type", "label", "preIcon", "inputProps"]
+                        },
+                        AiButton: {
+                            template: "<button><slot /></button>",
+                            props: ["primary", "clear", "block", "loading", "disabled"]
+                        }
                     }
                 }
             });
@@ -341,7 +364,10 @@ describe("Sign-in-chain flow (signInStep = CONTINUE_SIGN_IN_WITH_TOTP_SETUP)", (
     describe("submit error handling", () => {
         const buildSigninChainState = (): Partial<AuthStoreState> => ({
             signInStep: SIGN_IN_CHAIN_STEP,
-            totpSetup: { sharedSecret: "ABCD1234", setupUri: "otpauth://totp/FLIP" }
+            totpSetup: {
+                sharedSecret: "ABCD1234",
+                setupUri: "otpauth://totp/FLIP"
+            }
         });
 
         test("CodeMismatchException shows the 'Invalid code' snackbar (user retry will help)", async () => {
@@ -350,9 +376,7 @@ describe("Sign-in-chain flow (signInStep = CONTINUE_SIGN_IN_WITH_TOTP_SETUP)", (
             const authStore = useAuthStore();
             // Cognito's canonical name for a wrong TOTP digit; the page
             // treats this as a retryable user error, not an infra error.
-            const mismatch = Object.assign(new Error("Invalid code passed"), {
-                name: "CodeMismatchException"
-            });
+            const mismatch = Object.assign(new Error("Invalid code passed"), { name: "CodeMismatchException" });
             (authStore.confirmTotpSetup as unknown as ReturnType<typeof vi.fn>)
                 .mockRejectedValueOnce(mismatch);
 
@@ -376,9 +400,7 @@ describe("Sign-in-chain flow (signInStep = CONTINUE_SIGN_IN_WITH_TOTP_SETUP)", (
             const wrapper = mountMfaSetup(buildSigninChainState());
             await flushPromises();
             const authStore = useAuthStore();
-            const expired = Object.assign(new Error("Your software token has expired."), {
-                name: "ExpiredCodeException"
-            });
+            const expired = Object.assign(new Error("Your software token has expired."), { name: "ExpiredCodeException" });
             (authStore.confirmTotpSetup as unknown as ReturnType<typeof vi.fn>)
                 .mockRejectedValueOnce(expired);
 
@@ -438,17 +460,21 @@ describe("Sign-in-chain flow (signInStep = CONTINUE_SIGN_IN_WITH_TOTP_SETUP)", (
                 user: {
                     username: "u",
                     userId: "u",
-                    attributes: { sub: "s", email: "u@e.com" },
+                    attributes: {
+                        sub: "s",
+                        email: "u@e.com"
+                    },
                     permissions: []
                 },
                 mfaEnabled: false,
-                totpSetup: { sharedSecret: "ABCD1234", setupUri: "otpauth://totp/FLIP" }
+                totpSetup: {
+                    sharedSecret: "ABCD1234",
+                    setupUri: "otpauth://totp/FLIP"
+                }
             });
             await flushPromises();
             const authStore = useAuthStore();
-            const mismatch = Object.assign(new Error("Invalid code passed"), {
-                name: "CodeMismatchException"
-            });
+            const mismatch = Object.assign(new Error("Invalid code passed"), { name: "CodeMismatchException" });
             (authStore.completeMfaEnrolment as unknown as ReturnType<typeof vi.fn>)
                 .mockRejectedValueOnce(mismatch);
 
@@ -470,7 +496,10 @@ describe("Sign-in-chain flow (signInStep = CONTINUE_SIGN_IN_WITH_TOTP_SETUP)", (
             mockToDataURL.mockRejectedValueOnce(new Error("invalid URI"));
             const wrapper = mountMfaSetup({
                 signInStep: SIGN_IN_CHAIN_STEP,
-                totpSetup: { sharedSecret: "ABCD1234", setupUri: "not-a-valid-uri" }
+                totpSetup: {
+                    sharedSecret: "ABCD1234",
+                    setupUri: "not-a-valid-uri"
+                }
             });
             await flushPromises();
 
@@ -485,7 +514,10 @@ describe("Sign-in-chain flow (signInStep = CONTINUE_SIGN_IN_WITH_TOTP_SETUP)", (
             const setupUri = "otpauth://totp/FLIP:user?secret=ABCD1234";
             mountMfaSetup({
                 signInStep: SIGN_IN_CHAIN_STEP,
-                totpSetup: { sharedSecret: "ABCD1234", setupUri }
+                totpSetup: {
+                    sharedSecret: "ABCD1234",
+                    setupUri
+                }
             });
             await flushPromises();
 

--- a/flip-ui/src/unit-tests/pages/auth/__tests__/mfa-verify.spec.ts
+++ b/flip-ui/src/unit-tests/pages/auth/__tests__/mfa-verify.spec.ts
@@ -15,9 +15,8 @@ import { createTestingPinia } from "@pinia/testing";
 import { flushPromises, mount, VueWrapper } from "@vue/test-utils";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
-import { useAuthStore } from "@/store/auth";
-
 import MfaVerify from "@/pages/auth/mfa-verify.vue";
+import { useAuthStore } from "@/store/auth";
 
 // Route/router mocks — the page calls routeChange.* and we need to assert
 // on which navigation target it picked.
@@ -149,9 +148,7 @@ describe("mfa-verify page", () => {
             await flushPromises();
             const authStore = useAuthStore();
             (authStore.confirmTotpChallenge as unknown as ReturnType<typeof vi.fn>)
-                .mockRejectedValueOnce(Object.assign(new Error("Code mismatch"), {
-                    name: "CodeMismatchException"
-                }));
+                .mockRejectedValueOnce(Object.assign(new Error("Code mismatch"), { name: "CodeMismatchException" }));
 
             await wrapper.find("form").trigger("submit");
             await flushPromises();
@@ -167,9 +164,7 @@ describe("mfa-verify page", () => {
             await flushPromises();
             const authStore = useAuthStore();
             (authStore.confirmTotpChallenge as unknown as ReturnType<typeof vi.fn>)
-                .mockRejectedValueOnce(Object.assign(new Error("Token has expired"), {
-                    name: "ExpiredCodeException"
-                }));
+                .mockRejectedValueOnce(Object.assign(new Error("Token has expired"), { name: "ExpiredCodeException" }));
 
             await wrapper.find("form").trigger("submit");
             await flushPromises();
@@ -209,7 +204,10 @@ describe("mfa-verify page", () => {
 
             expect(mockSnackbarError).toHaveBeenCalledTimes(1);
             const [payload] = mockSnackbarError.mock.calls[0];
-            expect(payload).toMatchObject({ title: "Sign-in failed", text: "Network Error" });
+            expect(payload).toMatchObject({
+                title: "Sign-in failed",
+                text: "Network Error"
+            });
             expect(mockViewProjects).not.toHaveBeenCalled();
         });
 
@@ -240,7 +238,10 @@ describe("mfa-verify page", () => {
             await wrapper.find("form").trigger("submit");
             await flushPromises();
 
-            const btn = wrapper.findComponent({ ref: undefined, name: "AiButton" });
+            const btn = wrapper.findComponent({
+                ref: undefined,
+                name: "AiButton"
+            });
             // AiButton is stubbed — just verify the page didn't get
             // stuck: the store action completed (rejected) and the page
             // moved on to the error branch, so submitting again should

--- a/flip-ui/src/unit-tests/pages/auth/__tests__/new-password.spec.ts
+++ b/flip-ui/src/unit-tests/pages/auth/__tests__/new-password.spec.ts
@@ -15,9 +15,8 @@ import { createTestingPinia } from "@pinia/testing";
 import { flushPromises, mount, VueWrapper } from "@vue/test-utils";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
-import { useAuthStore } from "@/store/auth";
-
 import NewPassword from "@/pages/auth/new-password.vue";
+import { useAuthStore } from "@/store/auth";
 
 const mockGotoLogin = vi.fn();
 const mockViewProjects = vi.fn();
@@ -45,9 +44,7 @@ vi.mock("@/utils/snackbar", () => ({
 // The onBeforeMount guard delegates to isUserUnconfirmedCheck — stub it
 // so we can force each branch (unconfirmed → stay, else → redirect).
 const mockIsUserUnconfirmedCheck = vi.fn();
-vi.mock("@/utils/auth", () => ({
-    isUserUnconfirmedCheck: (...args: unknown[]) => mockIsUserUnconfirmedCheck(...args)
-}));
+vi.mock("@/utils/auth", () => ({ isUserUnconfirmedCheck: (...args: unknown[]) => mockIsUserUnconfirmedCheck(...args) }));
 
 interface AuthStoreState {
     signInStep: string | null;

--- a/flip-ui/src/unit-tests/pages/users/__tests__/UserManagement.spec.ts
+++ b/flip-ui/src/unit-tests/pages/users/__tests__/UserManagement.spec.ts
@@ -15,8 +15,8 @@
 
 import { createTestingPinia } from "@pinia/testing";
 import { flushPromises, mount, VueWrapper } from "@vue/test-utils";
-import { ref } from "vue";
 import { beforeEach, describe, expect, it, test, vi } from "vitest";
+import { ref } from "vue";
 
 import UserManagement from "@/pages/admin/users.vue";
 
@@ -33,8 +33,15 @@ vi.mock("swrv", () => {
                 .then((d) => { data.value = d; })
                 .catch((e) => { error.value = e; });
         }
-        return { data, error, mutate: vi.fn(), isValidating: ref(false) };
+
+        return {
+            data,
+            error,
+            mutate: vi.fn(),
+            isValidating: ref(false)
+        };
     };
+
     return { default: useSWRV };
 });
 
@@ -54,9 +61,7 @@ vi.mock("@/services/user-service", () => ({
     updateUserRoles: (...args: unknown[]) => mockUpdateUserRoles(...args)
 }));
 
-vi.mock("@/services/role-service", () => ({
-    getRoles: (...args: unknown[]) => mockGetRoles(...args)
-}));
+vi.mock("@/services/role-service", () => ({ getRoles: (...args: unknown[]) => mockGetRoles(...args) }));
 
 const mockRouteNotAllowed = vi.fn();
 const mockViewProjects = vi.fn();
@@ -84,14 +89,16 @@ vi.mock("@/utils/snackbar", () => ({
 // Authorised by default — tests that need the 403 branch override with
 // mockResolvedValueOnce(false).
 const mockCanAccessRoute = vi.fn().mockResolvedValue(true);
-vi.mock("@/utils/route-validator", () => ({
-    canAccessRoute: (...args: unknown[]) => mockCanAccessRoute(...args)
-}));
+vi.mock("@/utils/route-validator", () => ({ canAccessRoute: (...args: unknown[]) => mockCanAccessRoute(...args) }));
 
 const SAMPLE_USER = {
     id: "user-1",
     email: "user@example.com",
-    roles: [{ id: "role-1", rolename: "admin", roledescription: "Administrator" }],
+    roles: [{
+        id: "role-1",
+        rolename: "admin",
+        roledescription: "Administrator"
+    }],
     isDisabled: false
 };
 
@@ -161,8 +168,16 @@ describe("User Management", () => {
         });
         mockGetRoles.mockResolvedValue({
             roles: [
-                { id: "role-1", rolename: "admin", roledescription: "Administrator" },
-                { id: "role-2", rolename: "viewer", roledescription: "View-only" }
+                {
+                    id: "role-1",
+                    rolename: "admin",
+                    roledescription: "Administrator"
+                },
+                {
+                    id: "role-2",
+                    rolename: "viewer",
+                    roledescription: "View-only"
+                }
             ]
         });
     });
@@ -204,6 +219,7 @@ describe("User Management", () => {
             // Select the sample user so the action panel renders.
             await wrapper.find("[data-test='user']").trigger("click");
             await flushPromises();
+
             return wrapper;
         }
 
@@ -282,7 +298,11 @@ describe("User Management", () => {
             return {
                 id: "user-1",
                 email: "user@example.com",
-                roles: [{ id: "role-1", rolename: "admin", roledescription: "Administrator" }],
+                roles: [{
+                    id: "role-1",
+                    rolename: "admin",
+                    roledescription: "Administrator"
+                }],
                 isDisabled: false
             };
         }
@@ -303,6 +323,7 @@ describe("User Management", () => {
             await flushPromises();
             await flushPromises();
             await wrapper.find("[data-test='add-viewer-btn']").trigger("click");
+
             return wrapper;
         }
 

--- a/flip-ui/src/utils/__tests__/auth.spec.ts
+++ b/flip-ui/src/utils/__tests__/auth.spec.ts
@@ -19,9 +19,7 @@ import { useAuthStore } from "@/store/auth";
 import { authCheck, isUserUnconfirmedCheck, NO_FORCED_SIGNOUT_PATHS } from "@/utils/auth";
 import { Snackbar } from "@/utils/snackbar";
 
-vi.mock("aws-amplify/auth", () => ({
-    fetchAuthSession: vi.fn()
-}));
+vi.mock("aws-amplify/auth", () => ({ fetchAuthSession: vi.fn() }));
 
 // The module eagerly calls Hub.listen at import time; stub the utils to
 // keep the listener registration cheap and side-effect-free. Use
@@ -29,9 +27,7 @@ vi.mock("aws-amplify/auth", () => ({
 // (vi.mock is lifted to the top of the module at transform time). Tests
 // below read `capturedListener.fn` to invoke the real callback even
 // after vi.clearAllMocks() wipes mock.calls history.
-const capturedListener = vi.hoisted(() => ({
-    fn: null as ((data: { payload: { event: string } }) => void) | null
-}));
+const capturedListener = vi.hoisted(() => ({ fn: null as ((data: { payload: { event: string } }) => void) | null }));
 
 vi.mock("aws-amplify/utils", () => ({
     Hub: {
@@ -45,7 +41,15 @@ vi.mock("aws-amplify/utils", () => ({
 }));
 
 vi.mock("@/router", () => ({
-    default: { push: vi.fn(), currentRoute: { value: { path: "/", fullPath: "/" } } },
+    default: {
+        push: vi.fn(),
+        currentRoute: {
+            value: {
+                path: "/",
+                fullPath: "/"
+            }
+        }
+    },
     routeChange: { gotoLogin: vi.fn() }
 }));
 
@@ -65,7 +69,11 @@ function makeNext(): { next: Next; calls: (string | undefined)[] } {
     const next: Next = (path?: string) => {
         calls.push(path);
     };
-    return { next, calls };
+
+    return {
+        next,
+        calls
+    };
 }
 
 // Minimal RouteLocationNormalized stand-in — authCheck only reads `path`.
@@ -110,7 +118,10 @@ describe("authCheck", () => {
         auth.user = {
             username: "u",
             userId: "id",
-            attributes: { sub: "s", email: "u@e.com" },
+            attributes: {
+                sub: "s",
+                email: "u@e.com"
+            },
             permissions: []
         };
         auth.signInStep = "DONE";
@@ -187,7 +198,10 @@ describe("authCheck", () => {
             auth.user = {
                 username: "u",
                 userId: "id",
-                attributes: { sub: "s", email: "u@e.com" },
+                attributes: {
+                    sub: "s",
+                    email: "u@e.com"
+                },
                 permissions: []
             };
             auth.mfaEnabled = true;
@@ -209,7 +223,10 @@ describe("authCheck", () => {
         auth.user = {
             username: "u",
             userId: "id",
-            attributes: { sub: "s", email: "u@e.com" },
+            attributes: {
+                sub: "s",
+                email: "u@e.com"
+            },
             permissions: []
         };
         auth.mfaEnabled = false;
@@ -231,7 +248,10 @@ describe("authCheck", () => {
         auth.user = {
             username: "u",
             userId: "id",
-            attributes: { sub: "s", email: "u@e.com" },
+            attributes: {
+                sub: "s",
+                email: "u@e.com"
+            },
             permissions: []
         };
         auth.mfaEnabled = false;
@@ -254,7 +274,10 @@ describe("authCheck", () => {
         auth.user = {
             username: "u",
             userId: "id",
-            attributes: { sub: "s", email: "u@e.com" },
+            attributes: {
+                sub: "s",
+                email: "u@e.com"
+            },
             permissions: []
         };
         auth.mfaEnabled = false;
@@ -319,7 +342,10 @@ describe("authCheck — Cypress hook (VITE_E2E build flag)", () => {
         const user = {
             username: "u",
             userId: "id",
-            attributes: { sub: "s", email: "u@e.com" },
+            attributes: {
+                sub: "s",
+                email: "u@e.com"
+            },
             permissions: ["CanManageProjects"]
         };
         window.localStorage.setItem("cypress.auth.user", JSON.stringify(user));
@@ -400,12 +426,20 @@ describe("authCheck — Cypress hook (VITE_E2E build flag)", () => {
         auth.user = {
             username: "preloaded",
             userId: "p",
-            attributes: { sub: "p", email: "p@e.com" },
+            attributes: {
+                sub: "p",
+                email: "p@e.com"
+            },
             permissions: []
         };
         window.localStorage.setItem(
             "cypress.auth.user",
-            JSON.stringify({ username: "fromStorage", userId: "x", attributes: {}, permissions: [] })
+            JSON.stringify({
+                username: "fromStorage",
+                userId: "x",
+                attributes: {},
+                permissions: []
+            })
         );
         const { next, calls } = makeNext();
 
@@ -431,7 +465,10 @@ describe("__cypressTriggerSessionExpiry", () => {
         // re-imported auth.ts captures *our* Hub.dispatch reference.
         const dispatch = vi.fn();
         vi.doMock("aws-amplify/utils", () => ({
-            Hub: { listen: vi.fn(), dispatch }
+            Hub: {
+                listen: vi.fn(),
+                dispatch
+            }
         }));
 
         await import("@/utils/auth");
@@ -456,7 +493,10 @@ describe("__cypressTriggerSessionExpiry", () => {
         vi.stubEnv("VITE_E2E", "");
         vi.resetModules();
         vi.doMock("aws-amplify/utils", () => ({
-            Hub: { listen: vi.fn(), dispatch: vi.fn() }
+            Hub: {
+                listen: vi.fn(),
+                dispatch: vi.fn()
+            }
         }));
         // Make sure we're starting from a clean state.
         delete (window as unknown as { __cypressTriggerSessionExpiry?: unknown })
@@ -491,7 +531,10 @@ describe("isUserUnconfirmedCheck", () => {
         auth.user = {
             username: "u",
             userId: "id",
-            attributes: { sub: "s", email: "u@e.com" },
+            attributes: {
+                sub: "s",
+                email: "u@e.com"
+            },
             permissions: []
         };
         auth.signInStep = "DONE";
@@ -530,6 +573,7 @@ describe("Hub listener (tokenRefresh_failure)", () => {
         if (!capturedListener.fn) {
             throw new Error("Hub listener was not captured at module load");
         }
+
         return capturedListener.fn;
     }
 
@@ -570,7 +614,10 @@ describe("Hub listener (tokenRefresh_failure)", () => {
         auth.user = {
             username: "u",
             userId: "id",
-            attributes: { sub: "s", email: "u@e.com" },
+            attributes: {
+                sub: "s",
+                email: "u@e.com"
+            },
             permissions: []
         };
 


### PR DESCRIPTION
## Summary

`npm run lint` only linted files exactly **two levels** under `src/` (13 of 99 `.vue` files). The script passed **unquoted** globs (`npx eslint ./src/**/*.vue ./src/**/*.ts`), and npm runs scripts under `/bin/sh` where globstar is off — so `**` collapses to a single `*` and the shell pre-expands the globs before eslint sees them. eslint never gets the `**` patterns, so its own globstar-aware globbing never runs. Everything ≥3 levels deep — most of `src/partials/**` and the entire `[projectId]/[modelId]` route tree — was silently unlinted.

- **Commit 1 (`fix`)** — quote the globs so eslint expands them itself; grandfather three legacy single-word component names (`Timeline`/`Training`/`Filter`) via a scoped `eslint.config.mjs` override rather than renaming them app-wide.
- **Commit 2 (`style`)** — `eslint --fix` across the now-linted files, plus the 23 residual errors `--fix` can't auto-resolve:
  - drop unused `catch (e)` bindings (optional catch binding)
  - remove an unused import in `ProjectStatus.vue`
  - `@ts-ignore` → `@ts-expect-error` (with description) in the model page
  - fix a stale `@typescript-eslint/ban-types` disable directive (now `no-empty-object-type`) in `env.d.ts`
  - type test wrappers as `ReturnType<typeof mount>` instead of `any`

## Result

- `npm run lint` → **0 errors** (previously passed but covered only ~13% of files). 25 pre-existing, non-blocking warnings remain (`max-len`, `vue/no-required-prop-with-default`).
- `npm run test:unit` → **512 passing**, unchanged. No behaviour changes.
- flip-ui CI (`test_flip_ui.yml`) gates on `npm run lint` + `npm run test:unit` — both green.

## Notes / out of scope

- `npm run build` (vue-tsc) is **not** a CI gate and already has ~12 pre-existing type errors on `develop` (unrelated files; surfaced only because I ran a type-check while verifying). Left for a separate PR.
- 41 files touched, mostly mechanical reformatting. With other branches in flight, conflicts are mechanically resolvable: take `develop` and re-run `npx eslint "./src/**/*.vue" "./src/**/*.ts" --fix`.

## Test plan

- [ ] `cd flip-ui && npm ci`
- [ ] `npm run lint` → 0 errors
- [ ] `npm run test:unit` → green
- [ ] Spot-check enforcement on a deep file (e.g. `src/partials/projects/ProjectStatus.vue`): add a temporary style violation and confirm `npm run lint` now flags it