### PR TITLE
docs: sync README/CLAUDE.md drift and add missing return type hints

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,7 +94,7 @@ change, since those live in the image layer, not the mounted `src/`.
 ```bash
 make unit_test             # All unit tests across all services (from root)
 make integration_test      # flip-api + trust integration tests (from root)
-make tests                 # flip-ui + flip-api tests (from root)
+make tests                 # flip-ui unit + e2e tests, then flip-api test suite (from root)
 make e2e_smoke             # End-to-end smoke against a running stack (see below)
 # From a service directory (e.g., flip-api/):
 make test                  # ruff + mypy + pytest (unit + integration)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -372,8 +372,8 @@ To run unit tests across all services in the main repository from the root:
 make unit_test
 ```
 
-`make tests` is a narrower target that runs `flip-ui` unit tests followed by the full `flip-api` test suite (ruff,
-mypy, and pytest).
+`make tests` is a narrower target that runs `flip-ui` unit and Cypress e2e tests followed by the full `flip-api`
+test suite (ruff, mypy, and pytest).
 
 For the `flip-fl-base` repository, unit tests can be run with:
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,8 @@ For example:
 | `make ci` | Run the CI pipeline locally using `act` |
 | `make up-local-trust` | Run a local (on-premises) trust (set `PROD=true` or `PROD=stag` for environment) |
 | `make unit_test` | Run unit tests across all services |
-| `make tests` | Run flip-ui unit tests and the full flip-api test suite (lint + mypy + pytest) |
+| `make tests` | Run flip-ui unit and e2e tests followed by the full flip-api test suite (lint + mypy + pytest) |
+| `make e2e_smoke` | Drive a full project lifecycle (create → upload → train → download) against an already-running stack (not run in CI) |
 | `make lock` | Regenerate every service's `uv.lock` from its `pyproject.toml` |
 | `make debug SERVICE=<name>` | Restart one service in debug mode (waits for a debugger on port 5678). Services: `flip-api`, `fl-api-net-1`, `trust-api`, `imaging-api`, `data-access-api` |
 | `make debug-off SERVICE=<name>` | Take a single service back out of debug mode |

--- a/flip-api/CLAUDE.md
+++ b/flip-api/CLAUDE.md
@@ -8,7 +8,7 @@ Central Hub REST API. FastAPI + asyncpg + SQLModel. Handles user auth (Cognito),
 
 | File | Purpose |
 |------|---------|
-| `src/flip_api/__init__.py` | FastAPI app factory, middleware, router registration |
+| `src/flip_api/main.py` | FastAPI app factory, middleware, router registration |
 | `src/flip_api/config.py` | Pydantic settings, env var loading |
 | `src/flip_api/db/database.py` | asyncpg async session, DB connection |
 | `src/flip_api/db/models/main_models.py` | SQLModel ORM: Project, Trust, Model, File, etc. |
@@ -41,7 +41,7 @@ Central Hub REST API. FastAPI + asyncpg + SQLModel. Handles user auth (Cognito),
 
 ```bash
 make test          # ruff + mypy + pytest (unit + integration)
-make unit_test     # ruff + mypy + pytest unit + step function tests (--skip-client --skip-db)
+make unit_test     # ruff + mypy + pytest unit + step function tests (--skip-client)
 make integration_test  # Integration tests only
 make local_test    # Tests without Docker (--skip-client --skip-db)
 make lint          # ruff check --fix (in Docker)

--- a/flip-api/src/flip_api/user_services/get_user.py
+++ b/flip-api/src/flip_api/user_services/get_user.py
@@ -29,7 +29,7 @@ def get_user(
     user_id: str,
     request: Request,
     token_id: UUID = Depends(verify_token),
-):
+) -> CognitoUser:
     """
     Get user details by ID or email.
 

--- a/flip-api/src/flip_api/user_services/register_user.py
+++ b/flip-api/src/flip_api/user_services/register_user.py
@@ -79,7 +79,7 @@ def register_user(
     request: Request,
     db: Session = Depends(get_session),
     token_id: UUID = Depends(verify_token),
-):
+) -> IUserResponse:
     """
     Register a new user in Cognito.
 


### PR DESCRIPTION
> _This PR is an automated scheduled weekly task by Alex's Claude Code._

## Summary

Picked up from a weekly audit of `README.md` / `CLAUDE.md` / `CONTRIBUTING.md` / readthedocs sources against the actual code on `develop`, plus a sweep for docstrings whose `Returns` clause didn't match the function signature.

### Documentation drift
- **`make tests` description was stale** across root `README.md` (line 89), root `CLAUDE.md` (line 97), and `CONTRIBUTING.md` (line 375-376). The root `Makefile` target now runs `flip-ui unit_test`, `flip-ui e2e_test`, then `flip-api test` — the docs only mentioned the unit step. Updated each to list the e2e step.
- **`make e2e_smoke` was missing from the root `README.md` command table** even though it exists in the `Makefile` and is documented in the root `CLAUDE.md`. Added a row.
- **`flip-api/CLAUDE.md` Key Files table** pointed at `src/flip_api/__init__.py` as the FastAPI app factory, but `__init__.py` is empty — the factory, middleware, and router registration all live in `src/flip_api/main.py`. Updated.
- **`flip-api/CLAUDE.md` Commands table** described `make unit_test` as passing `--skip-client --skip-db`. The actual recipe in `flip-api/Makefile` only passes `--skip-client`; `--skip-db` is only on `local_test`. Corrected.

### Type-annotation drift
Both of these endpoints have docstrings that explicitly document a `Returns:` type but were missing the `->` annotation on the signature itself:
- `flip-api/src/flip_api/user_services/register_user.py::register_user` — added `-> IUserResponse`
- `flip-api/src/flip_api/user_services/get_user.py::get_user` — added `-> CognitoUser`

`mypy --ignore-missing-imports` and `ruff check` both pass on the changed files. The targeted unit suites (`tests/unit/user_services/test_register_user.py`, `test_get_user.py`) pass — 13/13.

### Out of scope / not changed
A handful of other observations that I deliberately left out of this PR because they're either pre-existing patterns or could be re-litigated separately:
- Many FastAPI router handlers across `flip-api/src/flip_api/{project,model,fl,cohort}_services/` lack an explicit `->` annotation while still declaring a `Returns:` in their docstring. The codebase treats `response_model=` on the decorator as the contract. Touching all of those would be a wider refactor.
- `trust/imaging-api/CLAUDE.md` and `trust/data-access-api/CLAUDE.md` list `make test` / `make unit_test` but omit `local_test`, `lint`, `mypy`, `up`, `down`, `build`, `shell`. They're discoverable via `make help` / Makefile read; not strictly drift.
- `trust/orthanc/README.md` still keeps a legacy SharePoint link alongside the new Hugging Face mirror — kept "for reference" appears intentional.

## Test plan
- [x] `uv run mypy --ignore-missing-imports src/flip_api/user_services/{get_user,register_user}.py` — `Success: no issues found in 2 source files`
- [x] `uv run ruff check src/flip_api/user_services/{get_user,register_user}.py` — `All checks passed!`
- [x] `pytest tests/unit/user_services/test_get_user.py tests/unit/user_services/test_register_user.py` — 13 passed
- [ ] CI on this PR runs the full flip-api unit + integration suites — gating merge on green.

---
_Generated by [Claude Code](https://claude.ai/code/session_011Sndq3CuCNJ8kLokQ2u1DQ)_