### PR TITLE
fix(trust): address PR #567 review feedback

### DIFF
--- a/trust/Makefile
+++ b/trust/Makefile
@@ -157,11 +157,16 @@ build:
 
 # Pull/build behaviour is governed by $(UP_PULL_FLAGS): pulls fresh FL images
 # when DOCKER_FL_REGISTRY is set, builds from source on BUILD=true, no-op otherwise.
-# ensure omop and orthanc data are up to date before bringing up trust 1
-up-trust-1: update-omop-data update-orthanc-data
+# Refresh only Trust 1's omop + orthanc data (TRUST=1) before bringing it up, so
+# starting a single trust doesn't download/extract the other trust's data. Done via
+# a recursive $(MAKE) rather than as prerequisites: `up` builds both up-trust-1 and
+# up-trust-2, and a shared phony prerequisite would be built once (de-duplicated to a
+# single TRUST value) — separate sub-makes keep each trust's refresh independent.
+up-trust-1:
 	@echo "🚢 Starting Trust 1 services..."
 	@echo "⚙️ Using environment file ${MAIN_ENV_FILE}"
 	@echo "🧠 FL_BACKEND=$(FL_BACKEND) ($(FL_BACKEND_COMPOSE_FILE))"
+	$(MAKE) update-omop-data update-orthanc-data TRUST=1
 	mkdir -p ${BASE_IMAGES_DOWNLOAD_DIR_TRUST1}
 	$(TRUST_1_VARS) DEBUG=${DEBUG} ${DOCKER_COMPOSE_CMD} -f deploy/compose_trust-1_override.yml -p ${trust1} up -d $(UP_PULL_FLAGS)
 
@@ -210,11 +215,13 @@ down-local-trust:
 
 # Pull/build behaviour is governed by $(UP_PULL_FLAGS): pulls fresh FL images
 # when DOCKER_FL_REGISTRY is set, builds from source on BUILD=true, no-op otherwise.
-# ensure omop and orthanc data are up to date before bringing up trust 2
-up-trust-2: update-omop-data update-orthanc-data
+# Refresh only Trust 2's data (TRUST=2) before bringing it up — see up-trust-1 for
+# why this is a recursive $(MAKE) call rather than a prerequisite.
+up-trust-2:
 	@echo "🚢 Starting Trust 2 services..."
 	@echo "⚙️ Using environment file ${MAIN_ENV_FILE}"
 	@echo "🧠 FL_BACKEND=$(FL_BACKEND) ($(FL_BACKEND_COMPOSE_FILE))"
+	$(MAKE) update-omop-data update-orthanc-data TRUST=2
 	mkdir -p ${BASE_IMAGES_DOWNLOAD_DIR_TRUST2}
 	$(TRUST_2_VARS) ${DOCKER_COMPOSE_CMD} -p ${trust2} up -d $(UP_PULL_FLAGS)
 

--- a/trust/omop-db/.gitignore
+++ b/trust/omop-db/.gitignore
@@ -11,4 +11,4 @@
 #
 
 volumes/*/db_data
-volumes/.local_data_version
+volumes/.local_data_version*


### PR DESCRIPTION
## What this is

A **suggestions PR targeting `trust-data-from-huggingface`** (the head branch of #567), so merging it folds these changes directly into that PR. It implements two of the three points from the review on #567.

Branched from the current #567 head (`5dfb335`), so the diff is exactly the two fixes below.

## Changes

### 1. 🟠 (was blocking) omop-db `.gitignore` now covers the renamed version files
`update_omop_data.sh` writes `volumes/.local_data_version_trust1` / `_trust2`, but the ignore rule only matched the exact old path, leaving the new markers untracked (they showed up in `git status` after `make update-omop-data` / `up-trust-*`).

- `volumes/.local_data_version` → `volumes/.local_data_version*`

Verified with `git check-ignore`: the legacy file **and** both `_trust1` / `_trust2` markers now match. (Orthanc is unaffected — its `.gitignore` already ignores all of `volumes/`.)

### 3. 🟡 `up-trust-1` / `up-trust-2` use the `TRUST=` selector
Both targets now refresh only their own trust's omop + orthanc data (`TRUST=1` / `TRUST=2`) instead of pulling the other trust's ~2 GB too.

Implemented via a recursive `$(MAKE) … TRUST=N` in the recipe rather than as shared prerequisites **on purpose**: `make up` builds both `up-trust-1` and `up-trust-2`, and a shared phony prerequisite (`update-omop-data`) would be built only once — de-duplicated to a single `TRUST` value, leaving the other trust's data stale. Separate sub-makes keep each trust's refresh independent, so `make up` still refreshes both.

### Not included
Review point 2 (the one-time legacy version-file migration / orphan cleanup) is intentionally **not** part of this PR.

## Validation

- `git check-ignore` confirms the per-trust markers are now ignored (#1).
- `trust/Makefile` parses cleanly.
- `make up` still refreshes **both** trusts (recursive sub-makes, not a de-duplicated shared prerequisite); `make up-trust-1` / `up-trust-2` now refresh only their own.

https://claude.ai/code/session_01BapHJy2dZ8FVRwvo6yPuih