### PR TITLE
feat(#519): surface privacy-suppressed cohort counts and block staging zero/suppressed trusts

### DIFF
--- a/flip-api/src/flip_api/domain/interfaces/project.py
+++ b/flip-api/src/flip_api/domain/interfaces/project.py
@@ -66,6 +66,11 @@ class IProjectQuery(BaseModel):
     # non-null ``error``. Excluded from staging — even though we got a
     # reply, we have no usable cohort count.
     errored_trust_ids: list[UUID] = Field(default_factory=list, alias="erroredTrustIds")
+    # Subset of ``responded_trust_ids`` (disjoint from ``errored_trust_ids``) whose
+    # cohort count is 0 — either a genuine zero match or a privacy-suppressed
+    # below-threshold count (see issue #519). Excluded from staging: there is no
+    # cohort to build an imaging project against.
+    empty_trust_ids: list[UUID] = Field(default_factory=list, alias="emptyTrustIds")
     total_cohort: int | None = Field(default=None, alias="totalCohort")
     created: str | None = Field(default=None)
     created_by: str | None = Field(default=None, alias="createdBy")

--- a/flip-api/src/flip_api/domain/schemas/cohort.py
+++ b/flip-api/src/flip_api/domain/schemas/cohort.py
@@ -97,6 +97,9 @@ class OmopCohortResultsResponse(BaseModel):
     # and "still running" — see AggregatedCohortStats for the threat model.
     trust_record_counts: dict[str, int] = Field(default_factory=dict, alias="trustRecordCounts")
     trust_errors: dict[str, str] = Field(default_factory=dict, alias="trustErrors")
+    # trust_ids that privacy-suppressed their count (below threshold). The UI shows
+    # a "suppressed" chip instead of a literal 0 for these trusts. See issue #519.
+    trust_suppressed: list[str] = Field(default_factory=list, alias="trustSuppressed")
 
     model_config = ConfigDict(
         populate_by_name=True,

--- a/flip-api/src/flip_api/domain/schemas/private.py
+++ b/flip-api/src/flip_api/domain/schemas/private.py
@@ -40,6 +40,11 @@ class OmopCohortResults(BaseModel):
     # decryption failure, etc.). When set, the hub records the trust as errored
     # instead of leaving its per-trust UI status stuck on "running".
     error: str | None = None
+    # True when the trust privacy-suppressed the count (below COHORT_QUERY_THRESHOLD)
+    # rather than genuinely matching zero patients. Set by data-access-api and
+    # forwarded verbatim by trust-api. Lets the UI show a "suppressed" chip instead
+    # of a literal 0 that reads as "no data available". See issue #519.
+    suppressed: bool = False
 
     @validator("data", pre=True, always=True)
     def ensure_data_is_list(cls, value: Any) -> list[Any]:
@@ -73,6 +78,9 @@ class TrustSpecificData(BaseModel):  # Parsed from query_result.data JSON string
     record_count: int
     data: list[OmopData]
     error: str | None = None
+    # Mirrors OmopCohortResults.suppressed; persisted in QueryResult.data so the
+    # aggregator can flag privacy-suppressed trusts. See issue #519.
+    suppressed: bool = False
 
 
 class AggregatedTrustFieldResult(BaseModel):
@@ -96,6 +104,11 @@ class AggregatedCohortStats(BaseModel):  # Stored as JSON in query_stats.stats
     # trust_id (str) -> error message for trusts whose cohort query failed.
     # Mutually exclusive with trust_record_counts for the same trust.
     trust_errors: dict[str, str] = Field(default_factory=dict)
+    # trust_ids (str) that privacy-suppressed their count (below threshold).
+    # A suppressed trust still appears in trust_record_counts with count 0 — this
+    # list tells the UI to render a "suppressed" chip instead of a literal 0 that
+    # would read as "no data available". See issue #519.
+    trust_suppressed: list[str] = Field(default_factory=list)
 
 
 # Helper structure for data fetched from DB for aggregation

--- a/flip-api/src/flip_api/domain/schemas/private.py
+++ b/flip-api/src/flip_api/domain/schemas/private.py
@@ -40,7 +40,7 @@ class OmopCohortResults(BaseModel):
     # decryption failure, etc.). When set, the hub records the trust as errored
     # instead of leaving its per-trust UI status stuck on "running".
     error: str | None = None
-    # True when the trust privacy-suppressed the count (below COHORT_QUERY_THRESHOLD)
+    # True when the trust privacy-suppressed a non-zero count below COHORT_QUERY_THRESHOLD,
     # rather than genuinely matching zero patients. Set by data-access-api and
     # forwarded verbatim by trust-api. Lets the UI show a "suppressed" chip instead
     # of a literal 0 that reads as "no data available". See issue #519.

--- a/flip-api/src/flip_api/domain/schemas/private.py
+++ b/flip-api/src/flip_api/domain/schemas/private.py
@@ -40,10 +40,11 @@ class OmopCohortResults(BaseModel):
     # decryption failure, etc.). When set, the hub records the trust as errored
     # instead of leaving its per-trust UI status stuck on "running".
     error: str | None = None
-    # True when the trust privacy-suppressed a non-zero count below COHORT_QUERY_THRESHOLD,
-    # rather than genuinely matching zero patients. Set by data-access-api and
-    # forwarded verbatim by trust-api. Lets the UI show a "suppressed" chip instead
-    # of a literal 0 that reads as "no data available". See issue #519.
+    # True when the trust privacy-suppressed a below-threshold count. A genuine zero is
+    # suppressed identically, so this never reveals whether >=1 patient matched. Set by
+    # data-access-api and forwarded verbatim by trust-api. Lets the UI show a
+    # "below-threshold" chip instead of a literal 0 that reads as "no data available".
+    # See issue #519.
     suppressed: bool = False
 
     @validator("data", pre=True, always=True)

--- a/flip-api/src/flip_api/private_services/receive_cohort_results.py
+++ b/flip-api/src/flip_api/private_services/receive_cohort_results.py
@@ -90,6 +90,7 @@ def _save_individual_result(db: Session, cohort_results: OmopCohortResults) -> N
         "record_count": cohort_results.record_count,
         "data": [d.model_dump() for d in cohort_results.data],
         "error": cohort_results.error,
+        "suppressed": cohort_results.suppressed,
     })
 
     # Try to retrieve existing result
@@ -195,6 +196,7 @@ def _aggregate_and_save_results(db: Session, query_id: UUID) -> None:
 
         trust_record_counts: dict[str, int] = {}
         trust_errors: dict[str, str] = {}
+        trust_suppressed: list[str] = []
         for i, ptd in enumerate(parsed_trust_data_list):
             trust_id_str = fetched_data.trust_id[i]
             if ptd.error:
@@ -203,6 +205,11 @@ def _aggregate_and_save_results(db: Session, query_id: UUID) -> None:
                 trust_errors[trust_id_str] = _redact_trust_error(ptd.error)
             else:
                 trust_record_counts[trust_id_str] = ptd.record_count
+                # A suppressed trust still "responded successfully" (count 0), so it
+                # belongs in trust_record_counts; trust_suppressed flags it so the UI
+                # shows a suppression chip instead of a literal 0 (issue #519).
+                if ptd.suppressed:
+                    trust_suppressed.append(trust_id_str)
 
         all_field_names: set[str] = set()
         for trust_data_item in parsed_trust_data_list:
@@ -254,6 +261,7 @@ def _aggregate_and_save_results(db: Session, query_id: UUID) -> None:
             trusts_results=aggregated_field_results,
             trust_record_counts=trust_record_counts,
             trust_errors=trust_errors,
+            trust_suppressed=trust_suppressed,
         )
 
         # 4. Save aggregated stats

--- a/flip-api/src/flip_api/private_services/receive_cohort_results.py
+++ b/flip-api/src/flip_api/private_services/receive_cohort_results.py
@@ -197,6 +197,8 @@ def _aggregate_and_save_results(db: Session, query_id: UUID) -> None:
         trust_record_counts: dict[str, int] = {}
         trust_errors: dict[str, str] = {}
         trust_suppressed: list[str] = []
+        # error and suppressed are mutually exclusive by construction — data-access-api
+        # never sets both — so the suppressed flag is only read in the non-errored branch.
         for i, ptd in enumerate(parsed_trust_data_list):
             trust_id_str = fetched_data.trust_id[i]
             if ptd.error:

--- a/flip-api/src/flip_api/project_services/get_projects.py
+++ b/flip-api/src/flip_api/project_services/get_projects.py
@@ -34,9 +34,7 @@ from flip_api.domain.interfaces.project import IProject, IProjectQuery
 from flip_api.domain.schemas.actions import ProjectAuditAction
 from flip_api.domain.schemas.status import TaskStatus
 from flip_api.project_services.services.project_services import (
-    _collect_empty_cohort_trust_ids,
-    _collect_errored_trust_ids,
-    _distinct_responded_trust_ids,
+    _classify_responded_trust_ids,
     get_trusts_approval_status_for_projects,
 )
 from flip_api.utils.logger import logger
@@ -226,9 +224,11 @@ def _load_latest_query_per_project(
             continue
         rows_by_query.setdefault(qid, []).append((tid, data))
     for qid, rows in rows_by_query.items():
-        errored_trust_ids_by_query[qid] = _collect_errored_trust_ids(rows, query_id=qid)
-        empty_trust_ids_by_query[qid] = _collect_empty_cohort_trust_ids(rows, query_id=qid)
-        responded_trust_ids_by_query[qid] = _distinct_responded_trust_ids(rows)
+        (
+            responded_trust_ids_by_query[qid],
+            errored_trust_ids_by_query[qid],
+            empty_trust_ids_by_query[qid],
+        ) = _classify_responded_trust_ids(rows, query_id=qid)
 
     # Trust task state per query, split by status:
     #   PENDING   → "queued" chip (queued at hub, trust hasn't polled)

--- a/flip-api/src/flip_api/project_services/get_projects.py
+++ b/flip-api/src/flip_api/project_services/get_projects.py
@@ -209,7 +209,7 @@ def _load_latest_query_per_project(
 
     query_ids = [qid for qid, _, _, _, _, _ in latest_per_project.values()]
 
-    # QueryResult rows give us the responded set + errored carve-out per
+    # QueryResult rows give us the responded set + errored/empty carve-outs per
     # query. Volume is bounded (queries-in-page × trusts).
     errored_trust_ids_by_query: dict[UUID, list[UUID]] = {qid: [] for qid in query_ids}
     empty_trust_ids_by_query: dict[UUID, list[UUID]] = {qid: [] for qid in query_ids}

--- a/flip-api/src/flip_api/project_services/get_projects.py
+++ b/flip-api/src/flip_api/project_services/get_projects.py
@@ -34,6 +34,7 @@ from flip_api.domain.interfaces.project import IProject, IProjectQuery
 from flip_api.domain.schemas.actions import ProjectAuditAction
 from flip_api.domain.schemas.status import TaskStatus
 from flip_api.project_services.services.project_services import (
+    _collect_empty_cohort_trust_ids,
     _collect_errored_trust_ids,
     _distinct_responded_trust_ids,
     get_trusts_approval_status_for_projects,
@@ -213,6 +214,7 @@ def _load_latest_query_per_project(
     # QueryResult rows give us the responded set + errored carve-out per
     # query. Volume is bounded (queries-in-page × trusts).
     errored_trust_ids_by_query: dict[UUID, list[UUID]] = {qid: [] for qid in query_ids}
+    empty_trust_ids_by_query: dict[UUID, list[UUID]] = {qid: [] for qid in query_ids}
     responded_trust_ids_by_query: dict[UUID, list[UUID]] = {qid: [] for qid in query_ids}
     rows_by_query: dict[UUID, list[tuple[UUID | None, str | None]]] = {qid: [] for qid in query_ids}
     pair_rows = session.exec(
@@ -225,6 +227,7 @@ def _load_latest_query_per_project(
         rows_by_query.setdefault(qid, []).append((tid, data))
     for qid, rows in rows_by_query.items():
         errored_trust_ids_by_query[qid] = _collect_errored_trust_ids(rows, query_id=qid)
+        empty_trust_ids_by_query[qid] = _collect_empty_cohort_trust_ids(rows, query_id=qid)
         responded_trust_ids_by_query[qid] = _distinct_responded_trust_ids(rows)
 
     # Trust task state per query, split by status:
@@ -277,6 +280,7 @@ def _load_latest_query_per_project(
             cancelled_trust_ids=cancelled_trust_ids_by_query.get(qid, []),
             responded_trust_ids=responded_trust_ids_by_query.get(qid, []),
             errored_trust_ids=errored_trust_ids_by_query.get(qid, []),
+            empty_trust_ids=empty_trust_ids_by_query.get(qid, []),
             total_cohort=total_cohort_by_query.get(qid, 0),
             # `Z` suffix so the browser parses as UTC (naive UTC column).
             created=(qcreated.isoformat(timespec="milliseconds") + "Z") if qcreated else None,

--- a/flip-api/src/flip_api/project_services/services/project_services.py
+++ b/flip-api/src/flip_api/project_services/services/project_services.py
@@ -73,8 +73,9 @@ def _classify_responded_trust_ids(
       A trust must be here — and not errored or empty — to be stage-eligible; the set is
       also surfaced to the per-trust UI.
     - **errored**: responded trusts whose ``data`` carries a non-null ``error``, or that fail
-      to parse at all. Better to mark the trust red than silently swallow a corrupt response
-      and let staging include results we never validated.
+      to parse (malformed JSON, or a ``record_count`` that won't coerce to an int). Better to
+      mark the trust red than silently swallow a corrupt response and let staging include
+      results we never validated.
     - **empty**: responded, non-errored trusts with ``record_count == 0`` — a genuine zero
       match or a privacy-suppressed below-threshold count (the trust sets ``record_count=0``
       either way; ``suppressed`` only tells the two apart for display, see issue #519). These
@@ -104,7 +105,17 @@ def _classify_responded_trust_ids(
             continue
         if data.get("error"):
             errored.append(tid)
-        elif int(data.get("record_count") or 0) == 0:
+            continue
+        try:
+            record_count = int(data.get("record_count") or 0)
+        except (ValueError, TypeError) as e:
+            # A corrupt count in otherwise-valid JSON is treated like a malformed payload:
+            # mark the trust errored (red chip, excluded from staging) rather than let the
+            # coercion raise and 500 the whole project listing. See issue #519 review.
+            logger.warning(f"Could not parse record_count for query {query_id}, trust {tid}: {e}")
+            errored.append(tid)
+            continue
+        if record_count == 0:
             empty.append(tid)
     return responded, errored, empty
 

--- a/flip-api/src/flip_api/project_services/services/project_services.py
+++ b/flip-api/src/flip_api/project_services/services/project_services.py
@@ -77,9 +77,10 @@ def _classify_responded_trust_ids(
       mark the trust red than silently swallow a corrupt response and let staging include
       results we never validated.
     - **empty**: responded, non-errored trusts with ``record_count == 0`` — a genuine zero
-      match or a privacy-suppressed below-threshold count (the trust sets ``record_count=0``
-      either way; ``suppressed`` only tells the two apart for display, see issue #519). These
-      have no usable cohort and must not be stage-eligible.
+      match or a privacy-suppressed below-threshold count. The trust reports both as
+      ``record_count=0`` and flags both ``suppressed`` (they are deliberately
+      indistinguishable, see issue #519), so neither has a usable cohort and both must be
+      excluded from staging.
 
     Args:
         rows (Sequence[tuple[UUID | None, str | None]]): ``(trust_id, data_json)`` pairs from QueryResult.

--- a/flip-api/src/flip_api/project_services/services/project_services.py
+++ b/flip-api/src/flip_api/project_services/services/project_services.py
@@ -161,6 +161,46 @@ def _distinct_responded_trust_ids(
     return out
 
 
+def _collect_empty_cohort_trust_ids(
+    rows: Sequence[tuple[UUID | None, str | None]],
+    *,
+    query_id: UUID,
+) -> list[UUID]:
+    """Extract trust IDs that responded with no usable cohort (``record_count == 0``).
+
+    Covers both a genuine zero match and a privacy-suppressed below-threshold count
+    (the trust sets ``record_count=0`` in both cases; ``suppressed`` only tells the
+    two apart for display — see issue #519). Errored rows are excluded here because
+    they are already carved out by ``_collect_errored_trust_ids``; a malformed row is
+    likewise left to the errored path. These trusts must not be stage-eligible: there
+    is no cohort to build an imaging project against (issue #519 follow-up).
+
+    Args:
+        rows (Sequence[tuple[UUID | None, str | None]]): ``(trust_id, data_json)`` pairs from QueryResult.
+        query_id (UUID): The query the rows belong to — used for logging only.
+
+    Returns:
+        list[UUID]: Trust IDs that responded with a zero/suppressed count (subset of responded, minus errored).
+    """
+    empty: list[UUID] = []
+    seen: set[UUID] = set()
+    for tid, data_str in rows:
+        if tid is None or tid in seen:
+            continue
+        seen.add(tid)
+        try:
+            data = json.loads(data_str) if data_str else {}
+        except (ValueError, TypeError) as e:
+            # Malformed payload is handled as errored elsewhere; don't double-flag.
+            logger.warning(f"Malformed QueryResult.data for query {query_id}, trust {tid}: {e}")
+            continue
+        if data.get("error"):
+            continue
+        if int(data.get("record_count") or 0) == 0:
+            empty.append(tid)
+    return empty
+
+
 def update_project_user_access(project_id: UUID, user_ids: list[UUID], session: Session) -> None:
     """
     Updates the user access for a project by creating new ProjectUserAccess entries for the provided user IDs.
@@ -892,6 +932,7 @@ def get_project(project_id: UUID, session: Session) -> IProjectResponse:
             select(QueryResult.trust_id, QueryResult.data).where(QueryResult.query_id == query.id)
         ).all()
         errored_trust_ids = _collect_errored_trust_ids(result_rows, query_id=query.id)
+        empty_trust_ids = _collect_empty_cohort_trust_ids(result_rows, query_id=query.id)
         responded_trust_ids = _distinct_responded_trust_ids(result_rows)
         pending_trust_ids, cancelled_trust_ids = _load_task_status_trust_ids(query.id, session)
         queried_trust_ids = list(query.queried_trust_ids)
@@ -916,6 +957,7 @@ def get_project(project_id: UUID, session: Session) -> IProjectResponse:
             cancelled_trust_ids=cancelled_trust_ids,
             responded_trust_ids=responded_trust_ids,
             errored_trust_ids=errored_trust_ids,
+            empty_trust_ids=empty_trust_ids,
             total_cohort=total_cohort,
             # `Z` suffix so the browser parses as UTC (naive UTC column).
             created=(query.created.isoformat(timespec="milliseconds") + "Z") if query.created else None,

--- a/flip-api/src/flip_api/project_services/services/project_services.py
+++ b/flip-api/src/flip_api/project_services/services/project_services.py
@@ -58,29 +58,44 @@ from flip_api.utils.logger import logger
 from flip_api.utils.paging_utils import IPagedResponse, PagingInfo, get_paging_details
 
 
-def _collect_errored_trust_ids(
+def _classify_responded_trust_ids(
     rows: Sequence[tuple[UUID | None, str | None]],
     *,
     query_id: UUID,
-) -> list[UUID]:
-    """Extract trust IDs whose QueryResult data carries a non-null ``error``.
+) -> tuple[list[UUID], list[UUID], list[UUID]]:
+    """Split QueryResult rows into ``(responded, errored, empty)`` trust IDs in one pass.
 
-    A row that fails to parse at all also counts as errored — better to mark
-    the trust red than silently swallow a corrupt response.
+    Each distinct trust's ``data`` blob is parsed once and classified, rather than walked
+    separately per category. All three lists preserve row order and dedup a trust by its
+    first occurrence; ``errored`` and ``empty`` are disjoint subsets of ``responded``.
+
+    - **responded**: every distinct non-null trust ID that posted a row (success or error).
+      A trust must be here — and not errored or empty — to be stage-eligible; the set is
+      also surfaced to the per-trust UI.
+    - **errored**: responded trusts whose ``data`` carries a non-null ``error``, or that fail
+      to parse at all. Better to mark the trust red than silently swallow a corrupt response
+      and let staging include results we never validated.
+    - **empty**: responded, non-errored trusts with ``record_count == 0`` — a genuine zero
+      match or a privacy-suppressed below-threshold count (the trust sets ``record_count=0``
+      either way; ``suppressed`` only tells the two apart for display, see issue #519). These
+      have no usable cohort and must not be stage-eligible.
 
     Args:
         rows (Sequence[tuple[UUID | None, str | None]]): ``(trust_id, data_json)`` pairs from QueryResult.
         query_id (UUID): The query the rows belong to — used for logging only.
 
     Returns:
-        list[UUID]: Errored trust IDs (subset of those that responded).
+        tuple[list[UUID], list[UUID], list[UUID]]: ``(responded, errored, empty)`` trust IDs.
     """
+    responded: list[UUID] = []
     errored: list[UUID] = []
+    empty: list[UUID] = []
     seen: set[UUID] = set()
     for tid, data_str in rows:
         if tid is None or tid in seen:
             continue
         seen.add(tid)
+        responded.append(tid)
         try:
             data = json.loads(data_str) if data_str else {}
         except (ValueError, TypeError) as e:
@@ -89,7 +104,9 @@ def _collect_errored_trust_ids(
             continue
         if data.get("error"):
             errored.append(tid)
-    return errored
+        elif int(data.get("record_count") or 0) == 0:
+            empty.append(tid)
+    return responded, errored, empty
 
 
 def _load_task_status_trust_ids(
@@ -131,74 +148,6 @@ def _load_task_status_trust_ids(
             cancelled.append(tid)
 
     return pending, cancelled
-
-
-def _distinct_responded_trust_ids(
-    rows: Sequence[tuple[UUID | None, str | None]],
-) -> list[UUID]:
-    """Distinct trust IDs that posted any QueryResult row, in input order.
-
-    Two consumers:
-
-    1. The staging guard — a trust must be in this set (and not in
-       ``errored_trust_ids``) to be stageable, otherwise we'd commit the
-       project to data we never received.
-    2. The ``responded_trust_ids`` field surfaced to the per-trust UI.
-
-    Args:
-        rows (Sequence[tuple[UUID | None, str | None]]): ``(trust_id, data_json)`` pairs from QueryResult.
-
-    Returns:
-        list[UUID]: Distinct responded trust IDs preserving row order.
-    """
-    seen: set[UUID] = set()
-    out: list[UUID] = []
-    for tid, _ in rows:
-        if tid is None or tid in seen:
-            continue
-        seen.add(tid)
-        out.append(tid)
-    return out
-
-
-def _collect_empty_cohort_trust_ids(
-    rows: Sequence[tuple[UUID | None, str | None]],
-    *,
-    query_id: UUID,
-) -> list[UUID]:
-    """Extract trust IDs that responded with no usable cohort (``record_count == 0``).
-
-    Covers both a genuine zero match and a privacy-suppressed below-threshold count
-    (the trust sets ``record_count=0`` in both cases; ``suppressed`` only tells the
-    two apart for display — see issue #519). Errored rows are excluded here because
-    they are already carved out by ``_collect_errored_trust_ids``; a malformed row is
-    likewise left to the errored path. These trusts must not be stage-eligible: there
-    is no cohort to build an imaging project against (issue #519 follow-up).
-
-    Args:
-        rows (Sequence[tuple[UUID | None, str | None]]): ``(trust_id, data_json)`` pairs from QueryResult.
-        query_id (UUID): The query the rows belong to — used for logging only.
-
-    Returns:
-        list[UUID]: Trust IDs that responded with a zero/suppressed count (subset of responded, minus errored).
-    """
-    empty: list[UUID] = []
-    seen: set[UUID] = set()
-    for tid, data_str in rows:
-        if tid is None or tid in seen:
-            continue
-        seen.add(tid)
-        try:
-            data = json.loads(data_str) if data_str else {}
-        except (ValueError, TypeError) as e:
-            # Malformed payload is handled as errored elsewhere; don't double-flag.
-            logger.warning(f"Malformed QueryResult.data for query {query_id}, trust {tid}: {e}")
-            continue
-        if data.get("error"):
-            continue
-        if int(data.get("record_count") or 0) == 0:
-            empty.append(tid)
-    return empty
 
 
 def update_project_user_access(project_id: UUID, user_ids: list[UUID], session: Session) -> None:
@@ -926,14 +875,14 @@ def get_project(project_id: UUID, session: Session) -> IProjectResponse:
     query_data = None
     if query_row:
         query, created_by_name = query_row
-        # Step 3: per-trust QueryResult rows — drive the "errored" carve-out
-        # for staging and the responded set.
+        # Step 3: per-trust QueryResult rows — drive the errored/empty carve-outs
+        # for staging and the responded set surfaced to the UI.
         result_rows = session.exec(
             select(QueryResult.trust_id, QueryResult.data).where(QueryResult.query_id == query.id)
         ).all()
-        errored_trust_ids = _collect_errored_trust_ids(result_rows, query_id=query.id)
-        empty_trust_ids = _collect_empty_cohort_trust_ids(result_rows, query_id=query.id)
-        responded_trust_ids = _distinct_responded_trust_ids(result_rows)
+        responded_trust_ids, errored_trust_ids, empty_trust_ids = _classify_responded_trust_ids(
+            result_rows, query_id=query.id
+        )
         pending_trust_ids, cancelled_trust_ids = _load_task_status_trust_ids(query.id, session)
         queried_trust_ids = list(query.queried_trust_ids)
 

--- a/flip-api/src/flip_api/project_services/services/project_services.py
+++ b/flip-api/src/flip_api/project_services/services/project_services.py
@@ -104,6 +104,12 @@ def _classify_responded_trust_ids(
             logger.warning(f"Malformed QueryResult.data for query {query_id}, trust {tid}: {e}")
             errored.append(tid)
             continue
+        if not isinstance(data, dict):
+            # Valid JSON but not an object (e.g. "null", "[]") — treat like a malformed
+            # payload: mark errored rather than let .get() raise and 500 the read path.
+            logger.warning(f"Non-object QueryResult.data for query {query_id}, trust {tid}")
+            errored.append(tid)
+            continue
         if data.get("error"):
             errored.append(tid)
             continue

--- a/flip-api/src/flip_api/project_services/stage_project.py
+++ b/flip-api/src/flip_api/project_services/stage_project.py
@@ -111,12 +111,13 @@ def stage_project_endpoint(
         f"Project {project_id} has query with {len(project_data.query.queried_trust_ids)} trusts queried."
     )
 
-    # Three guards, each catching a distinct way an operator could end up
-    # staging on a trust they don't have data for. The UI already filters
-    # the selector — these guard direct API callers.
+    # Four guards, each catching a distinct way an operator could end up
+    # staging on a trust they don't have a usable cohort for. The UI already
+    # filters the selector — these guard direct API callers.
     queried_trust_ids = set(project_data.query.queried_trust_ids)
     responded_trust_ids = set(project_data.query.responded_trust_ids)
     errored_trust_ids = set(project_data.query.errored_trust_ids)
+    empty_trust_ids = set(project_data.query.empty_trust_ids)
 
     # (1) Late-joiners: trust joined the platform after the query was
     # dispatched, so it isn't in the queried set at all.
@@ -151,6 +152,20 @@ def stage_project_endpoint(
             detail=(
                 f"Trusts {failed_trust_ids} returned an error for the cohort query for project "
                 f"{project_id} and cannot be staged."
+            ),
+        )
+
+    # (4) Empty cohort: trust replied successfully but with 0 records — either a
+    # genuine zero match or a privacy-suppressed below-threshold count (#519).
+    # Either way there's no cohort to build an imaging project against, so the
+    # trust isn't stage-eligible.
+    empty_cohort_trust_ids = [tid for tid in payload.trusts if tid in empty_trust_ids]
+    if empty_cohort_trust_ids:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=(
+                f"Trusts {empty_cohort_trust_ids} returned no cohort records (zero or privacy-suppressed) "
+                f"for project {project_id} and cannot be staged."
             ),
         )
 

--- a/flip-api/tests/unit/private_services/test_receive_cohort_results.py
+++ b/flip-api/tests/unit/private_services/test_receive_cohort_results.py
@@ -143,8 +143,9 @@ class TestPydanticModels:
         assert payload.error is None
 
     def test_omop_cohort_results_accepts_suppressed_flag(self, sample_cohort_dict):
-        """A privacy-suppressed trust reports record_count=0 with suppressed=True so
-        the hub can tell suppression apart from a genuine zero match (#519)."""
+        """A privacy-suppressed trust reports record_count=0 with suppressed=True so the
+        hub can flag the below-threshold trust (a genuine zero is flagged the same way, so
+        it reveals no membership) (#519)."""
         sample_cohort_dict["record_count"] = 0
         sample_cohort_dict["data"] = []
         sample_cohort_dict["suppressed"] = True

--- a/flip-api/tests/unit/private_services/test_receive_cohort_results.py
+++ b/flip-api/tests/unit/private_services/test_receive_cohort_results.py
@@ -142,6 +142,29 @@ class TestPydanticModels:
         payload = OmopCohortResults(**sample_cohort_dict)
         assert payload.error is None
 
+    def test_omop_cohort_results_accepts_suppressed_flag(self, sample_cohort_dict):
+        """A privacy-suppressed trust reports record_count=0 with suppressed=True so
+        the hub can tell suppression apart from a genuine zero match (#519)."""
+        sample_cohort_dict["record_count"] = 0
+        sample_cohort_dict["data"] = []
+        sample_cohort_dict["suppressed"] = True
+        payload = OmopCohortResults(**sample_cohort_dict)
+        assert payload.suppressed is True
+
+    def test_omop_cohort_results_suppressed_defaults_to_false(self, sample_cohort_dict):
+        payload = OmopCohortResults(**sample_cohort_dict)
+        assert payload.suppressed is False
+
+    def test_aggregated_cohort_stats_carries_trust_suppressed(self):
+        stats = AggregatedCohortStats(
+            record_count=5,
+            trusts_results=[],
+            trust_record_counts={"trustA": 5, "trustB": 0},
+            trust_suppressed=["trustB"],
+        )
+        assert stats.trust_suppressed == ["trustB"]
+        assert stats.trust_record_counts == {"trustA": 5, "trustB": 0}
+
     def test_fetched_aggregation_data_creation(self):
         fetched = FetchedAggregationData(trust_name=["Trust X"], trust_id=["idX"], data=['{"key": "value"}'])
         assert fetched.trust_name == ["Trust X"]
@@ -270,6 +293,38 @@ class TestAggregateAndSaveResults:
             str(trust_b_id): 4,
             str(trust_c_id): 0,
         }
+
+    def test_aggregate_flags_suppressed_trusts(
+        self, mock_db_session: MagicMock, query_id_for_agg: UUID
+    ):
+        """A privacy-suppressed trust still counts as "responded" (count 0 in
+        trust_record_counts) but is also listed in ``trust_suppressed`` so the UI
+        renders a "suppressed" chip instead of a literal 0 (#519)."""
+        trust_a_id = uuid.uuid4()
+        trust_b_id = uuid.uuid4()
+
+        trust_a_data = TrustSpecificData(
+            record_count=7, data=[OmopData(name="age", results=[Results(value="<50", count=7)])]
+        ).model_dump_json()
+        # Below-threshold trust: count suppressed to 0, suppressed=True.
+        trust_b_data = TrustSpecificData(record_count=0, data=[], suppressed=True).model_dump_json()
+
+        rows = [
+            ("Trust A", trust_a_id, trust_a_data),
+            ("Trust B", trust_b_id, trust_b_data),
+        ]
+
+        existing_stats_mock = MagicMock()
+        mock_db_session.exec.return_value.all.return_value = rows
+        mock_db_session.exec.return_value.first.return_value = existing_stats_mock
+
+        _aggregate_and_save_results(mock_db_session, query_id_for_agg)
+
+        saved = json.loads(existing_stats_mock.stats)
+        # Suppressed count contributes 0 to the total and still appears as "responded".
+        assert saved["record_count"] == 7
+        assert saved["trust_record_counts"] == {str(trust_a_id): 7, str(trust_b_id): 0}
+        assert saved["trust_suppressed"] == [str(trust_b_id)]
 
     def test_aggregate_surfaces_trust_errors(
         self, mock_db_session: MagicMock, query_id_for_agg: UUID

--- a/flip-api/tests/unit/project_services/services/test_project_services.py
+++ b/flip-api/tests/unit/project_services/services/test_project_services.py
@@ -783,103 +783,98 @@ class TestGetUsersWithAccess:
         assert result == []
 
 
-# Helpers introduced by the connection-status PR — _collect_errored_trust_ids,
+# Helpers introduced by the connection-status PR — _classify_responded_trust_ids,
 # update_project_user_access, plus warn paths in get_project_models_service /
 # unstage_project_service.
 
 
-class TestCollectErroredTrustIds:
-    """A QueryResult row whose `data` JSON fails to parse is treated as errored.
+class TestClassifyRespondedTrustIds:
+    """One pass over QueryResult rows splits responded trusts into errored vs empty.
 
-    Better to surface the trust as red in the UI than silently swallow a corrupt
-    response — the latter would let staging-eligibility include a trust whose
-    results we never validated.
+    A row whose `data` JSON fails to parse is treated as errored — better to surface the
+    trust as red than silently swallow a corrupt response, which would let staging include
+    a trust whose results we never validated. A non-errored trust with `record_count == 0`
+    (a genuine zero or a privacy-suppressed count, #519) is empty: responded but with no
+    usable cohort, so excluded from staging eligibility. `errored` and `empty` are disjoint.
     """
 
     def test_marks_malformed_json_as_errored(self):
-        from flip_api.project_services.services.project_services import _collect_errored_trust_ids
+        from flip_api.project_services.services.project_services import _classify_responded_trust_ids
 
         tid = uuid4()
-        result = _collect_errored_trust_ids([(tid, "not-a-json-blob")], query_id=uuid4())
+        responded, errored, empty = _classify_responded_trust_ids([(tid, "not-a-json-blob")], query_id=uuid4())
 
-        assert result == [tid]
+        assert responded == [tid]
+        assert errored == [tid]
+        assert empty == []
 
     def test_explicit_error_field_marks_trust_as_errored(self):
-        from flip_api.project_services.services.project_services import _collect_errored_trust_ids
+        from flip_api.project_services.services.project_services import _classify_responded_trust_ids
 
         tid = uuid4()
-        result = _collect_errored_trust_ids(
+        # An errored row is never double-flagged as empty even though its count is 0.
+        responded, errored, empty = _classify_responded_trust_ids(
             [(tid, '{"record_count": 0, "error": "OMOP timeout"}')], query_id=uuid4()
         )
 
-        assert result == [tid]
+        assert responded == [tid]
+        assert errored == [tid]
+        assert empty == []
 
-    def test_success_payload_is_not_marked_errored(self):
-        from flip_api.project_services.services.project_services import _collect_errored_trust_ids
+    def test_success_payload_is_neither_errored_nor_empty(self):
+        from flip_api.project_services.services.project_services import _classify_responded_trust_ids
 
         tid = uuid4()
-        result = _collect_errored_trust_ids(
+        responded, errored, empty = _classify_responded_trust_ids(
             [(tid, '{"record_count": 7, "error": null}')], query_id=uuid4()
         )
 
-        assert result == []
-
-
-class TestCollectEmptyCohortTrustIds:
-    """A trust that responded with 0 records — genuine zero or privacy-suppressed
-    (#519) — has no usable cohort and must be excluded from staging eligibility.
-    """
+        assert responded == [tid]
+        assert errored == []
+        assert empty == []
 
     def test_zero_record_count_is_flagged_empty(self):
-        from flip_api.project_services.services.project_services import _collect_empty_cohort_trust_ids
+        from flip_api.project_services.services.project_services import _classify_responded_trust_ids
 
         tid = uuid4()
-        result = _collect_empty_cohort_trust_ids(
+        responded, errored, empty = _classify_responded_trust_ids(
             [(tid, '{"record_count": 0, "error": null}')], query_id=uuid4()
         )
 
-        assert result == [tid]
+        assert responded == [tid]
+        assert errored == []
+        assert empty == [tid]
 
     def test_suppressed_count_is_flagged_empty(self):
-        from flip_api.project_services.services.project_services import _collect_empty_cohort_trust_ids
+        from flip_api.project_services.services.project_services import _classify_responded_trust_ids
 
         tid = uuid4()
-        result = _collect_empty_cohort_trust_ids(
+        responded, errored, empty = _classify_responded_trust_ids(
             [(tid, '{"record_count": 0, "suppressed": true, "error": null}')], query_id=uuid4()
         )
 
-        assert result == [tid]
+        assert responded == [tid]
+        assert errored == []
+        assert empty == [tid]
 
-    def test_non_empty_count_is_not_flagged(self):
-        from flip_api.project_services.services.project_services import _collect_empty_cohort_trust_ids
+    def test_mixed_batch_partitions_in_one_pass_preserving_order(self):
+        # Every distinct trust is "responded"; errored/empty are disjoint subsets in row order.
+        from flip_api.project_services.services.project_services import _classify_responded_trust_ids
 
-        tid = uuid4()
-        result = _collect_empty_cohort_trust_ids(
-            [(tid, '{"record_count": 7, "error": null}')], query_id=uuid4()
+        ok, err, zero = uuid4(), uuid4(), uuid4()
+        responded, errored, empty = _classify_responded_trust_ids(
+            [
+                (ok, '{"record_count": 7}'),
+                (err, '{"record_count": 0, "error": "OMOP timeout"}'),
+                (None, '{"record_count": 0}'),  # no trust id — skipped entirely
+                (zero, '{"record_count": 0}'),
+            ],
+            query_id=uuid4(),
         )
 
-        assert result == []
-
-    def test_errored_row_is_not_double_flagged_as_empty(self):
-        # An errored trust is already carved out by _collect_errored_trust_ids;
-        # it must not also land in the empty set even though its count is 0.
-        from flip_api.project_services.services.project_services import _collect_empty_cohort_trust_ids
-
-        tid = uuid4()
-        result = _collect_empty_cohort_trust_ids(
-            [(tid, '{"record_count": 0, "error": "OMOP timeout"}')], query_id=uuid4()
-        )
-
-        assert result == []
-
-    def test_malformed_row_is_not_flagged_empty(self):
-        # Malformed payloads are handled by the errored path; don't double-flag.
-        from flip_api.project_services.services.project_services import _collect_empty_cohort_trust_ids
-
-        tid = uuid4()
-        result = _collect_empty_cohort_trust_ids([(tid, "not-a-json-blob")], query_id=uuid4())
-
-        assert result == []
+        assert responded == [ok, err, zero]
+        assert errored == [err]
+        assert empty == [zero]
 
 
 class TestUpdateProjectUserAccess:

--- a/flip-api/tests/unit/project_services/services/test_project_services.py
+++ b/flip-api/tests/unit/project_services/services/test_project_services.py
@@ -902,6 +902,19 @@ class TestClassifyRespondedTrustIds:
         assert errored == [tid]
         assert empty == []
 
+    @pytest.mark.parametrize("blob", ["null", "[]", "true"])
+    def test_non_dict_json_is_errored(self, blob: str):
+        # Valid JSON that isn't an object (null/list/scalar) is treated like a malformed
+        # payload — errored, not an AttributeError on data.get() that would 500 the read.
+        from flip_api.project_services.services.project_services import _classify_responded_trust_ids
+
+        tid = uuid4()
+        responded, errored, empty = _classify_responded_trust_ids([(tid, blob)], query_id=uuid4())
+
+        assert responded == [tid]
+        assert errored == [tid]
+        assert empty == []
+
 
 class TestUpdateProjectUserAccess:
     """Persists one `ProjectUserAccess` row per user id in a single commit.

--- a/flip-api/tests/unit/project_services/services/test_project_services.py
+++ b/flip-api/tests/unit/project_services/services/test_project_services.py
@@ -825,6 +825,63 @@ class TestCollectErroredTrustIds:
         assert result == []
 
 
+class TestCollectEmptyCohortTrustIds:
+    """A trust that responded with 0 records — genuine zero or privacy-suppressed
+    (#519) — has no usable cohort and must be excluded from staging eligibility.
+    """
+
+    def test_zero_record_count_is_flagged_empty(self):
+        from flip_api.project_services.services.project_services import _collect_empty_cohort_trust_ids
+
+        tid = uuid4()
+        result = _collect_empty_cohort_trust_ids(
+            [(tid, '{"record_count": 0, "error": null}')], query_id=uuid4()
+        )
+
+        assert result == [tid]
+
+    def test_suppressed_count_is_flagged_empty(self):
+        from flip_api.project_services.services.project_services import _collect_empty_cohort_trust_ids
+
+        tid = uuid4()
+        result = _collect_empty_cohort_trust_ids(
+            [(tid, '{"record_count": 0, "suppressed": true, "error": null}')], query_id=uuid4()
+        )
+
+        assert result == [tid]
+
+    def test_non_empty_count_is_not_flagged(self):
+        from flip_api.project_services.services.project_services import _collect_empty_cohort_trust_ids
+
+        tid = uuid4()
+        result = _collect_empty_cohort_trust_ids(
+            [(tid, '{"record_count": 7, "error": null}')], query_id=uuid4()
+        )
+
+        assert result == []
+
+    def test_errored_row_is_not_double_flagged_as_empty(self):
+        # An errored trust is already carved out by _collect_errored_trust_ids;
+        # it must not also land in the empty set even though its count is 0.
+        from flip_api.project_services.services.project_services import _collect_empty_cohort_trust_ids
+
+        tid = uuid4()
+        result = _collect_empty_cohort_trust_ids(
+            [(tid, '{"record_count": 0, "error": "OMOP timeout"}')], query_id=uuid4()
+        )
+
+        assert result == []
+
+    def test_malformed_row_is_not_flagged_empty(self):
+        # Malformed payloads are handled by the errored path; don't double-flag.
+        from flip_api.project_services.services.project_services import _collect_empty_cohort_trust_ids
+
+        tid = uuid4()
+        result = _collect_empty_cohort_trust_ids([(tid, "not-a-json-blob")], query_id=uuid4())
+
+        assert result == []
+
+
 class TestUpdateProjectUserAccess:
     """Persists one `ProjectUserAccess` row per user id in a single commit.
 

--- a/flip-api/tests/unit/project_services/services/test_project_services.py
+++ b/flip-api/tests/unit/project_services/services/test_project_services.py
@@ -876,6 +876,32 @@ class TestClassifyRespondedTrustIds:
         assert errored == [err]
         assert empty == [zero]
 
+    def test_missing_record_count_is_flagged_empty(self):
+        # A responded, non-errored row with no record_count defaults to 0 → empty (no
+        # usable cohort) — the safe back-compat reading for pre-upgrade rows.
+        from flip_api.project_services.services.project_services import _classify_responded_trust_ids
+
+        tid = uuid4()
+        responded, errored, empty = _classify_responded_trust_ids([(tid, '{"error": null}')], query_id=uuid4())
+
+        assert responded == [tid]
+        assert errored == []
+        assert empty == [tid]
+
+    def test_uncoercible_record_count_is_errored(self):
+        # A record_count that won't coerce to an int is treated like a malformed payload —
+        # errored, not an unhandled 500 on the read path (#519 review).
+        from flip_api.project_services.services.project_services import _classify_responded_trust_ids
+
+        tid = uuid4()
+        responded, errored, empty = _classify_responded_trust_ids(
+            [(tid, '{"record_count": "not-a-number"}')], query_id=uuid4()
+        )
+
+        assert responded == [tid]
+        assert errored == [tid]
+        assert empty == []
+
 
 class TestUpdateProjectUserAccess:
     """Persists one `ProjectUserAccess` row per user id in a single commit.

--- a/flip-api/tests/unit/project_services/test_stage_project.py
+++ b/flip-api/tests/unit/project_services/test_stage_project.py
@@ -71,10 +71,12 @@ def mock_project_data():
     mock_project = MagicMock()
     mock_project.status = ProjectStatus.UNSTAGED.value
     mock_project.query = MagicMock()
-    # Default: both trusts in the standard payload have responded successfully.
+    # Default: both trusts in the standard payload have responded successfully
+    # with a usable (non-empty) cohort.
     mock_project.query.queried_trust_ids = [_TRUST_A, _TRUST_B]
     mock_project.query.responded_trust_ids = [_TRUST_A, _TRUST_B]
     mock_project.query.errored_trust_ids = []
+    mock_project.query.empty_trust_ids = []
     return mock_project
 
 
@@ -277,6 +279,39 @@ def test_stage_project_rejects_errored_trust(
     assert response.status_code == status.HTTP_400_BAD_REQUEST
     assert str(_TRUST_B) in response.json()["detail"]
     assert "error" in response.json()["detail"].lower()
+    mock_stage.assert_not_called()
+
+
+def test_stage_project_rejects_empty_cohort_trust(
+    app_fixture, client, test_user_id, test_project_id
+):
+    """A trust that responded with 0 records — a genuine zero match or a
+    privacy-suppressed below-threshold count (#519) — has no cohort to build an
+    imaging project against. Staging against it must 400."""
+    mock_session = MagicMock()
+    app_fixture.dependency_overrides[get_session] = lambda: mock_session
+    app_fixture.dependency_overrides[verify_token] = lambda: test_user_id
+
+    mock_project_data = MagicMock()
+    mock_project_data.status = ProjectStatus.UNSTAGED.value
+    mock_project_data.query = MagicMock()
+    mock_project_data.query.queried_trust_ids = [_TRUST_A, _TRUST_B]
+    mock_project_data.query.responded_trust_ids = [_TRUST_A, _TRUST_B]
+    mock_project_data.query.errored_trust_ids = []
+    mock_project_data.query.empty_trust_ids = [_TRUST_B]  # 0 records / suppressed
+
+    payload = StageProjectRequest(trusts=[_TRUST_A, _TRUST_B]).model_dump(mode="json")
+
+    with (
+        patch("flip_api.project_services.stage_project.can_modify_project", return_value=True),
+        patch("flip_api.project_services.stage_project.get_project", return_value=mock_project_data),
+        patch("flip_api.project_services.stage_project.stage_project_service") as mock_stage,
+    ):
+        response = client.post(f"/api/projects/{test_project_id}/stage", json=payload)
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert str(_TRUST_B) in response.json()["detail"]
+    assert "no cohort records" in response.json()["detail"].lower()
     mock_stage.assert_not_called()
 
 

--- a/flip-ui/mocks/projects/seed-data.ts
+++ b/flip-ui/mocks/projects/seed-data.ts
@@ -71,6 +71,7 @@ export const projectDataPage1: IProject[] = [
             totalCohort: 32567,
             queriedTrustIds: ["00000000-0000-0000-0000-000000000001", "00000000-0000-0000-0000-000000000002"],
             erroredTrustIds: [],
+            emptyTrustIds: [],
             respondedTrustIds: ["00000000-0000-0000-0000-000000000001", "00000000-0000-0000-0000-000000000002"],
             pendingTrustIds: [],
             cancelledTrustIds: []
@@ -94,6 +95,7 @@ export const projectDataPage1: IProject[] = [
             totalCohort: 32567,
             queriedTrustIds: ["00000000-0000-0000-0000-000000000001", "00000000-0000-0000-0000-000000000002"],
             erroredTrustIds: [],
+            emptyTrustIds: [],
             respondedTrustIds: ["00000000-0000-0000-0000-000000000001", "00000000-0000-0000-0000-000000000002"],
             pendingTrustIds: [],
             cancelledTrustIds: []
@@ -115,6 +117,7 @@ export const projectDataPage1: IProject[] = [
             totalCohort: 32567,
             queriedTrustIds: ["00000000-0000-0000-0000-000000000001", "00000000-0000-0000-0000-000000000002"],
             erroredTrustIds: [],
+            emptyTrustIds: [],
             respondedTrustIds: ["00000000-0000-0000-0000-000000000001", "00000000-0000-0000-0000-000000000002"],
             pendingTrustIds: [],
             cancelledTrustIds: []
@@ -138,6 +141,7 @@ export const projectDataPage1: IProject[] = [
             totalCohort: 32567,
             queriedTrustIds: ["00000000-0000-0000-0000-000000000001", "00000000-0000-0000-0000-000000000002"],
             erroredTrustIds: [],
+            emptyTrustIds: [],
             respondedTrustIds: ["00000000-0000-0000-0000-000000000001", "00000000-0000-0000-0000-000000000002"],
             pendingTrustIds: [],
             cancelledTrustIds: []
@@ -159,6 +163,7 @@ export const projectDataPage1: IProject[] = [
             totalCohort: 32567,
             queriedTrustIds: ["00000000-0000-0000-0000-000000000001", "00000000-0000-0000-0000-000000000002"],
             erroredTrustIds: [],
+            emptyTrustIds: [],
             respondedTrustIds: ["00000000-0000-0000-0000-000000000001", "00000000-0000-0000-0000-000000000002"],
             pendingTrustIds: [],
             cancelledTrustIds: []
@@ -237,6 +242,7 @@ export const projectDataPage1: IProject[] = [
             totalCohort: 32567,
             queriedTrustIds: ["00000000-0000-0000-0000-000000000001", "00000000-0000-0000-0000-000000000002"],
             erroredTrustIds: [],
+            emptyTrustIds: [],
             respondedTrustIds: ["00000000-0000-0000-0000-000000000001", "00000000-0000-0000-0000-000000000002"],
             pendingTrustIds: [],
             cancelledTrustIds: []
@@ -259,6 +265,7 @@ export const projectDataPage1: IProject[] = [
             totalCohort: 32567,
             queriedTrustIds: ["00000000-0000-0000-0000-000000000001", "00000000-0000-0000-0000-000000000002"],
             erroredTrustIds: [],
+            emptyTrustIds: [],
             respondedTrustIds: ["00000000-0000-0000-0000-000000000001", "00000000-0000-0000-0000-000000000002"],
             pendingTrustIds: [],
             cancelledTrustIds: []
@@ -293,6 +300,7 @@ export const projectDataPage1: IProject[] = [
             totalCohort: 32567,
             queriedTrustIds: ["00000000-0000-0000-0000-000000000001", "00000000-0000-0000-0000-000000000002"],
             erroredTrustIds: [],
+            emptyTrustIds: [],
             respondedTrustIds: ["00000000-0000-0000-0000-000000000001", "00000000-0000-0000-0000-000000000002"],
             pendingTrustIds: [],
             cancelledTrustIds: []

--- a/flip-ui/src/pages/__tests__/projects.spec.ts
+++ b/flip-ui/src/pages/__tests__/projects.spec.ts
@@ -362,6 +362,7 @@ describe("Projects Page", () => {
                     cancelledTrustIds: [],
                     respondedTrustIds: [],
                     erroredTrustIds: [],
+                    emptyTrustIds: [],
                     totalCohort: total
                 }
                 : undefined

--- a/flip-ui/src/pages/project/[projectId]/__tests__/index.spec.ts
+++ b/flip-ui/src/pages/project/[projectId]/__tests__/index.spec.ts
@@ -75,7 +75,12 @@ const stubs = {
         props: ["steps"]
     },
     ProjectApproval: { template: "<div data-test=\"stub-project-approval\" />" },
-    ProjectStaging: { template: "<div data-test=\"stub-project-staging\" />" },
+    ProjectStaging: {
+        // Expose the computed stageable set so tests can assert the parent's
+        // exclusion logic (errored / never-responded / empty trusts).
+        template: "<div data-test=\"stub-project-staging\" :data-stageable=\"(stageableTrustIds || []).join(',')\" />",
+        props: ["stageableTrustIds", "hasQuery", "projectStaged", "staging"]
+    },
     ProjectStatus: { template: "<div data-test=\"stub-project-status\" />" },
     Transition: { template: "<div><slot /></div>" },
     // Render the slot so breadcrumb copy is exercised (the real RouterLink is
@@ -172,6 +177,25 @@ describe("Project page (/project/[id]/index.vue)", () => {
         const wrapper = mountProjectPage({ project });
         const step02 = wrapper.find("[data-test=step-02]");
         expect(step02.attributes("data-completed")).toBe("true");
+    });
+
+    test("excludes errored and empty (0-record/suppressed) trusts from the stageable set", async () => {
+        const project = baseProject();
+        project.query = {
+            id: "q1",
+            name: "q",
+            query: "SELECT 1",
+            queriedTrustIds: ["t1", "t2", "t3", "t4"],
+            respondedTrustIds: ["t1", "t2", "t3"],
+            erroredTrustIds: ["t2"],
+            emptyTrustIds: ["t3"]
+        } as unknown as IProject["query"];
+        const wrapper = mountProjectPage({ project });
+        await flushPromises();
+
+        // t1 only: t2 errored, t3 returned 0/suppressed, t4 never responded (#519).
+        const staging = wrapper.find("[data-test=stub-project-staging]");
+        expect(staging.attributes("data-stageable")).toBe("t1");
     });
 
     test("marks Project Staged when status moves off UNSTAGED, and Project Approved when status is APPROVED", () => {

--- a/flip-ui/src/pages/project/[projectId]/index.vue
+++ b/flip-ui/src/pages/project/[projectId]/index.vue
@@ -236,16 +236,17 @@ const projectApproved = computed(() => {
     return project?.value?.status === "APPROVED";
 });
 
-// Stageable = trusts that responded successfully. Excludes late-joiners
-// (not dispatched), never-responded (dispatched but no QueryResult), and
-// errored (responded with an error blob). Mirrors the server-side guard
-// in stage_project.py.
+// Stageable = trusts that responded with a usable cohort. Excludes
+// late-joiners (not dispatched), never-responded (dispatched but no
+// QueryResult), errored (responded with an error blob), and empty
+// (responded with 0 records — genuine zero or privacy-suppressed, #519).
+// Mirrors the server-side guards in stage_project.py.
 const stageableTrustIds = computed<string[] | undefined>(() => {
     const q = project?.value?.query;
     if (!q) return undefined;
-    const errored = new Set(q.erroredTrustIds ?? []);
+    const excluded = new Set([...(q.erroredTrustIds ?? []), ...(q.emptyTrustIds ?? [])]);
 
-    return (q.respondedTrustIds ?? []).filter((id) => !errored.has(id));
+    return (q.respondedTrustIds ?? []).filter((id) => !excluded.has(id));
 });
 
 const isOwnerOrHasAccess = () => {

--- a/flip-ui/src/partials/cohort-query/CohortAggregateCard.vue
+++ b/flip-ui/src/partials/cohort-query/CohortAggregateCard.vue
@@ -75,6 +75,7 @@ interface IResultsShape {
     trustsResults?: IFieldShape[];
     trustRecordCounts?: Record<string, number>;
     trustErrors?: Record<string, string>;
+    trustSuppressed?: string[];
 }
 
 const perTrustCounts = computed<Record<string, number>>(() => {
@@ -120,6 +121,17 @@ const erroredCount = computed(() => {
     return trusts.filter(t => t.id in errors).length;
 });
 
+// Trusts that matched some patients but suppressed the count for privacy. Surfaced
+// in the subtitle so the headline total isn't misread as the whole picture (#519).
+const suppressedCount = computed(() => {
+    if (props.submitting) return 0;
+    const trusts = Array.isArray(trustStore.getTrusts) ? trustStore.getTrusts : [];
+    const r = results.value as unknown as IResultsShape | null;
+    const suppressed = new Set(r?.trustSuppressed ?? []);
+
+    return trusts.filter(t => suppressed.has(t.id)).length;
+});
+
 const runningCount = computed(() => Math.max(0, trustCount.value - completeCount.value - erroredCount.value));
 
 const anyRunning = computed(() => runningCount.value > 0);
@@ -131,6 +143,7 @@ const subtitle = computed(() => {
     parts.push(`${completeCount.value} trusts complete`);
     if (runningCount.value > 0) parts.push(`${runningCount.value} running`);
     if (erroredCount.value > 0) parts.push(`${erroredCount.value} errored`);
+    if (suppressedCount.value > 0) parts.push(`${suppressedCount.value} suppressed`);
 
     return parts.join(" · ");
 });

--- a/flip-ui/src/partials/cohort-query/CohortAggregateCard.vue
+++ b/flip-ui/src/partials/cohort-query/CohortAggregateCard.vue
@@ -121,8 +121,9 @@ const erroredCount = computed(() => {
     return trusts.filter(t => t.id in errors).length;
 });
 
-// Trusts that matched some patients but suppressed the count for privacy. Surfaced
-// in the subtitle so the headline total isn't misread as the whole picture (#519).
+// Trusts whose cohort is below the privacy threshold and was suppressed (the exact count,
+// which may be zero, is hidden). Surfaced in the subtitle so the headline total isn't
+// misread as the whole picture (#519).
 const suppressedCount = computed(() => {
     if (props.submitting) return 0;
     const trusts = Array.isArray(trustStore.getTrusts) ? trustStore.getTrusts : [];

--- a/flip-ui/src/partials/cohort-query/CohortAggregateCard.vue
+++ b/flip-ui/src/partials/cohort-query/CohortAggregateCard.vue
@@ -99,10 +99,27 @@ const perTrustErrors = computed<Record<string, string>>(() => {
     return r?.trustErrors ?? {};
 });
 
+// Restrict the subtitle's counts to the trusts this project actually queried, so the
+// segments (complete · running · errored · suppressed) share one denominator and stay
+// consistent even if the trust store and the query response ever drift. Falls back to
+// "all known trusts" when the query hasn't loaded yet (or pre-#519 data lacks the field),
+// preserving prior behaviour (e.g. all trusts shown running before any results arrive).
+const queriedTrustIdSet = computed<Set<string> | null>(() => {
+    const ids = projectStore.project?.query?.queriedTrustIds;
+
+    return ids?.length ? new Set(ids) : null;
+});
+
+const isQueried = (id: string): boolean => {
+    const s = queriedTrustIdSet.value;
+
+    return !s || s.has(id);
+};
+
 const trustCount = computed(() => {
     const trusts = Array.isArray(trustStore.getTrusts) ? trustStore.getTrusts : [];
 
-    return trusts.length;
+    return trusts.filter(t => isQueried(t.id)).length;
 });
 
 const completeCount = computed(() => {
@@ -110,7 +127,7 @@ const completeCount = computed(() => {
     const trusts = Array.isArray(trustStore.getTrusts) ? trustStore.getTrusts : [];
     const counts = perTrustCounts.value;
 
-    return trusts.filter(t => t.id in counts).length;
+    return trusts.filter(t => isQueried(t.id) && t.id in counts).length;
 });
 
 const erroredCount = computed(() => {
@@ -118,7 +135,7 @@ const erroredCount = computed(() => {
     const trusts = Array.isArray(trustStore.getTrusts) ? trustStore.getTrusts : [];
     const errors = perTrustErrors.value;
 
-    return trusts.filter(t => t.id in errors).length;
+    return trusts.filter(t => isQueried(t.id) && t.id in errors).length;
 });
 
 // Trusts whose cohort is below the privacy threshold and was suppressed (the exact count,
@@ -130,7 +147,7 @@ const suppressedCount = computed(() => {
     const r = results.value as unknown as IResultsShape | null;
     const suppressed = new Set(r?.trustSuppressed ?? []);
 
-    return trusts.filter(t => suppressed.has(t.id)).length;
+    return trusts.filter(t => isQueried(t.id) && suppressed.has(t.id)).length;
 });
 
 const runningCount = computed(() => Math.max(0, trustCount.value - completeCount.value - erroredCount.value));

--- a/flip-ui/src/partials/cohort-query/PerTrustResponse.vue
+++ b/flip-ui/src/partials/cohort-query/PerTrustResponse.vue
@@ -96,6 +96,14 @@
                         running
                     </span>
                     <span
+                        v-else-if="row.suppressed"
+                        class="inline-flex items-center gap-1.5 px-2 py-0.5 text-[11px] font-semibold tracking-wide text-amber-700 dark:text-amber-300 rounded-full bg-amber-100 dark:bg-amber-900/40"
+                        title="Matched some patients, but the count is below the privacy threshold and was suppressed by the trust"
+                    >
+                        <span class="inline-block w-1.5 h-1.5 bg-amber-500 rounded-full" />
+                        suppressed
+                    </span>
+                    <span
                         v-else
                         class="text-lg font-semibold tabular-nums text-gray-900 dark:text-gray-100"
                     >
@@ -153,6 +161,7 @@ interface IResultsShape {
     trustsResults?: IFieldShape[];
     trustRecordCounts?: Record<string, number>;
     trustErrors?: Record<string, string>;
+    trustSuppressed?: string[];
 }
 
 const perTrustCounts = computed<Record<string, number>>(() => {
@@ -177,6 +186,15 @@ const perTrustErrors = computed<Record<string, string>>(() => {
     return r?.trustErrors ?? {};
 });
 
+// Set of trust ids whose count was privacy-suppressed (below threshold). These
+// trusts responded successfully but render a "suppressed" chip instead of a
+// literal 0 that would read as "no data available". See issue #519.
+const perTrustSuppressed = computed<Set<string>>(() => {
+    const r = results.value as unknown as IResultsShape | null;
+
+    return new Set(r?.trustSuppressed ?? []);
+});
+
 interface IRow {
     id: string;
     code: string;
@@ -187,12 +205,14 @@ interface IRow {
     running: boolean;
     errored: boolean;
     error: string | null;
+    suppressed: boolean;
 }
 
 const rows = computed<IRow[]>(() => {
     const trusts = Array.isArray(trustStore.getTrusts) ? trustStore.getTrusts : [];
     const counts = perTrustCounts.value;
     const errors = perTrustErrors.value;
+    const suppressed = perTrustSuppressed.value;
 
     // Three cases:
     // 1. Mid-submit: fan-out targets the live trust list — render every
@@ -246,7 +266,9 @@ const rows = computed<IRow[]>(() => {
                 cancelled,
                 running,
                 errored,
-                error: errored ? (errors[t.id] || null) : null
+                error: errored ? (errors[t.id] || null) : null,
+                // Only meaningful once the trust has responded (not errored/in-flight).
+                suppressed: responded && suppressed.has(t.id)
             };
         })
         .sort((a, b) => a.code.localeCompare(b.code));

--- a/flip-ui/src/partials/cohort-query/PerTrustResponse.vue
+++ b/flip-ui/src/partials/cohort-query/PerTrustResponse.vue
@@ -98,7 +98,7 @@
                     <span
                         v-else-if="row.suppressed"
                         class="inline-flex items-center gap-1.5 px-2 py-0.5 text-[11px] font-semibold tracking-wide text-amber-700 dark:text-amber-300 rounded-full bg-amber-100 dark:bg-amber-900/40"
-                        title="Matched some patients, but the count is below the privacy threshold and was suppressed by the trust"
+                        title="The matching cohort is below the privacy threshold, so the trust suppressed the exact count (which may be zero)"
                     >
                         <span class="inline-block w-1.5 h-1.5 bg-amber-500 rounded-full" />
                         suppressed

--- a/flip-ui/src/partials/cohort-query/__tests__/CohortAggregateCard.spec.ts
+++ b/flip-ui/src/partials/cohort-query/__tests__/CohortAggregateCard.spec.ts
@@ -45,8 +45,8 @@ const TRUSTS = [
     }
 ];
 
-function mountCard(options: { data?: unknown; submitting?: boolean } = {}) {
-    const { data = null, submitting = false } = options;
+function mountCard(options: { data?: unknown; submitting?: boolean; queriedTrustIds?: string[] } = {}) {
+    const { data = null, submitting = false, queriedTrustIds } = options;
     swrvMock.value = data;
 
     return mount(CohortAggregateCard, {
@@ -61,7 +61,10 @@ function mountCard(options: { data?: unknown; submitting?: boolean } = {}) {
                         project: {
                             id: "p-1",
                             status: "UNSTAGED",
-                            query: { id: "q-1" }
+                            query: {
+                                id: "q-1",
+                                ...(queriedTrustIds ? { queriedTrustIds } : {})
+                            }
                         }
                     }
                 }
@@ -182,6 +185,32 @@ describe("CohortAggregateCard", () => {
 
         expect(wrapper.text()).toContain("0 trusts complete");
         expect(wrapper.text()).toContain("3 running");
+    });
+
+    it("restricts the subtitle counts to the queried trust set when queriedTrustIds is present", async () => {
+        // trust-3 is in the store but was not queried for this project. With
+        // queriedTrustIds = [trust-1, trust-2] it must not inflate the running count:
+        // denominator is 2 (trust-1 complete, trust-2 suppressed → both complete), 0 running.
+        const data = {
+            recordCount: 5,
+            trustsResults: [],
+            trustRecordCounts: {
+                "trust-1": 5,
+                "trust-2": 0
+            },
+            trustSuppressed: ["trust-2"]
+        };
+        const wrapper = mountCard({
+            data,
+            queriedTrustIds: ["trust-1", "trust-2"]
+        });
+        await nextTick();
+        await flushPromises();
+
+        expect(wrapper.text()).toContain("2 trusts complete");
+        expect(wrapper.text()).toContain("1 suppressed");
+        // trust-3 (un-queried) is excluded, so nothing is counted as running.
+        expect(wrapper.text()).not.toContain("running");
     });
 
     it("falls back to the legacy trustsResults shape when trustRecordCounts is absent", async () => {

--- a/flip-ui/src/partials/cohort-query/__tests__/CohortAggregateCard.spec.ts
+++ b/flip-ui/src/partials/cohort-query/__tests__/CohortAggregateCard.spec.ts
@@ -119,6 +119,28 @@ describe("CohortAggregateCard", () => {
         expect(wrapper.text()).toContain("1 errored");
     });
 
+    it("includes a suppressed segment when any trust privacy-suppressed its count", async () => {
+        // trust-2 matched some patients but the count was below the privacy
+        // threshold; the headline total (5) understates the picture, so the
+        // subtitle calls out the suppressed trust (#519).
+        const data = {
+            recordCount: 5,
+            trustsResults: [],
+            trustRecordCounts: {
+                "trust-1": 5,
+                "trust-2": 0
+            },
+            trustSuppressed: ["trust-2"]
+        };
+        const wrapper = mountCard({ data });
+        await nextTick();
+        await flushPromises();
+
+        expect(wrapper.text()).toContain("2 trusts complete");
+        expect(wrapper.text()).toContain("1 running");
+        expect(wrapper.text()).toContain("1 suppressed");
+    });
+
     it("drops the '(live)' marker and patients-so-far suffix once all trusts have responded", async () => {
         const data = {
             recordCount: 12,

--- a/flip-ui/src/partials/cohort-query/__tests__/CohortAggregateCard.spec.ts
+++ b/flip-ui/src/partials/cohort-query/__tests__/CohortAggregateCard.spec.ts
@@ -120,9 +120,9 @@ describe("CohortAggregateCard", () => {
     });
 
     it("includes a suppressed segment when any trust privacy-suppressed its count", async () => {
-        // trust-2 matched some patients but the count was below the privacy
-        // threshold; the headline total (5) understates the picture, so the
-        // subtitle calls out the suppressed trust (#519).
+        // trust-2's cohort fell below the privacy threshold and was suppressed (its
+        // count may be 1-9 or zero); the subtitle calls it out so a suppressed trust
+        // isn't silently dropped from the picture (#519).
         const data = {
             recordCount: 5,
             trustsResults: [],

--- a/flip-ui/src/partials/cohort-query/__tests__/CohortQuery.spec.ts
+++ b/flip-ui/src/partials/cohort-query/__tests__/CohortQuery.spec.ts
@@ -99,6 +99,7 @@ const stagedProjectWithQuery: IProject = {
         cancelledTrustIds: [],
         respondedTrustIds: [],
         erroredTrustIds: [],
+        emptyTrustIds: [],
         totalCohort: 100
     }
 };
@@ -114,6 +115,7 @@ const unstagedProjectWithQuery: IProject = {
         cancelledTrustIds: [],
         respondedTrustIds: [],
         erroredTrustIds: [],
+        emptyTrustIds: [],
         totalCohort: 100
     }
 };

--- a/flip-ui/src/partials/cohort-query/__tests__/PerTrustResponse.spec.ts
+++ b/flip-ui/src/partials/cohort-query/__tests__/PerTrustResponse.spec.ts
@@ -144,6 +144,32 @@ describe("PerTrustResponse", () => {
         expect(t3.text()).toContain("running");
     });
 
+    it("shows a 'suppressed' chip (not a literal 0) for a privacy-suppressed trust", async () => {
+        // trust-1 returned a real count; trust-2 matched some patients but the
+        // count fell below the privacy threshold and was suppressed by the trust.
+        // It must not read as a bare "0" / "no data available" (#519).
+        const data = {
+            recordCount: 7,
+            trustsResults: [],
+            trustRecordCounts: {
+                "trust-1": 7,
+                "trust-2": 0
+            },
+            trustSuppressed: ["trust-2"]
+        };
+        const wrapper = mountPerTrustResponse({ data });
+        await nextTick();
+        await flushPromises();
+
+        const t1 = rowFor(wrapper, "T1")!;
+        const t2 = rowFor(wrapper, "T2")!;
+
+        expect(t1.text()).toContain("7");
+
+        expect(t2.text()).toContain("suppressed");
+        expect(t2.text()).not.toContain("running");
+    });
+
     it("falls back to per-field aggregation when trustRecordCounts is absent (back-compat)", async () => {
         // Pre-upgrade QueryStats rows lack trustRecordCounts; the component
         // must still mark trust-1 as responded based on the field results.

--- a/flip-ui/src/partials/cohort-query/__tests__/PerTrustResponse.spec.ts
+++ b/flip-ui/src/partials/cohort-query/__tests__/PerTrustResponse.spec.ts
@@ -145,9 +145,9 @@ describe("PerTrustResponse", () => {
     });
 
     it("shows a 'suppressed' chip (not a literal 0) for a privacy-suppressed trust", async () => {
-        // trust-1 returned a real count; trust-2 matched some patients but the
-        // count fell below the privacy threshold and was suppressed by the trust.
-        // It must not read as a bare "0" / "no data available" (#519).
+        // trust-1 returned a real count; trust-2's cohort fell below the privacy
+        // threshold and was suppressed by the trust (the count may be zero). It must
+        // not read as a bare "0" / "no data available" (#519).
         const data = {
             recordCount: 7,
             trustsResults: [],

--- a/flip-ui/src/partials/projects/ProjectStaging.vue
+++ b/flip-ui/src/partials/projects/ProjectStaging.vue
@@ -136,11 +136,11 @@ import { filterByQueriedTrustIds } from "@/utils/cohort/query";
 interface IProjectStagingProps {
     staging: boolean;
     hasQuery: boolean;
-    // Trust IDs that posted a successful (non-errored) QueryResult. Stage
+    // Trust IDs that posted a successful, non-empty QueryResult. Stage
     // selector is intersected with this — late-joiners, never-responded,
-    // and errored trusts are all excluded because we have no usable cohort
-    // count for them. Computed by the parent as
-    // `respondedTrustIds − erroredTrustIds`.
+    // errored, and empty (0-record/privacy-suppressed) trusts are all
+    // excluded because we have no usable cohort count for them. Computed by
+    // the parent as `respondedTrustIds − erroredTrustIds − emptyTrustIds`.
     stageableTrustIds?: string[];
 }
 

--- a/flip-ui/src/services/project-service.ts
+++ b/flip-ui/src/services/project-service.ts
@@ -43,11 +43,15 @@ export interface IProjectQuery {
     // approved without them). UI shows a "skipped" chip.
     cancelledTrustIds: string[];
     // Subset of `queriedTrustIds` that posted any QueryResult row (success
-    // or error). Stageable = `respondedTrustIds − erroredTrustIds`.
+    // or error). Stageable = `respondedTrustIds − erroredTrustIds − emptyTrustIds`.
     respondedTrustIds: string[];
     // Subset of `respondedTrustIds` whose response carried an error.
     // Staging additionally excludes these — we have no usable cohort count.
     erroredTrustIds: string[];
+    // Subset of `respondedTrustIds` that returned 0 records — genuine zero
+    // match or privacy-suppressed below-threshold count (#519). Staging
+    // excludes these: there's no cohort to build an imaging project against.
+    emptyTrustIds: string[];
     totalCohort: number;
     created?: string | null;
     createdBy?: string | null;

--- a/trust/data-access-api/data_access_api/routers/cohort.py
+++ b/trust/data-access-api/data_access_api/routers/cohort.py
@@ -87,13 +87,14 @@ def receive_cohort_query(query_input: CohortQueryInput) -> StatisticsResponse:
     """
     Receives a cohort query and returns the aggregated statistics.
 
-    Below-threshold results are privacy-suppressed: a non-zero count below the
-    threshold comes back as a normal ``StatisticsResponse`` with ``record_count=0``,
-    empty ``data`` and ``suppressed=True``, *not* an HTTP error. Returning an error
-    here caused trust-api to skip reporting back to the hub, which left the per-trust
-    UI status stuck on "running". A genuine zero match comes back the same way but with
-    ``suppressed=False``, so the hub/UI can tell a privacy-suppressed count apart from a
-    true zero (issue #519).
+    Below-threshold results are privacy-suppressed: any count below the threshold —
+    including a genuine zero — comes back as a normal ``StatisticsResponse`` with
+    ``record_count=0``, empty ``data`` and ``suppressed=True``, *not* an HTTP error.
+    Returning an error here caused trust-api to skip reporting back to the hub, which left
+    the per-trust UI status stuck on "running". A true zero and a small below-threshold
+    count are deliberately indistinguishable so the response can't reveal that >=1 patient
+    matched; the ``suppressed`` flag only tells the hub/UI to show a "below-threshold" chip
+    rather than a bare 0 (issue #519).
 
     Args:
         query_input (data_access_api.routers.schema.CohortQueryInput): The input data for the cohort query.

--- a/trust/data-access-api/data_access_api/routers/cohort.py
+++ b/trust/data-access-api/data_access_api/routers/cohort.py
@@ -88,9 +88,11 @@ def receive_cohort_query(query_input: CohortQueryInput) -> StatisticsResponse:
     Receives a cohort query and returns the aggregated statistics.
 
     Below-threshold results are privacy-suppressed: the response is a normal
-    ``StatisticsResponse`` with ``record_count=0`` and empty ``data``, *not*
-    an HTTP error. Returning an error here caused trust-api to skip reporting
-    back to the hub, which left the per-trust UI status stuck on "running".
+    ``StatisticsResponse`` with ``record_count=0``, empty ``data`` and
+    ``suppressed=True``, *not* an HTTP error. Returning an error here caused
+    trust-api to skip reporting back to the hub, which left the per-trust UI
+    status stuck on "running". The ``suppressed`` flag lets the hub/UI tell a
+    privacy-suppressed count apart from a genuine zero match (issue #519).
 
     Args:
         query_input (data_access_api.routers.schema.CohortQueryInput): The input data for the cohort query.

--- a/trust/data-access-api/data_access_api/routers/cohort.py
+++ b/trust/data-access-api/data_access_api/routers/cohort.py
@@ -87,12 +87,13 @@ def receive_cohort_query(query_input: CohortQueryInput) -> StatisticsResponse:
     """
     Receives a cohort query and returns the aggregated statistics.
 
-    Below-threshold results are privacy-suppressed: the response is a normal
-    ``StatisticsResponse`` with ``record_count=0``, empty ``data`` and
-    ``suppressed=True``, *not* an HTTP error. Returning an error here caused
-    trust-api to skip reporting back to the hub, which left the per-trust UI
-    status stuck on "running". The ``suppressed`` flag lets the hub/UI tell a
-    privacy-suppressed count apart from a genuine zero match (issue #519).
+    Below-threshold results are privacy-suppressed: a non-zero count below the
+    threshold comes back as a normal ``StatisticsResponse`` with ``record_count=0``,
+    empty ``data`` and ``suppressed=True``, *not* an HTTP error. Returning an error
+    here caused trust-api to skip reporting back to the hub, which left the per-trust
+    UI status stuck on "running". A genuine zero match comes back the same way but with
+    ``suppressed=False``, so the hub/UI can tell a privacy-suppressed count apart from a
+    true zero (issue #519).
 
     Args:
         query_input (data_access_api.routers.schema.CohortQueryInput): The input data for the cohort query.

--- a/trust/data-access-api/data_access_api/routers/schema.py
+++ b/trust/data-access-api/data_access_api/routers/schema.py
@@ -68,10 +68,10 @@ class StatisticsResponse(BaseModel):
     record_count: int
     created: str
     data: list[dict[str, Any]]
-    # True when the count was privacy-suppressed (below ``COHORT_QUERY_THRESHOLD``)
-    # rather than a genuine zero match. Without this, ``record_count=0`` on the wire
-    # is indistinguishable from "matched no patients", so the hub/UI misread a
-    # suppressed trust as "no data available". See issue #519.
+    # True when a non-zero count below ``COHORT_QUERY_THRESHOLD`` was privacy-suppressed
+    # to 0, as opposed to a genuine zero match (which returns ``record_count=0`` with
+    # ``suppressed=False``). Lets the hub/UI render a "suppressed" chip instead of a bare
+    # 0 that reads as "no data available". See issue #519.
     suppressed: bool = False
 
 

--- a/trust/data-access-api/data_access_api/routers/schema.py
+++ b/trust/data-access-api/data_access_api/routers/schema.py
@@ -68,10 +68,10 @@ class StatisticsResponse(BaseModel):
     record_count: int
     created: str
     data: list[dict[str, Any]]
-    # True when a non-zero count below ``COHORT_QUERY_THRESHOLD`` was privacy-suppressed
-    # to 0, as opposed to a genuine zero match (which returns ``record_count=0`` with
-    # ``suppressed=False``). Lets the hub/UI render a "suppressed" chip instead of a bare
-    # 0 that reads as "no data available". See issue #519.
+    # True when the count was privacy-suppressed for being below ``COHORT_QUERY_THRESHOLD``.
+    # A genuine zero is suppressed identically to a 1..N-1 count, so this never reveals
+    # whether >=1 patient matched; it only tells the hub/UI to render a "below-threshold"
+    # chip instead of a bare 0 that reads as "no data available". See issue #519.
     suppressed: bool = False
 
 

--- a/trust/data-access-api/data_access_api/routers/schema.py
+++ b/trust/data-access-api/data_access_api/routers/schema.py
@@ -68,6 +68,11 @@ class StatisticsResponse(BaseModel):
     record_count: int
     created: str
     data: list[dict[str, Any]]
+    # True when the count was privacy-suppressed (below ``COHORT_QUERY_THRESHOLD``)
+    # rather than a genuine zero match. Without this, ``record_count=0`` on the wire
+    # is indistinguishable from "matched no patients", so the hub/UI misread a
+    # suppressed trust as "no data available". See issue #519.
+    suppressed: bool = False
 
 
 class AccessionIdsResponse(BaseModel):

--- a/trust/data-access-api/data_access_api/services/cohort.py
+++ b/trust/data-access-api/data_access_api/services/cohort.py
@@ -383,10 +383,12 @@ def get_statistics(df: pd.DataFrame, query_input: CohortQueryInput, threshold: i
     - Aggregates the number of occurrences of each unique value per column.
 
     Below-threshold counts are privacy-suppressed by returning a ``StatisticsResponse``
-    with ``record_count=0`` and empty ``data`` — the count itself is suppressed, not
-    just the per-field breakdown. This is intentional so the trust still has a normal
-    response to forward to the hub; raising HTTPException here previously caused
-    trust-api to skip the hub callback and leave the per-trust UI status stuck.
+    with ``record_count=0``, empty ``data`` and ``suppressed=True`` — the count itself
+    is suppressed, not just the per-field breakdown. This is intentional so the trust
+    still has a normal response to forward to the hub; raising HTTPException here
+    previously caused trust-api to skip the hub callback and leave the per-trust UI
+    status stuck. The ``suppressed`` flag lets the hub/UI tell a privacy-suppressed
+    count apart from a genuine zero match (issue #519).
 
     Args:
         df (pd.DataFrame): Query results dataframe.
@@ -410,6 +412,7 @@ def get_statistics(df: pd.DataFrame, query_input: CohortQueryInput, threshold: i
             record_count=0,
             created=datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%d"),
             data=[],
+            suppressed=True,
         )
 
     stats = StatisticsResponse(

--- a/trust/data-access-api/data_access_api/services/cohort.py
+++ b/trust/data-access-api/data_access_api/services/cohort.py
@@ -428,6 +428,7 @@ def get_statistics(df: pd.DataFrame, query_input: CohortQueryInput, threshold: i
         record_count=record_count,
         created=datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%d"),
         data=[get_counts(df), get_null_counts(df)],
+        suppressed=False,
     )
 
     if "person_id" in df.columns:

--- a/trust/data-access-api/data_access_api/services/cohort.py
+++ b/trust/data-access-api/data_access_api/services/cohort.py
@@ -382,14 +382,16 @@ def get_statistics(df: pd.DataFrame, query_input: CohortQueryInput, threshold: i
     - Counts the number of records.
     - Aggregates the number of occurrences of each unique value per column.
 
-    A non-zero count below the threshold is privacy-suppressed by returning a
-    ``StatisticsResponse`` with ``record_count=0``, empty ``data`` and ``suppressed=True``
-    — the count itself is suppressed, not just the per-field breakdown. A genuine zero
-    match is returned the same way but with ``suppressed=False``, so the hub/UI can tell a
-    privacy-suppressed count apart from a true zero (issue #519). Suppression is intentional
-    rather than an HTTPException so the trust still has a normal response to forward to the
-    hub; raising here previously caused trust-api to skip the hub callback and leave the
-    per-trust UI status stuck.
+    Below-threshold counts are privacy-suppressed by returning a ``StatisticsResponse``
+    with ``record_count=0``, empty ``data`` and ``suppressed=True`` — the count itself is
+    suppressed, not just the per-field breakdown. A genuine zero is suppressed identically
+    to a small (1..threshold-1) count, so the two are indistinguishable on the wire and the
+    response cannot be used to infer that >=1 patient matched (membership disclosure — issue
+    #519, security review). The ``suppressed`` flag only tells the hub/UI to render a
+    "below-threshold" chip instead of a bare 0; it does not reveal which 0s were genuine.
+    Suppression is intentional rather than an HTTPException so the trust still has a normal
+    response to forward to the hub; raising here previously caused trust-api to skip the hub
+    callback and leave the per-trust UI status stuck.
 
     Args:
         df (pd.DataFrame): Query results dataframe.
@@ -403,13 +405,13 @@ def get_statistics(df: pd.DataFrame, query_input: CohortQueryInput, threshold: i
     record_count = len(df)
 
     if record_count < COHORT_QUERY_THRESHOLD:
-        # A non-zero count below the threshold is privacy-suppressed to 0; a genuine
-        # zero match is returned as a true 0 (suppressed=False) so the hub/UI can tell
-        # the two apart (issue #519). Both carry record_count=0 with empty data.
-        suppressed = record_count > 0
+        # Privacy-suppress every below-threshold count, INCLUDING a genuine zero: a true
+        # zero and a small (1..threshold-1) count return identically (record_count=0,
+        # suppressed=True) so the response can't reveal that >=1 patient matched.
+        # Distinguishing them would leak membership/existence (issue #519, security review).
         logger.info(
-            f"Query returned {record_count} records (< {COHORT_QUERY_THRESHOLD}); returning"
-            f" {'privacy-suppressed' if suppressed else 'genuine'} 0-count response"
+            f"Query returned {record_count} records (< {COHORT_QUERY_THRESHOLD});"
+            " returning privacy-suppressed 0-count response"
         )
         return StatisticsResponse(
             query_id=query_input.query_id,
@@ -417,7 +419,7 @@ def get_statistics(df: pd.DataFrame, query_input: CohortQueryInput, threshold: i
             record_count=0,
             created=datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%d"),
             data=[],
-            suppressed=suppressed,
+            suppressed=True,
         )
 
     stats = StatisticsResponse(

--- a/trust/data-access-api/data_access_api/services/cohort.py
+++ b/trust/data-access-api/data_access_api/services/cohort.py
@@ -382,13 +382,14 @@ def get_statistics(df: pd.DataFrame, query_input: CohortQueryInput, threshold: i
     - Counts the number of records.
     - Aggregates the number of occurrences of each unique value per column.
 
-    Below-threshold counts are privacy-suppressed by returning a ``StatisticsResponse``
-    with ``record_count=0``, empty ``data`` and ``suppressed=True`` — the count itself
-    is suppressed, not just the per-field breakdown. This is intentional so the trust
-    still has a normal response to forward to the hub; raising HTTPException here
-    previously caused trust-api to skip the hub callback and leave the per-trust UI
-    status stuck. The ``suppressed`` flag lets the hub/UI tell a privacy-suppressed
-    count apart from a genuine zero match (issue #519).
+    A non-zero count below the threshold is privacy-suppressed by returning a
+    ``StatisticsResponse`` with ``record_count=0``, empty ``data`` and ``suppressed=True``
+    — the count itself is suppressed, not just the per-field breakdown. A genuine zero
+    match is returned the same way but with ``suppressed=False``, so the hub/UI can tell a
+    privacy-suppressed count apart from a true zero (issue #519). Suppression is intentional
+    rather than an HTTPException so the trust still has a normal response to forward to the
+    hub; raising here previously caused trust-api to skip the hub callback and leave the
+    per-trust UI status stuck.
 
     Args:
         df (pd.DataFrame): Query results dataframe.
@@ -402,9 +403,13 @@ def get_statistics(df: pd.DataFrame, query_input: CohortQueryInput, threshold: i
     record_count = len(df)
 
     if record_count < COHORT_QUERY_THRESHOLD:
+        # A non-zero count below the threshold is privacy-suppressed to 0; a genuine
+        # zero match is returned as a true 0 (suppressed=False) so the hub/UI can tell
+        # the two apart (issue #519). Both carry record_count=0 with empty data.
+        suppressed = record_count > 0
         logger.info(
-            f"Query returned insufficient results ({record_count} < {COHORT_QUERY_THRESHOLD});"
-            " returning privacy-suppressed 0-count response"
+            f"Query returned {record_count} records (< {COHORT_QUERY_THRESHOLD}); returning"
+            f" {'privacy-suppressed' if suppressed else 'genuine'} 0-count response"
         )
         return StatisticsResponse(
             query_id=query_input.query_id,
@@ -412,7 +417,7 @@ def get_statistics(df: pd.DataFrame, query_input: CohortQueryInput, threshold: i
             record_count=0,
             created=datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%d"),
             data=[],
-            suppressed=True,
+            suppressed=suppressed,
         )
 
     stats = StatisticsResponse(

--- a/trust/data-access-api/tests/integration/test_cohort_endpoint.py
+++ b/trust/data-access-api/tests/integration/test_cohort_endpoint.py
@@ -69,6 +69,9 @@ def test_cohort_endpoint_suppresses_below_threshold(http_client):
     body = response.json()
     assert body["record_count"] == 0
     assert body["data"] == []
+    # The 0 is privacy suppression, flagged so the hub/UI can tell it apart from a
+    # genuine zero match (#519).
+    assert body["suppressed"] is True
 
 
 def test_cohort_endpoint_rejects_unsafe_sql(http_client):

--- a/trust/data-access-api/tests/integration/test_cohort_endpoint.py
+++ b/trust/data-access-api/tests/integration/test_cohort_endpoint.py
@@ -73,14 +73,15 @@ def test_cohort_endpoint_suppresses_below_threshold(http_client):
     body = response.json()
     assert body["record_count"] == 0
     assert body["data"] == []
-    # The 0 is privacy suppression of a real (1-9) count, flagged so the hub/UI can tell
-    # it apart from a genuine zero match (#519).
+    # The 0 is privacy suppression of a real (1-9) count; a genuine zero is suppressed the
+    # same way, so the flag can't reveal which 0s were genuine (#519).
     assert body["suppressed"] is True
 
 
-def test_cohort_endpoint_genuine_zero_not_suppressed(http_client):
-    """A query matching no rows returns a true zero: record_count=0 with suppressed=False,
-    so the hub/UI renders a literal 0 rather than a "suppressed" chip (#519)."""
+def test_cohort_endpoint_genuine_zero_is_suppressed(http_client):
+    """Privacy regression: a query matching no rows is suppressed identically to a
+    below-threshold count (record_count=0, suppressed=True), so the wire never reveals a
+    genuine zero apart from a small count (#519, security review)."""
     response = http_client.post(
         "/cohort",
         json=_cohort_payload(
@@ -91,7 +92,7 @@ def test_cohort_endpoint_genuine_zero_not_suppressed(http_client):
     body = response.json()
     assert body["record_count"] == 0
     assert body["data"] == []
-    assert body["suppressed"] is False
+    assert body["suppressed"] is True
 
 
 def test_cohort_endpoint_rejects_unsafe_sql(http_client):

--- a/trust/data-access-api/tests/integration/test_cohort_endpoint.py
+++ b/trust/data-access-api/tests/integration/test_cohort_endpoint.py
@@ -58,7 +58,29 @@ def test_cohort_endpoint_returns_aggregates_for_image_occurrences(http_client):
 
 
 def test_cohort_endpoint_suppresses_below_threshold(http_client):
-    """A below-threshold cohort is privacy-suppressed: HTTP 200 with empty data."""
+    """A non-zero below-threshold cohort (4 XR rows in the seed) is privacy-suppressed:
+    HTTP 200 with record_count=0, empty data and suppressed=True (#519)."""
+    response = http_client.post(
+        "/cohort",
+        json=_cohort_payload(
+            # modality_concept_id 4013632 = 'XR' (Plain Film); the seed has 4 such rows,
+            # below the threshold of 10 — a genuine below-threshold count, not a zero.
+            "SELECT person_id, modality_concept_id, accession_id "
+            "FROM omop.image_occurrence WHERE modality_concept_id = 4013632"
+        ),
+    )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["record_count"] == 0
+    assert body["data"] == []
+    # The 0 is privacy suppression of a real (1-9) count, flagged so the hub/UI can tell
+    # it apart from a genuine zero match (#519).
+    assert body["suppressed"] is True
+
+
+def test_cohort_endpoint_genuine_zero_not_suppressed(http_client):
+    """A query matching no rows returns a true zero: record_count=0 with suppressed=False,
+    so the hub/UI renders a literal 0 rather than a "suppressed" chip (#519)."""
     response = http_client.post(
         "/cohort",
         json=_cohort_payload(
@@ -69,9 +91,7 @@ def test_cohort_endpoint_suppresses_below_threshold(http_client):
     body = response.json()
     assert body["record_count"] == 0
     assert body["data"] == []
-    # The 0 is privacy suppression, flagged so the hub/UI can tell it apart from a
-    # genuine zero match (#519).
-    assert body["suppressed"] is True
+    assert body["suppressed"] is False
 
 
 def test_cohort_endpoint_rejects_unsafe_sql(http_client):

--- a/trust/data-access-api/tests/routers/test_cohort.py
+++ b/trust/data-access-api/tests/routers/test_cohort.py
@@ -129,7 +129,8 @@ def test_receive_cohort_query_too_few_records(mock_validate_query, mock_get_sett
     body = response.json()
     assert body["record_count"] == 0
     assert body["data"] == []
-    # The 0 is privacy suppression, not a genuine zero — flagged on the wire (#519).
+    # Below-threshold count is privacy-suppressed on the wire (a genuine zero is suppressed
+    # the same way, so it can't reveal whether >=1 patient matched) (#519).
     assert body["suppressed"] is True
     assert body["query_id"] == sample_query_input["query_id"]
     assert body["trust_id"] == sample_query_input["trust_id"]
@@ -139,8 +140,9 @@ def test_receive_cohort_query_too_few_records(mock_validate_query, mock_get_sett
 @patch("data_access_api.routers.cohort.get_settings")
 @patch("data_access_api.routers.cohort.validate_query")
 def test_receive_cohort_query_zero_records(mock_validate_query, mock_get_settings, mock_get_records):
-    """A query that genuinely returns 0 rows is a valid response flagged as a true zero
-    (suppressed=False), distinct from a below-threshold privacy suppression (#519)."""
+    """A query that genuinely returns 0 rows is privacy-suppressed identically to a
+    below-threshold count (suppressed=True), so the wire can't reveal a true zero from a
+    small count (#519, security review)."""
     mock_get_settings.return_value.COHORT_QUERY_THRESHOLD = 5
 
     mock_df = pd.DataFrame({"col1": []})
@@ -152,8 +154,8 @@ def test_receive_cohort_query_zero_records(mock_validate_query, mock_get_setting
     body = response.json()
     assert body["record_count"] == 0
     assert body["data"] == []
-    # A genuine zero match is NOT a privacy suppression.
-    assert body["suppressed"] is False
+    # A genuine zero is suppressed the same as a 1..N-1 count — no membership leak.
+    assert body["suppressed"] is True
 
 
 @patch("data_access_api.routers.cohort.get_records")

--- a/trust/data-access-api/tests/routers/test_cohort.py
+++ b/trust/data-access-api/tests/routers/test_cohort.py
@@ -139,7 +139,8 @@ def test_receive_cohort_query_too_few_records(mock_validate_query, mock_get_sett
 @patch("data_access_api.routers.cohort.get_settings")
 @patch("data_access_api.routers.cohort.validate_query")
 def test_receive_cohort_query_zero_records(mock_validate_query, mock_get_settings, mock_get_records):
-    """A query that returns 0 rows is also a valid, privacy-suppressed response."""
+    """A query that genuinely returns 0 rows is a valid response flagged as a true zero
+    (suppressed=False), distinct from a below-threshold privacy suppression (#519)."""
     mock_get_settings.return_value.COHORT_QUERY_THRESHOLD = 5
 
     mock_df = pd.DataFrame({"col1": []})
@@ -151,6 +152,8 @@ def test_receive_cohort_query_zero_records(mock_validate_query, mock_get_setting
     body = response.json()
     assert body["record_count"] == 0
     assert body["data"] == []
+    # A genuine zero match is NOT a privacy suppression.
+    assert body["suppressed"] is False
 
 
 @patch("data_access_api.routers.cohort.get_records")

--- a/trust/data-access-api/tests/routers/test_cohort.py
+++ b/trust/data-access-api/tests/routers/test_cohort.py
@@ -129,6 +129,8 @@ def test_receive_cohort_query_too_few_records(mock_validate_query, mock_get_sett
     body = response.json()
     assert body["record_count"] == 0
     assert body["data"] == []
+    # The 0 is privacy suppression, not a genuine zero — flagged on the wire (#519).
+    assert body["suppressed"] is True
     assert body["query_id"] == sample_query_input["query_id"]
     assert body["trust_id"] == sample_query_input["trust_id"]
 

--- a/trust/data-access-api/tests/services/test_cohort.py
+++ b/trust/data-access-api/tests/services/test_cohort.py
@@ -81,6 +81,8 @@ def test_get_statistics(mock_read_sql, mock_df):
 
     # Check the record count
     assert stats.record_count == 21
+    # An above-threshold count is a genuine result, not privacy-suppressed.
+    assert stats.suppressed is False
 
 
 @patch("pandas.read_sql")
@@ -105,6 +107,9 @@ def test_get_statistics_below_threshold(mock_read_sql, mock_df_below_threshold):
     assert stats.data == []
     assert stats.query_id == "2"
     assert stats.trust_id == "mock_trust"
+    # The 0 is privacy suppression, not a genuine zero match — flagged so the
+    # hub/UI can tell the two apart (#519).
+    assert stats.suppressed is True
 
 
 @patch("data_access_api.services.cohort.COHORT_QUERY_THRESHOLD", 10)
@@ -133,6 +138,7 @@ def test_get_statistics_fails_global_threshold(mock_read_sql):
     stats = get_statistics(mock_df_medium, query_input, threshold=5)
     assert stats.record_count == 0
     assert stats.data == []
+    assert stats.suppressed is True
 
 
 @patch("pandas.read_sql")

--- a/trust/data-access-api/tests/services/test_cohort.py
+++ b/trust/data-access-api/tests/services/test_cohort.py
@@ -107,8 +107,8 @@ def test_get_statistics_below_threshold(mock_read_sql, mock_df_below_threshold):
     assert stats.data == []
     assert stats.query_id == "2"
     assert stats.trust_id == "mock_trust"
-    # The 0 is privacy suppression, not a genuine zero match — flagged so the
-    # hub/UI can tell the two apart (#519).
+    # Below-threshold count is privacy-suppressed; the flag drives the UI's "below-threshold"
+    # chip (a genuine zero is suppressed the same way, so it reveals no membership) (#519).
     assert stats.suppressed is True
 
 
@@ -142,10 +142,11 @@ def test_get_statistics_fails_global_threshold(mock_read_sql):
 
 
 @patch("pandas.read_sql")
-def test_get_statistics_genuine_zero_not_suppressed(mock_read_sql):
-    """A query that genuinely matches 0 patients returns ``record_count=0`` but
-    ``suppressed=False`` — a true zero is not a privacy suppression, so the hub/UI can
-    tell it apart from a below-threshold count (#519)."""
+def test_get_statistics_genuine_zero_is_suppressed(mock_read_sql):
+    """Privacy regression: a genuine zero match is suppressed IDENTICALLY to a small
+    below-threshold count (``record_count=0``, ``suppressed=True``). Distinguishing the two
+    would leak that >=1 patient matched a narrow query — keep this bit closed (#519,
+    security review)."""
     mock_df_empty = pd.DataFrame({"modality": [], "manufacturer": [], "accession_id": []})
     mock_read_sql.return_value = mock_df_empty
 
@@ -160,7 +161,7 @@ def test_get_statistics_genuine_zero_not_suppressed(mock_read_sql):
     stats = get_statistics(mock_df_empty, query_input, threshold=10)
     assert stats.record_count == 0
     assert stats.data == []
-    assert stats.suppressed is False
+    assert stats.suppressed is True
 
 
 @patch("pandas.read_sql")

--- a/trust/data-access-api/tests/services/test_cohort.py
+++ b/trust/data-access-api/tests/services/test_cohort.py
@@ -142,6 +142,28 @@ def test_get_statistics_fails_global_threshold(mock_read_sql):
 
 
 @patch("pandas.read_sql")
+def test_get_statistics_genuine_zero_not_suppressed(mock_read_sql):
+    """A query that genuinely matches 0 patients returns ``record_count=0`` but
+    ``suppressed=False`` — a true zero is not a privacy suppression, so the hub/UI can
+    tell it apart from a below-threshold count (#519)."""
+    mock_df_empty = pd.DataFrame({"modality": [], "manufacturer": [], "accession_id": []})
+    mock_read_sql.return_value = mock_df_empty
+
+    query_input = CohortQueryInput(
+        encrypted_project_id="my_project",
+        query_id="4",
+        query_name="query_4",
+        query="SELECT * FROM omop.radiology_occurrence WHERE 1 = 0",
+        trust_id="mock_trust",
+    )
+
+    stats = get_statistics(mock_df_empty, query_input, threshold=10)
+    assert stats.record_count == 0
+    assert stats.data == []
+    assert stats.suppressed is False
+
+
+@patch("pandas.read_sql")
 def test_get_records_undefined_table_error(mock_read_sql):
     """
     Test get_records with UndefinedTable error.

--- a/trust/trust-api/tests/integration/test_cohort_query.py
+++ b/trust/trust-api/tests/integration/test_cohort_query.py
@@ -188,12 +188,15 @@ async def test_realistic_cte_multi_join_shaped_query(stub_hub_received):
 
 
 @pytest.mark.asyncio
-async def test_empty_result_below_threshold_suppresses_to_hub(stub_hub_received):
-    """A below-threshold cohort is privacy-suppressed by data-access-api (200 + empty data).
-    trust-api treats it as success and forwards the empty result to the hub so the per-trust
-    chip resolves to "responded" with record_count=0 instead of being stuck on "running"."""
+async def test_below_threshold_result_suppresses_to_hub(stub_hub_received):
+    """A non-zero below-threshold cohort (4 XR rows in the seed) is privacy-suppressed by
+    data-access-api (200 + empty data, suppressed=True). trust-api treats it as success and
+    forwards the suppressed result to the hub so the per-trust chip resolves to "responded"
+    with record_count=0 instead of being stuck on "running"."""
     result = await handle_cohort_query(
-        _payload("SELECT * FROM omop.image_occurrence WHERE accession_id = 'NONEXISTENT'")
+        # modality_concept_id 4013632 = 'XR'; the seed has 4 such rows (below the threshold
+        # of 10) — a genuine below-threshold count, not a zero match.
+        _payload("SELECT * FROM omop.image_occurrence WHERE modality_concept_id = 4013632")
     )
 
     assert result == {"success": True}

--- a/trust/trust-api/tests/integration/test_cohort_query.py
+++ b/trust/trust-api/tests/integration/test_cohort_query.py
@@ -207,8 +207,8 @@ async def test_below_threshold_result_suppresses_to_hub(stub_hub_received):
     assert body["query_id"] == "qid-1"
     assert body["trust_id"] == "trust_test"
     assert body["record_count"] == 0
-    # The suppression flag must survive the trust-api passthrough so the hub/UI can
-    # tell a privacy-suppressed 0 apart from a genuine zero match (#519).
+    # The suppression flag must survive the trust-api passthrough so the hub/UI can render
+    # the "below-threshold" chip (a genuine zero is suppressed the same way) (#519).
     assert body["suppressed"] is True
 
 

--- a/trust/trust-api/tests/integration/test_cohort_query.py
+++ b/trust/trust-api/tests/integration/test_cohort_query.py
@@ -204,6 +204,9 @@ async def test_empty_result_below_threshold_suppresses_to_hub(stub_hub_received)
     assert body["query_id"] == "qid-1"
     assert body["trust_id"] == "trust_test"
     assert body["record_count"] == 0
+    # The suppression flag must survive the trust-api passthrough so the hub/UI can
+    # tell a privacy-suppressed 0 apart from a genuine zero match (#519).
+    assert body["suppressed"] is True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
**OK (ABOVE THRESHOLD)** 
<img width="1512" height="865" alt="Screenshot 2026-06-02 at 14 05 56" src="https://github.com/user-attachments/assets/d09b1679-1942-45b9-a20c-ba47af714ab4" />

**SUPPRESSED (BELOW THRESHOLD, 1-9)**
<img width="1512" height="865" alt="Screenshot 2026-06-02 at 14 06 04" src="https://github.com/user-attachments/assets/f4a1d04b-b88e-4c11-815a-2698447cd8ca" />

**ZERO (NO RECORDS)** -- intentionally indistinguishable, to avoid extracting info about whether a very specific person is in the database ('membership-inference protection')
<img width="1512" height="865" alt="Screenshot 2026-06-02 at 14 06 12" src="https://github.com/user-attachments/assets/b25244db-d5a3-4e03-9903-a72566408297" />


# Description

A trust whose cohort count fell below `COHORT_QUERY_THRESHOLD` returned `record_count=0` with no marker, so a **privacy-suppressed** result was wire-indistinguishable from "no data available" — a researcher/operator read the suppressed `0` as an empty/failed query, defeating the point of the threshold. Worse, such a trust passed every staging guard, so it could be staged and approved, creating an imaging project for a trust with no cohort to build against.

This PR (1) **flags** below-threshold cohorts with a `suppressed` marker threaded end-to-end, so the UI shows a clear "below-threshold" chip instead of a bare `0`, and (2) **blocks staging/approval** of trusts that returned zero **or** suppressed cohorts.

**Membership-inference safety (security review).** A below-threshold count (1–9) and a genuine zero are **intentionally indistinguishable** on the wire — both return `record_count=0, suppressed=True`. An earlier iteration distinguished them (returning `suppressed=False` for a true zero); a commit security review correctly flagged that as a k-anonymity / membership-inference leak — a "suppressed" response would confirm that ≥1 patient matched a narrow, targeted query. The distinction was reverted: every count below the threshold, zero included, is suppressed identically. The `suppressed` flag drives the UI chip only; it never reveals which `0`s were genuine. Staging eligibility keys on `record_count == 0`, so both are blocked regardless.

## Linked Issues

- Fixes #519
- Follow-up (pre-existing, surfaced during verification): #579 — read-modify-write race in `_aggregate_and_save_results` that can drop a responded trust from the persisted aggregate. Out of scope for this PR; staging is unaffected.

## What changed

**1. Flag suppression, membership-safe (`eda291ff`, `da20275c`)**
- **data-access-api**: `StatisticsResponse` gains `suppressed: bool`; `get_statistics` sets it `True` for **every** count below `COHORT_QUERY_THRESHOLD` — a genuine zero is suppressed identically to a 1..N-1 count, so the wire can't reveal whether ≥1 patient matched.
- **trust-api**: forwards the response verbatim, so the flag reaches the hub (locked in by an integration assertion).
- **flip-api**: `OmopCohortResults` accepts `suppressed`; it's persisted in `QueryResult.data`, parsed via `TrustSpecificData`, and the suppressed trust ids are surfaced as `trust_suppressed` on `AggregatedCohortStats` / `OmopCohortResultsResponse` (alias `trustSuppressed`). A suppressed trust stays in `trust_record_counts` (count `0` — it did respond) and is additionally listed in `trust_suppressed`.
- **flip-ui**: `PerTrustResponse` renders a "below-threshold" chip instead of a literal `0`; `CohortAggregateCard` adds "N suppressed" to the subtitle. Tooltip/copy worded so it's accurate whether the suppressed count is zero or 1–9.

**2. Block staging/approval of empty/suppressed trusts (`415ae28f`)**
- **flip-api**: responded, non-errored trusts whose `record_count == 0` (covers both genuine zero and suppressed) are surfaced as `empty_trust_ids` on `IProjectQuery` (built in both `get_project` and the project-list loader) and rejected by a **4th staging guard** in `stage_project`, mirroring the existing unqueried / never-responded / errored guards. Approval is blocked transitively — a trust that can't be staged has no `ProjectTrustIntersect` to approve.
- **flip-ui**: the project page's `stageableTrustIds` subtracts `emptyTrustIds`, so the stage selector never offers a trust the API would reject.

**3. Refactor — single-pass trust-id classifier (`08be3f4f`)**
- The three collectors (`_collect_errored_trust_ids`, `_distinct_responded_trust_ids`, and the new empty-cohort collector) each walked the same `QueryResult` rows independently, JSON-parsing every blob twice per project on each list/detail read. Collapsed into one `_classify_responded_trust_ids` that parses each row once and returns `(responded, errored, empty)`. Behaviour-identical (same first-occurrence dedup, disjoint errored/empty); tests consolidated. Net −56 lines.

**4. Robustness — corrupt `record_count` fails safe (`b96b903b`)**
- The `int(record_count)` coercion sat outside the JSON `try/except`, so a corrupt-but-parseable count would raise and 500 the project list/detail reads. It's now treated like a malformed payload — the trust is classified **errored** (excluded from staging) — matching the existing malformed-JSON path. Unreachable today (`record_count` is a validated int at every wire boundary) but removes the asymmetry.

## Checklist

- [x] Follows the project's coding conventions and style guide
- [ ] Updates documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Type of Change

- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] New tests added to cover the changes.
- [x] In-line docstrings updated.

## Testing & verification

- **Unit / lint / type**: flip-api **1106 passed** (+ new classifier and robustness tests); data-access-api **147 passed**; flip-ui **21** cohort-query / project-page specs passed (suppressed chip, aggregate subtitle, `stageableTrustIds` exclusion). ruff + mypy + ESLint clean.
- **Privacy regression tests**: `get_statistics(empty_df).suppressed is True` (and the router/integration equivalents) assert a genuine zero stays suppressed, so the membership-leak bit can't drift back open.
- **Live dev verification** — ran all three scenarios end-to-end against the dev stack (central hub + GSTT + KCH trusts) via the cohort API (screenshots above):
  - **OK** — CT cohort → real per-trust counts (GSTT 21, KCH 20; total 41), no chip, not stage-blocked.
  - **SUPPRESSED** — same `+ LIMIT 5` → both trusts `record_count=0` + below-threshold chip, stage-blocked.
  - **ZERO** — same `+ nonexistent accession` → both trusts `record_count=0` + the **same** chip (indistinguishable from SUPPRESSED). Confirmed at the source: both `QueryResult` rows returned `record_count=0, suppressed=True`.
- Integration tests that need a live Postgres/OMOP run in CI; the behaviour was also exercised by the live dev run above.

## Additional Notes

- A suppressed trust may have matched real (1–9) patients or genuinely zero — the platform treats both identically for staging eligibility (no usable cohort either way) and never discloses which.
- The `flip` Python package (in `flip-fl-base`/`flip-fl-base-flower`) is unaffected — this change is confined to the cohort-stats path.

---
_Generated by [Claude Code](https://claude.ai/code/session_012oCgqBLgYyz7DuNTXpzoJX)_
