### PR TITLE
feat(#568): dev FL creds sidecar so the flower fl-server runs at native uid

### DIFF
--- a/deploy/aws-creds/Dockerfile
+++ b/deploy/aws-creds/Dockerfile
@@ -1,0 +1,19 @@
+# Copyright (c) Guy's and St Thomas' NHS Foundation Trust & King's College London
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# #568: boto3-based container-credential sidecar (see app.py).
+
+FROM python:3.12-slim
+RUN pip install --no-cache-dir fastapi "uvicorn[standard]" boto3
+WORKDIR /app
+COPY app.py .
+# Non-privileged port so the container can run as the host (non-root) uid.
+CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8081"]

--- a/deploy/aws-creds/app.py
+++ b/deploy/aws-creds/app.py
@@ -33,6 +33,13 @@ app = FastAPI()
 _session = boto3.Session(profile_name=os.environ.get("AWS_PROFILE"))
 
 
+@app.get("/health")
+def health() -> JSONResponse:
+    # Liveness probe for the compose healthcheck. Deliberately does NOT touch boto3 — an expired
+    # SSO token must not mark the sidecar unhealthy and block dependents from ever starting.
+    return JSONResponse({"status": "ok"})
+
+
 @app.get("/creds")
 def creds() -> JSONResponse:
     try:
@@ -44,12 +51,22 @@ def creds() -> JSONResponse:
         logger.exception("Could not resolve AWS credentials")
         return JSONResponse({"error": "could not resolve credentials"}, status_code=500)
 
-    expiry = getattr(credentials, "_expiry_time", None)
+    # The SDK's container provider needs an Expiration to drive its re-poll cadence; without one
+    # it treats the creds as static and never refreshes, so they'd go stale mid-run. Prefer a
+    # public expiry_time if botocore exposes one, else fall back to the private attr, and format
+    # inside a try so a type change / naive datetime fails loudly (logged 500) instead of
+    # returning unrefreshable creds.
+    expiry = getattr(credentials, "expiry_time", None) or getattr(credentials, "_expiry_time", None)
+    try:
+        expiration = expiry.astimezone(timezone.utc).isoformat()
+    except (AttributeError, TypeError, ValueError):
+        logger.exception("Could not determine AWS credential expiry")
+        return JSONResponse({"error": "could not determine credential expiry"}, status_code=500)
+
     return JSONResponse({
         "AccessKeyId": frozen.access_key,
         "SecretAccessKey": frozen.secret_key,
         "Token": frozen.token,
-        # Expiration drives the SDK's re-poll cadence; on the next call we hand back
-        # boto3's freshly-refreshed creds.
-        "Expiration": expiry.astimezone(timezone.utc).isoformat() if expiry else None,
+        # On the next poll we hand back boto3's freshly-refreshed creds.
+        "Expiration": expiration,
     })

--- a/deploy/aws-creds/app.py
+++ b/deploy/aws-creds/app.py
@@ -1,0 +1,48 @@
+# Copyright (c) Guy's and St Thomas' NHS Foundation Trust & King's College London
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# #568: minimal boto3 container-credential provider. Resolves the host's
+# (modern sso_session) profile via boto3 — which the Go ecs-local-endpoints tool can't — and
+# serves the ECS creds JSON at /creds. boto3's RefreshableCredentials auto-refresh the role
+# creds from the SSO token, so FL containers fetch fresh, uid-agnostic creds over HTTP and
+# need no SSO mount, no root.
+
+import os
+from datetime import timezone
+
+import boto3
+from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+
+app = FastAPI()
+
+# Built once: get_credentials() returns a RefreshableCredentials object for SSO profiles,
+# and get_frozen_credentials() refreshes it in-place as it nears expiry.
+_session = boto3.Session(profile_name=os.environ.get("AWS_PROFILE"))
+
+
+@app.get("/creds")
+def creds() -> JSONResponse:
+    try:
+        credentials = _session.get_credentials()
+        frozen = credentials.get_frozen_credentials()
+    except Exception as exc:  # e.g. SSO token expired / not logged in
+        return JSONResponse({"error": f"could not resolve credentials: {exc}"}, status_code=500)
+
+    expiry = getattr(credentials, "_expiry_time", None)
+    return JSONResponse({
+        "AccessKeyId": frozen.access_key,
+        "SecretAccessKey": frozen.secret_key,
+        "Token": frozen.token,
+        # Expiration drives the SDK's re-poll cadence; on the next call we hand back
+        # boto3's freshly-refreshed creds.
+        "Expiration": expiry.astimezone(timezone.utc).isoformat() if expiry else None,
+    })

--- a/deploy/aws-creds/app.py
+++ b/deploy/aws-creds/app.py
@@ -15,12 +15,16 @@
 # creds from the SSO token, so FL containers fetch fresh, uid-agnostic creds over HTTP and
 # need no SSO mount, no root.
 
+import logging
 import os
 from datetime import timezone
 
 import boto3
 from fastapi import FastAPI
 from fastapi.responses import JSONResponse
+
+# uvicorn's error logger, so failure detail is visible via `docker logs aws-creds`.
+logger = logging.getLogger("uvicorn.error")
 
 app = FastAPI()
 
@@ -34,8 +38,11 @@ def creds() -> JSONResponse:
     try:
         credentials = _session.get_credentials()
         frozen = credentials.get_frozen_credentials()
-    except Exception as exc:  # e.g. SSO token expired / not logged in
-        return JSONResponse({"error": f"could not resolve credentials: {exc}"}, status_code=500)
+    except Exception:  # e.g. SSO token expired / not logged in
+        # Log the detail server-side (visible via `docker logs aws-creds` — e.g. to prompt
+        # `aws sso login`), but don't echo the exception text back to the caller (CWE-209).
+        logger.exception("Could not resolve AWS credentials")
+        return JSONResponse({"error": "could not resolve credentials"}, status_code=500)
 
     expiry = getattr(credentials, "_expiry_time", None)
     return JSONResponse({

--- a/deploy/compose.development.flower.yml
+++ b/deploy/compose.development.flower.yml
@@ -37,6 +37,14 @@ services:
       credentials_network:
         ipv4_address: 169.254.170.2
     restart: unless-stopped
+    healthcheck:
+      # #568: liveness only — hits /health (no boto3), so an expired SSO token doesn't mark the
+      # sidecar unhealthy and block dependents that wait on `condition: service_healthy`.
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8081/health', timeout=3)"]
+      interval: 5s
+      timeout: 5s
+      retries: 12
+      start_period: 10s
 
   fl-api-net-1:
     container_name: flip-fl-api-net-1
@@ -94,6 +102,11 @@ services:
   fl-server-net-1:
     container_name: fl-server-net-1
     image: ${DOCKER_FL_REGISTRY}${DOCKER_FL_SERVER_NAME}:${DOCKER_FL_TAG}
+    depends_on:
+      # #568: don't start until the creds sidecar is serving, so an early AWS call (or a
+      # sidecar restart) can't hit a closed port and fail credential resolution.
+      aws-creds:
+        condition: service_healthy
     volumes:
       # #568: AWS creds now come from the aws-creds sidecar via the container
       # credential provider (AWS_CONTAINER_CREDENTIALS_FULL_URI below) — no SSO
@@ -167,6 +180,10 @@ services:
   fl-server-net-2:
     container_name: fl-server-net-2
     image: ${DOCKER_FL_REGISTRY}${DOCKER_FL_SERVER_NAME}:${DOCKER_FL_TAG}
+    depends_on:
+      # #568: see net-1 — gate startup on the creds sidecar being healthy.
+      aws-creds:
+        condition: service_healthy
     volumes:
       # #568: AWS creds now come from the aws-creds sidecar via the container
       # credential provider (AWS_CONTAINER_CREDENTIALS_FULL_URI below) — no SSO

--- a/deploy/compose.development.flower.yml
+++ b/deploy/compose.development.flower.yml
@@ -16,6 +16,28 @@
 services:
   #################### CENTRAL HUB FL ####################
 
+  # #568: local container-credential-provider sidecar. Reads the host SSO
+  # profile and vends short-lived creds over HTTP at the ECS credential IP (169.254.170.2).
+  # FL containers fetch creds via the SDK's container provider (AWS_CONTAINER_CREDENTIALS_*) —
+  # no mounted token, so their uid is irrelevant. This is the ONE container that reads the
+  # mode-600 SSO token, so it runs as the host uid. Mirrors how ECS injects task-role creds.
+  aws-creds:
+    build: ./aws-creds
+    container_name: aws-creds
+    # Runs as the host uid — the ONE container that reads the host's mode-600 SSO token.
+    # boto3 inside it resolves the modern sso_session profile and auto-refreshes.
+    user: "${UID}:${GID}"
+    environment:
+      - HOME=/home/app                # so boto3 finds /home/app/.aws
+      - AWS_PROFILE=${AWS_PROFILE}
+      - AWS_REGION=${AWS_REGION}
+    volumes:
+      - ~/.aws:/home/app/.aws:ro
+    networks:
+      credentials_network:
+        ipv4_address: 169.254.170.2
+    restart: unless-stopped
+
   fl-api-net-1:
     container_name: flip-fl-api-net-1
     image: ${DOCKER_FL_REGISTRY}${DOCKER_FL_API_NAME}:${DOCKER_FL_TAG}
@@ -73,11 +95,9 @@ services:
     container_name: fl-server-net-1
     image: ${DOCKER_FL_REGISTRY}${DOCKER_FL_SERVER_NAME}:${DOCKER_FL_TAG}
     volumes:
-      # Mount the AWS credentials (needed to upload model results to S3).
-      # The image runs as `app` (uid 49999) with HOME=/app, so the mount
-      # lands at /app/.aws/ — the SDK's default lookup path for that user.
-      - ~/.aws/config:/app/.aws/config:ro
-      - ~/.aws/sso/cache:/app/.aws/sso/cache:rw
+      # #568: AWS creds now come from the aws-creds sidecar via the container
+      # credential provider (AWS_CONTAINER_CREDENTIALS_FULL_URI below) — no SSO
+      # mount, so this stays its native uid 49999 (no root, no GID 0).
       # Provisioned Flower secrets (only certificates are needed here)
       - ${FL_PROVISIONED_DIR}/net-1/certificates:/certs:ro
       # Shared with FL API: uploaded app bundles (sources + checkpoint) live under
@@ -93,7 +113,11 @@ services:
       - FLIP_API_INTERNAL_URL=${FLIP_API_INTERNAL_URL}
       - INTERNAL_SERVICE_KEY_HEADER=${INTERNAL_SERVICE_KEY_HEADER}
       - INTERNAL_SERVICE_KEY=${INTERNAL_SERVICE_KEY}
-      - AWS_PROFILE=${AWS_PROFILE}
+      - AWS_REGION=${AWS_REGION}
+      # #568: fetch creds from the aws-creds boto3 sidecar via the container provider.
+      # FULL_URI (link-local host → no auth token needed) so the sidecar can serve on the
+      # non-privileged :8081 as a non-root user.
+      - AWS_CONTAINER_CREDENTIALS_FULL_URI=http://169.254.170.2:8081/creds
     command:
       - --ssl-ca-certfile
       - /certs/ca.crt
@@ -108,6 +132,7 @@ services:
       - 9093:9093
     networks:
       - shared-net-1
+      - credentials_network  # #568: reach the aws-creds sidecar at 169.254.170.2
     restart: unless-stopped
     init: true
 
@@ -143,11 +168,9 @@ services:
     container_name: fl-server-net-2
     image: ${DOCKER_FL_REGISTRY}${DOCKER_FL_SERVER_NAME}:${DOCKER_FL_TAG}
     volumes:
-      # Mount the AWS credentials (needed to upload model results to S3).
-      # The image runs as `app` (uid 49999) with HOME=/app, so the mount
-      # lands at /app/.aws/ — the SDK's default lookup path for that user.
-      - ~/.aws/config:/app/.aws/config:ro
-      - ~/.aws/sso/cache:/app/.aws/sso/cache:rw
+      # #568: AWS creds now come from the aws-creds sidecar via the container
+      # credential provider (AWS_CONTAINER_CREDENTIALS_FULL_URI below) — no SSO
+      # mount, so this stays its native uid 49999 (no root, no GID 0).
       # Provisioned Flower secrets (only certificates are needed here)
       - ${FL_PROVISIONED_DIR}/net-2/certificates:/certs:ro
       # Shared with FL API: uploaded app bundles (sources + checkpoint) live under
@@ -163,7 +186,11 @@ services:
       - FLIP_API_INTERNAL_URL=${FLIP_API_INTERNAL_URL}
       - INTERNAL_SERVICE_KEY_HEADER=${INTERNAL_SERVICE_KEY_HEADER}
       - INTERNAL_SERVICE_KEY=${INTERNAL_SERVICE_KEY}
-      - AWS_PROFILE=${AWS_PROFILE}
+      - AWS_REGION=${AWS_REGION}
+      # #568: fetch creds from the aws-creds boto3 sidecar via the container provider.
+      # FULL_URI (link-local host → no auth token needed) so the sidecar can serve on the
+      # non-privileged :8081 as a non-root user.
+      - AWS_CONTAINER_CREDENTIALS_FULL_URI=http://169.254.170.2:8081/creds
     command:
       - --ssl-ca-certfile
       - /certs/ca.crt
@@ -176,6 +203,7 @@ services:
       - 0.0.0.0:9097
     networks:
       - shared-net-2
+      - credentials_network  # #568: reach the aws-creds sidecar at 169.254.170.2
     restart: unless-stopped
     init: true
 
@@ -202,3 +230,12 @@ services:
         condition: service_healthy
     networks:
       - shared-net-2
+
+# #568: compose-managed network carrying the ECS credential IP
+# (169.254.170.2) that the aws-creds sidecar binds and the FL servers reach.
+networks:
+  credentials_network:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 169.254.170.0/24


### PR DESCRIPTION
## Problem (#568)

In the dev stack a Flower FL run trains successfully but the model then enters `ERROR` because the **fl-server can't upload results to S3** — it runs as `flwr/base`'s non-root **uid 49999** and can't read the host's **mode-600 SSO token** mounted from `~/.aws/sso/cache`. (Surfaced once the flower FL images moved onto `flwr/base`'s non-root user; the nvflare fl-server avoids it only because that image runs as root.)

## Fix

A small **boto3 + FastAPI sidecar** (`deploy/aws-creds/`) that:
- reads the host SSO profile via boto3 — which understands the **modern `sso_session`** config and **auto-refreshes** the role creds (the Go `amazon-ecs-local-container-endpoints` tool can't parse `sso_session`);
- serves ECS-style creds JSON at the **link-local credential IP `169.254.170.2`**.

The flower fl-servers fetch creds through the SDK's **container credential provider** (`AWS_CONTAINER_CREDENTIALS_FULL_URI=http://169.254.170.2:8081/creds`) — **no SSO mount**, so they keep their **native uid 49999**: no root, no GID 0, no static creds. It's the same mechanism prod uses (ECS task role / EKS pod identity), so dev now mirrors prod. Only the sidecar reads the host token, and it runs as the host uid to do so.

## Why this over the alternatives
- **fl-server as root** (what nvflare does): works but discards the non-root hardening the `flwr/base` move introduced.
- **`user: "${UID}:${GID}"` (host uid)**: breaks the flower image — Flower writes `$HOME/.flwr` and `HOME=/home/app` is owned by the image uid, so a foreign uid can't.
- **`chmod o+r` the SSO token**: weakens host file perms and resets on every `aws sso login`.
- **`amazon-ecs-local-container-endpoints`**: can't parse the modern `sso_session` profile.

## Validation
`make up FL_BACKEND=flower` then `make e2e_smoke FL_BACKEND=flower` → reaches `RESULTS_UPLOADED` / Smoke passed, with the fl-server confirmed at `uid=49999` (no SSO mount) fetching creds from the sidecar (`GET /creds → 200`).

## Notes / for reviewers
- **Dev-stack only.** Prod FL containers use instance/task roles; the prod compose is untouched.
- Requires `aws sso login` on the host; the sidecar mounts `~/.aws:ro` and reads the profile named by `AWS_PROFILE`.
- The sidecar comes up with `make up FL_BACKEND=flower` (it's defined in the flower compose). It is intentionally **not** wired into `make restart-fl` (that target is shared with nvflare, which has no such sidecar); making `restart-fl` backend-aware could be a small follow-up.
- The FastAPI app is intentionally tiny; `imds-credential-server` is an off-the-shelf alternative if you'd rather not maintain ~30 lines.

Closes #568.
