### PR TITLE
fix(flip-api): seed roles and permissions idempotently by id

### DIFF
--- a/flip-api/src/flip_api/db/seed/permissions.py
+++ b/flip-api/src/flip_api/db/seed/permissions.py
@@ -16,25 +16,35 @@ from flip_api.db.models.user_models import Permission, PermissionRef
 
 
 def seed_permissions(session: Session) -> list[str]:
-    """Seed permissions into the database.
+    """Seed permissions into the database, idempotently.
+
+    Idempotency is keyed on the permission ``id`` (the stable :class:`PermissionRef`),
+    not the name — matching ``seed_roles``: a permission may be renamed while keeping
+    its id, so a name-keyed check would miss the existing row and collide on the
+    primary key when re-seeding a live database. An existing permission has its
+    name/description refreshed in place so renames apply.
 
     Args:
-        session (Session): The SQLModel session used for reads and inserts.
+        session (Session): The SQLModel session used for reads and writes.
 
     Returns:
         list[str]: All permission names present after seeding.
     """
     for perm_data in PermissionRef:
-        # Check if permission exists
-        statement = select(Permission).where(Permission.permission_name == perm_data.name)
-        existing_permission = session.exec(statement).first()
-
-        if not existing_permission:
-            # Create new permission
-            new_permission = Permission(
-                id=perm_data.value, permission_name=perm_data.name, permission_description=perm_data.name
+        existing_permission = session.get(Permission, perm_data.value)
+        if existing_permission:
+            # Refresh in place so a rename is applied without re-inserting the
+            # already-present primary key.
+            existing_permission.permission_name = perm_data.name
+            existing_permission.permission_description = perm_data.name
+        else:
+            session.add(
+                Permission(
+                    id=perm_data.value,
+                    permission_name=perm_data.name,
+                    permission_description=perm_data.name,
+                )
             )
-            session.add(new_permission)
 
     session.commit()
 

--- a/flip-api/src/flip_api/db/seed/roles.py
+++ b/flip-api/src/flip_api/db/seed/roles.py
@@ -11,11 +11,23 @@
 #
 
 
+from typing import TypedDict
+from uuid import UUID
+
 from sqlmodel import Session, select
 
 from flip_api.db.models.user_models import Role, RoleRef
 
-CURRENT_ROLES = [
+
+class RoleSeed(TypedDict):
+    """A predefined role to seed; ``id`` is the stable :class:`RoleRef` identity."""
+
+    id: UUID
+    name: str
+    description: str
+
+
+CURRENT_ROLES: list[RoleSeed] = [
     {
         "id": RoleRef.RESEARCHER.value,
         "name": "Researcher",
@@ -35,25 +47,29 @@ CURRENT_ROLES = [
 
 
 def seed_roles(session: Session) -> list[str]:
-    """Seed roles into the database.
+    """Seed roles into the database, idempotently.
+
+    Idempotency is keyed on the role ``id`` (the stable :class:`RoleRef`), not the
+    name. A role may be renamed across releases while keeping its id — e.g. the
+    ``observer`` → ``viewer`` rename — so matching on the (mutable) name would miss
+    the existing row and collide on the primary key when re-seeding a live database.
+    An existing role has its name/description refreshed in place so renames apply.
 
     Args:
-        session (Session): The SQLModel session used for reads and inserts.
+        session (Session): The SQLModel session used for reads and writes.
 
     Returns:
         list[str]: All role names present after seeding.
     """
     for role_data in CURRENT_ROLES:
-        # Check if role exists
-        statement = select(Role).where(Role.name == role_data["name"])
-        existing_role = session.exec(statement).first()
-
+        existing_role = session.get(Role, role_data["id"])
         if existing_role:
-            continue  # Skip if role already exists
+            # Refresh in place so a rename / description change is applied without
+            # re-inserting the already-present primary key.
+            existing_role.name = role_data["name"]
+            existing_role.description = role_data["description"]
         else:
-            # Create new role
-            new_role = Role(**role_data)
-            session.add(new_role)
+            session.add(Role(**role_data))
 
     session.commit()
 

--- a/flip-api/src/flip_api/db/seed/roles.py
+++ b/flip-api/src/flip_api/db/seed/roles.py
@@ -11,6 +11,7 @@
 #
 
 
+from datetime import datetime
 from typing import TypedDict
 from uuid import UUID
 
@@ -53,7 +54,8 @@ def seed_roles(session: Session) -> list[str]:
     name. A role may be renamed across releases while keeping its id — e.g. the
     ``observer`` → ``viewer`` rename — so matching on the (mutable) name would miss
     the existing row and collide on the primary key when re-seeding a live database.
-    An existing role has its name/description refreshed in place so renames apply.
+    An existing role has its name/description refreshed in place (bumping
+    ``updated_at``) so renames apply; an unchanged re-seed is left untouched.
 
     Args:
         session (Session): The SQLModel session used for reads and writes.
@@ -65,9 +67,13 @@ def seed_roles(session: Session) -> list[str]:
         existing_role = session.get(Role, role_data["id"])
         if existing_role:
             # Refresh in place so a rename / description change is applied without
-            # re-inserting the already-present primary key.
-            existing_role.name = role_data["name"]
-            existing_role.description = role_data["description"]
+            # re-inserting the already-present primary key. Only write — and bump
+            # updated_at — when something actually changed, so an ordinary re-seed
+            # stays a no-op and updated_at tracks the real change, not each deploy.
+            if existing_role.name != role_data["name"] or existing_role.description != role_data["description"]:
+                existing_role.name = role_data["name"]
+                existing_role.description = role_data["description"]
+                existing_role.updated_at = datetime.utcnow()
         else:
             session.add(Role(**role_data))
 

--- a/flip-api/tests/unit/db/seed/test_permissions.py
+++ b/flip-api/tests/unit/db/seed/test_permissions.py
@@ -1,0 +1,62 @@
+# Copyright (c) Guy's and St Thomas' NHS Foundation Trust & King's College London
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import pytest
+from sqlalchemy.pool import StaticPool
+from sqlmodel import Session, SQLModel, create_engine, select
+
+from flip_api.db.models.user_models import Permission, PermissionRef
+from flip_api.db.seed.permissions import seed_permissions
+
+
+@pytest.fixture
+def session():
+    """An isolated in-memory SQLite DB with only the ``permission`` table created,
+    so the primary-key constraint is enforced for the rename regression below."""
+    engine = create_engine(
+        "sqlite://", connect_args={"check_same_thread": False}, poolclass=StaticPool
+    )
+    SQLModel.metadata.create_all(engine, tables=[Permission.__table__])
+    with Session(engine) as session:
+        yield session
+
+
+def test_seed_permissions_seeds_all_on_empty_db(session):
+    """Every predefined permission is inserted into an empty database."""
+    seed_permissions(session)
+
+    by_id = {p.id: p.permission_name for p in session.exec(select(Permission)).all()}
+    assert by_id == {ref.value: ref.name for ref in PermissionRef}
+
+
+def test_seed_permissions_is_idempotent(session):
+    """Re-running the seed does not raise or create duplicates."""
+    seed_permissions(session)
+    seed_permissions(session)
+
+    assert len(session.exec(select(Permission)).all()) == len(list(PermissionRef))
+
+
+def test_seed_permissions_applies_rename_keeping_same_id(session):
+    """Regression: a permission renamed while keeping its id must update the
+    existing row in place, not insert a duplicate id (primary-key collision)."""
+    ref = next(iter(PermissionRef))
+    session.add(
+        Permission(id=ref.value, permission_name="OLD_NAME", permission_description="OLD_NAME")
+    )
+    session.commit()
+
+    seed_permissions(session)  # must not raise on the existing primary key
+
+    assert len(session.exec(select(Permission)).all()) == len(list(PermissionRef))
+    refreshed = session.get(Permission, ref.value)
+    assert refreshed.permission_name == ref.name  # rename applied in place

--- a/flip-api/tests/unit/db/seed/test_roles.py
+++ b/flip-api/tests/unit/db/seed/test_roles.py
@@ -10,12 +10,14 @@
 # limitations under the License.
 #
 
+from datetime import datetime
+
 import pytest
 from sqlalchemy.pool import StaticPool
 from sqlmodel import Session, SQLModel, create_engine, select
 
 from flip_api.db.models.user_models import Role, RoleRef
-from flip_api.db.seed.roles import seed_roles
+from flip_api.db.seed.roles import CURRENT_ROLES, seed_roles
 
 
 @pytest.fixture
@@ -38,11 +40,7 @@ def test_seed_roles_seeds_all_on_empty_db(session):
     seed_roles(session)
 
     by_id = {r.id: r.name for r in session.exec(select(Role)).all()}
-    assert by_id == {
-        RoleRef.RESEARCHER.value: "Researcher",
-        RoleRef.ADMIN.value: "Admin",
-        RoleRef.VIEWER.value: "Viewer",
-    }
+    assert by_id == {r["id"]: r["name"] for r in CURRENT_ROLES}
 
 
 def test_seed_roles_is_idempotent(session):
@@ -76,3 +74,33 @@ def test_seed_roles_applies_rename_keeping_same_id(session):
     assert len(roles) == 3  # no duplicate row for the reused id
     viewer = session.get(Role, RoleRef.VIEWER.value)
     assert viewer.name == "Viewer"  # rename applied in place
+
+
+def test_seed_roles_bumps_updated_at_on_rename(session):
+    """A rename refreshes ``updated_at`` so it reflects the modification, not creation."""
+    past = datetime(2000, 1, 1)
+    session.add(
+        Role(
+            id=RoleRef.VIEWER.value,
+            name="Observer",
+            description="Read-only access (pre-rename name).",
+            created_at=past,
+            updated_at=past,
+        )
+    )
+    session.commit()
+
+    seed_roles(session)
+
+    viewer = session.get(Role, RoleRef.VIEWER.value)
+    assert viewer.updated_at > past  # modification time moved forward
+
+
+def test_seed_roles_unchanged_reseed_leaves_updated_at(session):
+    """An ordinary re-seed with nothing changed must not bump ``updated_at``."""
+    seed_roles(session)
+    before = session.get(Role, RoleRef.VIEWER.value).updated_at
+
+    seed_roles(session)
+
+    assert session.get(Role, RoleRef.VIEWER.value).updated_at == before

--- a/flip-api/tests/unit/db/seed/test_roles.py
+++ b/flip-api/tests/unit/db/seed/test_roles.py
@@ -1,0 +1,78 @@
+# Copyright (c) Guy's and St Thomas' NHS Foundation Trust & King's College London
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import pytest
+from sqlalchemy.pool import StaticPool
+from sqlmodel import Session, SQLModel, create_engine, select
+
+from flip_api.db.models.user_models import Role, RoleRef
+from flip_api.db.seed.roles import seed_roles
+
+
+@pytest.fixture
+def session():
+    """An isolated in-memory SQLite DB with only the ``roles`` table created.
+
+    Real (not mocked) so the primary-key and unique constraints are enforced —
+    that is what the rename regression below depends on.
+    """
+    engine = create_engine(
+        "sqlite://", connect_args={"check_same_thread": False}, poolclass=StaticPool
+    )
+    SQLModel.metadata.create_all(engine, tables=[Role.__table__])
+    with Session(engine) as session:
+        yield session
+
+
+def test_seed_roles_seeds_all_on_empty_db(session):
+    """Every predefined role is inserted into an empty database."""
+    seed_roles(session)
+
+    by_id = {r.id: r.name for r in session.exec(select(Role)).all()}
+    assert by_id == {
+        RoleRef.RESEARCHER.value: "Researcher",
+        RoleRef.ADMIN.value: "Admin",
+        RoleRef.VIEWER.value: "Viewer",
+    }
+
+
+def test_seed_roles_is_idempotent(session):
+    """Re-running the seed does not raise or create duplicates."""
+    seed_roles(session)
+    seed_roles(session)
+
+    assert len(session.exec(select(Role)).all()) == 3
+
+
+def test_seed_roles_applies_rename_keeping_same_id(session):
+    """Regression: a role renamed while keeping its id (observer → viewer) must
+    update the existing row in place, not insert a duplicate id.
+
+    The live hub DB holds id ``cdee79c9-…`` under its old name ``Observer``;
+    keying idempotency on the (mutable) name misses it and collides on the
+    primary key when re-seeding. Keying on the id refreshes the row instead.
+    """
+    session.add(
+        Role(
+            id=RoleRef.VIEWER.value,
+            name="Observer",
+            description="Read-only access (pre-rename name).",
+        )
+    )
+    session.commit()
+
+    seed_roles(session)  # must not raise on the existing primary key
+
+    roles = session.exec(select(Role)).all()
+    assert len(roles) == 3  # no duplicate row for the reused id
+    viewer = session.get(Role, RoleRef.VIEWER.value)
+    assert viewer.name == "Viewer"  # rename applied in place


### PR DESCRIPTION
## What

`seed_roles` and `seed_permissions` keyed idempotency on the **mutable** role/permission name. The `observer` → `viewer` role rename (commit `206854ed`) kept the same id (`cdee79c9…`), so re-seeding a live hub DB missed the existing row by name and tried to `INSERT` the already-present id — failing with a `roles_pkey` `UniqueViolation`.

This stalls any `flip-api` image redeploy at the DB-seeding step: `entrypoint.sh` runs `seed_essential_data.py`, which exits non-zero on the violation, so the ECS task fails its health check and the rollout never completes (the old task keeps serving). `seed_permissions` had the same latent pattern (keyed on `permission_name`).

## Fix

- Key both seeders on the **stable id** (`RoleRef` / `PermissionRef`) via `session.get`, and refresh `name`/`description` in place so renames are applied rather than colliding on the primary key.
- Type the role seed entries with a `RoleSeed` `TypedDict`.

Both seeders remain idempotent for the ordinary re-seed case and are now also safe across a same-id rename.

## Tests

- New `tests/unit/db/seed/test_roles.py` and `tests/unit/db/seed/test_permissions.py`. Each adds a regression test that reproduces the primary-key collision (`UNIQUE constraint failed: …id`) against the old code and passes on the fix, alongside empty-DB and repeat-seed idempotency cases. They use an isolated in-memory SQLite session so the PK constraint is actually enforced.

Verified locally: 44 seed unit tests pass; `ruff` and `mypy` clean.

<!-- gk-ai-analysis-start:d34e224b2cc4e585b1ed73b37071c323ab881f64 -->
<!-- gk-ai-analysis-data:eyJzdW1tYXJ5IjoiVXBkYXRlZCByb2xlIGFuZCBwZXJtaXNzaW9uIHNlZWRlcnMgdG8gdXNlIHRoZSBzdGFibGUgSUQgZm9yIGlkZW1wb3RlbmN5IGNoZWNrcyBpbnN0ZWFkIG9mIG11dGFibGUgbmFtZXMsIHByZXZlbnRpbmcgcHJpbWFyeSBrZXkgY29sbGlzaW9ucyB3aGVuIGVudGl0aWVzIGFyZSByZW5hbWVkLiIsImtleUluc2lnaHRzIjpbeyJ0aXRsZSI6IklkZW1wb3RlbmN5IGJ5IElEIGluIHBlcm1pc3Npb24gc2VlZGluZyIsImRlc2NyaXB0aW9uIjoiVGhlIGBzZWVkX3Blcm1pc3Npb25zYCBmdW5jdGlvbiBub3cgcmV0cmlldmVzIHBlcm1pc3Npb25zIGJ5IElEIHVzaW5nIGBzZXNzaW9uLmdldGAgYW5kIHVwZGF0ZXMgdGhlIG5hbWUgYW5kIGRlc2NyaXB0aW9uIGluIHBsYWNlIGlmIHRoZSByZWNvcmQgZXhpc3RzLCByYXRoZXIgdGhhbiBxdWVyeWluZyBieSBuYW1lLiIsInNldmVyaXR5IjoibWVkaXVtIiwiZmlsZVBhdGgiOiJmbGlwLWFwaS9zcmMvZmxpcF9hcGkvZGIvc2VlZC9wZXJtaXNzaW9ucy5weSIsImxpbmVTdGFydCI6MzAsImxpbmVFbmQiOjQ0fSx7InRpdGxlIjoiSWRlbXBvdGVuY3kgYnkgSUQgaW4gcm9sZSBzZWVkaW5nIiwiZGVzY3JpcHRpb24iOiJUaGUgYHNlZWRfcm9sZXNgIGZ1bmN0aW9uIG5vdyByZXRyaWV2ZXMgcm9sZXMgYnkgSUQgYW5kIHVwZGF0ZXMgdGhlbSBpZiB0aGV5IGV4aXN0IGluc3RlYWQgb2YgcXVlcnlpbmcgYnkgbmFtZSBhbmQgc2tpcHBpbmcgZXhpc3RpbmcgcmVjb3Jkcy4iLCJzZXZlcml0eSI6Im1lZGl1bSIsImZpbGVQYXRoIjoiZmxpcC1hcGkvc3JjL2ZsaXBfYXBpL2RiL3NlZWQvcm9sZXMucHkiLCJsaW5lU3RhcnQiOjYyLCJsaW5lRW5kIjo2OX0seyJ0aXRsZSI6IkludHJvZHVjZWQgUm9sZVNlZWQgdHlwZSIsImRlc2NyaXB0aW9uIjoiQSBgUm9sZVNlZWRgIFR5cGVkRGljdCB3YXMgaW50cm9kdWNlZCB0byBzdHJvbmdseSB0eXBlIHRoZSBgQ1VSUkVOVF9ST0xFU2AgbGlzdCBkZWZpbml0aW9uLCBleHBsaWNpdGx5IGRlZmluaW5nIGBpZGAsIGBuYW1lYCwgYW5kIGBkZXNjcmlwdGlvbmAuIiwic2V2ZXJpdHkiOiJsb3ciLCJmaWxlUGF0aCI6ImZsaXAtYXBpL3NyYy9mbGlwX2FwaS9kYi9zZWVkL3JvbGVzLnB5IiwibGluZVN0YXJ0IjoyMCwibGluZUVuZCI6MjV9XSwiaXNzdWVzIjpbXSwic3VnZ2VzdGlvbnMiOltdLCJzZWN1cml0eSI6W119 -->
<!-- gk-ai-analysis-end:d34e224b2cc4e585b1ed73b37071c323ab881f64 -->

<!-- gitkraken-review-badge-begin -->
---
<a href="https://gitkraken.dev/review/github/londonaicentre/FLIP/pull/585?source=pr_review_chip">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://gitkraken.dev/images/figures/gitkraken-review-badge-dark.svg">
    <img src="https://gitkraken.dev/images/figures/gitkraken-review-badge-light.svg" alt="Open with GitKraken">
  </picture>
</a>
<!-- gitkraken-review-badge-end -->