### PR TITLE
fix(trust): default BASE_IMAGES_DOWNLOAD_DIR to /opt/flip/data/trust-<slot>

### DIFF
--- a/trust/deploy/compose_trust.production.flower.yml
+++ b/trust/deploy/compose_trust.production.flower.yml
@@ -18,8 +18,10 @@ services:
   fl-client-net-1:
     image: ghcr.io/londonaicentre/${DOCKER_FL_CLIENT_NAME}:${DOCKER_FL_TAG}
     volumes:
-      # Mount the base images download directory to share images downloaded from XNAT with FL clients
-      - ${BASE_IMAGES_DOWNLOAD_DIR}:/app/data/images
+      # Mount the base images download directory to share images downloaded from XNAT with FL clients.
+      # Unset in the prod kit → /opt/flip/data/trust-${FL_KIT_SLOT_NUMBER} (see imaging-api in
+      # compose_trust.production.yml for the full rationale; mirrors ORTHANC_STORAGE_DIR's default).
+      - ${BASE_IMAGES_DOWNLOAD_DIR:-/opt/flip/data/trust-${FL_KIT_SLOT_NUMBER}}:/app/data/images
       # Provisioned Flower secrets (certificates, keys).
       # FL_KIT_DIR is the kit root on the trust host — Ansible-managed
       # /opt/flip/fl-kit on the AWS EC2 trust (see site.yml), or wherever

--- a/trust/deploy/compose_trust.production.nvflare.yml
+++ b/trust/deploy/compose_trust.production.nvflare.yml
@@ -18,8 +18,10 @@ services:
   fl-client-net-1:
     image: ghcr.io/londonaicentre/${DOCKER_FL_CLIENT_NAME}:${DOCKER_FL_TAG}
     volumes:
-      # Mount the base images download directory to share images downloaded from XNAT with FL clients
-      - ${BASE_IMAGES_DOWNLOAD_DIR}:/app/data/images
+      # Mount the base images download directory to share images downloaded from XNAT with FL clients.
+      # Unset in the prod kit → /opt/flip/data/trust-${FL_KIT_SLOT_NUMBER} (see imaging-api in
+      # compose_trust.production.yml for the full rationale; mirrors ORTHANC_STORAGE_DIR's default).
+      - ${BASE_IMAGES_DOWNLOAD_DIR:-/opt/flip/data/trust-${FL_KIT_SLOT_NUMBER}}:/app/data/images
       # Provisioned NVFLARE secrets (certificates, fed_client.json).
       # FL_KIT_DIR is the kit root on the trust host — Ansible-managed
       # /opt/flip/fl-kit on the AWS EC2 trust (see site.yml), or wherever

--- a/trust/deploy/compose_trust.production.yml
+++ b/trust/deploy/compose_trust.production.yml
@@ -68,7 +68,11 @@ services:
       TRUST_INTERNAL_SERVICE_KEY: ${TRUST_INTERNAL_SERVICE_KEY}
     # NOTE the volume BASE_IMAGES_DOWNLOAD_DIR is mounted to share images downloaded from XNAT with FL clients
     volumes:
-      - ${BASE_IMAGES_DOWNLOAD_DIR}:/app/data/images
+      # Unset in the prod kit → fall through to the Ansible-pre-created, uid-1000-owned
+      # /opt/flip/data/trust-${FL_KIT_SLOT_NUMBER} (see site.yml). A relative kit value resolves to
+      # the admin workstation over the ssh docker context, gets auto-created as root, and makes
+      # imaging-api 500 every image download with EACCES → num_samples=0. Mirrors ORTHANC_STORAGE_DIR.
+      - ${BASE_IMAGES_DOWNLOAD_DIR:-/opt/flip/data/trust-${FL_KIT_SLOT_NUMBER}}:/app/data/images
 
   data-access-api:
     image: ghcr.io/londonaicentre/data-access-api:${DOCKER_TAG}


### PR DESCRIPTION
## Problem

On an EC2 trust, the prod trust compose mounted the image-staging dir with **no fallback**:
`- ${BASE_IMAGES_DOWNLOAD_DIR}:/app/data/images`. A **relative** kit value (`./data/trust`) is
resolved by Compose on the admin workstation under the `ssh://` docker context, shipped to the
EC2 daemon as an absolute workstation path, and **auto-created there as root**. imaging-api
(uid 1000) then returns **500 on every `POST /download/images/<net>`** with
`[Errno 13] Permission denied: '/app/data/images/<net>'` (`os.makedirs` in
`services/download.py`). The FL trainer skips every accession → 0 files → torch `num_samples=0`
crash. Surfaced live on the GSTT trust.

This is the same relative-bind-dir leak already mitigated for `ORTHANC_STORAGE_DIR` and
`OMOP_DATA_DIR`, which carry compose `:-` defaults so their kit vars can be left unset.
`BASE_IMAGES_DOWNLOAD_DIR` had no such default, so it couldn't be unset and stayed relative.

## Fix

Give the three prod compose mounts (imaging-api + both fl-client backends) a **slot-aware
default**:

```yaml
- ${BASE_IMAGES_DOWNLOAD_DIR:-/opt/flip/data/trust-${FL_KIT_SLOT_NUMBER}}:/app/data/images
```

- Compose reads the kit via `--env-file`, so `FL_KIT_SLOT_NUMBER` resolves (verified with
  `docker compose config`).
- Ansible `site.yml` already pre-creates `/opt/flip/data/trust-{1,2}` owned `ubuntu` (uid 1000),
  matching imaging-api's container uid — so the dir is writable.
- Prod kits can now leave `BASE_IMAGES_DOWNLOAD_DIR` unset and fall through, identical to
  `ORTHANC_STORAGE_DIR` / `OMOP_DATA_DIR`.

## Verification

Deployed to GSTT prod (slot Trust_1): the `/app/data/images` mount now resolves to
`/opt/flip/data/trust-1` (owned uid 1000), `os.makedirs` of a per-net subdir succeeds (was
EACCES), and imaging-api + fl-client are healthy.

## Follow-ups (not in this PR)

- The live GSTT kit (`trust/.env.GSTT.production`, gitignored) had `BASE_IMAGES_DOWNLOAD_DIR`
  commented out operationally.
- Comment the var out in the tracked template `trust/.env.example` (needs dev-vs-prod care — the
  dev compose has no `:-` default) and in `.env.BDMS.production` (slot 2, same bug when it
  deploys).
- `XNAT_DATA_DIR` has the same relative-leak shape but works because `xnat/Makefile up-xnat`
  chowns its dir on the host — left as-is (repointing would orphan the populated archive).
