### PR TITLE
fix: Researcher/Viewer can view Connection Status page (#557)

### DIFF
--- a/flip-api/src/flip_api/domain/interfaces/trust.py
+++ b/flip-api/src/flip_api/domain/interfaces/trust.py
@@ -26,17 +26,24 @@ class IBasicTrust(BaseModel):
     code: str | None = None
 
 
-class IAdminTrust(BaseModel):
+class ITrustStatus(BaseModel):
+    """Connection-status view of a trust, readable by any authenticated user.
+
+    Powers the Connection Status page (trust table + topology). Every field is
+    benign trust metadata — no secrets — so the endpoint that returns this
+    (GET /trust/status) is intentionally not admin-gated. Creating a trust
+    (POST /admin/trusts) stays admin-only.
+    """
+
     id: UUID
     name: str
     code: str | None = None
     region: str | None = None
-    # Timestamps surfaced as strings with an explicit UTC marker (Z) so the
-    # browser doesn't reinterpret a naive datetime as local time and skew the
+    # last_heartbeat is surfaced as a string with an explicit UTC marker (Z) so
+    # the browser doesn't reinterpret a naive datetime as local time and skew the
     # staleness calc. The DB column is `timestamp without time zone` but the
-    # values are written via datetime.now(timezone.utc), so they're already
-    # UTC — we just need to tag them on the wire.
-    created_at: str | None = None
+    # values are written via datetime.now(timezone.utc), so they're already UTC —
+    # we just need to tag it on the wire.
     last_heartbeat: str | None = None
     project_count: int = 0
 

--- a/flip-api/src/flip_api/main.py
+++ b/flip-api/src/flip_api/main.py
@@ -82,7 +82,7 @@ from flip_api.step_functions_services import (
 )
 from flip_api.trusts_services import (
     admin_create_trust,
-    admin_get_trusts,
+    get_trust_statuses,
     get_trusts,
     trusts_health_check,
     update_trust_status,
@@ -229,7 +229,7 @@ ROUTERS: tuple[APIRouter, ...] = (
     retrieve_model_step_function.router,
     # Trust services
     admin_create_trust.router,
-    admin_get_trusts.router,
+    get_trust_statuses.router,
     get_trusts.router,
     trusts_health_check.router,
     update_trust_status.router,

--- a/flip-api/src/flip_api/trusts_services/get_trust_statuses.py
+++ b/flip-api/src/flip_api/trusts_services/get_trust_statuses.py
@@ -17,15 +17,13 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy import func
 from sqlmodel import Session, col, select
 
-from flip_api.auth.auth_utils import has_permissions
 from flip_api.auth.dependencies import verify_token
 from flip_api.db.database import get_session
 from flip_api.db.models.main_models import ProjectTrustIntersect, Trust
-from flip_api.db.models.user_models import PermissionRef
-from flip_api.domain.interfaces.trust import IAdminTrust
+from flip_api.domain.interfaces.trust import ITrustStatus
 from flip_api.utils.logger import logger
 
-router = APIRouter(prefix="/admin/trusts", tags=["trusts_services"])
+router = APIRouter(prefix="/trust", tags=["trusts_services"])
 
 
 def _as_utc_iso(value: datetime | None) -> str | None:
@@ -35,6 +33,13 @@ def _as_utc_iso(value: datetime | None) -> str | None:
     via `datetime.now(timezone.utc)` — so they're already UTC, the timezone is
     just stripped on persist. Tagging the wire format prevents the browser from
     treating the naive ISO as local time.
+
+    Args:
+        value (datetime | None): A naive (or aware) UTC datetime, or None.
+
+    Returns:
+        str | None: ISO-8601 string with millisecond precision and a trailing
+        `Z`, or None when ``value`` is None.
     """
     if value is None:
         return None
@@ -42,32 +47,30 @@ def _as_utc_iso(value: datetime | None) -> str | None:
     return value.isoformat(timespec="milliseconds") + "Z"
 
 
-@router.get("", response_model=list[IAdminTrust], status_code=status.HTTP_200_OK)
-def admin_get_trusts(
+# [#557] Connection-status read — authenticated, NOT admin-gated.
+@router.get("/status", response_model=list[ITrustStatus], status_code=status.HTTP_200_OK)
+def get_trust_statuses(
     db: Session = Depends(get_session),
-    token_id: UUID = Depends(verify_token),
-) -> list[IAdminTrust]:
-    """List every trust with admin-level fields.
+    user_id: UUID = Depends(verify_token),
+) -> list[ITrustStatus]:
+    """List every trust's connection status for the Connection Status page.
+
+    Readable by any authenticated user (Researcher, Viewer, Admin) — the fields
+    are benign trust metadata (name, code, region, heartbeat, project count) with
+    no secrets, so this is deliberately not admin-gated. Creating a trust
+    (``POST /admin/trusts``) and the plaintext keys it returns stay admin-only.
 
     Args:
-        db (Session): Database session.
-        token_id (UUID): Authenticated user ID, used for the admin permission check.
+        db (Session): Database session, provided by dependency injection.
+        user_id (UUID): ID of the authenticated user making the request.
 
     Returns:
-        list[IAdminTrust]: Every trust with name, created_at, last_heartbeat,
+        list[ITrustStatus]: Every trust with name, code, region, last_heartbeat,
         and project_count (count of rows in ``project_trust_intersect``).
 
     Raises:
-        HTTPException: 403 if the caller lacks ``CAN_ACCESS_ADMIN_PANEL``;
-            500 on database error.
+        HTTPException: 500 on database error.
     """
-    if not has_permissions(token_id, [PermissionRef.CAN_ACCESS_ADMIN_PANEL], db):
-        logger.error(f"User {token_id} attempted to list trusts without admin permission")
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="Admin permission required to list trusts.",
-        )
-
     try:
         trusts = db.exec(select(Trust)).all()
 
@@ -80,12 +83,11 @@ def admin_get_trusts(
         counts: dict[UUID, int] = {row[0]: row[1] for row in count_rows if row[0] is not None}
 
         return [
-            IAdminTrust(
+            ITrustStatus(
                 id=t.id,
                 name=t.name,
                 code=t.code,
                 region=t.region,
-                created_at=_as_utc_iso(t.created_at),
                 last_heartbeat=_as_utc_iso(t.last_heartbeat),
                 project_count=counts.get(t.id, 0),
             )
@@ -94,7 +96,7 @@ def admin_get_trusts(
     except HTTPException:
         raise
     except Exception as e:
-        logger.exception("Error listing trusts for admin")
+        logger.exception("Error listing trust statuses")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Internal server error",

--- a/flip-api/tests/unit/trusts_services/test_get_trust_statuses.py
+++ b/flip-api/tests/unit/trusts_services/test_get_trust_statuses.py
@@ -10,17 +10,29 @@
 # limitations under the License.
 #
 
-"""Unit tests for the admin trust list endpoint."""
+"""Unit tests for the authenticated trust connection-status endpoint.
+
+This endpoint is deliberately NOT admin-gated: the connection-status page is
+visible to every authenticated role (Researcher, Viewer, Admin). The fields it
+returns are benign trust metadata — no secrets — so any authenticated user may
+read them. Creating a trust (POST /admin/trusts) remains admin-only.
+"""
 
 import uuid
 from datetime import datetime, timezone
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 from fastapi import HTTPException, status
+from fastapi.testclient import TestClient
 
+from flip_api.auth.dependencies import verify_token
+from flip_api.db.database import get_session
 from flip_api.db.models.main_models import Trust
-from flip_api.trusts_services.admin_get_trusts import _as_utc_iso, admin_get_trusts
+from flip_api.main import app
+from flip_api.trusts_services.get_trust_statuses import _as_utc_iso, get_trust_statuses
+
+client = TestClient(app)
 
 
 def _make_trust(name: str = "GSTT", code: str = "GST", region: str = "London") -> Trust:
@@ -63,21 +75,7 @@ def _db_with_trusts_and_counts(trusts, count_rows):
     return db
 
 
-@patch("flip_api.trusts_services.admin_get_trusts.has_permissions", return_value=False)
-def test_admin_get_trusts_403_without_admin_permission(mock_perms):
-    db = MagicMock()
-
-    with pytest.raises(HTTPException) as exc_info:
-        admin_get_trusts(db=db, token_id=uuid.uuid4())
-
-    assert exc_info.value.status_code == status.HTTP_403_FORBIDDEN
-    # The endpoint must short-circuit before touching the DB.
-    db.exec.assert_not_called()
-    mock_perms.assert_called_once()
-
-
-@patch("flip_api.trusts_services.admin_get_trusts.has_permissions", return_value=True)
-def test_admin_get_trusts_returns_serialised_trusts_with_project_counts(mock_perms):
+def test_get_trust_statuses_returns_serialised_trusts_with_project_counts():
     trust_a = _make_trust("Trust A", "TA", "London")
     trust_b = _make_trust("Trust B", "TB", "Manchester")
     db = _db_with_trusts_and_counts(
@@ -85,7 +83,7 @@ def test_admin_get_trusts_returns_serialised_trusts_with_project_counts(mock_per
         count_rows=[(trust_a.id, 3)],  # Trust B has no rows → count defaults to 0.
     )
 
-    result = admin_get_trusts(db=db, token_id=uuid.uuid4())
+    result = get_trust_statuses(db=db, user_id=uuid.uuid4())
 
     assert len(result) == 2
     by_id = {r.id: r for r in result}
@@ -93,15 +91,23 @@ def test_admin_get_trusts_returns_serialised_trusts_with_project_counts(mock_per
     assert by_id[trust_a.id].name == "Trust A"
     assert by_id[trust_a.id].code == "TA"
     assert by_id[trust_a.id].region == "London"
-    # created_at was tz-aware in the fixture; the helper still tags it Z.
-    assert by_id[trust_a.id].created_at is not None
-    assert by_id[trust_a.id].created_at.endswith("Z")
+    assert by_id[trust_a.id].last_heartbeat is None
     # Trust B was absent from the count rows → defaults to 0.
     assert by_id[trust_b.id].project_count == 0
 
 
-@patch("flip_api.trusts_services.admin_get_trusts.has_permissions", return_value=True)
-def test_admin_get_trusts_drops_null_trust_ids_from_count_aggregation(mock_perms):
+def test_get_trust_statuses_tags_heartbeat_as_utc():
+    trust = _make_trust("Beat", "BT", "London")
+    trust.last_heartbeat = datetime(2026, 5, 27, 12, 0, 0)
+    db = _db_with_trusts_and_counts(trusts=[trust], count_rows=[])
+
+    result = get_trust_statuses(db=db, user_id=uuid.uuid4())
+
+    assert result[0].last_heartbeat is not None
+    assert result[0].last_heartbeat.endswith("Z")
+
+
+def test_get_trust_statuses_drops_null_trust_ids_from_count_aggregation():
     """The count query is a left-join-style group_by; a NULL `trust_id` row
     is a join orphan and must not poison the counts map.
     """
@@ -111,35 +117,32 @@ def test_admin_get_trusts_drops_null_trust_ids_from_count_aggregation(mock_perms
         count_rows=[(None, 99), (trust.id, 5)],
     )
 
-    result = admin_get_trusts(db=db, token_id=uuid.uuid4())
+    result = get_trust_statuses(db=db, user_id=uuid.uuid4())
 
     assert len(result) == 1
     assert result[0].project_count == 5
 
 
-@patch("flip_api.trusts_services.admin_get_trusts.has_permissions", return_value=True)
-def test_admin_get_trusts_returns_empty_list_when_no_trusts(mock_perms):
+def test_get_trust_statuses_returns_empty_list_when_no_trusts():
     db = _db_with_trusts_and_counts(trusts=[], count_rows=[])
 
-    result = admin_get_trusts(db=db, token_id=uuid.uuid4())
+    result = get_trust_statuses(db=db, user_id=uuid.uuid4())
 
     assert result == []
 
 
-@patch("flip_api.trusts_services.admin_get_trusts.has_permissions", return_value=True)
-def test_admin_get_trusts_500_on_database_error(mock_perms):
+def test_get_trust_statuses_500_on_database_error():
     db = MagicMock()
     db.exec.side_effect = Exception("db down")
 
     with pytest.raises(HTTPException) as exc_info:
-        admin_get_trusts(db=db, token_id=uuid.uuid4())
+        get_trust_statuses(db=db, user_id=uuid.uuid4())
 
     assert exc_info.value.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
     assert "Internal server error" in exc_info.value.detail
 
 
-@patch("flip_api.trusts_services.admin_get_trusts.has_permissions", return_value=True)
-def test_admin_get_trusts_re_raises_inner_http_exception(mock_perms):
+def test_get_trust_statuses_re_raises_inner_http_exception():
     """An HTTPException raised mid-query must surface unchanged — the generic
     500 catch-all is for unexpected errors only, not for HTTP-shaped ones.
     """
@@ -147,7 +150,32 @@ def test_admin_get_trusts_re_raises_inner_http_exception(mock_perms):
     db.exec.side_effect = HTTPException(status_code=418, detail="teapot")
 
     with pytest.raises(HTTPException) as exc_info:
-        admin_get_trusts(db=db, token_id=uuid.uuid4())
+        get_trust_statuses(db=db, user_id=uuid.uuid4())
 
     assert exc_info.value.status_code == 418
     assert exc_info.value.detail == "teapot"
+
+
+def test_endpoint_is_accessible_to_authenticated_non_admin():
+    """Regression for #557: a non-admin (no admin permission anywhere in the
+    call) must get a 200 with the trust list — never a 403. The endpoint has no
+    admin gate, so verifying the token is the only requirement.
+    """
+    trust = _make_trust("Researcher-visible", "RV", "London")
+    db = _db_with_trusts_and_counts(trusts=[trust], count_rows=[(trust.id, 2)])
+
+    app.dependency_overrides[get_session] = lambda: db
+    app.dependency_overrides[verify_token] = lambda: uuid.uuid4()
+    try:
+        response = client.get("/api/trust/status")
+    finally:
+        del app.dependency_overrides[get_session]
+        del app.dependency_overrides[verify_token]
+
+    assert response.status_code == 200
+    body = response.json()
+    assert len(body) == 1
+    assert body[0]["name"] == "Researcher-visible"
+    assert body[0]["code"] == "RV"
+    assert body[0]["region"] == "London"
+    assert body[0]["project_count"] == 2

--- a/flip-ui/src/pages/ConnectionStatus.vue
+++ b/flip-ui/src/pages/ConnectionStatus.vue
@@ -529,7 +529,8 @@ import AiLoader from "@/components/AiLoader/AiLoader.vue";
 import FLNetsCard from "@/partials/connection/FLNetsCard.vue";
 import AddTrustModal from "@/partials/trusts/AddTrustModal.vue";
 import TrustKitModal from "@/partials/trusts/TrustKitModal.vue";
-import { getAdminTrusts, IAdminTrust, ICreatedTrust } from "@/services/admin-trusts-service";
+import { ICreatedTrust } from "@/services/admin-trusts-service";
+import { getTrustStatuses, ITrustStatus } from "@/services/trust-status-service";
 import { useAuthStore } from "@/store/auth";
 
 const authStore = useAuthStore();
@@ -544,9 +545,9 @@ const hoverTrustId = ref<string | null>(null);
 
 // SWRV handles 5s dedupe + 15s polling so the heartbeat column stays fresh
 // without per-page setInterval bookkeeping. Same pattern as ConnectionStatus.vue.
-const { data: trusts, mutate: refresh } = useSWRV<IAdminTrust[]>(
-    "/admin/trusts",
-    getAdminTrusts,
+const { data: trusts, mutate: refresh } = useSWRV<ITrustStatus[]>(
+    "/trust/status",
+    getTrustStatuses,
     {
         dedupingInterval: 5_000,
         shouldRetryOnError: false,
@@ -562,7 +563,7 @@ type TrustState = "online" | "degraded" | "offline";
 const HEARTBEAT_FRESH_S = 30;
 const HEARTBEAT_DEGRADED_S = 5 * 60;
 
-const trustState = (t: IAdminTrust): TrustState => {
+const trustState = (t: ITrustStatus): TrustState => {
     if (!t.last_heartbeat) return "offline";
     const ageS = (Date.now() - new Date(t.last_heartbeat).getTime()) / 1000;
     if (ageS < HEARTBEAT_FRESH_S) return "online";
@@ -630,7 +631,7 @@ const STATE_RANK: Record<TrustState, number> = {
     online: 2
 };
 
-interface IRenderedTrust extends IAdminTrust {
+interface IRenderedTrust extends ITrustStatus {
     _state: TrustState;
     _uptimePoints: string;
     _uptimeDots: { x: number; y: number }[];
@@ -686,7 +687,7 @@ const sortKey = ref<SortKey>("name");
 const sortDir = ref<SortDir>("asc");
 
 // Heartbeat age in seconds; null heartbeat = oldest (Infinity).
-const heartbeatAge = (t: IAdminTrust): number =>
+const heartbeatAge = (t: ITrustStatus): number =>
     t.last_heartbeat ? (Date.now() - new Date(t.last_heartbeat).getTime()) / 1000 : Infinity;
 
 const SORT_COMPARATORS: Record<SortKey, (a: IRenderedTrust, b: IRenderedTrust) => number> = {

--- a/flip-ui/src/pages/__tests__/ConnectionStatus.spec.ts
+++ b/flip-ui/src/pages/__tests__/ConnectionStatus.spec.ts
@@ -16,18 +16,27 @@ import { mount } from "@vue/test-utils";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ref } from "vue";
 
-import { IAdminTrust } from "@/services/admin-trusts-service";
+import { ITrustStatus } from "@/services/trust-status-service";
 
 import ConnectionStatus from "../ConnectionStatus.vue";
 
-const mockSwrvData = ref<IAdminTrust[] | undefined>(undefined);
+// Capture the (key, fetcher, options) the page wires SWRV with, so a test can
+// assert it polls the authenticated /trust/status endpoint rather than the
+// admin-only /admin/trusts (regression for #557).
+const { swrvCalls } = vi.hoisted(() => ({ swrvCalls: [] as unknown[][] }));
+
+const mockSwrvData = ref<ITrustStatus[] | undefined>(undefined);
 
 vi.mock("swrv", () => ({
-    default: () => ({
-        data: mockSwrvData,
-        mutate: vi.fn(),
-        error: ref(null)
-    })
+    default: (...args: unknown[]) => {
+        swrvCalls.push(args);
+
+        return {
+            data: mockSwrvData,
+            mutate: vi.fn(),
+            error: ref(null)
+        };
+    }
 }));
 
 const stubs = {
@@ -60,13 +69,12 @@ const stubs = {
 const now = Date.now();
 const seconds = (n: number) => new Date(now - n * 1000).toISOString();
 
-const fixture: IAdminTrust[] = [
+const fixture: ITrustStatus[] = [
     {
         id: "t1",
         name: "Zebra NHS Trust",
         code: "ZNT",
         region: "London",
-        created_at: null,
         last_heartbeat: seconds(10),
         project_count: 1
     },
@@ -75,7 +83,6 @@ const fixture: IAdminTrust[] = [
         name: "Acme NHS Trust",
         code: "ANT",
         region: "South West",
-        created_at: null,
         last_heartbeat: null,
         project_count: 7
     },
@@ -84,7 +91,6 @@ const fixture: IAdminTrust[] = [
         name: "Maple NHS Trust",
         code: "MNT",
         region: "North East",
-        created_at: null,
         last_heartbeat: seconds(120),
         project_count: 3
     }
@@ -119,6 +125,7 @@ const codesInOrder = (wrapper: ReturnType<typeof mountPage>): string[] =>
 
 beforeEach(() => {
     mockSwrvData.value = undefined;
+    swrvCalls.length = 0;
 });
 
 describe("ConnectionStatus", () => {
@@ -184,6 +191,25 @@ describe("ConnectionStatus", () => {
         mockSwrvData.value = fixture;
         const wrapper = mountPage({ permissions: [] });
         await wrapper.vm.$nextTick();
+        expect(wrapper.find("[data-test='add-trust-btn']").exists()).toBe(false);
+    });
+
+    it("sources statuses from the authenticated /trust/status endpoint, not admin-only /admin/trusts", () => {
+        // #557: a non-admin polling /admin/trusts gets a 403 → perpetual spinner.
+        // The page must use the non-admin connection-status endpoint instead.
+        mockSwrvData.value = fixture;
+        mountPage({ permissions: [] });
+        expect(swrvCalls[0][0]).toBe("/trust/status");
+    });
+
+    it("lets a non-admin (Researcher / Viewer) load trust statuses with no Add Trust control", async () => {
+        // Acceptance criteria for #557: a non-admin sees the statuses populate
+        // (no perpetual loader) while the admin-only Add Trust control stays hidden.
+        mockSwrvData.value = fixture;
+        const wrapper = mountPage({ permissions: [] });
+        await wrapper.vm.$nextTick();
+        expect(wrapper.find("[data-test='ai-loader']").exists()).toBe(false);
+        expect(wrapper.findAll("[data-test='trust-row']").length).toBe(fixture.length);
         expect(wrapper.find("[data-test='add-trust-btn']").exists()).toBe(false);
     });
 

--- a/flip-ui/src/services/__tests__/trust-status-service.spec.ts
+++ b/flip-ui/src/services/__tests__/trust-status-service.spec.ts
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2026 Guy's and St Thomas' NHS Foundation Trust & King's College London
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { _http } from "@/services/api";
+import { getTrustStatuses } from "@/services/trust-status-service";
+
+vi.mock("@/services/api", () => ({
+    _http: {
+        get: vi.fn(),
+        post: vi.fn(),
+        put: vi.fn(),
+        delete: vi.fn()
+    }
+}));
+
+describe("trust-status-service", () => {
+    beforeEach(() => {
+        vi.mocked(_http.get).mockReset();
+    });
+
+    describe("getTrustStatuses", () => {
+        it("GETs the non-admin /trust/status endpoint and returns the array", async () => {
+            // Regression for #557: the Connection Status page must source its
+            // data from an authenticated (non-admin) endpoint so Researcher /
+            // Viewer roles don't get a 403 and a perpetual spinner.
+            const statuses = [
+                {
+                    id: "t-1",
+                    name: "Trust_1",
+                    code: "T1",
+                    region: "London",
+                    last_heartbeat: null,
+                    project_count: 2
+                }
+            ];
+            vi.mocked(_http.get).mockResolvedValue({ data: statuses } as never);
+
+            const result = await getTrustStatuses();
+
+            expect(_http.get).toHaveBeenCalledWith("/trust/status");
+            expect(result).toEqual(statuses);
+        });
+
+        it("returns [] when the backend body is not an array", async () => {
+            // Defensive: the page drives a v-for off this list, so a non-array
+            // body must not crash the table / topology render.
+            vi.mocked(_http.get).mockResolvedValue({ data: { error: "oops" } } as never);
+
+            const result = await getTrustStatuses();
+
+            expect(result).toEqual([]);
+        });
+
+        it("propagates errors so SWRV keeps the loader instead of showing 'no trusts'", async () => {
+            // A genuine fetch failure (e.g. 500) must reject — SWRV then leaves
+            // `trusts` undefined and the page shows its loader, rather than
+            // misreporting an empty federation.
+            vi.mocked(_http.get).mockRejectedValue(new Error("Network Error"));
+
+            await expect(getTrustStatuses()).rejects.toThrow("Network Error");
+        });
+    });
+});

--- a/flip-ui/src/services/admin-trusts-service.ts
+++ b/flip-ui/src/services/admin-trusts-service.ts
@@ -13,16 +13,6 @@
 
 import { _http } from "./api";
 
-export interface IAdminTrust {
-    id: string;
-    name: string;
-    code: string | null;
-    region: string | null;
-    created_at: string | null;
-    last_heartbeat: string | null;
-    project_count: number;
-}
-
 export interface ICreatedTrust {
     id: string;
     name: string;
@@ -44,12 +34,6 @@ export interface ICreateTrustPayload {
     name: string;
     code: string;
     region?: string;
-}
-
-export async function getAdminTrusts(): Promise<IAdminTrust[]> {
-    const response = await _http.get<IAdminTrust[]>("/admin/trusts");
-
-    return Array.isArray(response.data) ? response.data : [];
 }
 
 export async function createAdminTrust(payload: ICreateTrustPayload): Promise<ICreatedTrust> {

--- a/flip-ui/src/services/trust-status-service.ts
+++ b/flip-ui/src/services/trust-status-service.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2026 Guy's and St Thomas' NHS Foundation Trust & King's College London
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { _http } from "./api";
+
+// Connection-status view of a trust — benign metadata only (no secrets), so
+// it's served by the authenticated (non-admin) GET /trust/status endpoint.
+// Mirrors the backend ITrustStatus schema.
+export interface ITrustStatus {
+    id: string;
+    name: string;
+    code: string | null;
+    region: string | null;
+    last_heartbeat: string | null;
+    project_count: number;
+}
+
+// Readable by any authenticated user (Researcher / Viewer / Admin). Errors are
+// intentionally NOT swallowed: a rejection lets SWRV keep the page's loader
+// rather than rendering a misleading empty federation. Creating a trust stays
+// admin-only (see createAdminTrust in admin-trusts-service).
+export async function getTrustStatuses(): Promise<ITrustStatus[]> {
+    const response = await _http.get<ITrustStatus[]>("/trust/status");
+
+    return Array.isArray(response.data) ? response.data : [];
+}


### PR DESCRIPTION
## Summary

Fixes #557. The Connection Status page (`/connectionstatus`) sourced its trust table + topology entirely from the admin-only `GET /admin/trusts`, so non-admin roles (Researcher, Viewer) received a **403** — which the axios interceptor swallows (it only forces sign-out on **401**) — leaving SWRV's `trusts` undefined and the main panel stuck on a perpetual loader.

This adds an authenticated (non-admin) **`GET /trust/status`** that returns benign trust metadata (name, code, region, `last_heartbeat`, `project_count`) and points the page at it. The admin-only `GET /admin/trusts` is retired. Creating a trust (`POST /admin/trusts`, which returns one-time plaintext keys) stays **admin-only** — both in the UI (`v-if="isAdmin"`) and server-side (`CAN_ACCESS_ADMIN_PANEL` → 403), covering Researcher and Viewer alike.

## Changes

**flip-api**
- New `ITrustStatus` schema and `get_trust_statuses.py` — `GET /trust/status`, `verify_token` only, no admin gate (the fields are benign metadata, no secrets).
- Removed `admin_get_trusts.py` + the now-dead `IAdminTrust`; wired the new router in `main.py`.

**flip-ui**
- New `trust-status-service.ts` (`getTrustStatuses` / `ITrustStatus`).
- `ConnectionStatus.vue` now polls `/trust/status`; removed the dead `getAdminTrusts` / `IAdminTrust`.

## Testing

- **flip-api** unit suite green (1157 passed), including a `TestClient` test that an authenticated **non-admin** gets `200` from `/trust/status`.
- **flip-ui** unit suite green (761 passed), including tests that a non-admin (a) sources `/trust/status` (not `/admin/trusts`), (b) sees statuses populate with no perpetual loader, and (c) gets **no** Add Trust control.
- Ruff / mypy / ESLint clean on the changed files.

## Acceptance criteria (#557)

- [x] Researcher/Viewer navigating to `/connectionstatus` see trust statuses populate — no perpetual spinner.
- [x] Add Trust button/modal remains hidden and inaccessible to non-admins (UI gate **and** server-side 403).
- [x] Admin behaviour (including Add Trust onboarding) is unchanged.
- [x] Unit tests cover a non-admin successfully loading trust statuses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Acceptance Criteria

*Imported from issue #557*

- A Researcher navigating to `/connectionstatus` sees the trust connection statuses (status, name, region, heartbeat, project count) populate — no perpetual spinner.
- The **Add Trust** button/modal remains hidden and inaccessible to non-admins.
- Admin behaviour (including Add Trust onboarding) is unchanged.
- Unit tests cover a non-admin successfully loading trust statuses on this page.