### PR TITLE
docs: reconcile READMEs/CLAUDE.md/RTD with fl-* code migration; add missing return type annotations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,10 +25,18 @@ FLIP/
 │       ├── AWS/        # Terraform/OpenTofu IaC + Ansible for AWS deployment
 │       └── local/      # Ansible playbooks for on-premises trust deployment
 ├── docs/               # Sphinx documentation (ReadTheDocs)
+├── flip-utils/         # `flip` pip-installable package — platform logic, NVFLARE components, Flower helpers
+├── fl_services/        # Docker images for FL networks (fl-server, fl-client, fl-api-base, fl-base)
+├── fl-apps/            # FL job-type implementations (standard, evaluation, diffusion_model, fed_opt) and tutorials
 └── scripts/            # Utility scripts
 ```
 
 Service-specific details are in `flip-api/CLAUDE.md`, `trust/CLAUDE.md`, `trust/*/CLAUDE.md`, and `deploy/providers/AWS/CLAUDE.md`.
+
+The `flip-utils/`, `fl_services/`, and `fl-apps/` trees were migrated into this mono-repo from the legacy
+`flip-fl-base` (NVFLARE) and `flip-fl-base-flower` (Flower) repositories. Those repositories still hold the
+provisioned workspaces / certs that `deploy/fl_backend.mk` points `FL_PROVISIONED_DIR` at by default — see
+[`README.md#federated-learning-setup`](README.md#federated-learning-setup).
 
 ## Tech Stack
 
@@ -109,7 +117,7 @@ make local_test            # Tests without Docker
 
 Prerequisites:
 - Stack up via `make up` (central hub + trusts + XNAT) with trusts registered; Orthanc PACS seeded with DICOM data so image pull has something to pull.
-- Sibling repo `../flip-fl-base-flower` (Flower) or `../flip-fl-base` (NVFLARE) checked out — its chest-xray tutorial supplies the model files and `query.sql`.
+- The chest-xray tutorial (supplies the model files and `query.sql`). The defaults in `flip-api/Makefile` still point at the sibling `../flip-fl-base/...` / `../flip-fl-base-flower/...` paths; the migrated in-repo equivalents live under `fl-apps/tutorials/image_classification/xray_classification/` and can be passed via `MODEL_FILES_DIR=` / `QUERY_FILE=`.
 
 Defaults track `FL_BACKEND` (default `nvflare`): `MODEL_FILES_DIR` and `QUERY_FILE` point at `../../flip-fl-base/tutorials/image_classification/xray_classification/`. Common overrides:
 
@@ -309,7 +317,7 @@ TruffleHog, detect-secrets, large file check (max 1000KB), merge conflict marker
 The senders construct the header inline at call sites:
 - `trust-api/trust_api/services/task_handlers.py::_trust_internal_headers()` — used on outbound imaging-api and data-access-api calls.
 - `imaging-api/imaging_api/services_external/data_access.py` — used on the outbound `/cohort/accession-ids` call.
-- The [`flip` Python package](https://github.com/londonaicentre/flip-fl-base/tree/main/flip) — lives in `flip-fl-base` and is consumed by both the NVFLARE (`flip-fl-base`) and Flower (`flip-fl-base-flower`) fl-client / fl-server images. Wraps every fl-client call to imaging-api (`flip.get_by_accession_number`, etc.) and data-access-api (`flip.get_dataframe`). The package reads `TRUST_INTERNAL_SERVICE_KEY` from `os.environ` and forwards it on every request. **User-uploaded training code (`client_app.py`, `server_app.py`, anything under `tutorials/`) does not deal with the header directly** — it calls `flip.*` and the package handles transport-level auth. Adding the header to these wrappers is a single follow-up PR in `flip-fl-base`, required before this branch can ship a working trust deployment.
+- The `flip` Python package — now lives at [`flip-utils/flip/`](flip-utils/flip/) in this mono-repo (was `flip-fl-base`/`flip`), consumed by both the NVFLARE and Flower fl-client / fl-server images built from `fl_services/`. Wraps every fl-client call to imaging-api (`flip.get_by_accession_number`, etc.) and data-access-api (`flip.get_dataframe`). The package reads `TRUST_INTERNAL_SERVICE_KEY` from `os.environ` and forwards it on every request. **User-uploaded training code (`client_app.py`, `server_app.py`, anything under `tutorials/`) does not deal with the header directly** — it calls `flip.*` and the package handles transport-level auth.
 
 ## Code Modification Rules
 
@@ -325,9 +333,9 @@ The senders construct the header inline at call sites:
 
 | Repository | Purpose |
 |-----------|---------|
-| [FLIP](https://github.com/londonaicentre/FLIP) | Main mono-repo |
-| [flip-fl-base](https://github.com/londonaicentre/flip-fl-base) | NVIDIA FLARE base library |
-| [flip-fl-base-flower](https://github.com/londonaicentre/flip-fl-base-flower) | Flower base library |
+| [FLIP](https://github.com/londonaicentre/FLIP) | Main mono-repo — central hub, trust services, UI, deployment, **and** the FL base library / services / tutorials (under `flip-utils/`, `fl_services/`, `fl-apps/`) |
+| [flip-fl-base](https://github.com/londonaicentre/flip-fl-base) | Legacy NVFLARE base library repo — code has been migrated into `flip-utils/` + `fl_services/` + `fl-apps/`; still hosts the provisioned NVFLARE workspace consumed by dev compose (`FL_PROVISIONED_DIR=../flip-fl-base/workspace`) |
+| [flip-fl-base-flower](https://github.com/londonaicentre/flip-fl-base-flower) | Legacy Flower base library repo — code has been migrated into this repo; still hosts the provisioned Flower certs consumed by dev compose (`FL_PROVISIONED_DIR=../flip-fl-base-flower/certs`) |
 
 ## Documentation Files
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -377,11 +377,14 @@ test suite (ruff, mypy, and pytest).
 For the migrated FL base library (now in `flip-utils/`), unit tests can be run with:
 
 ```bash
-make -C flip-utils unit-test
+cd flip-utils && uv run pytest tests/unit -s -vv
 ```
 
-Integration tests for the FL services live under `fl_services/` — see [`flip-utils/README.md`](flip-utils/README.md)
-and [`fl_services/README.md`](fl_services/README.md) for the provisioning and integration-test workflow.
+(The inherited `make unit-test` target documented in [`flip-utils/README.md`](flip-utils/README.md) is part of the
+still-in-progress reconciliation called out at the top of that README — `flip-utils/` does not yet ship a Makefile in
+this mono-repo.) See [`flip-utils/README.md`](flip-utils/README.md) (the "Unit Tests" / "Integration Testing"
+sections — subject to the in-progress reconciliation noted there) for the FL package's tests, and
+[`fl_services/README.md`](fl_services/README.md) for provisioning FL networks.
 
 **Testing fixtures**: For testing APIs and integration tests, we use [pytest fixtures](https://docs.pytest.org/en/latest/how-to/fixtures.html). Shared fixtures are defined in `conftest.py` files. In some cases, [`factory_boy`](https://factoryboy.readthedocs.io/) is used to create test data following production data structures.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,30 +41,30 @@ When creating issues, please use the appropriate issue template:
 
 FLIP is developed by the [London AI Centre](https://www.aicentre.co.uk/) in collaboration with Guy's and St Thomas' NHS Foundation Trust and King's College London. It is an open-source platform for federated training and evaluation of medical imaging AI models across healthcare institutions, while ensuring data privacy and security.
 
-The project spans three repositories:
-
-| Repository | Description |
-| --- | --- |
-| [FLIP](https://github.com/londonaicentre/FLIP) | Main mono-repo: Central Hub API, Trust APIs, UI, and Docker deployment |
-| [flip-fl-base](https://github.com/londonaicentre/flip-fl-base) | NVIDIA FLARE federated learning base application library, workflows, and tutorials |
-| [flip-fl-base-flower](https://github.com/londonaicentre/flip-fl-base-flower) | Flower federated learning base application library, workflows, and tutorials |
-
-The main FLIP repository follows a mono-repo structure with these key services:
+The FLIP repository is a mono-repo: it consolidates the Central Hub API, Trust APIs, UI, Docker deployment, **and**
+the federated learning code (base library, FL services, and tutorials) that was previously split across the legacy
+[`flip-fl-base`](https://github.com/londonaicentre/flip-fl-base) (NVFLARE) and
+[`flip-fl-base-flower`](https://github.com/londonaicentre/flip-fl-base-flower) (Flower) repositories. Those repositories
+still hold the provisioned NVFLARE workspaces / Flower certs consumed by the dev compose files (see
+[`README.md#federated-learning-setup`](README.md#federated-learning-setup)), but the FL Python/Docker source is now here.
 
 ```bash
 FLIP/
-├── deploy/             # Docker deployment files
+├── deploy/             # Docker deployment files (compose, AWS IaC, on-prem Ansible)
 ├── docs/               # Sphinx documentation
 ├── flip-api/           # Central Hub API service
 ├── flip-ui/            # UI service
-└── trust/              # Services deployed in individual trust environments
-    ├── data-access-api/    # Data access API
-    ├── imaging-api/        # Imaging API
-    ├── observability/      # Observability stack (Grafana, Loki, Alloy)
-    ├── omop-db/            # Mocked OMOP database
-    ├── orthanc/            # Mocked PACS service (Orthanc)
-    ├── trust-api/          # Trust API
-    └── xnat/               # Mocked XNAT service
+├── trust/              # Services deployed in individual trust environments
+│   ├── data-access-api/    # Data access API
+│   ├── imaging-api/        # Imaging API
+│   ├── observability/      # Observability stack (Grafana, Loki, Alloy)
+│   ├── omop-db/            # Mocked OMOP database
+│   ├── orthanc/            # Mocked PACS service (Orthanc)
+│   ├── trust-api/          # Trust API
+│   └── xnat/               # Mocked XNAT service
+├── flip-utils/         # `flip` Python package — platform logic, NVFLARE components, Flower helpers
+├── fl_services/        # Docker images for FL networks: fl-server, fl-client, fl-api-base, fl-base
+└── fl-apps/            # FL job-type implementations (standard, evaluation, diffusion_model, fed_opt) and tutorials
 ```
 
 ## Setting up the development environment
@@ -374,13 +374,14 @@ make unit_test
 `make tests` is a narrower target that runs `flip-ui` unit and Cypress e2e tests followed by the full `flip-api`
 test suite (ruff, mypy, and pytest).
 
-For the `flip-fl-base` repository, unit tests can be run with:
+For the migrated FL base library (now in `flip-utils/`), unit tests can be run with:
 
 ```bash
-make unit-test
+make -C flip-utils unit-test
 ```
 
-Integration tests for the FL base application are also available (see the [flip-fl-base README](https://github.com/londonaicentre/flip-fl-base#testing) for details).
+Integration tests for the FL services live under `fl_services/` — see [`flip-utils/README.md`](flip-utils/README.md)
+and [`fl_services/README.md`](fl_services/README.md) for the provisioning and integration-test workflow.
 
 **Testing fixtures**: For testing APIs and integration tests, we use [pytest fixtures](https://docs.pytest.org/en/latest/how-to/fixtures.html). Shared fixtures are defined in `conftest.py` files. In some cases, [`factory_boy`](https://factoryboy.readthedocs.io/) is used to create test data following production data structures.
 

--- a/Makefile
+++ b/Makefile
@@ -395,7 +395,9 @@ nvflare-provision-additional-client:
 # Drives a fresh project end-to-end against a running `make up` stack:
 # create → approve → upload model → wait for image pull → start training.
 # Defaults pick the chest-xray tutorial that matches FL_BACKEND (flower or
-# nvflare); both sit in sibling repos (flip-fl-base / flip-fl-base-flower).
+# nvflare). The NVFLARE defaults still target ../../flip-fl-base/tutorials/...
+# (legacy sibling) — the migrated in-repo equivalents now live under
+# fl-apps/tutorials/ and can be passed via MODEL_FILES_DIR= / QUERY_FILE=.
 # Useful for sanity-checking PRs without manually clicking through the UI.
 # See flip-api/Makefile for overrides (MODEL_FILES_DIR, QUERY_FILE, EXTRA_ARGS).
 e2e_smoke:

--- a/README.md
+++ b/README.md
@@ -40,17 +40,27 @@ FLIP is developed by the [London AI Centre](https://www.aicentre.co.uk/) in coll
 
 ## Repositories
 
-FLIP spans several repositories:
+This repository is the FLIP mono-repo: Central Hub API, Trust APIs, UI, Docker deployment, **and** the federated
+learning code (base library, FL services, and tutorials) that was previously split across `flip-fl-base` and
+`flip-fl-base-flower`. The FL code now lives under [`flip-utils/`](flip-utils/) (the pip-installable `flip` package),
+[`fl_services/`](fl_services/) (Docker services for FL server/client/API), and [`fl-apps/`](fl-apps/) (job-type
+implementations and tutorials).
 
-| Repository | Description |
+| Subdirectory | Description |
 | --- | --- |
-| [FLIP](https://github.com/londonaicentre/FLIP) | This repo: Central Hub API, Trust APIs, UI, and Docker deployment |
-| [flip-fl-base](https://github.com/londonaicentre/flip-fl-base) | NVIDIA FLARE federated learning base application library, workflows, and tutorials |
-| [flip-fl-base-flower](https://github.com/londonaicentre/flip-fl-base-flower) | Flower federated learning base application library, workflows, and tutorials |
+| [`flip-api/`](flip-api/) | Central Hub API service |
+| [`flip-ui/`](flip-ui/) | Frontend UI |
+| [`trust/`](trust/) | Trust-side services (trust-api, imaging-api, data-access-api, mock OMOP / Orthanc / XNAT) |
+| [`deploy/`](deploy/) | Docker Compose and infrastructure-as-code (AWS / on-prem) |
+| [`docs/`](docs/) | Sphinx documentation source (ReadTheDocs) |
+| [`flip-utils/`](flip-utils/) | `flip` Python package — platform logic, NVFLARE components, Flower helpers |
+| [`fl_services/`](fl_services/) | Docker images for FL networks: `fl-server`, `fl-client`, `fl-api-base`, `fl-base` |
+| [`fl-apps/`](fl-apps/) | FL job-type implementations (`standard`, `evaluation`, `diffusion_model`, `fed_opt`) and tutorials |
 
-This repository consolidates all FLIP services in a mono-repo that can be deployed together via Docker Compose. The
-federated learning images are pulled from [flip-fl-base](https://github.com/londonaicentre/flip-fl-base) and
-[flip-fl-base-flower](https://github.com/londonaicentre/flip-fl-base-flower).
+The legacy [`flip-fl-base`](https://github.com/londonaicentre/flip-fl-base) and
+[`flip-fl-base-flower`](https://github.com/londonaicentre/flip-fl-base-flower) repositories still hold the
+provisioned NVFLARE workspaces and Flower certs used at dev time — see
+[Federated Learning Setup](#federated-learning-setup) below.
 
 ## Deployment
 
@@ -205,7 +215,10 @@ docker compose -f deploy/compose.development.yml run --rm < service name >
 
 ### Federated Learning Setup
 
-The project supports [NVIDIA FLARE](https://developer.nvidia.com/flare) and [Flower Framework](https://flower.ai/) for federated learning. FLARE requires provisioned certificates and configuration files that are generated in the separate repository [flip-fl-base](https://github.com/londonaicentre/flip-fl-base) (see that repository for instructions on how to provision the workspace).
+The project supports [NVIDIA FLARE](https://developer.nvidia.com/flare) and [Flower Framework](https://flower.ai/) for
+federated learning. FLARE requires provisioned certificates and configuration files. As of the FL-code migration these
+can be generated from within this repo (`make nvflare-provision-2-nets`, see [`fl_services/README.md`](fl_services/README.md)),
+but until the deploy-side path migration lands the dev compose files still consume the legacy sibling-repo workspaces.
 
 1. **Path Resolution**: `FL_PROVISIONED_DIR` is derived from the `FL_BACKEND` selection inside [`deploy/fl_backend.mk`](deploy/fl_backend.mk) (no longer set in `.env.development`):
 
@@ -218,7 +231,9 @@ The project supports [NVIDIA FLARE](https://developer.nvidia.com/flare) and [Flo
 
 If you see errors like "fed_client.json does not exist" or "missing startup folder", verify that:
 
-- The [flip-fl-base](https://github.com/londonaicentre/flip-fl-base) repository is cloned as a sibling directory
+- Either the [flip-fl-base](https://github.com/londonaicentre/flip-fl-base) repository is cloned as a sibling directory
+  with a provisioned workspace, **or** override `FL_PROVISIONED_DIR` to point at the workspace you generated from
+  `make nvflare-provision-2-nets`
 - The workspace has been properly provisioned with NVFLARE certificates
 - The `FL_PROVISIONED_DIR` path is correctly resolved (check Makefile output)
 
@@ -245,6 +260,9 @@ The repository is organised as follows:
   - `orthanc`: Contains a mocked PACS service (uses [Orthanc](https://www.orthanc-server.com/))
   - `trust-api`: Contains the trust API service
   - `xnat`: Contains a mocked [XNAT](https://www.xnat.org/) service
+- `flip-utils`: The `flip` Python package — platform logic, NVFLARE components, Flower helpers (migrated from `flip-fl-base`)
+- `fl_services`: Docker images for FL networks — `fl-server`, `fl-client`, `fl-api-base`, `fl-base` (migrated from `flip-fl-base`)
+- `fl-apps`: FL job-type implementations (`standard`, `evaluation`, `diffusion_model`, `fed_opt`) and runnable tutorials
 
 ### Trust Authentication
 

--- a/docs/source/components/component-fl-nodes.rst
+++ b/docs/source/components/component-fl-nodes.rst
@@ -48,13 +48,14 @@ Then, the Central Hub API will take care of bundling together:
 - The files the user has uploaded
 - The static (non-modifiable) files that are required for the specific job type.
 
-For more information about currently supported apps, visit `flip-fl-base <https://github.com/londonaicentre/flip-fl-base/tree/main/src>`_
-and `flip-fl-base-flower <https://github.com/londonaicentre/flip-fl-base-flower/tree/main/src>`_ for NVFLARE and Flower respectively.
+For more information about currently supported apps, see the per-job-type implementations under
+`fl-apps/ <https://github.com/londonaicentre/FLIP/tree/develop/fl-apps>`_ (``standard``, ``evaluation``,
+``diffusion_model``, ``fed_opt``).
 
 Examples of how the same job type (standard -> federated averaging) can run different user-uploaded applications are:
 
-- `xray_classification <https://github.com/londonaicentre/flip-fl-base/tree/main/tutorials/image_classification/xray_classification>`_
-- `3d_spleen_segmentation <https://github.com/londonaicentre/flip-fl-base/tree/main/tutorials/image_segmentation/3d_spleen_segmentation>`_
+- `xray_classification <https://github.com/londonaicentre/FLIP/tree/develop/fl-apps/tutorials/image_classification/xray_classification>`_
+- `3d_spleen_segmentation <https://github.com/londonaicentre/FLIP/tree/develop/fl-apps/tutorials/image_segmentation/3d_spleen_segmentation>`_
 
 Both cases perform a supervised federated averaging training, but the data, architecture and training configuration are different.
 
@@ -69,8 +70,8 @@ Both cases perform a supervised federated averaging training, but the data, arch
 Data access and communication with external services
 ----------------------------------------------------
 
-Though the user is allowed to upload the training script that will run on the client side, the access to data will have 
-to be via the FLIP package (see `https://github.com/londonaicentre/flip-fl-base/tree/main/flip`).
+Though the user is allowed to upload the training script that will run on the client side, the access to data will have
+to be via the FLIP package (see `https://github.com/londonaicentre/FLIP/tree/develop/flip-utils/flip`).
 This package, installed by default in client and server nodes, will make a series of functions available to the user. 
 
 For data access:
@@ -93,8 +94,8 @@ There are currently some elements that are still under construction, and might n
 the description above:
 
 - for the Flower framework, users have to upload the `server_app.py` in addition to the `client_app.py` and additional auxiliary code, but in the future, this will not be the case. 
-- the static files (non-modifiable files) from NVFLARE are being moved from S3 buckets to the flip package. Currently, anything that isn't the `config_fed_server.json` and `config_fed_client.json` files is hosted in S3 buckets, 
+- the static files (non-modifiable files) from NVFLARE are being moved from S3 buckets to the flip package. Currently, anything that isn't the `config_fed_server.json` and `config_fed_client.json` files is hosted in S3 buckets,
   whereas the rest of the files are in the flip package. You can check what a fully bundled app looks like by consulting
-  the `src` folder in the `flip-fl-base` repository.
+  the per-job-type implementations under `fl-apps/ <https://github.com/londonaicentre/FLIP/tree/develop/fl-apps>`_.
 - we will be soon moving to a fully Pythonic version of NVFLARE apps, more up-to-date and easy to use.
 

--- a/docs/source/components/component-xnat.rst
+++ b/docs/source/components/component-xnat.rst
@@ -251,7 +251,7 @@ The following XNAT Event Service API endpoints are used by FLIP for managing per
 FLIP XNAT methods
 *****************
 
-The following methods are available to be used in training, located in the `flip-utils package <https://flip-fl-base.readthedocs.io/en/latest/index.html>`_:
+The following methods are available to be used in training, located in the `flip-utils package <https://github.com/londonaicentre/FLIP/tree/develop/flip-utils>`_:
 
 - ``get_dataframe(self, project_id: str, query: str) -> DataFrame``
     This retrieves data in the form of a Dataframe containing, at the minimum, accession IDs. The method takes in the project ID and the project query as parameters. These values are already passed in as parameters to the trainer to be used.

--- a/docs/source/user-guides/user-common.rst
+++ b/docs/source/user-guides/user-common.rst
@@ -314,7 +314,7 @@ Additional files may be uploaded, especially if these are referenced by the vali
 
 **For Flower apps**, the required files differ (e.g. ``client_app.py``, ``pyproject.toml``). See the :ref:`FL nodes documentation <flip-fl-nodes>` for Flower-specific file requirements and job types.
 
-For more information on model training and model files, please see the `FLIP tutorials <https://github.com/londonaicentre/flip-fl-base/tree/main/tutorials>`_.
+For more information on model training and model files, please see the `FLIP tutorials <https://github.com/londonaicentre/FLIP/tree/develop/fl-apps/tutorials>`_.
 
 .. warning::
 

--- a/docs/source/working-with-flip-apps/create-flip-app-from-flare.rst
+++ b/docs/source/working-with-flip-apps/create-flip-app-from-flare.rst
@@ -5,8 +5,10 @@ Create a FLIP app from a FLARE app
 .. note::
 
    This page is a placeholder. The NVIDIA FLARE walkthrough is still being written.
-   For the FLARE-specific SDK calls and app layout, see the
-   `flip-fl-base <https://github.com/londonaicentre/flip-fl-base>`_ repository in
+   For the FLARE-specific SDK calls and app layout, see the migrated FL code under
+   `flip-utils/flip/nvflare <https://github.com/londonaicentre/FLIP/tree/develop/flip-utils/flip/nvflare>`_
+   and the per-job-type apps and tutorials under
+   `fl-apps/ <https://github.com/londonaicentre/FLIP/tree/develop/fl-apps>`_ in
    the meantime.
 
    The Flower equivalent is available now — see

--- a/fl_services/fl-api-base/fl_api/routers/health.py
+++ b/fl_services/fl-api-base/fl_api/routers/health.py
@@ -18,7 +18,7 @@ router = APIRouter()
 
 
 @router.get("/")
-def index():
+def index() -> dict[str, str]:
     """
     A welcome message for the FLIP FL API.
 
@@ -29,7 +29,7 @@ def index():
 
 
 @router.get("/health/")
-def health():
+def health() -> dict[str, str]:
     """
     Updates of whether the FL API service is healthy.
 

--- a/fl_services/fl-api-base/fl_api/utils/exception_handlers.py
+++ b/fl_services/fl-api-base/fl_api/utils/exception_handlers.py
@@ -18,30 +18,30 @@ from nvflare.fuel.flare_api.api_spec import JobNotFound
 from starlette.exceptions import HTTPException as StarletteHTTPException
 
 
-def http_exception_handler(request: Request, exc: Exception):
+def http_exception_handler(request: Request, exc: Exception) -> JSONResponse:
     e = cast(StarletteHTTPException, exc)
     return JSONResponse(status_code=e.status_code, content={"detail": e.detail})
 
 
-def bad_request_handler(request: Request, exc: ValueError):
+def bad_request_handler(request: Request, exc: ValueError) -> JSONResponse:
     return JSONResponse(status_code=400, content={"detail": str(exc)})
 
 
-def value_error_handler(request: Request, exc: ValueError):
+def value_error_handler(request: Request, exc: ValueError) -> JSONResponse:
     return JSONResponse(status_code=400, content={"detail": str(exc)})
 
 
-def file_not_found_handler(request: Request, exc: FileNotFoundError):
+def file_not_found_handler(request: Request, exc: FileNotFoundError) -> JSONResponse:
     return JSONResponse(status_code=404, content={"detail": str(exc) or "File not found"})
 
 
-def job_not_found_handler(request: Request, exc: JobNotFound):
+def job_not_found_handler(request: Request, exc: JobNotFound) -> JSONResponse:
     return JSONResponse(status_code=404, content={"detail": str(exc) or "Job not found"})
 
 
-def validation_exception_handler(request: Request, exc: Exception):
+def validation_exception_handler(request: Request, exc: Exception) -> JSONResponse:
     return JSONResponse(status_code=422, content={"detail": str(exc)})
 
 
-def server_error_handler(request: Request, exc: Exception):
+def server_error_handler(request: Request, exc: Exception) -> JSONResponse:
     return JSONResponse(status_code=500, content={"detail": f"Internal server error: {str(exc)}"})

--- a/fl_services/fl-api-base/fl_api/utils/prepare_config.py
+++ b/fl_services/fl-api-base/fl_api/utils/prepare_config.py
@@ -356,7 +356,7 @@ def validate_config(config: dict) -> IOverridableConfig:
     """
     validated = IOverridableConfig()
 
-    def is_valid(value):
+    def is_valid(value: object) -> bool:
         return isinstance(value, (int, float)) and TrainingRound.MIN <= value <= TrainingRound.MAX
 
     if not isinstance(config, dict):

--- a/flip-utils/README.md
+++ b/flip-utils/README.md
@@ -11,26 +11,28 @@
     limitations under the License.
 -->
 
-# FLIP-FL-base-FLARE
+# flip-utils — the `flip` Python package
 
 <p align="left">
 <img src="assets/flip-flare-logo.png" height="200" alt='flip-flare-logo' />
 </p>
 
-[![codecov](https://codecov.io/gh/londonaicentre/flip-fl-base/graph/badge.svg)](https://codecov.io/gh/londonaicentre/flip-fl-base)
 [![PyPI version](https://img.shields.io/pypi/v/flip-utils)](https://pypi.org/project/flip-utils/)
-[![Docker - flare-fl-base](https://img.shields.io/badge/docker-flare--fl--base-blue?logo=docker)](https://github.com/londonaicentre/flip-fl-base/pkgs/container/flare-fl-base)
-[![Docker - flare-fl-server](https://img.shields.io/badge/docker-flare--fl--server-blue?logo=docker)](https://github.com/londonaicentre/flip-fl-base/pkgs/container/flare-fl-server)
-[![Docker - flare-fl-client](https://img.shields.io/badge/docker-flare--fl--client-blue?logo=docker)](https://github.com/londonaicentre/flip-fl-base/pkgs/container/flare-fl-client)
 [![Python 3.12+](https://img.shields.io/badge/python-3.12+-blue.svg)](https://www.python.org/downloads/)
-[![Documentation Status](https://readthedocs.org/projects/londonaicentreflip/badge/?version=latest)](https://londonaicentreflip.readthedocs.io/en/latest/)[![License](https://img.shields.io/badge/license-Apache--2.0-green.svg)](./LICENSE.md)
+[![Documentation Status](https://readthedocs.org/projects/londonaicentreflip/badge/?version=latest)](https://londonaicentreflip.readthedocs.io/en/latest/)[![License](https://img.shields.io/badge/license-Apache--2.0-green.svg)](../LICENSE.md)
 
-This repository contains the [FLIP](https://github.com/londonaicentre/FLIP) (Federated Learning and Interoperability
-Platform) federated learning base application utilities. It is a monorepo that includes:
+This directory is a sub-tree of the [FLIP](https://github.com/londonaicentre/FLIP) mono-repo. It hosts the
+pip-installable `flip` Python package (published as `flip-utils` on PyPI) that ships inside every FL server / client
+image and is imported as `from flip import ...` by user-uploaded training code. Sibling FL trees in the same mono-repo:
 
-- **[`flip`](./flip/)** — pip-installable Python package with platform logic, NVFLARE components, and utilities
-- **[`tutorials/`](./tutorials/)** — example applications you can run on the FLIP platform
-- **[`fl_services/`](./fl_services/)** — Docker services for running FL networks (server, clients, admin API)
+- **[`flip-utils/flip/`](./flip/)** — pip-installable Python package with platform logic, NVFLARE components, and utilities (this directory)
+- **[`../fl-apps/`](../fl-apps/)** — FL job-type implementations (`standard`, `evaluation`, `diffusion_model`, `fed_opt`) and runnable tutorials
+- **[`../fl_services/`](../fl_services/)** — Docker images for FL networks (server, clients, admin API)
+
+The rest of this README is largely inherited from the standalone `flip-fl-base` repository (now merged in) and is
+still being reconciled with the mono-repo layout — paths like `tutorials/` and `fl_services/` referred to here are
+the now-sibling top-level `fl-apps/` and `fl_services/` trees, and Make targets called out below run from the
+`flip-utils/` directory.
 
 ## Table of Contents
 

--- a/flip-utils/flip/constants/flip_constants.py
+++ b/flip-utils/flip/constants/flip_constants.py
@@ -112,7 +112,7 @@ def get_flip_constants() -> Union[DevSettings, ProdSettings]:
 class _FlipConstantsProxy:
     """Proxy to provide lazy loading via attribute access."""
 
-    def __getattribute__(self, name: str):
+    def __getattribute__(self, name: str) -> object:
         if name.startswith("_"):
             return object.__getattribute__(self, name)
         return getattr(get_flip_constants(), name)

--- a/flip-utils/flip/nvflare/components/cleanup.py
+++ b/flip-utils/flip/nvflare/components/cleanup.py
@@ -38,7 +38,7 @@ class CleanupImages(Executor):
 
         super().__init__()
 
-    def execute(self, task_name: str, shareable: Shareable, fl_ctx: FLContext, abort_signal: Signal):
+    def execute(self, task_name: str, shareable: Shareable, fl_ctx: FLContext, abort_signal: Signal) -> Shareable:
         try:
             if task_name in (FlipTasks.POST_VALIDATION, FlipTasks.POST_TASK):
                 cwd = os.getcwd()

--- a/flip-utils/flip/nvflare/components/evaluation_json_generator.py
+++ b/flip-utils/flip/nvflare/components/evaluation_json_generator.py
@@ -38,7 +38,7 @@ class EvaluationJsonGenerator(FLComponent):
         self._eval_results = {}
         self._json_file_name = json_file_name
 
-    def handle_evaluation_events(self, event_type: str, fl_ctx: FLContext):
+    def handle_evaluation_events(self, event_type: str, fl_ctx: FLContext) -> None:
         if event_type == EventType.START_RUN:
             self._eval_results.clear()
         elif event_type == AppEventType.VALIDATION_RESULT_RECEIVED:

--- a/flip-utils/flip/nvflare/components/flip_client_event_handler.py
+++ b/flip-utils/flip/nvflare/components/flip_client_event_handler.py
@@ -28,5 +28,5 @@ class ClientEventHandler(FLComponent):
     def __init__(self):
         super(ClientEventHandler, self).__init__()
 
-    def handle_event(self, event_type: str, fl_ctx: FLContext):
+    def handle_event(self, event_type: str, fl_ctx: FLContext) -> None:
         pass

--- a/flip-utils/flip/nvflare/components/flip_server_event_handler.py
+++ b/flip-utils/flip/nvflare/components/flip_server_event_handler.py
@@ -60,7 +60,7 @@ class ServerEventHandler(FLComponent):
             self.flip.update_status(self.model_id, ModelStatus.ERROR)
             raise ValueError(f"The model ID: {self.model_id} is not a valid UUID")
 
-    def handle_event(self, event_type: str, fl_ctx: FLContext):
+    def handle_event(self, event_type: str, fl_ctx: FLContext) -> None:
         self.__set_dependencies(fl_ctx)
 
         self.validation_json_generator.handle_evaluation_events(event_type, fl_ctx)
@@ -118,7 +118,7 @@ class ServerEventHandler(FLComponent):
 
             self.flip.update_status(self.model_id, self.final_status)
 
-    def __set_dependencies(self, fl_ctx: FLContext):
+    def __set_dependencies(self, fl_ctx: FLContext) -> None:
         if self.validation_json_generator is None:
             engine = fl_ctx.get_engine()
             self.validation_json_generator = engine.get_component(self.validation_json_generator_id)

--- a/flip-utils/flip/nvflare/components/persist_and_cleanup.py
+++ b/flip-utils/flip/nvflare/components/persist_and_cleanup.py
@@ -57,7 +57,7 @@ class PersistToS3AndCleanup(FLComponent):
             self.flip.update_status(self.model_id, ModelStatus.ERROR)
             raise ValueError(f"The model ID: {self.model_id} is not a valid UUID")
 
-    def execute(self, fl_ctx: FLContext):
+    def execute(self, fl_ctx: FLContext) -> None:
         try:
             self.log_info(fl_ctx, "Initializing PersistToS3AndCleanup")
             engine = fl_ctx.get_engine()
@@ -106,7 +106,7 @@ class PersistToS3AndCleanup(FLComponent):
             self.log_exception(fl_ctx, error_msg)
             raise
 
-    def upload_results_to_s3_bucket(self, fl_ctx: FLContext):
+    def upload_results_to_s3_bucket(self, fl_ctx: FLContext) -> None:
         """
         Uploads the final aggregated model and reports to an S3 bucket as a zip file.
         """
@@ -152,7 +152,7 @@ class PersistToS3AndCleanup(FLComponent):
             self.log_error(fl_ctx, str(e))
             raise
 
-    def cleanup(self, fl_ctx: FLContext):
+    def cleanup(self, fl_ctx: FLContext) -> None:
         """
         Cleans up the workspace by deleting the transfer and save directories for the model ID.
         """

--- a/flip-utils/flip/nvflare/components/validation_json_generator.py
+++ b/flip-utils/flip/nvflare/components/validation_json_generator.py
@@ -38,7 +38,7 @@ class ValidationJsonGenerator(FLComponent):
         self._val_results = {}
         self._json_file_name = json_file_name
 
-    def handle_evaluation_events(self, event_type: str, fl_ctx: FLContext):
+    def handle_evaluation_events(self, event_type: str, fl_ctx: FLContext) -> None:
         if event_type == EventType.START_RUN:
             self._val_results.clear()
         elif event_type == AppEventType.VALIDATION_RESULT_RECEIVED:

--- a/trust/data-access-api/README.md
+++ b/trust/data-access-api/README.md
@@ -21,7 +21,7 @@
 The **data-access-api** executes researcher-supplied SQL queries against the Trust's local OMOP database and returns
 aggregated statistics and dataframes. It is an internal Trust-side service called by the
 [trust-api](../trust-api/) (`/cohort`), [imaging-api](../imaging-api/) (`/cohort/accession-ids`),
-and the [`flip` Python package](https://github.com/londonaicentre/flip-fl-base/tree/main/flip)
+and the [`flip` Python package](https://github.com/londonaicentre/FLIP/tree/develop/flip-utils/flip)
 shipped to fl-client containers (`/cohort/dataframe`, via `flip.get_dataframe(...)`). All callers
 must authenticate with the trust-internal service key — see [Authentication](#authentication)
 below.
@@ -79,7 +79,7 @@ unauthenticated so liveness probes keep working.
 
 Callers in this repo: trust-api (`/cohort`) and imaging-api (`/cohort/accession-ids`). The fl-client
 container calls `/cohort/dataframe` indirectly: user training code calls `flip.get_dataframe(...)`
-from the [`flip` Python package](https://github.com/londonaicentre/flip-fl-base/tree/main/flip)
+from the [`flip` Python package](https://github.com/londonaicentre/FLIP/tree/develop/flip-utils/flip)
 (consumed by both NVFLARE and Flower fl-client / fl-server images), and that package reads
 `TRUST_INTERNAL_SERVICE_KEY` from `os.environ` and adds the header to its HTTP request. Tutorials
 and user-uploaded `client_app.py` / `server_app.py` do not deal with the header directly.

--- a/trust/imaging-api/README.md
+++ b/trust/imaging-api/README.md
@@ -151,7 +151,7 @@ Key environment variables (set in [`.env.development.example`](../../.env.develo
 imaging-api exposes privileged XNAT operations via a service account. To prevent any container on the trust Docker network — or any operator with SSM port-forward access — from acting as that service account, every router except `/health` requires callers to send `TRUST_INTERNAL_SERVICE_KEY` in the configured header. imaging-api compares the header against its own copy of the same per-trust key with a constant-time compare.
 
 Direct callers in this repo: trust-api. The fl-client container calls imaging-api indirectly via
-the [`flip` Python package](https://github.com/londonaicentre/flip-fl-base/tree/main/flip)
+the [`flip` Python package](https://github.com/londonaicentre/FLIP/tree/develop/flip-utils/flip)
 (consumed by both NVFLARE and Flower fl-client / fl-server images) —
 `flip.get_by_accession_number(...)` and friends read `TRUST_INTERNAL_SERVICE_KEY` from
 `os.environ` and add the header to every HTTP request. User training code (`client_app.py`,


### PR DESCRIPTION
> **Note:** This is an automated scheduled weekly task by Alex's Claude Code — reviewing READMEs, ReadTheDocs documentation, and CLAUDE.md files for drift against the code on `develop`, plus a sweep for missing return type annotations / mismatched docstrings.

## Summary

After PR #561 merged the federated learning code from `flip-fl-base` (NVFLARE) and `flip-fl-base-flower` (Flower) into this mono-repo (under `flip-utils/`, `fl_services/`, and `fl-apps/`), various top-level READMEs, CLAUDE.md files, and ReadTheDocs sources still framed those repositories as separate sibling projects, and a handful of dead URLs and missing return-type annotations got carried in with the migrated code. This PR reconciles the surfaces a reader of `develop` would hit first and adds the obvious missing return type annotations on the migrated tree.

## Documentation drift

### Top-level
- **`README.md` / `CONTRIBUTING.md` / `CLAUDE.md`** — rewrite the "Repositories" / "Project Structure" sections to list the migrated `flip-utils/`, `fl_services/`, and `fl-apps/` trees as first-class subdirectories. The legacy `flip-fl-base` / `flip-fl-base-flower` repositories are now scoped to "still hosts the provisioned NVFLARE workspace / Flower certs consumed by dev compose via `FL_PROVISIONED_DIR`" — that is still true (`deploy/fl_backend.mk` defaults to `../flip-fl-base/workspace`), so the docs now point at the right thing instead of the now-moved code.
- **`CLAUDE.md`** — soften the e2e_smoke "sibling repo" prerequisite to reflect that the in-repo `fl-apps/tutorials/image_classification/xray_classification/` works as an override, and update the trust-internal auth pointer for the `flip` Python package from `flip-fl-base/tree/main/flip` to in-repo `flip-utils/flip/`.
- **`Makefile`** — update the `e2e_smoke` comment to flag the in-repo `fl-apps/tutorials/` alternative.

### ReadTheDocs sources (`docs/source/...`)
- **`components/component-xnat.rst`** — fix a dead `https://flip-fl-base.readthedocs.io/...` URL (there is no separate RTD site for that repo now) and point it at `flip-utils/` here.
- **`components/component-fl-nodes.rst`** — redirect "supported apps" / "see the `src` folder in flip-fl-base" / xray + spleen tutorial GitHub links from the legacy repos to `fl-apps/` in this repo.
- **`user-guides/user-common.rst`** — redirect the "FLIP tutorials" external link to `fl-apps/tutorials/`.
- **`working-with-flip-apps/create-flip-app-from-flare.rst`** — redirect the placeholder pointer from `flip-fl-base` to in-repo `flip-utils/flip/nvflare/` + `fl-apps/`.

### Service READMEs
- **`trust/data-access-api/README.md`, `trust/imaging-api/README.md`** — both READMEs documented the `flip` Python package by linking to `flip-fl-base/tree/main/flip`; updated to `FLIP/tree/develop/flip-utils/flip`.
- **`flip-utils/README.md`** — this file was the standalone `flip-fl-base` README inherited wholesale by the migration (title `FLIP-FL-base-FLARE`, "This repository contains the FLIP...", "It is a monorepo that includes..."). Rewritten so it reads as a sub-directory of the FLIP mono-repo (not a standalone monorepo). Dropped the dead `flip-fl-base` codecov / docker / docs badges, kept the PyPI / Python / license / RTD badges. The body of the file is still largely inherited from the standalone repo; a note up top calls that out as still being reconciled.

The Flower-side walkthrough in `docs/source/working-with-flip-apps/create-flip-app-from-flower.rst` still references `flip-fl-base-flower/src/...` and `tutorials/monai/` and was left unchanged because the Flower tutorial tree (in particular `tutorials/monai/`) has not been migrated into `fl-apps/` yet — the references are still correct.

## Missing return type annotations on migrated code

The `flip-utils/` and `fl_services/fl-api-base/` trees came in from a different repo and predated the project's annotation conventions in a few spots. All added annotations are runtime no-ops; ruff and mypy still pass on the changed files (the only mypy errors on the touched files are pre-existing — verified against `develop`).

- `fl_services/fl-api-base/fl_api/utils/exception_handlers.py` — add `-> JSONResponse` on all seven handlers.
- `fl_services/fl-api-base/fl_api/routers/health.py` — add `-> dict[str, str]` on `index` and `health` (the docstrings already documented the return type).
- `fl_services/fl-api-base/fl_api/utils/prepare_config.py` — annotate the nested `is_valid` helper as `-> bool`.
- `flip-utils/flip/nvflare/components/{flip_client_event_handler, flip_server_event_handler, evaluation_json_generator, validation_json_generator, persist_and_cleanup}.py` — add `-> None` on `handle_event` / `handle_evaluation_events` / `execute` / `__set_dependencies` / `upload_results_to_s3_bucket` / `cleanup`.
- `flip-utils/flip/nvflare/components/cleanup.py` — `execute` returns `Shareable` on every path — annotate accordingly.
- `flip-utils/flip/constants/flip_constants.py` — annotate `_FlipConstantsProxy.__getattribute__` with `-> object`.

## Out of scope (called out but not fixed)

- **`deploy/fl_backend.mk`** still defaults `FL_PROVISIONED_DIR` to the legacy `../flip-fl-base/{workspace,certs}` sibling-repo paths, even though the in-repo `make nvflare-provision-2-nets` can generate the same artefacts. The dev compose overlays therefore still consume sibling-repo provisioned files. The `CLAUDE.md` and `README.md` updates here now call that out explicitly — actually moving the default would be a follow-up code migration, not a docs cleanup.
- **`flip-utils/pyproject.toml`** and **`fl_services/*/pyproject.toml`** do not enable ruff `UP042` (StrEnum); the migrated code still uses the legacy `class X(str, Enum)` pattern that the rest of the repo migrated away from in commit `3ea14a12`. The root `CLAUDE.md` claims `UP042` is enforced "across all Python projects" — that's now drift, but flipping it on in those configs would cascade into renaming every legacy `Enum` subclass in the migrated tree, which is too big a change for a docs PR.
- **`flip-api/Makefile`** still defaults `MODEL_FILES_DIR` / `QUERY_FILE` for `e2e_smoke` to `../../flip-fl-base/tutorials/...` and `../../flip-fl-base-flower/tutorials/...`. Left untouched here because flipping the defaults would change the path that runs by default for everyone on `make e2e_smoke` and that's a behaviour change, not a docs cleanup. The CLAUDE.md / Makefile-comment updates now flag the in-repo alternative.

## Verification

- `ruff check` passes on every changed `.py` file (`flip-utils/flip/...`, `fl_services/fl-api-base/fl_api/...`).
- `mypy` on the changed files shows no new errors — only the pre-existing ones already on `develop` (verified by stashing and re-running).

## Test plan

- [ ] ReadTheDocs build of `develop` after merge — no new warnings on the touched `.rst` files (especially `component-xnat.rst`, `component-fl-nodes.rst`, `user-common.rst`, `create-flip-app-from-flare.rst`).
- [ ] `make -C flip-utils unit-test` (or the equivalent flip-utils unit-test invocation) still passes — the only `.py` changes are added return-type annotations, no runtime behaviour changes.
- [ ] `cd fl_services/fl-api-base && make unit_test` still passes for the same reason.
- [ ] Spot-check rendered README on the GitHub PR view — confirm the new "Repositories" table and the new `flip-utils/`/`fl_services/`/`fl-apps/` rows render correctly.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Xi9eT8M299kLbS66Par4LB)_