### PR TITLE
docs: weekly drift sweep — README/CLAUDE.md/rst vs. current code

### DIFF
--- a/.env.development.example
+++ b/.env.development.example
@@ -307,15 +307,16 @@ FL_KIT_SLOT_NAMES=["Trust_1", "Trust_2"]
 # All trust-related variables live here as one separable block.
 #
 # Identity model:
-#   - The deploy registers trusts via `make register-trust-1` / `register-trust-2`
-#     (aggregate: `make register-trusts`), which call the register_trust CLI
-#     idempotently with the TRUST_<n>_* values below. The hub keeps NO trust
-#     list of its own — TRUST_<n>_* are read by the deploy Makefile only and
-#     are never mounted into the flip-api container.
+#   - The deploy registers trusts via `make register-trusts` (aggregate over
+#     the shipped kit examples) or `make register-trust KIT=<CODE>` (single
+#     trust), which call the register_trust CLI idempotently against the kit
+#     file's TRUST_CODE / TRUST_NAME. The hub keeps NO trust list of its own —
+#     trust identity is sourced from the kit files (trust/.env.<CODE>.<env>),
+#     not from this hub env file.
 #   - Auth is by API key alone (no URL-name segment, no env allowlist).
 #   - Per-trust plaintext credentials (TRUST_API_KEY, TRUST_INTERNAL_SERVICE_KEY,
 #     FL_KIT_SLOT, FL_KIT_SLOT_NUMBER, EXPECTED_TRUST_ID) live in
-#     `trust/.env.<slot>` kit files, written by the register-trust targets and
+#     `trust/.env.<CODE>.<env>` kit files, written by `make register-trust` and
 #     gitignored. trust/Makefile -includes them.
 # ─────────────────────────────────────────────────────────────────────────
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,7 @@ medical imaging AI models across healthcare institutions while preserving data p
 FLIP/
 ├── flip-api/           # Central Hub API (Python/FastAPI)
 ├── flip-ui/            # Frontend UI (Vue 3 / TypeScript / TailwindCSS)
+├── flip-utils/         # Shared Python utility package (the `flip` library)
 ├── trust/
 │   ├── trust-api/      # Trust API gateway (Python/FastAPI)
 │   ├── data-access-api/# OMOP database queries (Python/FastAPI)
@@ -20,6 +21,8 @@ FLIP/
 │   ├── omop-db/        # Mocked OMOP database (PostgreSQL)
 │   ├── orthanc/        # Mocked PACS server
 │   └── xnat/           # Mocked XNAT neuroimaging service
+├── fl_services/        # FL infrastructure containers (fl-api-base, fl-base, fl-client, fl-server)
+├── fl-apps/            # FL application templates and tutorials (NVFLARE + Flower)
 ├── deploy/             # Docker Compose files (dev/prod, flower/nvflare)
 │   └── providers/
 │       ├── AWS/        # Terraform/OpenTofu IaC + Ansible for AWS deployment

--- a/docs/source/sys-admin/admin-platform-support.rst
+++ b/docs/source/sys-admin/admin-platform-support.rst
@@ -31,7 +31,11 @@ encrypted tunnel for all outbound polling and FL client traffic in addition to t
 
    FLIP network architecture.
 
-The following is the list of ports required to be opened for the Secure Enclave communication:
+The following is the list of ports required to be opened for trust-host communication. No inbound
+ports are required on trust hosts; everything trust-side is outbound HTTPS to the Central Hub or
+to the FL server NLB. Operator access is via AWS Systems Manager Session Manager — port 22 (SSH)
+is never opened. Internal trust services (Orthanc, XNAT, trust-api Swagger) are accessible only
+via SSM port forwarding (``make forward-trust``).
 
 .. list-table:: Firewall Rules
    :header-rows: 1
@@ -41,42 +45,18 @@ The following is the list of ports required to be opened for the Secure Enclave 
    * - Description
      - Inbound
      - Outbound
-   * - SSH traffic for installation and updates
-     - 22
+   * - DICOM ingestion from local PACS into the trust XNAT
      -
-   * - DICOM ingestion from PACS / modality
-     - 8081
+     - local PACS DICOM ports
+   * - Trust → Central Hub task polling (HTTPS)
      -
-   * - Grafana access
-     - 2632
+     - 443
+   * - FL client → FL server (via NLB)
      -
-   * - Kibana access
-     - 32010 / 15601
+     - configured ``FL_SERVER_PORT``
+   * - Operator access to trust host
+     - none (SSM Session Manager)
      -
-   * - Orthanc system access
-     - 4242 / 8042
-     -
-   * - Orthanc debugging access
-     - 4245 / 8045
-     -
-   * - FLIP API
-     - 8000-8003
-     -
-   * - Kubernetes ingress ports
-     - 32472 / 32473
-     -
-   * - Kubernetes control port
-     - 6443
-     -
-   * - FLIP communication ports
-     -
-     - 30001 - 30100
-   * - Connection from XNAT to local PACS systems
-     -
-     - local PACS ports
-   * - VPN traffic
-     -
-     - 500 / 4500
 
 *****************
 Backup / Restore

--- a/trust/CLAUDE.md
+++ b/trust/CLAUDE.md
@@ -11,7 +11,7 @@ Trust services run at each healthcare institution (cloud EC2 or on-prem). All tr
 | data-access-api | 8010 | OMOP database queries for cohort analysis |
 | fl-client | — | FL participant (connects outbound to FL server via NLB) |
 | omop-db | 5432 | Mocked OMOP patient database (PostgreSQL) |
-| orthanc | 4242 | Mocked DICOM PACS server |
+| orthanc | 8042 | Mocked DICOM PACS server (UI/REST; DICOM port 4242 is internal to the trust network and not bound to the host) |
 | xnat | 8104 | Mocked neuroimaging platform |
 | observability | 3000/3100 | Grafana + Loki monitoring stack |
 

--- a/trust/trust-api/README.md
+++ b/trust/trust-api/README.md
@@ -46,8 +46,9 @@ or the full stack:
 make up
 ```
 
-API documentation (Swagger UI) is available at the port defined by `TRUST_API_PORT` in
-[`.env.development.example`](../../.env.development.example):
+API documentation (Swagger UI) is available at the port defined by `TRUST_API_PORT` in this
+trust's kit file (`trust/.env.<CODE>.<env>`; templates: `trust/.env.GSTT.development.example`,
+`trust/.env.KCH.development.example`, default `8020`):
 
 ```
 http://localhost:<TRUST_API_PORT>/docs
@@ -55,7 +56,10 @@ http://localhost:<TRUST_API_PORT>/docs
 
 ## Configuration
 
-Key environment variables (set in [`.env.development.example`](../../.env.development.example)):
+Key environment variables. Per-trust values (ports, keys, expected trust id) live in this
+trust's kit file (`trust/.env.<CODE>.<env>`); hub-shared values (`AES_KEY_BASE64`,
+`CENTRAL_HUB_API_URL`) are synced into the kit's Hub-shared block by
+`make register-trust KIT=<CODE>` (live in prod, inherited from the hub `.env.<env>` in dev):
 
 | Variable | Description |
 | --- | --- |
@@ -63,11 +67,11 @@ Key environment variables (set in [`.env.development.example`](../../.env.develo
 | `DATA_ACCESS_API_URL` | Internal URL of the data-access-api |
 | `IMAGING_API_URL` | Internal URL of the imaging-api |
 | `CENTRAL_HUB_API_URL` | URL of the Central Hub API (for task polling) |
-| `TRUST_API_KEY` | Per-trust API key for authenticating with the Central Hub. Lives in this trust's kit file (`trust/.env.<CODE>.<env>`), written by `make register-trusts` |
+| `TRUST_API_KEY` | Per-trust API key for authenticating with the Central Hub. Lives in this trust's kit file (`trust/.env.<CODE>.<env>`), written by `make register-trust KIT=<CODE>` |
 | `AES_KEY_BASE64` | Base64-encoded AES-256 key shared with the hub, used to decrypt encrypted task payloads |
 | `POLL_INTERVAL_SECONDS` | Polling frequency in seconds (default: 5) |
 | `TRUST_INTERNAL_SERVICE_KEY_HEADER` | Header name for trust-internal service auth (default `X-Trust-Internal-Service-Key`) |
-| `TRUST_INTERNAL_SERVICE_KEY` | Per-trust plaintext key. Forwarded outbound on every call to imaging-api and data-access-api so those services can authenticate the caller. Minted by `register_trust` (`make register-trusts`) into this trust's kit file (`trust/.env.<CODE>.<env>`). |
+| `TRUST_INTERNAL_SERVICE_KEY` | Per-trust plaintext key. Forwarded outbound on every call to imaging-api and data-access-api so those services can authenticate the caller. Minted by `register_trust` (`make register-trust KIT=<CODE>`) into this trust's kit file (`trust/.env.<CODE>.<env>`). |
 
 ## Authentication
 


### PR DESCRIPTION
> _This is an automated scheduled weekly task by Alex's Claude Code._

## Summary

Weekly sweep across READMEs, root and service `CLAUDE.md` files, ReadTheDocs `.rst` sources, and Python docstring/type-annotation hygiene to catch and fix drift against the current `develop` code. Findings were verified against `Makefile` / `docker-compose*.yml` / `pyproject.toml` / source code before any change was made; low-confidence or stylistic findings were left untouched.

### Drift fixed

- **Root `CLAUDE.md` — Repository Structure tree.** Three top-level directories migrated into the monorepo (per PR #561) were missing: `flip-utils/`, `fl_services/`, `fl-apps/`. Added them with one-line purpose blurbs.
- **Root `.env.development.example` — Trust configuration block.** The identity-model comment still referenced `make register-trust-1` / `make register-trust-2` and `TRUST_<n>_*` enumeration. Those targets and vars are gone (verified: `grep -nE "register-trust-[0-9]"` over every Makefile is empty; the canonical CLAUDE.md describes the kit-file flow). Rewrote the comment to point at `make register-trusts` / `make register-trust KIT=<CODE>`.
- **`trust/CLAUDE.md` — service port table.** `orthanc | 4242` was misleading: `trust/deploy/compose_trust.development.yml` has `# - "${PACS_DICOM_PORT}:4242"` commented out, so 4242 is never bound to the host; only `8042` (UI/REST) is exposed. Updated the row to `8042` with a clarifying note about the internal-only DICOM port.
- **`trust/trust-api/README.md` — Configuration section.** Two false claims that `TRUST_API_PORT` and the per-trust env vars are "set in `.env.development.example`". They live in the per-trust kit file (`trust/.env.<CODE>.<env>`); verified by `grep TRUST_API_PORT .env.development.example` returning nothing while the kit examples carry it. Also bumped a stale `make register-trusts` reference to `make register-trust KIT=<CODE>` in two table rows.
- **`docs/source/sys-admin/admin-platform-support.rst` — Firewall Rules table.** The table contradicted the prose immediately above it ("No inbound firewall rules or port forwarding are required on trust hosts" / "Operator access is via AWS Systems Manager Session Manager") by listing inbound SSH on port 22, inbound app ports `8000-8003`, and two Kubernetes rows (FLIP doesn't use Kubernetes — Docker Compose + ECS Fargate per CLAUDE.md). Also explicitly forbidden by CLAUDE.md security rules ("SSH access via AWS SSM Session Manager only — no port 22 open"). Replaced with a concise outbound-only summary aligned with the current architecture.

### Not changed (deliberate)

- **`overview.rst`** mentions "NVIDIA DGX 1 processors" and "deployed across seven NHS Trusts". These are dated but read as marketing-style prose in a project overview, not technical claims. Left untouched.
- **Docstrings / type annotations.** A scan across `flip-api`, `trust-api`, `imaging-api`, `data-access-api`, `flip-utils`, and `fl_services` Python sources flagged only one candidate (`delete_models` in `model_service.py` line 208 — `user_id: str` vs the surrounding `user_id: UUID` pattern). On follow-up the `str` annotation is intentional: `IModelAuditAction.userid: str` in `domain/interfaces/model.py`, and the sole caller wraps the UUID with `str(current_user_id)` at `project_services.py:308`. No real drift — left as-is.
- **`fl-apps/` vs `flip-fl-base` tutorials.** Both currently exist; the e2e-smoke Makefile still points at the sibling repo. Not changing pending clarification on which is canonical.

## Test plan

- [ ] Sphinx docs still build (`cd docs && make docs`).
- [ ] Reviewer sanity-checks the firewall-table replacement against `deploy/providers/AWS/services.tf` / network ACLs to confirm no inbound rule was lost.
- [ ] No code/runtime changes — existing service test suites should continue to pass without modification.

https://claude.ai/code/session_01UHtuQciv6tKJzVDC4h7Yci

---
_Generated by [Claude Code](https://claude.ai/code/session_01UHtuQciv6tKJzVDC4h7Yci)_