### PR TITLE
fix(imaging-api): report failed imports instead of stuck "processing"

### DIFF
--- a/trust/imaging-api/imaging_api/db/models.py
+++ b/trust/imaging-api/imaging_api/db/models.py
@@ -44,8 +44,10 @@ class DirectArchiveSession(BaseModel):
     id: int
     created: datetime
     folder_name: str
-    # The session label XNAT assigns the directArchive session; for DQR imports this is the
-    # accession number, so it is what links an archive failure back to a cohort accession.
+    # The session label XNAT assigns the directArchive session; for DQR imports this is the accession
+    # number, the join key get_import_status uses to map an archive ERROR back to a cohort accession.
+    # Nullable: non-DQR or unlabelled archive rows have no label, so get_import_status falls back to
+    # folder_name (which carries the same accession) when this is None.
     name: str | None = None
     status: str
     project: str

--- a/trust/imaging-api/imaging_api/db/models.py
+++ b/trust/imaging-api/imaging_api/db/models.py
@@ -32,6 +32,7 @@ class DirectArchiveSessionORM(Base):
     id = Column(Integer, primary_key=True)
     created = Column(DateTime)
     folder_name = Column(String)
+    name = Column(String)
     status = Column(String)
     project = Column(String)
     timestamp = Column(DateTime)
@@ -43,6 +44,9 @@ class DirectArchiveSession(BaseModel):
     id: int
     created: datetime
     folder_name: str
+    # The session label XNAT assigns the directArchive session; for DQR imports this is the
+    # accession number, so it is what links an archive failure back to a cohort accession.
+    name: str | None = None
     status: str
     project: str
 

--- a/trust/imaging-api/imaging_api/services/retrieval.py
+++ b/trust/imaging-api/imaging_api/services/retrieval.py
@@ -36,6 +36,14 @@ from imaging_api.utils.logger import logger
 
 XNATAuthHeaders = Annotated[dict[str, str], Depends(get_xnat_auth_headers)]
 
+# Terminal-failure status values written by XNAT's DQR plugin / prearchive. Confirmed against XNAT
+# 1.9.x source: queued/executed PACS requests use PacsRequest.FAILED_STATUS_TEXT ("FAILED"); a
+# directArchive session uses PrearcUtils.PrearcStatus.ERROR. Any other status on a row that exists
+# means the import is still in flight. A successful directArchive deletes its row, so "successful" is
+# never read from these tables — it is determined solely by the experiment listing.
+_PACS_REQUEST_FAILED_STATUS = "FAILED"
+_DIRECT_ARCHIVE_FAILED_STATUS = "ERROR"
+
 
 async def retrieve_images_for_project(project_id: str, query: str, headers: XNATAuthHeaders) -> bool:
     """
@@ -188,27 +196,36 @@ async def get_import_status(project_id: str, query: str, headers: XNATAuthHeader
 
     import_status = ImportStatus()
 
+    # Partition the DQR records into terminal-failure vs still-in-flight accessions. A terminal failure
+    # (executed PACS request FAILED, or directArchive session ERROR) must be reported as `failed` so it
+    # is surfaced to the operator and retried — otherwise it lingers indefinitely as `processing`. Any
+    # other status on a record that exists means the import is still in flight. Note: an accession can be
+    # both received (executed RECEIVED) and failed (directArchive ERROR); `failed` takes precedence below.
+    failed_accessions = {
+        session.name for session in direct_archive_sessions if session.status == _DIRECT_ARCHIVE_FAILED_STATUS
+    } | {req.accession_number for req in executed_pacs_requests if req.status == _PACS_REQUEST_FAILED_STATUS}
+    in_progress_accessions = {
+        session.name for session in direct_archive_sessions if session.status != _DIRECT_ARCHIVE_FAILED_STATUS
+    } | {req.accession_number for req in executed_pacs_requests if req.status != _PACS_REQUEST_FAILED_STATUS}
+    queued_accessions = {req.accession_number for req in queued_pacs_requests}
+
     for accession_number in accession_ids:
         # TODO Unlike in the old repo, accession numbers are now not encrypted in OMOP database, so no need to decrypt
         # here.
 
-        # Check if the accession number is in the successfully imported list
+        # "successful" means archived as a queryable experiment — a directArchive that has only been
+        # RECEIVED is not yet archived, so it stays `processing` until the experiment appears.
         if accession_number in successfully_imported_accession_numbers:
             import_status.successful.append(accession_number)
-            continue
-
-        # Check if the accession number is in the executed PACS requests
-        if accession_number in [req.accession_number for req in executed_pacs_requests]:
+        elif accession_number in failed_accessions:
+            import_status.failed.append(accession_number)
+        elif accession_number in in_progress_accessions:
             import_status.processing.append(accession_number)
-            continue
-
-        # Check if the accession number is in the queued PACS requests
-        if accession_number in [req.accession_number for req in queued_pacs_requests]:
+        elif accession_number in queued_accessions:
             import_status.queued.append(accession_number)
-            continue
-
-        # Default if none have been reached
-        import_status.queue_failed.append(accession_number)
+        else:
+            # Never entered the DQR queue (e.g. no matching study on PACS).
+            import_status.queue_failed.append(accession_number)
 
     # Log the import status
     logger.info(

--- a/trust/imaging-api/imaging_api/services/retrieval.py
+++ b/trust/imaging-api/imaging_api/services/retrieval.py
@@ -201,11 +201,18 @@ async def get_import_status(project_id: str, query: str, headers: XNATAuthHeader
     # is surfaced to the operator and retried — otherwise it lingers indefinitely as `processing`. Any
     # other status on a record that exists means the import is still in flight. Note: an accession can be
     # both received (executed RECEIVED) and failed (directArchive ERROR); `failed` takes precedence below.
+    # A directArchive session's accession label is `name` (set for DQR imports); fall back to
+    # `folder_name` (which carries the same label) when `name` is NULL, so a NULL-named archive
+    # failure is still attributed to its accession rather than silently dropped.
     failed_accessions = {
-        session.name for session in direct_archive_sessions if session.status == _DIRECT_ARCHIVE_FAILED_STATUS
+        (session.name or session.folder_name)
+        for session in direct_archive_sessions
+        if session.status == _DIRECT_ARCHIVE_FAILED_STATUS
     } | {req.accession_number for req in executed_pacs_requests if req.status == _PACS_REQUEST_FAILED_STATUS}
     in_progress_accessions = {
-        session.name for session in direct_archive_sessions if session.status != _DIRECT_ARCHIVE_FAILED_STATUS
+        (session.name or session.folder_name)
+        for session in direct_archive_sessions
+        if session.status != _DIRECT_ARCHIVE_FAILED_STATUS
     } | {req.accession_number for req in executed_pacs_requests if req.status != _PACS_REQUEST_FAILED_STATUS}
     queued_accessions = {req.accession_number for req in queued_pacs_requests}
 

--- a/trust/imaging-api/imaging_api/services/retrieval.py
+++ b/trust/imaging-api/imaging_api/services/retrieval.py
@@ -36,11 +36,12 @@ from imaging_api.utils.logger import logger
 
 XNATAuthHeaders = Annotated[dict[str, str], Depends(get_xnat_auth_headers)]
 
-# Terminal-failure status values written by XNAT's DQR plugin / prearchive. Confirmed against XNAT
-# 1.9.x source: queued/executed PACS requests use PacsRequest.FAILED_STATUS_TEXT ("FAILED"); a
-# directArchive session uses PrearcUtils.PrearcStatus.ERROR. Any other status on a row that exists
-# means the import is still in flight. A successful directArchive deletes its row, so "successful" is
-# never read from these tables — it is determined solely by the experiment listing.
+# Terminal-failure status values. Verified against XNAT 1.9.3 source — re-check on any XNAT upgrade,
+# since a renamed value would silently misclassify a failed import as in-flight `processing`:
+#   - queued/executed PACS requests (DQR plugin):  PacsRequest.FAILED_STATUS_TEXT == "FAILED"
+#   - directArchive sessions (XNAT prearchive):    PrearcUtils.PrearcStatus.ERROR
+# Any other status on a row that exists means the import is still in flight. A successful directArchive
+# deletes its row, so "successful" is never read from these tables — only from the experiment listing.
 _PACS_REQUEST_FAILED_STATUS = "FAILED"
 _DIRECT_ARCHIVE_FAILED_STATUS = "ERROR"
 
@@ -144,6 +145,13 @@ async def get_import_status(project_id: str, query: str, headers: XNATAuthHeader
     * `Failed`: Studies that failed to import
     * `Queued`: Studies waiting in the queue
     * `QueueFailed`: Studies that couldn't be queued for import
+
+    Known limitation: only *terminal* failures (executed `FAILED`, directArchive `ERROR`) are
+    reported as `Failed`. A study wedged in a non-terminal state with no further transition — e.g.
+    executed `ISSUED` (the C-MOVE was issued but objects never arrive) or a directArchive stuck at
+    `RECEIVING`/`BUILDING` (a hung build that neither errors nor deletes its row) — stays `Processing`
+    indefinitely and is therefore never retried. Detecting "stuck" would need a staleness window
+    (the rows carry `timestamp`); not implemented here.
 
     1. Fetch the cohort's accession IDs from the data access API
     2. Get project experiments

--- a/trust/imaging-api/tests/services/test_retrieval.py
+++ b/trust/imaging-api/tests/services/test_retrieval.py
@@ -396,6 +396,81 @@ async def test_get_import_status_direct_archive_receiving_is_processing(
     assert status.queue_failed == []
 
 
+@pytest.mark.asyncio
+@patch("imaging_api.services.retrieval.get_experiments")
+@patch("imaging_api.services.retrieval.get_accession_ids", new_callable=AsyncMock)
+@patch("imaging_api.services.retrieval.encrypt")
+async def test_get_import_status_direct_archive_error_without_name_falls_back_to_folder_name(
+    mock_encrypt, mock_get_accession_ids, mock_get_experiments, headers,
+):
+    """A directArchive ERROR whose `name` is NULL is still attributed via its folder_name.
+
+    XNAT populates `name` for DQR imports, but it can be NULL for other archive rows; folder_name
+    carries the same accession label, so a NULL-named archive failure is recovered, not dropped.
+    """
+    mock_encrypt.return_value = "encrypted_id"
+    mock_get_accession_ids.return_value = ["ACC_X"]
+    mock_get_experiments.return_value = []
+
+    direct_archive = [
+        DirectArchiveSession(
+            id=1, created=datetime(2023, 1, 1), folder_name="ACC_X", status="ERROR", project="proj1", name=None,
+        )
+    ]
+    p_session, p_direct, p_executed, p_queued = _mock_get_session(direct_archive=direct_archive)
+    with p_session, p_direct, p_executed, p_queued:
+        status = await get_import_status("proj1", "SELECT *", headers)
+
+    assert status.failed == ["ACC_X"]
+    assert status.queue_failed == []
+
+
+@pytest.mark.asyncio
+@patch("imaging_api.services.retrieval.get_experiments")
+@patch("imaging_api.services.retrieval.get_accession_ids", new_callable=AsyncMock)
+@patch("imaging_api.services.retrieval.encrypt")
+async def test_get_import_status_failed_precedes_queued(
+    mock_encrypt, mock_get_accession_ids, mock_get_experiments, headers,
+):
+    """A terminal-failed accession that also has a (re-)queued row is reported `failed`, not `queued`."""
+    mock_encrypt.return_value = "encrypted_id"
+    mock_get_accession_ids.return_value = ["ACC"]
+    mock_get_experiments.return_value = []
+
+    queued = [QueuedPacsRequest(
+        id=2, created=datetime(2023, 1, 1), accession_number="ACC", status="QUEUED", xnat_project="proj1",
+    )]
+    p_session, p_direct, p_executed, p_queued = _mock_get_session(executed=[_executed("ACC", "FAILED")], queued=queued)
+    with p_session, p_direct, p_executed, p_queued:
+        status = await get_import_status("proj1", "SELECT *", headers)
+
+    assert status.failed == ["ACC"]
+    assert status.queued == []
+
+
+@pytest.mark.asyncio
+@patch("imaging_api.services.retrieval.get_experiments")
+@patch("imaging_api.services.retrieval.get_accession_ids", new_callable=AsyncMock)
+@patch("imaging_api.services.retrieval.encrypt")
+async def test_get_import_status_experiment_present_beats_stale_direct_archive_error(
+    mock_encrypt, mock_get_accession_ids, mock_get_experiments, headers,
+):
+    """`successful` (archived as an experiment) wins over a stale directArchive ERROR for the same accession."""
+    mock_encrypt.return_value = "encrypted_id"
+    mock_get_accession_ids.return_value = ["ACC"]
+    mock_get_experiments.return_value = [
+        Experiment(ID="e1", label="ACC", date="2023-01-01", project="proj1",
+                   insert_date="2023-01-01", xsiType="xnat:ctScanData", URI="/exp/e1"),
+    ]
+
+    p_session, p_direct, p_executed, p_queued = _mock_get_session(direct_archive=[_direct_archive("ACC", "ERROR")])
+    with p_session, p_direct, p_executed, p_queued:
+        status = await get_import_status("proj1", "SELECT *", headers)
+
+    assert status.successful == ["ACC"]
+    assert status.failed == []
+
+
 # ===========================================================================
 # retry_retrieve_images_for_project
 # ===========================================================================
@@ -531,3 +606,34 @@ async def test_retry_multiple_studies_uses_first(
     assert result is True
     call_args = mock_queue.call_args[0][0]
     assert call_args.studies[0].study_instance_uid == "1.2.3.1"
+
+
+@pytest.mark.asyncio
+@patch("imaging_api.services.retrieval.queue_image_import_request")
+@patch("imaging_api.services.retrieval.query_by_accession_number")
+@patch("imaging_api.services.retrieval.get_experiments")
+@patch("imaging_api.services.retrieval.get_accession_ids", new_callable=AsyncMock)
+@patch("imaging_api.services.retrieval.encrypt")
+@patch("imaging_api.services.retrieval.get_project")
+async def test_retry_requeues_terminal_failures_end_to_end(
+    mock_get_project, mock_encrypt, mock_get_accession_ids, mock_get_experiments, mock_query, mock_queue, headers,
+):
+    """Producer->consumer seam: a real terminal failure flows from get_import_status `failed` into the re-queue.
+
+    No get_import_status mock — an executed FAILED request must be classified `failed` by the producer
+    and then re-queried + re-queued by retry. Guards against the two halves drifting apart.
+    """
+    mock_get_project.return_value = MagicMock()
+    mock_encrypt.return_value = "encrypted_id"
+    mock_get_accession_ids.return_value = ["ACC_FAIL"]
+    mock_get_experiments.return_value = []
+    mock_query.return_value = [_make_study("ACC_FAIL")]
+    mock_queue.return_value = [_make_import_response("ACC_FAIL")]
+
+    p_session, p_direct, p_executed, p_queued = _mock_get_session(executed=[_executed("ACC_FAIL", "FAILED")])
+    with p_session, p_direct, p_executed, p_queued:
+        result = await retry_retrieve_images_for_project("proj1", "SELECT *", headers)
+
+    assert result is True
+    mock_query.assert_called_once_with("ACC_FAIL", headers)
+    assert mock_queue.call_args[0][0].studies[0].accession_number == "ACC_FAIL"

--- a/trust/imaging-api/tests/services/test_retrieval.py
+++ b/trust/imaging-api/tests/services/test_retrieval.py
@@ -16,7 +16,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from fastapi import HTTPException
 
-from imaging_api.db.models import ExecutedPacsRequest, QueuedPacsRequest
+from imaging_api.db.models import DirectArchiveSession, ExecutedPacsRequest, QueuedPacsRequest
 from imaging_api.routers.schemas import Experiment, ImportStatus, ImportStudyResponse, Patient, Study
 from imaging_api.services.retrieval import (
     get_import_status,
@@ -288,6 +288,112 @@ async def test_get_import_status_no_experiments(
 
     assert status.successful == []
     assert status.queue_failed == ["ACC1"]
+
+
+def _executed(accession_number: str, status: str) -> ExecutedPacsRequest:
+    return ExecutedPacsRequest(
+        id=1, created=datetime(2023, 1, 1), accession_number=accession_number, status=status, xnat_project="proj1",
+    )
+
+
+def _direct_archive(accession_number: str, status: str) -> DirectArchiveSession:
+    return DirectArchiveSession(
+        id=1, created=datetime(2023, 1, 1), folder_name=accession_number, status=status, project="proj1",
+        name=accession_number,
+    )
+
+
+@pytest.mark.asyncio
+@patch("imaging_api.services.retrieval.get_experiments")
+@patch("imaging_api.services.retrieval.get_accession_ids", new_callable=AsyncMock)
+@patch("imaging_api.services.retrieval.encrypt")
+async def test_get_import_status_executed_failed_is_failed(
+    mock_encrypt, mock_get_accession_ids, mock_get_experiments, headers,
+):
+    """A PACS retrieval that errored (executed status FAILED) is `failed`, not `processing`."""
+    mock_encrypt.return_value = "encrypted_id"
+    mock_get_accession_ids.return_value = ["ACC_FAIL"]
+    mock_get_experiments.return_value = []
+
+    p_session, p_direct, p_executed, p_queued = _mock_get_session(executed=[_executed("ACC_FAIL", "FAILED")])
+    with p_session, p_direct, p_executed, p_queued:
+        status = await get_import_status("proj1", "SELECT *", headers)
+
+    assert status.failed == ["ACC_FAIL"]
+    assert status.processing == []
+    assert status.queue_failed == []
+
+
+@pytest.mark.asyncio
+@patch("imaging_api.services.retrieval.get_experiments")
+@patch("imaging_api.services.retrieval.get_accession_ids", new_callable=AsyncMock)
+@patch("imaging_api.services.retrieval.encrypt")
+async def test_get_import_status_direct_archive_error_is_failed(
+    mock_encrypt, mock_get_accession_ids, mock_get_experiments, headers,
+):
+    """A directArchive build that errored (status ERROR) is `failed`, not `queue_failed`/`processing`."""
+    mock_encrypt.return_value = "encrypted_id"
+    mock_get_accession_ids.return_value = ["ACC_ARCH_FAIL"]
+    mock_get_experiments.return_value = []
+
+    p_session, p_direct, p_executed, p_queued = _mock_get_session(
+        direct_archive=[_direct_archive("ACC_ARCH_FAIL", "ERROR")],
+    )
+    with p_session, p_direct, p_executed, p_queued:
+        status = await get_import_status("proj1", "SELECT *", headers)
+
+    assert status.failed == ["ACC_ARCH_FAIL"]
+    assert status.processing == []
+    assert status.queue_failed == []
+
+
+@pytest.mark.asyncio
+@patch("imaging_api.services.retrieval.get_experiments")
+@patch("imaging_api.services.retrieval.get_accession_ids", new_callable=AsyncMock)
+@patch("imaging_api.services.retrieval.encrypt")
+async def test_get_import_status_direct_archive_error_overrides_received(
+    mock_encrypt, mock_get_accession_ids, mock_get_experiments, headers,
+):
+    """A study whose transfer RECEIVED but whose directArchive build then errored is `failed`.
+
+    This is the failure mode (study left the queue but never became a queryable experiment)
+    that was previously reported as `processing` forever.
+    """
+    mock_encrypt.return_value = "encrypted_id"
+    mock_get_accession_ids.return_value = ["ACC_X"]
+    mock_get_experiments.return_value = []
+
+    p_session, p_direct, p_executed, p_queued = _mock_get_session(
+        direct_archive=[_direct_archive("ACC_X", "ERROR")], executed=[_executed("ACC_X", "RECEIVED")],
+    )
+    with p_session, p_direct, p_executed, p_queued:
+        status = await get_import_status("proj1", "SELECT *", headers)
+
+    assert status.failed == ["ACC_X"]
+    assert status.processing == []
+
+
+@pytest.mark.asyncio
+@patch("imaging_api.services.retrieval.get_experiments")
+@patch("imaging_api.services.retrieval.get_accession_ids", new_callable=AsyncMock)
+@patch("imaging_api.services.retrieval.encrypt")
+async def test_get_import_status_direct_archive_receiving_is_processing(
+    mock_encrypt, mock_get_accession_ids, mock_get_experiments, headers,
+):
+    """A directArchive build still in progress (RECEIVING) is `processing`, not `failed`/`queue_failed`."""
+    mock_encrypt.return_value = "encrypted_id"
+    mock_get_accession_ids.return_value = ["ACC_RECV"]
+    mock_get_experiments.return_value = []
+
+    p_session, p_direct, p_executed, p_queued = _mock_get_session(
+        direct_archive=[_direct_archive("ACC_RECV", "RECEIVING")],
+    )
+    with p_session, p_direct, p_executed, p_queued:
+        status = await get_import_status("proj1", "SELECT *", headers)
+
+    assert status.processing == ["ACC_RECV"]
+    assert status.failed == []
+    assert status.queue_failed == []
 
 
 # ===========================================================================


### PR DESCRIPTION
## Problem

`get_import_status` (imaging-api) never populated `import_status.failed` and classified **any** executed PACS request as `processing` regardless of its status. So a study that left the queue but failed to retrieve (executed status `FAILED`) or failed its directArchive build (directArchive status `ERROR`) was reported as `processing` **indefinitely** — never surfaced as failed, and never retried by `retry_retrieve_images_for_project` (which only re-queues `failed + queue_failed`). The UI's "Failed" count (which sums `failed + queueFailed`) therefore only ever reflected *never-queued* studies, never genuine retrieve/archive failures.

Fixes #613.

## Change

- `get_import_status` now classifies terminal failures into `failed`:
  - executed PACS request `status == FAILED`, or
  - directArchive session `status == ERROR`.
- Precedence: `successful` → `failed` → `processing` → `queued` → `queue_failed`. `successful` is still sourced **solely** from the experiment listing, so a `RECEIVED`-but-not-yet-archived study stays `processing` until its experiment appears.
- `DirectArchiveSession` gains a `name` field (the XNAT session label = accession number for DQR imports) so an archive `ERROR` can be linked back to its cohort accession; it falls back to `folder_name` when `name` is NULL (see below).

Status values confirmed against XNAT 1.9.x source (`PacsRequest.FAILED_STATUS_TEXT == "FAILED"`, `PrearcUtils.PrearcStatus.ERROR`; a successful directArchive **deletes** its row — hence `successful` is read only from the experiment listing) and verified on a live dev stack.

## Tests

Classifier unit tests in `tests/services/test_retrieval.py`: executed `FAILED` → `failed`; directArchive `ERROR` → `failed`; directArchive `ERROR` overriding executed `RECEIVED` → `failed` (the "left the queue, never archived" case); directArchive `RECEIVING` → `processing`; plus the review-driven additions below. Full imaging-api suite green (256 passed); ruff + mypy clean.

## Addressed from PR review

- **NULL-named directArchive failures are now attributed** (were dropped). When a directArchive session's `name` is NULL, `get_import_status` falls back to `folder_name` (which carries the same accession label), so a NULL-named `ERROR` is reported `failed` instead of `queue_failed`.
- **Added regression tests:** the folder_name fallback; `failed` precedence over `queued`; `successful` precedence over a stale directArchive `ERROR`; and an end-to-end producer→consumer test that a real terminal failure flows from `get_import_status` into the retry re-queue.
- **Stuck-state gap documented:** the `get_import_status` docstring now states that only *terminal* failures are reported as `Failed` — a study wedged at executed `ISSUED`, or directArchive `RECEIVING`/`BUILDING` with no further transition, stays `Processing` and is never retried.
- **Comment provenance pinned:** the terminal-failure status constants are pinned to XNAT 1.9.3 source (DQR-plugin vs prearchive origins separated, re-check-on-upgrade note); `DirectArchiveSession.name`'s nullable rationale + folder_name fallback are documented.

## Remaining follow-ups (separate / optional)

- **Time-box the stuck state (optional):** the gap is now documented; actually reclassifying a study that has sat non-terminal beyond a staleness window (the rows carry `timestamp`) as `failed` so it surfaces and retries is a future enhancement, not in this PR.
- **`ImportStatus` partition-type redesign:** the 5 parallel `list[str]` buckets can't express "each accession is in exactly one bucket" — the *shape* of this bug. A single-state-per-accession map (+ `StrEnum`) would prevent the class, but it's a wire-contract change (routers/trust-api/UI), so its own PR.
- **Retry fire-and-forget outcome:** `retry_retrieve_images_for_project` runs as a background task; its aggregate `False`/exception outcome isn't surfaced. Pre-existing, tangential — separate.

## Notes

Independent of #612 (different function); branched off `develop`.
