### PR TITLE
fix(security): grant FOWNER + DAC_OVERRIDE to gosu-postgres services

### DIFF
--- a/deploy/compose.development.yml
+++ b/deploy/compose.development.yml
@@ -196,6 +196,8 @@ services:
       - ALL
     cap_add:
       - CHOWN
+      - DAC_OVERRIDE
+      - FOWNER
       - SETUID
       - SETGID
     networks:

--- a/trust/deploy/compose_trust.development.yml
+++ b/trust/deploy/compose_trust.development.yml
@@ -29,6 +29,8 @@ services:
       - ALL
     cap_add:
       - CHOWN
+      - DAC_OVERRIDE
+      - FOWNER
       - SETUID
       - SETGID
     environment:

--- a/trust/deploy/compose_trust.production.yml
+++ b/trust/deploy/compose_trust.production.yml
@@ -29,6 +29,8 @@ services:
       - ALL
     cap_add:
       - CHOWN
+      - DAC_OVERRIDE
+      - FOWNER
       - SETUID
       - SETGID
     environment:

--- a/trust/xnat/docker-compose-stack.yml
+++ b/trust/xnat/docker-compose-stack.yml
@@ -51,6 +51,8 @@ services:
       - ALL
     cap_add:
       - CHOWN
+      - DAC_OVERRIDE
+      - FOWNER
       - SETUID
       - SETGID
     environment:


### PR DESCRIPTION
## Problem

`make up` fails for anyone bringing the stack up a **second** time (i.e. with a persisted Postgres volume):

```
⏳ Waiting for the hub (flip-api) to be ready on :8080...
❌ flip-api not ready after 180s — is the hub up?
make: *** [Makefile:417: _wait-for-hub] Error 1
```

The hub itself is fine — it's blocked on a **dead database**. `flip-db` exits 1 immediately on startup:

```
chmod: changing permissions of '/var/lib/postgresql/data': Operation not permitted
chmod: changing permissions of '/var/run/postgresql': Operation not permitted
find:  '/var/lib/postgresql/data': Permission denied
```

flip-api's entrypoint then loops `flip-db:5432 - no response` forever, never binds `:8080`, and `register-trusts` times out.

## Root cause

The hardened cap set for the gosu/postgres services was:

```yaml
cap_drop: [ALL]
cap_add:  [CHOWN, SETUID, SETGID]
```

That is sufficient **only on a fresh volume**, where the data dir starts root-owned (owner-`chmod` works, root can traverse it). On every subsequent start the cluster already exists owned by the postgres user (uid 999) mode `0700`, and the official entrypoint — running as root — re-runs `chmod 00700 $PGDATA` plus a `find $PGDATA \! -user postgres -exec chown …` sweep:

- `chmod` on a dir owned by another uid needs **`CAP_FOWNER`** → the `Operation not permitted` error.
- traversing a `0700` dir owned by another uid needs **`CAP_DAC_OVERRIDE`** → the `Permission denied` error.

Both were dropped. The earlier capability fix (0a7db48f) only restored `SETUID`/`SETGID` for gosu and was validated on a fresh volume, so this regression on a persisted volume went unnoticed.

## Fix

Add `CAP_FOWNER` and `CAP_DAC_OVERRIDE` to all three gosu-postgres services:

| Service | File |
|---|---|
| flip-db | `deploy/compose.development.yml` |
| omop-db | `trust/deploy/compose_trust.development.yml`, `trust/deploy/compose_trust.production.yml` |
| xnat-db | `trust/xnat/docker-compose-stack.yml` |

(`deploy/compose.production.yml` has no Postgres — the prod hub uses RDS.)

## Verification

On a **persisted** flip-db volume (the failing case):

- `flip-db` → `Up`, log: `database system is ready to accept connections` (no chmod/find errors).
- effective caps: `CAP_CHOWN CAP_DAC_OVERRIDE CAP_FOWNER CAP_SETGID CAP_SETUID`.
- `flip-api` → serves `:8080` (`/api/docs` = 200).
- `make register-trusts` → `✅ Hub ready` + kit files written for GSTT/KCH.

omop-db / xnat-db carry the identical image/entrypoint/cap-gap and the identical fix; they are exercised by a trust bring-up.