### PR TITLE
fix(imaging-api): count imports via unfiltered global experiment listing

### DIFF
--- a/trust/imaging-api/imaging_api/routers/schemas.py
+++ b/trust/imaging-api/imaging_api/routers/schemas.py
@@ -157,7 +157,7 @@ class Experiment(BaseModel):
     """
     Short representation of an experiment on XNAT, it is the result of the REST API call
 
-    ``GET f"{XNAT_URL}/data/projects/{project_id}/experiments"``
+    ``GET f"{XNAT_URL}/data/experiments?project={project_id}"``
     """
 
     id: str = Field(..., alias="ID")

--- a/trust/imaging-api/imaging_api/services/projects.py
+++ b/trust/imaging-api/imaging_api/services/projects.py
@@ -32,7 +32,7 @@ from imaging_api.routers.schemas import (
 from imaging_api.routers.users import add_user_to_project
 from imaging_api.services.users import create_user_from_central_hub_user, get_user_profile_by
 from imaging_api.utils.enums import ProjectPreArchiveSettings
-from imaging_api.utils.exceptions import AlreadyExistsError, NotFoundError
+from imaging_api.utils.exceptions import AlreadyExistsError, NotFoundError, XnatFetchError
 from imaging_api.utils.logger import logger
 
 XNAT_URL = get_settings().XNAT_URL
@@ -530,7 +530,7 @@ def get_experiments(project_id: str, headers: dict[str, str]) -> list[Experiment
         list[Experiment]: List of XNAT experiment objects.
 
     Raises:
-        Exception: If there is an error while fetching the experiments from XNAT.
+        imaging_api.utils.exceptions.XnatFetchError: If XNAT returns a non-200 response for the experiments listing.
     """
     get_project(project_id, headers)
 
@@ -544,7 +544,7 @@ def get_experiments(project_id: str, headers: dict[str, str]) -> list[Experiment
     # Check the status before parsing: a non-200 XNAT response carries an HTML/plain-text body, so
     # parsing it as JSON first would raise and mask the real HTTP status.
     if response.status_code != 200:
-        raise Exception(f"Error: XNAT experiments fetch failed: {response.status_code} - {response.text}")
+        raise XnatFetchError(f"Error: XNAT experiments fetch failed: {response.status_code} - {response.text}")
 
     return [Experiment(**experiment) for experiment in response.json()["ResultSet"]["Result"]]
 

--- a/trust/imaging-api/imaging_api/services/projects.py
+++ b/trust/imaging-api/imaging_api/services/projects.py
@@ -534,13 +534,19 @@ def get_experiments(project_id: str, headers: dict[str, str]) -> list[Experiment
     """
     get_project(project_id, headers)
 
-    response = requests.get(f"{XNAT_URL}/data/projects/{project_id}/experiments", headers=headers)
-    experiments = [Experiment(**experiment) for experiment in response.json()["ResultSet"]["Result"]]
+    # Use the GLOBAL experiments listing filtered by project, NOT the project-scoped
+    # /data/projects/{id}/experiments. The project-scoped listing is filtered by per-data-type
+    # element security, so sessions whose modality is not registered there (e.g.
+    # xnat:dxSessionData for chest X-rays) are silently omitted — making the import look stuck
+    # at "0 imported". The global listing returns identical fields without that filter.
+    response = requests.get(f"{XNAT_URL}/data/experiments", params={"project": project_id}, headers=headers)
 
-    if response.status_code == 200:
-        return experiments
-    else:
+    # Check the status before parsing: a non-200 XNAT response carries an HTML/plain-text body, so
+    # parsing it as JSON first would raise and mask the real HTTP status.
+    if response.status_code != 200:
         raise Exception(f"Error: XNAT experiments fetch failed: {response.status_code} - {response.text}")
+
+    return [Experiment(**experiment) for experiment in response.json()["ResultSet"]["Result"]]
 
 
 def get_experiment(project_id: str, experiment_id_or_label: str, headers: dict[str, str]) -> dict:

--- a/trust/imaging-api/imaging_api/utils/exceptions.py
+++ b/trust/imaging-api/imaging_api/utils/exceptions.py
@@ -26,6 +26,19 @@ class AlreadyExistsError(Exception):
     pass
 
 
+class XnatFetchError(Exception):
+    """Exception raised when a read from XNAT returns a non-200 response.
+
+    A typed alternative to a bare ``Exception`` for upstream XNAT fetch failures,
+    so callers can tell "XNAT itself failed" apart from a local/parsing error. A
+    plain ``Exception`` subclass (no custom ``__init__``) so ``str(err)`` keeps
+    rendering the raised message verbatim; the routers' generic ``except Exception``
+    handler continues to surface it as HTTP 500.
+    """
+
+    pass
+
+
 class InternalServerError(Exception):
     """Exception raised for internal server errors."""
 

--- a/trust/imaging-api/tests/services/test_projects.py
+++ b/trust/imaging-api/tests/services/test_projects.py
@@ -35,7 +35,7 @@ from imaging_api.services.projects import (
     set_project_prearchive_settings,
     to_create_project,
 )
-from imaging_api.utils.exceptions import AlreadyExistsError, NotFoundError
+from imaging_api.utils.exceptions import AlreadyExistsError, NotFoundError, XnatFetchError
 
 
 @pytest.fixture
@@ -607,7 +607,7 @@ def test_get_experiments_failure(mock_get_project, mock_get, headers):
     mock_get.return_value = MagicMock(
         status_code=500, text="Error", json=MagicMock(side_effect=ValueError("no json")),
     )
-    with pytest.raises(Exception, match="XNAT experiments fetch failed"):
+    with pytest.raises(XnatFetchError, match="XNAT experiments fetch failed"):
         get_experiments("TEST", headers)
 
 

--- a/trust/imaging-api/tests/services/test_projects.py
+++ b/trust/imaging-api/tests/services/test_projects.py
@@ -602,9 +602,36 @@ def test_get_experiments_success(mock_get_project, mock_get, headers):
 @patch("imaging_api.services.projects.get_project")
 def test_get_experiments_failure(mock_get_project, mock_get, headers):
     mock_get_project.return_value = Project(**_PROJECT_DICT)
-    mock_get.return_value = MagicMock(status_code=500, text="Error")
+    # A real XNAT non-200 serves an HTML/plain-text body, so .json() raises. The status must be
+    # checked before the body is parsed, otherwise the JSON error masks the true HTTP status.
+    mock_get.return_value = MagicMock(
+        status_code=500, text="Error", json=MagicMock(side_effect=ValueError("no json")),
+    )
     with pytest.raises(Exception, match="XNAT experiments fetch failed"):
         get_experiments("TEST", headers)
+
+
+@patch("imaging_api.services.projects.requests.get")
+@patch("imaging_api.services.projects.get_project")
+def test_get_experiments_uses_unfiltered_global_listing(mock_get_project, mock_get, headers):
+    # Regression guard: get_experiments must query the GLOBAL experiments endpoint filtered by
+    # project, NOT the project-scoped /data/projects/{id}/experiments. The project-scoped listing
+    # is filtered by per-data-type element security, so sessions whose modality is not registered
+    # there (e.g. xnat:dxSessionData for chest X-rays) are silently omitted and the import shows
+    # "0 imported". The global listing returns identical fields without that filter.
+    mock_get_project.return_value = Project(**_PROJECT_DICT)
+    mock_get.return_value = MagicMock(
+        status_code=200,
+        json=MagicMock(return_value={"ResultSet": {"Result": []}}),
+    )
+
+    get_experiments("TEST", headers)
+
+    called = mock_get.call_args
+    # Global endpoint, project passed as a (URL-encoded) query parameter — NOT the project-scoped path.
+    assert called.args[0].endswith("/data/experiments")
+    assert called.kwargs["params"] == {"project": "TEST"}
+    assert "/data/projects/TEST/experiments" not in called.args[0]
 
 
 # ===========================================================================


### PR DESCRIPTION
## What

Points `get_experiments` at the **global** XNAT experiment listing `GET /data/experiments?project={id}` instead of the **project-scoped** `GET /data/projects/{id}/experiments`, so cohort imports are counted regardless of DICOM modality.

## Why

`get_import_status` marks a cohort accession `successful` only if it appears in `get_experiments`. The project-scoped listing is filtered by XNAT per-data-type **element security**, so sessions whose modality is not in the default secure set (`cr/ct/mr/pet/petmr`) are silently omitted — e.g. chest X-rays, which archive as `xnat:dxSessionData`. The studies are correctly archived and retrievable, but the import shows a permanent **"0 imported"**, blocking any workflow gated on import completion (notably the FL image-pull step).

The global listing roots on `xnat:experimentData` (a secure element), so no `extension IN (...)` element-security predicate is applied and **every modality is counted**. Image retrieval is unaffected — it uses direct experiment/scan access by ID/label, not the filtered listing.

Full root-cause analysis (verified against XNAT 1.9.3.5 source and reproduced on a live dev stack) is in the linked issue.

## Provenance

These `trust/imaging-api` changes were developed on the #605 branch (via #611, which merged into #605's branch rather than develop). This PR extracts **only** the imaging-api fix so it can land on `develop` independently of the chest-X-ray dataset-loader scripts in #605. It supersedes the reverted per-modality element-security registration approach (which required an XNAT restart, per-modality SQL, and manual recovery for pre-existing projects).

## Changes

- `services/projects.py` — query the global listing; check HTTP status before parsing the body (a non-200 XNAT response serves HTML/plain text, so parsing JSON first would mask the real status).
- `routers/schemas.py` — update the `Experiment` docstring to the new endpoint.
- `tests/services/test_projects.py` — regression guard asserting the global endpoint + `project` query param is used (not the project-scoped path); update the failure test to a non-JSON error body.

## Testing

- `uv run pytest tests/services/test_projects.py` — 43 passed
- `ruff check` clean, `mypy` clean on the changed source files

Closes #612