### PR TITLE
fix(flip-utils): normalise HttpUrl base before joining trust-internal paths

### DIFF
--- a/flip-utils/flip/core/standard.py
+++ b/flip-utils/flip/core/standard.py
@@ -57,6 +57,27 @@ def _trust_internal_headers() -> dict[str, str]:
     return {FlipConstants.TRUST_INTERNAL_SERVICE_KEY_HEADER: FlipConstants.TRUST_INTERNAL_SERVICE_KEY}
 
 
+def _join_url(base: object, path: str) -> str:
+    """Join a base URL with a path, tolerating a trailing slash on the base.
+
+    Pydantic v2 serializes a host-only ``HttpUrl`` with a trailing slash
+    (e.g. ``http://data-access-api:8000/``), so naive f-string concatenation
+    with ``/cohort/dataframe`` yields a double slash (``//cohort/dataframe``)
+    that Starlette does not route — producing a spurious ``404 Not Found``.
+    Normalising the base before joining keeps every trust-internal and
+    hub-internal call working regardless of whether the configured URL carries
+    a trailing slash. See FLIP#652.
+
+    Args:
+        base: The base URL (``str`` or pydantic ``HttpUrl``).
+        path: The path to append (a leading slash is optional).
+
+    Returns:
+        str: ``<base-without-trailing-slash>/<path-without-leading-slash>``.
+    """
+    return f"{str(base).rstrip('/')}/{path.lstrip('/')}"
+
+
 def _hub_internal_headers() -> dict[str, str]:
     """Return the auth header sent on every hub-internal call.
 
@@ -120,7 +141,7 @@ class FLIPStandardProd(FLIPBase):
             "query": query,
         }
 
-        endpoint = f"{FlipConstants.DATA_ACCESS_API_URL}/cohort/dataframe"
+        endpoint = _join_url(FlipConstants.DATA_ACCESS_API_URL, "cohort/dataframe")
 
         response = requests.post(
             endpoint,
@@ -171,7 +192,7 @@ class FLIPStandardProd(FLIPBase):
             "accession_id": accession_id,
         }
 
-        endpoint = f"{FlipConstants.IMAGING_API_URL}/download/images/{FlipConstants.NET_ID}"
+        endpoint = _join_url(FlipConstants.IMAGING_API_URL, f"download/images/{FlipConstants.NET_ID}")
 
         for resource in resources:
             if resource != ResourceType.SEGMENTATION:
@@ -245,7 +266,7 @@ class FLIPStandardProd(FLIPBase):
             "files": files,
         }
 
-        endpoint = f"{FlipConstants.IMAGING_API_URL}/upload/images/{FlipConstants.NET_ID}"
+        endpoint = _join_url(FlipConstants.IMAGING_API_URL, f"upload/images/{FlipConstants.NET_ID}")
 
         response = requests.put(
             endpoint,
@@ -271,7 +292,7 @@ class FLIPStandardProd(FLIPBase):
         if Utils.is_valid_uuid(model_id) is False:
             raise ValueError(f"Invalid model ID: {model_id}, cant update model status")
 
-        endpoint = f"{FlipConstants.FLIP_API_INTERNAL_URL}/model/{model_id}/status/{new_model_status.value}"
+        endpoint = _join_url(FlipConstants.FLIP_API_INTERNAL_URL, f"model/{model_id}/status/{new_model_status.value}")
 
         self.logger.info(f"Attempting to update model status to [{new_model_status}]")
         try:
@@ -315,7 +336,7 @@ class FLIPStandardProd(FLIPBase):
             result=value,
         ).model_dump()
 
-        endpoint = f"{FlipConstants.FLIP_API_INTERNAL_URL}/model/{model_id}/metrics"
+        endpoint = _join_url(FlipConstants.FLIP_API_INTERNAL_URL, f"model/{model_id}/metrics")
 
         self.logger.info(f"Attempting to send metrics raised by {client_name}...")
 
@@ -363,7 +384,7 @@ class FLIPStandardProd(FLIPBase):
             log=formatted_exception,
         ).model_dump()
 
-        endpoint = f"{FlipConstants.FLIP_API_INTERNAL_URL}/model/{model_id}/logs"
+        endpoint = _join_url(FlipConstants.FLIP_API_INTERNAL_URL, f"model/{model_id}/logs")
 
         self.logger.info(f"Attempting to send the exception raised by {client_name} to the Central Hub...")
 

--- a/flip-utils/tests/unit/core/test_standard.py
+++ b/flip-utils/tests/unit/core/test_standard.py
@@ -18,6 +18,7 @@ from unittest.mock import Mock, patch
 
 import pandas as pd
 import pytest
+from pydantic import HttpUrl
 from requests import HTTPError
 
 from flip.constants import ModelStatus, ResourceType
@@ -195,6 +196,36 @@ class TestFLIPStandardProdGetDataframe:
             assert isinstance(df, pd.DataFrame)
             assert len(df) == 1
             assert df["accession_id"].iloc[0] == "ACC001"
+
+    def test_get_dataframe_endpoint_has_no_double_slash_with_httpurl(self, flip_prod):
+        """Regression (FLIP#652): a host-only pydantic HttpUrl must not yield a double slash.
+
+        In production DATA_ACCESS_API_URL is a pydantic v2 ``HttpUrl``, which serializes a
+        host-only URL with a trailing slash (``http://data-access-api:8000/``). Naive
+        f-string concatenation then built ``.../8000//cohort/dataframe`` — a path Starlette
+        does not route, so data-access-api returned 404 and the trainer crashed before any
+        image fetch (a root cause of the num_samples=0 / NaN clog). The earlier test mocked
+        the URL as a bare ``str`` (no trailing slash) and only substring-checked the path, so
+        it never caught this. Pin the real ``HttpUrl`` type and assert the exact endpoint.
+        """
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.text = json.dumps([{"accession_id": "ACC001", "label": 0}])
+
+        with (
+            patch("flip.core.standard.FlipConstants") as mock_constants,
+            patch("flip.core.standard.requests.post", return_value=mock_response) as mock_post,
+        ):
+            mock_constants.DATA_ACCESS_API_URL = HttpUrl("http://data-access-api:8000")
+            mock_constants.TRUST_INTERNAL_SERVICE_KEY_HEADER = "x-trust-internal-service-key"
+            mock_constants.TRUST_INTERNAL_SERVICE_KEY = "test-trust-internal-key"
+
+            flip_prod.get_dataframe(project_id="proj-1", query="SELECT * FROM table")
+
+            called_url = mock_post.call_args[0][0]
+            assert called_url == "http://data-access-api:8000/cohort/dataframe"
+            # No empty path segment anywhere after the scheme.
+            assert "//" not in called_url.split("://", 1)[1]
 
     def test_get_dataframe_forwards_empty_key_header(self, flip_prod):
         """Header is always sent, even when TRUST_INTERNAL_SERVICE_KEY is the default empty string.

--- a/flip-utils/uv.lock
+++ b/flip-utils/uv.lock
@@ -3,7 +3,7 @@ revision = 3
 requires-python = ">=3.12"
 
 [options]
-exclude-newer = "2026-06-21T12:02:48.469272657Z"
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P3D"
 
 [manifest]


### PR DESCRIPTION
# Description

In production, `DATA_ACCESS_API_URL`, `IMAGING_API_URL` and `FLIP_API_INTERNAL_URL` are pydantic v2 `HttpUrl` values. Pydantic v2 serializes a host-only `HttpUrl` with a **trailing slash** (e.g. `http://data-access-api:8000/`). The fl-client built endpoints by naive f-string concatenation, producing a double slash — `http://data-access-api:8000//cohort/dataframe` — which Starlette does not route, so **every trust-internal and hub-internal call returned 404**. This was a root cause of the `num_samples=0` / NaN clog: the trainer crashed before any image fetch.

This PR adds a `_join_url(base, path)` helper that strips the trailing slash from the base and the leading slash from the path before joining, and routes every endpoint build (`get_dataframe`, image download/upload, model status/metrics/logs) through it. The fix is tolerant whether or not the configured URL carries a trailing slash.

## Linked Issues

Fixes #652

## Checklist

- [x] Follows the project's coding conventions and style guide
- [ ] Updates documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Type of Change

- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [x] In-line docstrings updated.
- [ ] Documentation updated, tested `make -C docs/ docs`.

## Testing

- [x] Quick tests passed locally: `uv run pytest tests/unit/core/test_standard.py` (25 passed).
- [x] `uv run ruff check` clean on changed files; `mypy` introduces no new errors (4 pre-existing on develop).

The added regression test pins the real `HttpUrl` type (the previous test mocked the URL as a bare `str` with no trailing slash, so it never caught this) and asserts the exact endpoint `http://data-access-api:8000/cohort/dataframe` with no double slash.

## Additional Notes

`flip-utils/uv.lock` carries an incidental `exclude-newer` timestamp refresh from the dependency-cooldown mechanism (no dependency version changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
