### PR TITLE
fix(fl-api): harden path-traversal + SSRF + command-injection (#649)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,7 +131,31 @@ make e2e_smoke FL_BACKEND=flower                               # use the Flower 
 make e2e_smoke MODEL_FILES_DIR=/path/app QUERY_FILE=/path/q.sql
 make e2e_smoke EXTRA_ARGS="--abort-midway"                     # exercise the FL stop-training path
 make e2e_smoke EXTRA_ARGS="--image-pull-threshold 0.5 --image-pull-timeout 1200"
+make e2e_smoke EXTRA_ARGS="--project-id <UUID>"               # reuse an approved project (see below)
 ```
+
+The `--project-id <UUID>` override (printed as `project_id=<UUID>` at the start of any run) reuses an
+existing approved project: it skips cohort submission + approval and jumps straight to model
+create → upload → train → download. The image-pull wait still runs but returns immediately when the
+studies are already pulled — so it lets you iterate on training/app code (and re-run after an upload
+or fl-api change) without re-creating the project and re-pulling DICOM (~6 min/backend) each time.
+
+**Testing a change on BOTH FL backends in one sitting (the backend switch).** The pulled DICOM lives in
+each trust's Orthanc/XNAT, which `make restart-fl` leaves untouched — so you can pull once on the first
+backend and *reuse the same project* for the second, skipping the second image pull entirely:
+
+```bash
+# 0. Rebuild the fl-api image(s) from your branch first — the running stack serves PUBLISHED images,
+#    not your code. Full: `make build-fl FL_BACKEND=<backend>`; fl-api-only fast path:
+#    DOCKER_GID=$(id -g) docker compose -f fl-services/<backend>/compose.dev.yml build <fl-api|flip-fl-api>
+make e2e_smoke FL_BACKEND=flower                                          # note the printed project_id=<UUID>
+make restart-fl FL_BACKEND=nvflare DOCKER_FL_REGISTRY= DOCKER_FL_TAG=dev  # switch backend onto rebuilt :dev images
+make e2e_smoke FL_BACKEND=nvflare EXTRA_ARGS="--project-id <UUID>"        # reuse project → skip cohort + re-pull
+```
+
+Before trusting either run, confirm the live container actually carries your code (the stack silently
+runs old images otherwise): `docker exec flip-fl-api-net-1 cat fl_api/utils/upload.py`. See
+[Running FL Tutorials Locally](#running-fl-tutorials-locally) for `make build-fl` / `:dev` image details.
 
 ### Running FL Tutorials Locally
 

--- a/fl-services/flower/fl-api-flower/fl_api/app.py
+++ b/fl-services/flower/fl-api-flower/fl_api/app.py
@@ -38,6 +38,7 @@ from fl_api.schemas import (
     normalize_status,
 )
 from fl_api.utils.upload import upload_application
+from fl_api.utils.validation import safe_join, validate_app_folder_name
 
 logger = logging.getLogger("uvicorn")
 
@@ -56,11 +57,6 @@ _submission_in_progress = False
 
 _node_mapping_lock = threading.Lock()
 _node_trust_mapping: dict[str, str] = {}  # Flower node_id → trust name
-
-
-def _get_allowed_job_folders() -> set[str]:
-    raw_value = os.getenv("ALLOWED_JOB_FOLDERS", "numpy,3d_spleen_segmentation,3d_spleen_segmentation_evaluation")
-    return {item.strip() for item in raw_value.split(",") if item.strip()}
 
 
 def _get_src_root() -> Path:
@@ -164,16 +160,13 @@ def _parse_flwr_payload(result: subprocess.CompletedProcess[str], action_name: s
 
 
 def _validate_app_folder(app_folder: str) -> Path:
-    # allowed_job_folders = _get_allowed_job_folders()
-    # if app_folder not in allowed_job_folders:
-    #     raise HTTPException(
-    #         status_code=status.HTTP_400_BAD_REQUEST,
-    #         detail=(f"Invalid app folder '{app_folder}'. Allowed values: {sorted(allowed_job_folders)}"),
-    #     )
-
-    # Uploaded apps and static tutorial apps both live under the src root: the FL API
-    # downloads bundles into FLOWER_SRC_ROOT/<model_id>, alongside the tutorial folders.
-    job_dir = _get_src_root() / app_folder
+    # app_folder is an uploaded-model UUID or a static tutorial folder name, so it can't be
+    # restricted to an allow-list; instead reject traversal sequences and confirm the
+    # resolved path stays under the src root. Uploaded apps and tutorial apps both live
+    # there: the FL API downloads bundles into FLOWER_SRC_ROOT/<model_id>, alongside the
+    # tutorial folders.
+    validate_app_folder_name(app_folder)
+    job_dir = safe_join(_get_src_root(), app_folder)
     if not job_dir.is_dir():
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -424,26 +417,31 @@ def _find_terminal_run(src_root: Path, run_id: str) -> JobMetadata | None:
 
 @app.delete("/abort_run/{run_id}", status_code=status.HTTP_200_OK, response_model=JobMetadata)
 @app.delete("/abort_job/{run_id}", include_in_schema=False)  # alias, hide from docs
-def abort_run(run_id: str) -> JobMetadata:
+def abort_run(run_id: int) -> JobMetadata:
+    # Flower run ids are integers (flwr Context.run_id: int). Typing the path param as int
+    # makes FastAPI reject any non-numeric value with 422 before it can reach the `flwr
+    # stop` argv, closing the command-line-injection surface; downstream code keeps using
+    # the string form.
     src_root = _get_src_root()
-    command = ["uvx", "flwr", "stop", run_id, "local", "--format", "json"]
+    run_id_str = str(run_id)
+    command = ["uvx", "flwr", "stop", run_id_str, "local", "--format", "json"]
     result = _run_flwr_command(command, src_root, "stop")
 
     if result.returncode == 0:
         # A successful `flwr stop` means the run is stopped. `flwr stop --format json`
         # emits {"success": true, "run-id": ...} with no status field, so the post-abort
         # status is unconditionally STOPPED — same as fl-api-base's /abort_job.
-        return JobMetadata(job_id=run_id, status=JobStatus.STOPPED)
+        return JobMetadata(job_id=run_id_str, status=JobStatus.STOPPED)
 
     # `flwr stop` failed: the run may already be terminal. Aborting an already-terminal
     # run must be idempotent — fall back to `flwr list` and return its terminal status.
-    terminal = _find_terminal_run(src_root, run_id)
+    terminal = _find_terminal_run(src_root, run_id_str)
     if terminal is not None:
         return terminal
 
     raise HTTPException(
         status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-        detail=f"Failed to abort job {run_id}: {result.stderr.strip()}",
+        detail=f"Failed to abort job {run_id_str}: {result.stderr.strip()}",
     )
 
 

--- a/fl-services/flower/fl-api-flower/fl_api/app.py
+++ b/fl-services/flower/fl-api-flower/fl_api/app.py
@@ -38,7 +38,7 @@ from fl_api.schemas import (
     normalize_status,
 )
 from fl_api.utils.upload import upload_application
-from fl_api.utils.validation import safe_join, validate_app_folder_name
+from fl_api.utils.validation import safe_join, validate_app_folder_name, validate_model_id
 
 logger = logging.getLogger("uvicorn")
 
@@ -159,21 +159,31 @@ def _parse_flwr_payload(result: subprocess.CompletedProcess[str], action_name: s
         ) from err
 
 
-def _validate_app_folder(app_folder: str) -> Path:
-    # app_folder is an uploaded-model UUID or a static tutorial folder name, so it can't be
-    # restricted to an allow-list; instead reject traversal sequences and confirm the
-    # resolved path stays under the src root. Uploaded apps and tutorial apps both live
-    # there: the FL API downloads bundles into FLOWER_SRC_ROOT/<model_id>, alongside the
-    # tutorial folders.
-    validate_app_folder_name(app_folder)
-    job_dir = safe_join(_get_src_root(), app_folder)
+def _resolve_job_dir(folder: str) -> Path:
+    # Resolve <src_root>/<folder> with traversal containment and confirm it exists. The name
+    # itself is validated by the caller (a UUID for production submit, a charset-guarded
+    # folder name for tutorials) before we get here.
+    job_dir = safe_join(_get_src_root(), folder)
     if not job_dir.is_dir():
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=f"Job folder path does not exist: {job_dir}",
         )
-
     return job_dir
+
+
+def _validate_job_folder(job_folder: str) -> Path:
+    # Production submit: flip-api submits an uploaded model by its uuid4 (the cross-backend
+    # /submit_job contract, same `job_folder` shape as fl-api-base), so it must be a UUID.
+    validate_model_id(job_folder)
+    return _resolve_job_dir(job_folder)
+
+
+def _validate_tutorial_folder(tutorial_name: str) -> Path:
+    # Tutorial submit: pre-baked tutorial folders (e.g. "numpy", "xray_classification") are
+    # submitted by name, not a UUID, so they get a charset/traversal guard instead.
+    validate_app_folder_name(tutorial_name)
+    return _resolve_job_dir(tutorial_name)
 
 
 def _get_federation_nodes(src_root: Path) -> list[dict[str, Any]]:
@@ -313,11 +323,7 @@ def list_runs() -> list[JobMetadata]:
     return _parse_runs_payload(payload)
 
 
-@app.post("/submit_run/{app_folder}", status_code=status.HTTP_200_OK, response_model=str)
-@app.post("/submit_job/{app_folder}", include_in_schema=False)  # alias, hide from docs
-def submit_run(app_folder: str) -> str:
-    job_dir = _validate_app_folder(app_folder)
-
+def _submit_from_job_dir(job_dir: Path, label: str) -> str:
     global _submission_in_progress
 
     # config.toml holds the run-config overrides for this app. It may sit on a
@@ -355,7 +361,7 @@ def submit_run(app_folder: str) -> str:
         except HTTPException as err:
             raise HTTPException(
                 status_code=err.status_code,
-                detail=f"Failed to submit job from folder {app_folder}: {err.detail}",
+                detail=f"Failed to submit job from folder {label}: {err.detail}",
             ) from err
 
         response_payload = _parse_flwr_payload(result, "submit")
@@ -376,7 +382,7 @@ def submit_run(app_folder: str) -> str:
 
         logger.info(
             "Submitted Flower job from '%s' using command: %s",
-            app_folder,
+            label,
             " ".join(command),
         )
         return resp.run_id
@@ -385,6 +391,21 @@ def submit_run(app_folder: str) -> str:
             _submission_in_progress = False
         if run_config_path is not None:
             os.unlink(run_config_path)
+
+
+@app.post("/submit_run/{job_folder}", status_code=status.HTTP_200_OK, response_model=str)
+@app.post("/submit_job/{job_folder}", include_in_schema=False)  # alias flip-api calls with a UUID
+def submit_run(job_folder: str) -> str:
+    # Production path: flip-api submits an uploaded model by its UUID (the cross-backend
+    # /submit_job contract). UUID-strict, so a non-UUID can never reach the job dir or flwr.
+    return _submit_from_job_dir(_validate_job_folder(job_folder), job_folder)
+
+
+@app.post("/submit_tutorial/{tutorial_name}", status_code=status.HTTP_200_OK, response_model=str)
+def submit_tutorial(tutorial_name: str) -> str:
+    # Tutorial path: pre-baked tutorial folders are submitted by name (not a UUID), e.g.
+    # `numpy` / `xray_classification`. Charset/traversal-guarded, contained under the src root.
+    return _submit_from_job_dir(_validate_tutorial_folder(tutorial_name), tutorial_name)
 
 
 def _find_terminal_run(src_root: Path, run_id: str) -> JobMetadata | None:

--- a/fl-services/flower/fl-api-flower/fl_api/app.py
+++ b/fl-services/flower/fl-api-flower/fl_api/app.py
@@ -19,6 +19,7 @@ import tempfile
 import threading
 from pathlib import Path
 from typing import Any
+from uuid import UUID
 
 import grpc
 from fastapi import FastAPI, HTTPException, Query, status
@@ -38,7 +39,7 @@ from fl_api.schemas import (
     normalize_status,
 )
 from fl_api.utils.upload import upload_application
-from fl_api.utils.validation import safe_join, validate_model_id, validate_tutorial_folder_name
+from fl_api.utils.validation import safe_join, validate_tutorial_folder_name
 
 logger = logging.getLogger("uvicorn")
 
@@ -170,13 +171,6 @@ def _resolve_job_dir(folder: str) -> Path:
             detail=f"Job folder path does not exist: {job_dir}",
         )
     return job_dir
-
-
-def _validate_job_folder(job_folder: str) -> Path:
-    # Production submit: flip-api submits an uploaded model by its uuid4 (the cross-backend
-    # /submit_job contract, same `job_folder` shape as fl-api-base), so it must be a UUID.
-    validate_model_id(job_folder)
-    return _resolve_job_dir(job_folder)
 
 
 def _validate_tutorial_folder(tutorial_name: str) -> Path:
@@ -395,10 +389,20 @@ def _submit_from_job_dir(job_dir: Path, label: str) -> str:
 
 @app.post("/submit_run/{job_folder}", status_code=status.HTTP_200_OK, response_model=str)
 @app.post("/submit_job/{job_folder}", include_in_schema=False)  # alias flip-api calls with a UUID
-def submit_run(job_folder: str) -> str:
-    # Production path: flip-api submits an uploaded model by its UUID (the cross-backend
-    # /submit_job contract). UUID-strict, so a non-UUID can never reach the job dir or flwr.
-    return _submit_from_job_dir(_validate_job_folder(job_folder), job_folder)
+def submit_run(job_folder: UUID) -> str:
+    """Submit the uploaded application in ``job_folder`` to the Flower control plane.
+
+    Args:
+        job_folder (UUID): The Central Hub model_id. The uploaded application lives in
+            ``FLOWER_SRC_ROOT/<model_id>`` (created by ``/upload_app/{model_id}``), so the
+            submit "job folder" and the upload "model_id" are the same UUID — flip-api calls
+            this via the ``/submit_job`` alias. FastAPI rejects any non-UUID path segment
+            with 422 before the handler runs, so the folder name is guaranteed safe.
+
+    Returns:
+        str: The Flower run id of the submitted job.
+    """
+    return _submit_from_job_dir(_resolve_job_dir(str(job_folder)), str(job_folder))
 
 
 @app.post("/submit_tutorial/{tutorial_name}", status_code=status.HTTP_200_OK, response_model=str)
@@ -467,16 +471,16 @@ def abort_run(run_id: int) -> JobMetadata:
 
 
 @app.post("/upload_app/{model_id}", status_code=status.HTTP_200_OK)
-def upload_app(model_id: str, body: UploadAppRequest) -> dict[str, str]:
+def upload_app(model_id: UUID, body: UploadAppRequest) -> dict[str, str]:
     """
     Upload an application to the server.
 
     Args:
-        model_id (str): The ID of the model to associate the application with.
+        model_id (UUID): The ID of the model to associate the application with.
         body (UploadAppRequest): The request body containing the application details.
 
     Returns:
         dict[str, str]: A dictionary containing the status of the upload.
     """
     upload_dir = _get_src_root()
-    return upload_application(model_id, body, upload_dir=upload_dir)
+    return upload_application(str(model_id), body, upload_dir=upload_dir)

--- a/fl-services/flower/fl-api-flower/fl_api/app.py
+++ b/fl-services/flower/fl-api-flower/fl_api/app.py
@@ -38,7 +38,7 @@ from fl_api.schemas import (
     normalize_status,
 )
 from fl_api.utils.upload import upload_application
-from fl_api.utils.validation import safe_join, validate_app_folder_name, validate_model_id
+from fl_api.utils.validation import safe_join, validate_model_id, validate_tutorial_folder_name
 
 logger = logging.getLogger("uvicorn")
 
@@ -182,7 +182,7 @@ def _validate_job_folder(job_folder: str) -> Path:
 def _validate_tutorial_folder(tutorial_name: str) -> Path:
     # Tutorial submit: pre-baked tutorial folders (e.g. "numpy", "xray_classification") are
     # submitted by name, not a UUID, so they get a charset/traversal guard instead.
-    validate_app_folder_name(tutorial_name)
+    validate_tutorial_folder_name(tutorial_name)
     return _resolve_job_dir(tutorial_name)
 
 

--- a/fl-services/flower/fl-api-flower/fl_api/utils/upload.py
+++ b/fl-services/flower/fl-api-flower/fl_api/utils/upload.py
@@ -8,7 +8,7 @@ from tomlkit import dumps, parse
 
 from fl_api.schemas import UploadAppRequest
 from fl_api.utils.logger import logger
-from fl_api.utils.validation import safe_join, validate_bundle_url, validate_model_id
+from fl_api.utils.validation import safe_join, validate_bundle_url
 
 
 def _key_after_model_id(url: str, model_id: str) -> Path:
@@ -73,11 +73,8 @@ def upload_application(model_id: str, body: UploadAppRequest, upload_dir: Path) 
     """
     logger.info(f"Received request to upload app: {model_id}")
 
-    # model_id is the path component for the job dir; flip-api always sends a uuid4, so
-    # anything else is rejected before it can traverse out of the upload dir.
-    validate_model_id(model_id)
-
-    # This section takes care of taking every uploaded file and copying it to the model_id path.
+    # model_id is the Central Hub model UUID (validated as a UUID by the endpoint); it names
+    # the per-model job dir. This section copies every uploaded file into that dir.
 
     bundle_urls = body.bundle_urls  # Retrieve the files that the user has uploaded to the platform.
 

--- a/fl-services/flower/fl-api-flower/fl_api/utils/upload.py
+++ b/fl-services/flower/fl-api-flower/fl_api/utils/upload.py
@@ -8,6 +8,7 @@ from tomlkit import dumps, parse
 
 from fl_api.schemas import UploadAppRequest
 from fl_api.utils.logger import logger
+from fl_api.utils.validation import safe_join, validate_bundle_url, validate_model_id
 
 
 def _key_after_model_id(url: str, model_id: str) -> Path:
@@ -72,12 +73,16 @@ def upload_application(model_id: str, body: UploadAppRequest, upload_dir: Path) 
     """
     logger.info(f"Received request to upload app: {model_id}")
 
+    # model_id is the path component for the job dir; flip-api always sends a uuid4, so
+    # anything else is rejected before it can traverse out of the upload dir.
+    validate_model_id(model_id)
+
     # This section takes care of taking every uploaded file and copying it to the model_id path.
 
     bundle_urls = body.bundle_urls  # Retrieve the files that the user has uploaded to the platform.
 
     # We create the job app in the upload dir folder
-    job_dir = upload_dir / model_id
+    job_dir = safe_join(upload_dir, model_id)
 
     # If the job directory already exists, we remove it to avoid conflicts with previous uploads.
     if job_dir.exists():
@@ -92,9 +97,12 @@ def upload_application(model_id: str, body: UploadAppRequest, upload_dir: Path) 
     for url in bundle_urls:
         logger.info(f"Downloading file from {url}")
 
+        # The FL API fetches each URL server-side, so reject non-https / off-origin URLs.
+        validate_bundle_url(url)
+
         # Reconstruct structure under job_dir using the URL path after model_id
         relative_path = _key_after_model_id(url, model_id)  # e.g. app/config.toml
-        dest_path = job_dir / relative_path  # e.g. job_dir/app/config.toml
+        dest_path = safe_join(job_dir, *relative_path.parts)  # contained under job_dir
         dest_path.parent.mkdir(parents=True, exist_ok=True)
 
         try:

--- a/fl-services/flower/fl-api-flower/fl_api/utils/upload.py
+++ b/fl-services/flower/fl-api-flower/fl_api/utils/upload.py
@@ -103,12 +103,18 @@ def upload_application(model_id: str, body: UploadAppRequest, upload_dir: Path) 
         dest_path.parent.mkdir(parents=True, exist_ok=True)
 
         try:
-            with requests.get(url, stream=True, timeout=60) as resp:
+            with requests.get(url, stream=True, timeout=60, allow_redirects=False) as resp:
+                # A redirect would dodge validate_bundle_url (which only saw the original URL),
+                # reopening the SSRF hole; treat any 3xx as a failure.
+                if resp.is_redirect or resp.is_permanent_redirect:
+                    raise HTTPException(status_code=400, detail=f"Bundle URL returned a redirect: {url!r}.")
                 resp.raise_for_status()
                 with open(dest_path, "wb") as f:
                     for chunk in resp.iter_content(chunk_size=1024 * 1024):
                         if chunk:
                             f.write(chunk)
+        except HTTPException:
+            raise  # propagate the 400 redirect rejection unchanged (not a generic download failure)
         except Exception as e:
             logger.error(f"Failed to download file from {url} with error: {e}")
             raise HTTPException(status_code=500, detail=f"Failed to download file from {url}: {e}")

--- a/fl-services/flower/fl-api-flower/fl_api/utils/validation.py
+++ b/fl-services/flower/fl-api-flower/fl_api/utils/validation.py
@@ -20,6 +20,7 @@ operator with an SSM port-forward, could reach the API directly), every request 
 that becomes a filesystem path or an outbound fetch is validated here first.
 """
 
+import ipaddress
 import os
 import re
 from pathlib import Path
@@ -84,13 +85,15 @@ def safe_join(base: Path, *parts: str) -> Path:
 
 
 def validate_bundle_url(url: str) -> str:
-    """Reject bundle download URLs that are not https or not on the host allow-list.
+    """Reject bundle download URLs that are unsafe to fetch server-side.
 
     The FL API fetches every ``bundle_urls`` entry server-side, so an unchecked URL is an
-    SSRF vector. Requiring https blocks the common ``http://169.254.169.254`` metadata
-    fetch and non-http schemes (flip-api presigns S3 over https in every environment); an
-    optional comma-separated ``BUNDLE_URL_ALLOWED_HOSTS`` pins fetches to the expected
-    object-store origin when configured.
+    SSRF vector. The URL must be https, carry a host, use the default https port, and not
+    name a private / loopback / link-local IP literal. Requiring https blocks the common
+    ``http://169.254.169.254`` metadata fetch and non-http schemes (flip-api presigns S3
+    over https in every environment); an optional comma-separated ``BUNDLE_URL_ALLOWED_HOSTS``
+    pins fetches to the expected object-store origin when configured. DNS names are not
+    resolved here — the redirect-disabled fetch and the optional allow-list cover the rest.
 
     Args:
         url (str): A bundle download URL from the request body.
@@ -99,7 +102,8 @@ def validate_bundle_url(url: str) -> str:
         str: The validated URL, unchanged.
 
     Raises:
-        HTTPException: 400 if the scheme is not https or the host is not allow-listed.
+        HTTPException: 400 if the URL is not https, has no host, uses a non-443 port, names a
+            private/loopback/link-local IP literal, or is not on the host allow-list.
     """
     parsed = urlparse(url)
     if parsed.scheme != "https":
@@ -107,10 +111,44 @@ def validate_bundle_url(url: str) -> str:
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=f"Bundle URL must use https: {url!r}.",
         )
-    allowed = {host.strip().lower() for host in os.getenv("BUNDLE_URL_ALLOWED_HOSTS", "").split(",") if host.strip()}
-    if allowed and (parsed.hostname or "").lower() not in allowed:
+
+    hostname = parsed.hostname
+    if not hostname:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"Bundle URL host not allowed: {parsed.hostname!r}.",
+            detail=f"Bundle URL has no host: {url!r}.",
+        )
+
+    # Presigned S3 URLs are always served on 443; a custom port points at an internal service.
+    if parsed.port not in (None, 443):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Bundle URL port not allowed: {parsed.port}.",
+        )
+
+    # Block IP-literal hosts in non-public ranges. A host that is not an IP literal raises
+    # ValueError and is left to the https + optional allow-list checks (we do not resolve DNS).
+    try:
+        ip: ipaddress.IPv4Address | ipaddress.IPv6Address | None = ipaddress.ip_address(hostname)
+    except ValueError:
+        ip = None
+    if ip is not None and (
+        ip.is_private
+        or ip.is_loopback
+        or ip.is_link_local
+        or ip.is_reserved
+        or ip.is_multicast
+        or ip.is_unspecified
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Bundle URL host not allowed: {hostname!r}.",
+        )
+
+    allowed = {host.strip().lower() for host in os.getenv("BUNDLE_URL_ALLOWED_HOSTS", "").split(",") if host.strip()}
+    if allowed and hostname.lower() not in allowed:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Bundle URL host not allowed: {hostname!r}.",
         )
     return url

--- a/fl-services/flower/fl-api-flower/fl_api/utils/validation.py
+++ b/fl-services/flower/fl-api-flower/fl_api/utils/validation.py
@@ -37,8 +37,8 @@ def validate_tutorial_folder_name(name: str) -> str:
     """Reject tutorial folder names that could escape the source root.
 
     Accepts the pre-baked tutorial folder names (e.g. ``numpy``); rejects path separators,
-    parent references, hidden names and empty values. Production submit uses
-    ``validate_model_id`` instead — it only ever receives a UUID.
+    parent references, hidden names and empty values. Production submit takes a ``UUID``-typed
+    path param instead, so it needs no separate name guard.
 
     Args:
         name (str): The tutorial folder name taken from the request path.
@@ -120,10 +120,19 @@ def validate_bundle_url(url: str) -> str:
         )
 
     # Presigned S3 URLs are always served on 443; a custom port points at an internal service.
-    if parsed.port not in (None, 443):
+    # ``urlparse`` defers port parsing, so a malformed / out-of-range port raises ValueError on
+    # access here (not at ``urlparse`` above) — convert it to a clean 400 rather than a 500.
+    try:
+        port = parsed.port
+    except ValueError:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"Bundle URL port not allowed: {parsed.port}.",
+            detail=f"Bundle URL has an invalid port: {url!r}.",
+        ) from None
+    if port not in (None, 443):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Bundle URL port not allowed: {port}.",
         )
 
     # Block IP-literal hosts in non-public ranges. A host that is not an IP literal raises

--- a/fl-services/flower/fl-api-flower/fl_api/utils/validation.py
+++ b/fl-services/flower/fl-api-flower/fl_api/utils/validation.py
@@ -22,7 +22,6 @@ that becomes a filesystem path or an outbound fetch is validated here first.
 
 import os
 import re
-import uuid
 from pathlib import Path
 from urllib.parse import urlparse
 
@@ -31,31 +30,6 @@ from fastapi import HTTPException, status
 # Tutorial folders are submitted by name (e.g. "numpy", "3d_spleen_segmentation_evaluation"),
 # so the tutorial submit path can't be UUID-only; this guards the name instead.
 _SAFE_NAME = re.compile(r"^[A-Za-z0-9._-]+$")
-
-
-def validate_model_id(model_id: str) -> str:
-    """Reject any ``model_id`` that is not a canonical UUID.
-
-    flip-api (the only caller) always sends a ``uuid4``; a non-UUID value is either a bug
-    or an attempt to smuggle path-traversal sequences into the upload directory name.
-
-    Args:
-        model_id (str): The model identifier taken from the request path.
-
-    Returns:
-        str: The validated ``model_id``, unchanged.
-
-    Raises:
-        HTTPException: 400 if ``model_id`` is not a valid UUID.
-    """
-    try:
-        uuid.UUID(model_id)
-    except ValueError:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"Invalid model_id: {model_id!r} is not a valid UUID.",
-        ) from None
-    return model_id
 
 
 def validate_tutorial_folder_name(name: str) -> str:

--- a/fl-services/flower/fl-api-flower/fl_api/utils/validation.py
+++ b/fl-services/flower/fl-api-flower/fl_api/utils/validation.py
@@ -28,8 +28,8 @@ from urllib.parse import urlparse
 
 from fastapi import HTTPException, status
 
-# app_folder is either an uploaded-model UUID or a pre-baked tutorial folder
-# (e.g. "numpy", "3d_spleen_segmentation_evaluation"), so it cannot be UUID-only.
+# Tutorial folders are submitted by name (e.g. "numpy", "3d_spleen_segmentation_evaluation"),
+# so the tutorial submit path can't be UUID-only; this guards the name instead.
 _SAFE_NAME = re.compile(r"^[A-Za-z0-9._-]+$")
 
 
@@ -58,14 +58,15 @@ def validate_model_id(model_id: str) -> str:
     return model_id
 
 
-def validate_app_folder_name(name: str) -> str:
-    """Reject app/job folder names that could escape the source root.
+def validate_tutorial_folder_name(name: str) -> str:
+    """Reject tutorial folder names that could escape the source root.
 
-    Accepts uploaded-model UUIDs and the pre-baked tutorial folder names; rejects path
-    separators, parent references, hidden names and empty values.
+    Accepts the pre-baked tutorial folder names (e.g. ``numpy``); rejects path separators,
+    parent references, hidden names and empty values. Production submit uses
+    ``validate_model_id`` instead — it only ever receives a UUID.
 
     Args:
-        name (str): The app folder name taken from the request path.
+        name (str): The tutorial folder name taken from the request path.
 
     Returns:
         str: The validated name, unchanged.
@@ -76,7 +77,7 @@ def validate_app_folder_name(name: str) -> str:
     if not name or ".." in name or name.startswith(".") or not _SAFE_NAME.match(name):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"Invalid app folder name: {name!r}.",
+            detail=f"Invalid tutorial folder name: {name!r}.",
         )
     return name
 

--- a/fl-services/flower/fl-api-flower/fl_api/utils/validation.py
+++ b/fl-services/flower/fl-api-flower/fl_api/utils/validation.py
@@ -1,0 +1,141 @@
+# Copyright (c) 2026 Flower Labs GmbH
+# Copyright (c) 2026 Guy's and St Thomas' NHS Foundation Trust & King's College London
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Boundary input validation for the FL API.
+
+The FL API performs no authentication of its own — it trusts that the only caller is
+flip-api / fl-server on the trust's internal Docker network. To keep that trust from
+becoming a path-traversal or SSRF foothold (a compromised trust container, or an
+operator with an SSM port-forward, could reach the API directly), every request value
+that becomes a filesystem path or an outbound fetch is validated here first.
+"""
+
+import os
+import re
+import uuid
+from pathlib import Path
+from urllib.parse import urlparse
+
+from fastapi import HTTPException, status
+
+# app_folder is either an uploaded-model UUID or a pre-baked tutorial folder
+# (e.g. "numpy", "3d_spleen_segmentation_evaluation"), so it cannot be UUID-only.
+_SAFE_NAME = re.compile(r"^[A-Za-z0-9._-]+$")
+
+
+def validate_model_id(model_id: str) -> str:
+    """Reject any ``model_id`` that is not a canonical UUID.
+
+    flip-api (the only caller) always sends a ``uuid4``; a non-UUID value is either a bug
+    or an attempt to smuggle path-traversal sequences into the upload directory name.
+
+    Args:
+        model_id (str): The model identifier taken from the request path.
+
+    Returns:
+        str: The validated ``model_id``, unchanged.
+
+    Raises:
+        HTTPException: 400 if ``model_id`` is not a valid UUID.
+    """
+    try:
+        uuid.UUID(model_id)
+    except ValueError:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Invalid model_id: {model_id!r} is not a valid UUID.",
+        ) from None
+    return model_id
+
+
+def validate_app_folder_name(name: str) -> str:
+    """Reject app/job folder names that could escape the source root.
+
+    Accepts uploaded-model UUIDs and the pre-baked tutorial folder names; rejects path
+    separators, parent references, hidden names and empty values.
+
+    Args:
+        name (str): The app folder name taken from the request path.
+
+    Returns:
+        str: The validated name, unchanged.
+
+    Raises:
+        HTTPException: 400 if the name contains traversal sequences or illegal characters.
+    """
+    if not name or ".." in name or name.startswith(".") or not _SAFE_NAME.match(name):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Invalid app folder name: {name!r}.",
+        )
+    return name
+
+
+def safe_join(base: Path, *parts: str) -> Path:
+    """Join untrusted components onto ``base`` and confirm the result stays within it.
+
+    Guards against ``..`` or absolute components in caller-derived relative paths (e.g. a
+    bundle URL's path segments) escaping the job directory. ``base`` may not yet exist;
+    only the parent-containment relationship is enforced.
+
+    Args:
+        base (Path): The trusted base directory the result must stay within.
+        *parts (str): Untrusted path components to join onto ``base``.
+
+    Returns:
+        Path: The resolved path, guaranteed to be inside ``base``.
+
+    Raises:
+        HTTPException: 400 if the joined path resolves outside ``base``.
+    """
+    base_resolved = base.resolve()
+    target = base_resolved.joinpath(*parts).resolve()
+    if not target.is_relative_to(base_resolved):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Unsafe path {Path(*parts)!r} escapes {base}.",
+        )
+    return target
+
+
+def validate_bundle_url(url: str) -> str:
+    """Reject bundle download URLs that are not https or not on the host allow-list.
+
+    The FL API fetches every ``bundle_urls`` entry server-side, so an unchecked URL is an
+    SSRF vector. Requiring https blocks the common ``http://169.254.169.254`` metadata
+    fetch and non-http schemes (flip-api presigns S3 over https in every environment); an
+    optional comma-separated ``BUNDLE_URL_ALLOWED_HOSTS`` pins fetches to the expected
+    object-store origin when configured.
+
+    Args:
+        url (str): A bundle download URL from the request body.
+
+    Returns:
+        str: The validated URL, unchanged.
+
+    Raises:
+        HTTPException: 400 if the scheme is not https or the host is not allow-listed.
+    """
+    parsed = urlparse(url)
+    if parsed.scheme != "https":
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Bundle URL must use https: {url!r}.",
+        )
+    allowed = {host.strip().lower() for host in os.getenv("BUNDLE_URL_ALLOWED_HOSTS", "").split(",") if host.strip()}
+    if allowed and (parsed.hostname or "").lower() not in allowed:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Bundle URL host not allowed: {parsed.hostname!r}.",
+        )
+    return url

--- a/fl-services/flower/fl-api-flower/tests/test_abort_run.py
+++ b/fl-services/flower/fl-api-flower/tests/test_abort_run.py
@@ -69,9 +69,17 @@ def test_abort_run_failure_when_run_not_terminal(client, src_root, mock_flwr_run
         }
     )
 
-    response = client.delete("/abort_run/does-not-exist")
+    response = client.delete("/abort_run/1234567890")
 
     assert response.status_code == 500
+
+
+def test_abort_run_rejects_non_numeric_run_id(client, src_root):
+    # Flower run ids are integers, so a non-numeric path segment is rejected by FastAPI
+    # (422) before it can reach the `flwr stop` command line.
+    response = client.delete("/abort_run/not-a-number")
+
+    assert response.status_code == 422
 
 
 def test_abort_run_failure_when_terminal_run_missing_status(client, src_root, mock_flwr_run):

--- a/fl-services/flower/fl-api-flower/tests/test_contract.py
+++ b/fl-services/flower/fl-api-flower/tests/test_contract.py
@@ -29,7 +29,8 @@ def test_docs_and_openapi_contract(client):
         "/check_server_status",
         "/check_client_status",
         "/list_runs",
-        "/submit_run/{app_folder}",
+        "/submit_run/{job_folder}",
+        "/submit_tutorial/{tutorial_name}",
         "/abort_run/{run_id}",
         "/upload_app/{model_id}",
     ):
@@ -43,7 +44,7 @@ def test_docs_and_openapi_contract(client):
         "application/json"
     ]["schema"]
     list_schema = spec["paths"]["/list_runs"]["get"]["responses"]["200"]["content"]["application/json"]["schema"]
-    submit_schema = spec["paths"]["/submit_run/{app_folder}"]["post"]["responses"]["200"]["content"][
+    submit_schema = spec["paths"]["/submit_run/{job_folder}"]["post"]["responses"]["200"]["content"][
         "application/json"
     ]["schema"]
     abort_schema = spec["paths"]["/abort_run/{run_id}"]["delete"]["responses"]["200"]["content"]["application/json"][

--- a/fl-services/flower/fl-api-flower/tests/test_submit_run.py
+++ b/fl-services/flower/fl-api-flower/tests/test_submit_run.py
@@ -15,6 +15,7 @@ import subprocess
 from pathlib import Path
 
 import pytest
+from fastapi import HTTPException
 from tomlkit import parse
 
 from fl_api import app as app_module
@@ -128,3 +129,11 @@ def test_submit_run_execution_failures(
     response = client.post("/submit_run/numpy")
 
     assert response.status_code == 500
+
+
+@pytest.mark.parametrize("bad", ["..", "../etc", "a/b", ".hidden"])
+def test_validate_app_folder_rejects_traversal(src_root, bad):
+    """app_folder names with traversal sequences or separators are rejected (400)."""
+    with pytest.raises(HTTPException) as exc:
+        app_module._validate_app_folder(bad)
+    assert exc.value.status_code == 400

--- a/fl-services/flower/fl-api-flower/tests/test_submit_run.py
+++ b/fl-services/flower/fl-api-flower/tests/test_submit_run.py
@@ -55,10 +55,10 @@ def test_submit_job_alias_with_uuid_success(client, src_root, mock_flwr_run):
 
 @pytest.mark.parametrize("endpoint", ["/submit_run", "/submit_job"])
 def test_production_submit_rejects_non_uuid(client, src_root, endpoint):
-    """A non-UUID (e.g. a tutorial folder name) is rejected with 400 on the production endpoints."""
+    """A non-UUID (e.g. a tutorial folder name) is rejected by FastAPI UUID validation (422)."""
     response = client.post(f"{endpoint}/numpy")
 
-    assert response.status_code == 400
+    assert response.status_code == 422
 
 
 # --- Tutorial submit: /submit_tutorial is name-based (still traversal-guarded) ---
@@ -164,12 +164,4 @@ def test_validate_tutorial_folder_rejects_traversal(src_root, bad):
     """Tutorial folder names with traversal sequences or separators are rejected (400)."""
     with pytest.raises(HTTPException) as exc:
         app_module._validate_tutorial_folder(bad)
-    assert exc.value.status_code == 400
-
-
-@pytest.mark.parametrize("bad", ["numpy", "not-a-uuid", "../etc"])
-def test_validate_job_folder_rejects_non_uuid(src_root, bad):
-    """The production submit validator requires a UUID."""
-    with pytest.raises(HTTPException) as exc:
-        app_module._validate_job_folder(bad)
     assert exc.value.status_code == 400

--- a/fl-services/flower/fl-api-flower/tests/test_submit_run.py
+++ b/fl-services/flower/fl-api-flower/tests/test_submit_run.py
@@ -13,6 +13,7 @@
 
 import subprocess
 from pathlib import Path
+from uuid import uuid4
 
 import pytest
 from fastapi import HTTPException
@@ -20,31 +21,60 @@ from tomlkit import parse
 
 from fl_api import app as app_module
 
+_NUMPY_RUN_OK = (
+    '{"success": true,"run-id":"5489160741982607593",'
+    '"fab-id":"flwrlabs/quickstart-numpy","fab-name":"quickstart-numpy",'
+    '"fab-version":"1.0.0","fab-hash":"9fcfbb69",'
+    '"fab-filename":"flwrlabs.quickstart-numpy.1-0-0.9fcfbb69.fab"}'
+)
 
-def test_submit_run_success(client, src_root, mock_flwr_run, monkeypatch):
-    (src_root / "numpy").mkdir(parents=True, exist_ok=True)
-    monkeypatch.setenv("ALLOWED_JOB_FOLDERS", "numpy,3d_spleen_segmentation")
-    mock_flwr_run(
-        stdout=(
-            "{"
-            '"success": true,'
-            '"run-id":"5489160741982607593",'
-            '"fab-id":"flwrlabs/quickstart-numpy",'
-            '"fab-name":"quickstart-numpy",'
-            '"fab-version":"1.0.0",'
-            '"fab-hash":"9fcfbb69",'
-            '"fab-filename":"flwrlabs.quickstart-numpy.1-0-0.9fcfbb69.fab"'
-            "}"
-        )
-    )
 
-    response = client.post("/submit_run/numpy")
+# --- Production submit: /submit_run + /submit_job are UUID-strict ---
+
+
+def test_submit_run_with_uuid_success(client, src_root, mock_flwr_run):
+    model_id = str(uuid4())
+    (src_root / model_id).mkdir(parents=True, exist_ok=True)
+    mock_flwr_run(stdout=_NUMPY_RUN_OK)
+
+    response = client.post(f"/submit_run/{model_id}")
 
     assert response.status_code == 200
 
 
-def test_submit_run_merges_flip_job_dir_into_run_config(client, src_root, monkeypatch):
-    """submit_run merges flip-job-dir into a temp run-config file, leaving config.toml untouched."""
+def test_submit_job_alias_with_uuid_success(client, src_root, mock_flwr_run):
+    """The /submit_job alias (what flip-api calls) behaves identically and is UUID-strict."""
+    model_id = str(uuid4())
+    (src_root / model_id).mkdir(parents=True, exist_ok=True)
+    mock_flwr_run(stdout='{"success": true,"run-id":"123"}')
+
+    response = client.post(f"/submit_job/{model_id}")
+
+    assert response.status_code == 200
+
+
+@pytest.mark.parametrize("endpoint", ["/submit_run", "/submit_job"])
+def test_production_submit_rejects_non_uuid(client, src_root, endpoint):
+    """A non-UUID (e.g. a tutorial folder name) is rejected with 400 on the production endpoints."""
+    response = client.post(f"{endpoint}/numpy")
+
+    assert response.status_code == 400
+
+
+# --- Tutorial submit: /submit_tutorial is name-based (still traversal-guarded) ---
+
+
+def test_submit_tutorial_success(client, src_root, mock_flwr_run):
+    (src_root / "numpy").mkdir(parents=True, exist_ok=True)
+    mock_flwr_run(stdout=_NUMPY_RUN_OK)
+
+    response = client.post("/submit_tutorial/numpy")
+
+    assert response.status_code == 200
+
+
+def test_submit_tutorial_merges_flip_job_dir_into_run_config(client, src_root, monkeypatch):
+    """submit merges flip-job-dir into a temp run-config file, leaving config.toml untouched."""
     app_dir = src_root / "eval_app" / "app"
     app_dir.mkdir(parents=True, exist_ok=True)
     config_toml = app_dir / "config.toml"
@@ -54,7 +84,7 @@ def test_submit_run_merges_flip_job_dir_into_run_config(client, src_root, monkey
 
     def _capture(command, *_args, **_kwargs):
         captured["command"] = command
-        # the temp --run-config file still exists here (before submit_run's finally)
+        # the temp --run-config file still exists here (before the finally block)
         run_config_arg = command[command.index("--run-config") + 1]
         captured["run_config"] = parse(Path(run_config_arg).read_text())
         return subprocess.CompletedProcess(
@@ -70,10 +100,10 @@ def test_submit_run_merges_flip_job_dir_into_run_config(client, src_root, monkey
 
     monkeypatch.setattr(app_module.subprocess, "run", _capture)
 
-    response = client.post("/submit_run/eval_app")
+    response = client.post("/submit_tutorial/eval_app")
+
     assert response.status_code == 200
 
-    # the run-config passed to flwr merges flip-job-dir with the app's config.toml
     run_config = captured["run_config"]
     assert run_config["flip-job-dir"] == str(app_dir)
     assert run_config["checkpoint"] == "model.pt"
@@ -81,21 +111,18 @@ def test_submit_run_merges_flip_job_dir_into_run_config(client, src_root, monkey
     assert config_toml.read_text() == 'checkpoint = "model.pt"\n'
 
 
-@pytest.mark.parametrize("app_folder", ["invalid", "numpy"])
-def test_submit_run_input_validation(client, src_root, monkeypatch, app_folder):
-    monkeypatch.setenv("ALLOWED_JOB_FOLDERS", "numpy,3d_spleen_segmentation")
-
-    response = client.post(f"/submit_run/{app_folder}")
+def test_submit_tutorial_folder_not_found(client, src_root):
+    """A valid-but-nonexistent tutorial folder is rejected with 400."""
+    response = client.post("/submit_tutorial/numpy")
 
     assert response.status_code == 400
 
 
-def test_submit_run_conflict_when_submission_in_progress(client, src_root, monkeypatch):
+def test_submit_tutorial_conflict_when_submission_in_progress(client, src_root):
     (src_root / "numpy").mkdir(parents=True, exist_ok=True)
-    monkeypatch.setenv("ALLOWED_JOB_FOLDERS", "numpy,3d_spleen_segmentation")
     app_module._submission_in_progress = True
 
-    response = client.post("/submit_run/numpy")
+    response = client.post("/submit_tutorial/numpy")
 
     assert response.status_code == 409
 
@@ -108,32 +135,41 @@ def test_submit_run_conflict_when_submission_in_progress(client, src_root, monke
         (None, 0, "not-json", ""),
     ],
 )
-def test_submit_run_execution_failures(
+def test_submit_tutorial_execution_failures(
     client,
     src_root,
     mock_flwr_run,
-    monkeypatch,
     exception,
     returncode,
     stdout,
     stderr,
 ):
     (src_root / "numpy").mkdir(parents=True, exist_ok=True)
-    monkeypatch.setenv("ALLOWED_JOB_FOLDERS", "numpy,3d_spleen_segmentation")
 
     if exception is not None:
         mock_flwr_run(exception=exception)
     else:
         mock_flwr_run(returncode=returncode, stdout=stdout, stderr=stderr)
 
-    response = client.post("/submit_run/numpy")
+    response = client.post("/submit_tutorial/numpy")
 
     assert response.status_code == 500
 
 
+# --- Validator units ---
+
+
 @pytest.mark.parametrize("bad", ["..", "../etc", "a/b", ".hidden"])
-def test_validate_app_folder_rejects_traversal(src_root, bad):
-    """app_folder names with traversal sequences or separators are rejected (400)."""
+def test_validate_tutorial_folder_rejects_traversal(src_root, bad):
+    """Tutorial folder names with traversal sequences or separators are rejected (400)."""
     with pytest.raises(HTTPException) as exc:
-        app_module._validate_app_folder(bad)
+        app_module._validate_tutorial_folder(bad)
+    assert exc.value.status_code == 400
+
+
+@pytest.mark.parametrize("bad", ["numpy", "not-a-uuid", "../etc"])
+def test_validate_job_folder_rejects_non_uuid(src_root, bad):
+    """The production submit validator requires a UUID."""
+    with pytest.raises(HTTPException) as exc:
+        app_module._validate_job_folder(bad)
     assert exc.value.status_code == 400

--- a/fl-services/flower/fl-api-flower/tests/test_upload_app.py
+++ b/fl-services/flower/fl-api-flower/tests/test_upload_app.py
@@ -12,6 +12,7 @@
 #
 
 from unittest.mock import Mock
+from uuid import uuid4
 
 import pytest
 from tomlkit import parse
@@ -56,7 +57,7 @@ def mock_requests_get(monkeypatch):
 
 def test_upload_app_basic_success(client, upload_dir, mock_requests_get):
     """Test basic app upload with pyproject.toml and config.toml."""
-    model_id = "test-model-123"
+    model_id = str(uuid4())
 
     pyproject_content = b"""
 [tool.flwr.app]
@@ -101,7 +102,7 @@ checkpoint = "model.pt"
 
 def test_upload_app_injects_flip_params_without_touching_pyproject(client, upload_dir, mock_requests_get):
     """config.toml receives the FLIP params; pyproject.toml is left untouched."""
-    model_id = "test-inject-123"
+    model_id = str(uuid4())
 
     pyproject_content = b"""
 [tool.flwr.app]
@@ -163,7 +164,7 @@ def test_upload_app_places_checkpoint_in_job_dir(client, upload_dir, mock_reques
     They are no longer routed to a separate volume: the evaluation ServerApp reads
     them from the job dir via the injected flip-job-dir run-config value.
     """
-    model_id = "test-checkpoint-123"
+    model_id = str(uuid4())
 
     pyproject_content = b"""
 [tool.flwr.app]
@@ -199,7 +200,7 @@ num_server_rounds = 3
 
 def test_upload_app_keeps_config_toml_in_app_dir(client, upload_dir, mock_requests_get):
     """config.toml stays in app/ (where submit_run reads it); it is not moved to the job root."""
-    model_id = "test-config-location-123"
+    model_id = str(uuid4())
 
     pyproject_content = b"""
 [tool.flwr.app]
@@ -244,7 +245,7 @@ path = "model_path"
 
 def test_upload_app_download_failure(client, upload_dir, mock_requests_get):
     """Test that upload fails gracefully when file download fails."""
-    model_id = "test-download-fail-123"
+    model_id = str(uuid4())
 
     # Mock only one URL, making the second fail
     mock_requests_get({
@@ -268,7 +269,7 @@ def test_upload_app_download_failure(client, upload_dir, mock_requests_get):
 
 def test_upload_app_cleans_existing_directories(client, upload_dir, mock_requests_get):
     """Test that an existing job directory is cleaned before upload."""
-    model_id = "test-clean-123"
+    model_id = str(uuid4())
 
     # Create an existing job directory with an old file
     job_dir = upload_dir / model_id
@@ -305,3 +306,58 @@ num_server_rounds = 3
 
     # New file should exist
     assert (job_dir / "pyproject.toml").exists()
+
+
+def test_upload_app_rejects_non_uuid_model_id(client, upload_dir):
+    """A non-UUID model_id (e.g. a traversal attempt) is rejected before any filesystem write."""
+    body = UploadAppRequest(project_id="p", cohort_query="*", trusts=["t"], bundle_urls=[])
+
+    response = client.post("/upload_app/not-a-uuid", json=body.model_dump())
+
+    assert response.status_code == 400
+
+
+def test_upload_app_rejects_path_traversal_bundle_url(client, upload_dir):
+    """A bundle URL whose path escapes the model dir is rejected by the containment check."""
+    model_id = str(uuid4())
+    body = UploadAppRequest(
+        project_id="p",
+        cohort_query="*",
+        trusts=["t"],
+        bundle_urls=[f"https://example.com/{model_id}/../../etc/passwd"],
+    )
+
+    response = client.post(f"/upload_app/{model_id}", json=body.model_dump())
+
+    assert response.status_code == 400
+
+
+def test_upload_app_rejects_non_https_bundle_url(client, upload_dir):
+    """Non-https bundle URLs (SSRF vector, e.g. the metadata endpoint) are rejected."""
+    model_id = str(uuid4())
+    body = UploadAppRequest(
+        project_id="p",
+        cohort_query="*",
+        trusts=["t"],
+        bundle_urls=[f"http://169.254.169.254/{model_id}/app/config.toml"],
+    )
+
+    response = client.post(f"/upload_app/{model_id}", json=body.model_dump())
+
+    assert response.status_code == 400
+
+
+def test_upload_app_rejects_disallowed_bundle_host(client, upload_dir, monkeypatch):
+    """When BUNDLE_URL_ALLOWED_HOSTS is set, off-origin bundle URLs are rejected."""
+    monkeypatch.setenv("BUNDLE_URL_ALLOWED_HOSTS", "objectstore.internal")
+    model_id = str(uuid4())
+    body = UploadAppRequest(
+        project_id="p",
+        cohort_query="*",
+        trusts=["t"],
+        bundle_urls=[f"https://example.com/{model_id}/app/config.toml"],
+    )
+
+    response = client.post(f"/upload_app/{model_id}", json=body.model_dump())
+
+    assert response.status_code == 400

--- a/fl-services/flower/fl-api-flower/tests/test_upload_app.py
+++ b/fl-services/flower/fl-api-flower/tests/test_upload_app.py
@@ -309,12 +309,12 @@ num_server_rounds = 3
 
 
 def test_upload_app_rejects_non_uuid_model_id(client, upload_dir):
-    """A non-UUID model_id (e.g. a traversal attempt) is rejected before any filesystem write."""
+    """A non-UUID model_id is rejected by FastAPI's UUID path-param validation (422)."""
     body = UploadAppRequest(project_id="p", cohort_query="*", trusts=["t"], bundle_urls=[])
 
     response = client.post("/upload_app/not-a-uuid", json=body.model_dump())
 
-    assert response.status_code == 400
+    assert response.status_code == 422
 
 
 def test_upload_app_rejects_path_traversal_bundle_url(client, upload_dir):

--- a/fl-services/flower/fl-api-flower/tests/test_upload_app.py
+++ b/fl-services/flower/fl-api-flower/tests/test_upload_app.py
@@ -34,9 +34,11 @@ def mock_requests_get(monkeypatch):
     """Mock requests.get to simulate file downloads."""
 
     def _mock_get(url_to_content: dict[str, bytes]):
-        def _get(url, stream=True, timeout=60):
+        def _get(url, stream=True, timeout=60, allow_redirects=True):
             mock_response = Mock()
             mock_response.raise_for_status = Mock()
+            mock_response.is_redirect = False
+            mock_response.is_permanent_redirect = False
             if url in url_to_content:
                 content = url_to_content[url]
                 mock_response.iter_content = Mock(return_value=[content])
@@ -356,6 +358,35 @@ def test_upload_app_rejects_disallowed_bundle_host(client, upload_dir, monkeypat
         cohort_query="*",
         trusts=["t"],
         bundle_urls=[f"https://example.com/{model_id}/app/config.toml"],
+    )
+
+    response = client.post(f"/upload_app/{model_id}", json=body.model_dump())
+
+    assert response.status_code == 400
+
+
+def test_upload_app_rejects_redirect_response(client, upload_dir, monkeypatch):
+    """A 3xx redirect on a bundle fetch is rejected: it would dodge validate_bundle_url (SSRF)."""
+    model_id = str(uuid4())
+
+    def _redirecting_get(url, stream=True, timeout=60, allow_redirects=True):
+        mock_response = Mock()
+        mock_response.is_redirect = True
+        mock_response.is_permanent_redirect = False
+        mock_response.raise_for_status = Mock()
+        mock_response.__enter__ = Mock(return_value=mock_response)
+        mock_response.__exit__ = Mock(return_value=False)
+        return mock_response
+
+    import fl_api.utils.upload as upload_module
+
+    monkeypatch.setattr(upload_module.requests, "get", _redirecting_get)
+
+    body = UploadAppRequest(
+        project_id="project-123",
+        cohort_query="*",
+        trusts=["trust1"],
+        bundle_urls=[f"https://example.com/{model_id}/pyproject.toml"],
     )
 
     response = client.post(f"/upload_app/{model_id}", json=body.model_dump())

--- a/fl-services/flower/fl-api-flower/tests/test_validation.py
+++ b/fl-services/flower/fl-api-flower/tests/test_validation.py
@@ -19,21 +19,8 @@ from fastapi import HTTPException
 from fl_api.utils.validation import (
     safe_join,
     validate_bundle_url,
-    validate_model_id,
     validate_tutorial_folder_name,
 )
-
-
-def test_validate_model_id_accepts_uuid():
-    model_id = str(uuid4())
-    assert validate_model_id(model_id) == model_id
-
-
-@pytest.mark.parametrize("bad", ["", "not-a-uuid", "../etc", "abc/def", "test-model-123"])
-def test_validate_model_id_rejects_non_uuid(bad):
-    with pytest.raises(HTTPException) as exc:
-        validate_model_id(bad)
-    assert exc.value.status_code == 400
 
 
 @pytest.mark.parametrize("name", ["numpy", "3d_spleen_segmentation_evaluation", str(uuid4()), "app-trust1"])

--- a/fl-services/flower/fl-api-flower/tests/test_validation.py
+++ b/fl-services/flower/fl-api-flower/tests/test_validation.py
@@ -70,3 +70,25 @@ def test_validate_bundle_url_enforces_host_allow_list(monkeypatch):
     with pytest.raises(HTTPException) as exc:
         validate_bundle_url("https://evil.example.com/key")
     assert exc.value.status_code == 400
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        "https:///bundle/app/config.toml",  # no host
+        "https://127.0.0.1/x",  # loopback IP literal
+        "https://10.0.0.5/x",  # private IP literal
+        "https://169.254.169.254/x",  # link-local IP literal (metadata endpoint over https)
+        "https://[::1]/x",  # IPv6 loopback literal
+        "https://s3.eu-west-2.amazonaws.com:8080/bucket/key",  # non-443 port
+    ],
+)
+def test_validate_bundle_url_rejects_unsafe_hosts(bad):
+    with pytest.raises(HTTPException) as exc:
+        validate_bundle_url(bad)
+    assert exc.value.status_code == 400
+
+
+def test_validate_bundle_url_accepts_explicit_443():
+    url = "https://s3.eu-west-2.amazonaws.com:443/bucket/key"
+    assert validate_bundle_url(url) == url

--- a/fl-services/flower/fl-api-flower/tests/test_validation.py
+++ b/fl-services/flower/fl-api-flower/tests/test_validation.py
@@ -18,9 +18,9 @@ from fastapi import HTTPException
 
 from fl_api.utils.validation import (
     safe_join,
-    validate_app_folder_name,
     validate_bundle_url,
     validate_model_id,
+    validate_tutorial_folder_name,
 )
 
 
@@ -37,14 +37,14 @@ def test_validate_model_id_rejects_non_uuid(bad):
 
 
 @pytest.mark.parametrize("name", ["numpy", "3d_spleen_segmentation_evaluation", str(uuid4()), "app-trust1"])
-def test_validate_app_folder_name_accepts_valid(name):
-    assert validate_app_folder_name(name) == name
+def test_validate_tutorial_folder_name_accepts_valid(name):
+    assert validate_tutorial_folder_name(name) == name
 
 
 @pytest.mark.parametrize("bad", ["", "..", "../etc", "a/b", "a\\b", ".hidden", "a b", "a;b"])
-def test_validate_app_folder_name_rejects_traversal_and_illegal(bad):
+def test_validate_tutorial_folder_name_rejects_traversal_and_illegal(bad):
     with pytest.raises(HTTPException) as exc:
-        validate_app_folder_name(bad)
+        validate_tutorial_folder_name(bad)
     assert exc.value.status_code == 400
 
 

--- a/fl-services/flower/fl-api-flower/tests/test_validation.py
+++ b/fl-services/flower/fl-api-flower/tests/test_validation.py
@@ -1,0 +1,85 @@
+# Copyright (c) 2026 Flower Labs GmbH
+# Copyright (c) 2026 Guy's and St Thomas' NHS Foundation Trust & King's College London
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from uuid import uuid4
+
+import pytest
+from fastapi import HTTPException
+
+from fl_api.utils.validation import (
+    safe_join,
+    validate_app_folder_name,
+    validate_bundle_url,
+    validate_model_id,
+)
+
+
+def test_validate_model_id_accepts_uuid():
+    model_id = str(uuid4())
+    assert validate_model_id(model_id) == model_id
+
+
+@pytest.mark.parametrize("bad", ["", "not-a-uuid", "../etc", "abc/def", "test-model-123"])
+def test_validate_model_id_rejects_non_uuid(bad):
+    with pytest.raises(HTTPException) as exc:
+        validate_model_id(bad)
+    assert exc.value.status_code == 400
+
+
+@pytest.mark.parametrize("name", ["numpy", "3d_spleen_segmentation_evaluation", str(uuid4()), "app-trust1"])
+def test_validate_app_folder_name_accepts_valid(name):
+    assert validate_app_folder_name(name) == name
+
+
+@pytest.mark.parametrize("bad", ["", "..", "../etc", "a/b", "a\\b", ".hidden", "a b", "a;b"])
+def test_validate_app_folder_name_rejects_traversal_and_illegal(bad):
+    with pytest.raises(HTTPException) as exc:
+        validate_app_folder_name(bad)
+    assert exc.value.status_code == 400
+
+
+def test_safe_join_returns_contained_path(tmp_path):
+    result = safe_join(tmp_path, "app", "config.toml")
+    assert result == (tmp_path / "app" / "config.toml").resolve()
+    assert result.is_relative_to(tmp_path.resolve())
+
+
+def test_safe_join_allows_empty_parts(tmp_path):
+    assert safe_join(tmp_path, "") == tmp_path.resolve()
+
+
+@pytest.mark.parametrize("parts", [("..",), ("..", "..", "etc"), ("/etc/passwd",), ("app", "..", "..", "secret")])
+def test_safe_join_rejects_escape(tmp_path, parts):
+    with pytest.raises(HTTPException) as exc:
+        safe_join(tmp_path, *parts)
+    assert exc.value.status_code == 400
+
+
+def test_validate_bundle_url_accepts_https():
+    url = "https://example.com/bundle/app/config.toml"
+    assert validate_bundle_url(url) == url
+
+
+@pytest.mark.parametrize("bad", ["http://example.com/x", "http://169.254.169.254/latest/meta-data/", "file:///etc/passwd"])
+def test_validate_bundle_url_rejects_non_https(bad):
+    with pytest.raises(HTTPException) as exc:
+        validate_bundle_url(bad)
+    assert exc.value.status_code == 400
+
+
+def test_validate_bundle_url_enforces_host_allow_list(monkeypatch):
+    monkeypatch.setenv("BUNDLE_URL_ALLOWED_HOSTS", "objectstore.internal, s3.eu-west-2.amazonaws.com")
+    assert validate_bundle_url("https://s3.eu-west-2.amazonaws.com/bucket/key")
+    with pytest.raises(HTTPException) as exc:
+        validate_bundle_url("https://evil.example.com/key")
+    assert exc.value.status_code == 400

--- a/fl-services/flower/fl-api-flower/tests/test_validation.py
+++ b/fl-services/flower/fl-api-flower/tests/test_validation.py
@@ -81,6 +81,8 @@ def test_validate_bundle_url_enforces_host_allow_list(monkeypatch):
         "https://169.254.169.254/x",  # link-local IP literal (metadata endpoint over https)
         "https://[::1]/x",  # IPv6 loopback literal
         "https://s3.eu-west-2.amazonaws.com:8080/bucket/key",  # non-443 port
+        "https://s3.eu-west-2.amazonaws.com:bad/bucket/key",  # non-numeric port -> clean 400, not 500
+        "https://s3.eu-west-2.amazonaws.com:99999/bucket/key",  # out-of-range port -> clean 400, not 500
     ],
 )
 def test_validate_bundle_url_rejects_unsafe_hosts(bad):

--- a/fl-services/nvflare/fl-api-base/fl_api/routers/application.py
+++ b/fl-services/nvflare/fl-api-base/fl_api/routers/application.py
@@ -12,6 +12,8 @@
 
 # Application: upload, monitor
 
+from uuid import UUID
+
 from fastapi import APIRouter, Depends, status
 
 from fl_api.core.dependencies import get_session
@@ -23,19 +25,20 @@ router = APIRouter()
 
 
 @router.post("/upload_app/{model_id}", status_code=status.HTTP_200_OK)
-def upload_app(model_id: str, body: UploadAppRequest, session: FLIP_Session = Depends(get_session)) -> dict[str, str]:
+def upload_app(model_id: UUID, body: UploadAppRequest, session: FLIP_Session = Depends(get_session)) -> dict[str, str]:
     """
     Upload an application to the server.
 
     Args:
-        model_id (str): The ID of the model to associate the application with.
+        model_id (UUID): The Central Hub model_id; names the per-model job dir that submit
+            later runs from. FastAPI rejects any non-UUID path segment with 422.
         body (UploadAppRequest): The request body containing the application details.
         session (FLIP_Session): The NVFlare session instance.
 
     Returns:
         dict[str, str]: A dictionary containing the status of the upload.
     """
-    return upload_application(model_id, body, upload_dir=session.upload_dir)
+    return upload_application(str(model_id), body, upload_dir=session.upload_dir)
 
 
 @router.get("/get_available_apps_to_upload", status_code=status.HTTP_200_OK, response_model=list[str])

--- a/fl-services/nvflare/fl-api-base/fl_api/routers/jobs.py
+++ b/fl-services/nvflare/fl-api-base/fl_api/routers/jobs.py
@@ -19,6 +19,7 @@ from nvflare.fuel.hci.client.fl_admin_api import TargetType
 from fl_api.core.dependencies import get_session
 from fl_api.utils.flip_session import FLIP_Session
 from fl_api.utils.schemas import JobMetadata, JobStatus, normalize_status
+from fl_api.utils.validation import validate_model_id
 
 router = APIRouter()
 
@@ -38,6 +39,10 @@ def submit_job(job_folder: str, session: FLIP_Session = Depends(get_session)) ->
     Raises:
         HTTPException: if the job submission fails due to any reason.
     """
+    # flip-api submits an uploaded model by its uuid4; reject anything else before it
+    # reaches the NVFLARE admin API or a filesystem path. (nvflare tutorials run on the
+    # simulator, not this endpoint, so there is no name-based submission path here.)
+    validate_model_id(job_folder)
     return session.submit_job(job_folder)
 
 

--- a/fl-services/nvflare/fl-api-base/fl_api/routers/jobs.py
+++ b/fl-services/nvflare/fl-api-base/fl_api/routers/jobs.py
@@ -12,6 +12,7 @@
 
 # Job functions: upload, monitor, delete and handle jobs
 from typing import Optional, Union
+from uuid import UUID
 
 from fastapi import APIRouter, Depends, status
 from nvflare.fuel.hci.client.fl_admin_api import TargetType
@@ -19,18 +20,20 @@ from nvflare.fuel.hci.client.fl_admin_api import TargetType
 from fl_api.core.dependencies import get_session
 from fl_api.utils.flip_session import FLIP_Session
 from fl_api.utils.schemas import JobMetadata, JobStatus, normalize_status
-from fl_api.utils.validation import validate_model_id
 
 router = APIRouter()
 
 
 @router.post("/submit_job/{job_folder}")
-def submit_job(job_folder: str, session: FLIP_Session = Depends(get_session)) -> str:
+def submit_job(job_folder: UUID, session: FLIP_Session = Depends(get_session)) -> str:
     """
     Submits an existing job to the server.
 
     Args:
-        job_folder (str): folder where the job is located.
+        job_folder (UUID): The Central Hub model_id. The uploaded job lives in the folder
+            named after it (created by /upload_app/{model_id}), so the submit "job folder"
+            and the upload "model_id" are the same UUID; flip-api is the only caller.
+            FastAPI rejects any non-UUID path segment with 422 before this handler runs.
         session (FLIP_Session): FLIP session instance.
 
     Returns:
@@ -39,11 +42,7 @@ def submit_job(job_folder: str, session: FLIP_Session = Depends(get_session)) ->
     Raises:
         HTTPException: if the job submission fails due to any reason.
     """
-    # flip-api submits an uploaded model by its uuid4; reject anything else before it
-    # reaches the NVFLARE admin API or a filesystem path. (nvflare tutorials run on the
-    # simulator, not this endpoint, so there is no name-based submission path here.)
-    validate_model_id(job_folder)
-    return session.submit_job(job_folder)
+    return session.submit_job(str(job_folder))
 
 
 @router.get("/download_job/{job_id}")

--- a/fl-services/nvflare/fl-api-base/fl_api/utils/upload.py
+++ b/fl-services/nvflare/fl-api-base/fl_api/utils/upload.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from urllib.parse import urlparse
 
 import requests
+from fastapi import HTTPException
 
 from fl_api.utils.constants import META
 from fl_api.utils.io_utils import read_config
@@ -170,7 +171,13 @@ def upload_application(model_id: str, body: UploadAppRequest, upload_dir: str) -
         s3_file_dir, file_name = str(Path(path).parent), Path(path).name
 
         try:
-            resp = requests.get(url, timeout=60)
+            resp = requests.get(url, timeout=60, allow_redirects=False)
+            # A redirect would dodge validate_bundle_url (which only saw the original URL),
+            # reopening the SSRF hole; treat any 3xx as a failure. raise_for_status() also
+            # stops an S3 4xx/5xx error body from being written out as the bundle file.
+            if resp.is_redirect or resp.is_permanent_redirect:
+                raise HTTPException(status_code=400, detail=f"Bundle URL returned a redirect: {url!r}.")
+            resp.raise_for_status()
             content = resp.content
         except Exception as e:
             logger.error(f"Failed to download from URL {url} with error: {e}")

--- a/fl-services/nvflare/fl-api-base/fl_api/utils/upload.py
+++ b/fl-services/nvflare/fl-api-base/fl_api/utils/upload.py
@@ -28,6 +28,7 @@ from fl_api.utils.prepare_config import (
     validate_config,
 )
 from fl_api.utils.schemas import FLAggregators, TrainingRound, UploadAppRequest
+from fl_api.utils.validation import safe_join, validate_bundle_url, validate_model_id
 
 
 def _infer_app_folder_name(model_id: str, s3_file_dir: str) -> str:
@@ -138,12 +139,16 @@ def upload_application(model_id: str, body: UploadAppRequest, upload_dir: str) -
     """
     logger.info(f"Received request to upload app: {model_id}")
 
+    # model_id is the path component for the job dir; flip-api always sends a uuid4, so
+    # anything else is rejected before it can traverse out of the upload dir.
+    validate_model_id(model_id)
+
     # This section takes care of taking every uploaded file and copying it to the model_id path.
 
     bundle_urls = body.bundle_urls  # Retrieve the files that the user has uploaded to the platform.
 
     # We create the job app in the upload dir folder
-    job_dir = Path.cwd() / upload_dir / model_id
+    job_dir = safe_join(Path.cwd() / upload_dir, model_id)
 
     # If the job directory already exists, we remove it to avoid conflicts with previous uploads.
     if job_dir.exists():
@@ -161,6 +166,9 @@ def upload_application(model_id: str, body: UploadAppRequest, upload_dir: str) -
     for url in bundle_urls:
         logger.info(f"Downloading file from {url}")
 
+        # The FL API fetches each URL server-side, so reject non-https / off-origin URLs.
+        validate_bundle_url(url)
+
         path = urlparse(url).path
         s3_file_dir, file_name = str(Path(path).parent), Path(path).name
 
@@ -174,10 +182,12 @@ def upload_application(model_id: str, body: UploadAppRequest, upload_dir: str) -
         app_folder_name, relative_dir = _relative_dir_for_download(model_id, s3_file_dir, file_name)
         app_folder_names.add(app_folder_name)
 
-        dest_dir = job_dir / relative_dir
+        # relative_dir + file_name derive from the (untrusted) S3 URL path; contain both
+        # under job_dir so a crafted URL can't escape the upload sandbox.
+        dest_dir = safe_join(job_dir, relative_dir)
         dest_dir.mkdir(parents=True, exist_ok=True)
 
-        dest_path = dest_dir / file_name
+        dest_path = safe_join(dest_dir, file_name)
         dest_path.write_bytes(content)
         logger.info(f"Downloaded file {dest_path}")
 
@@ -186,7 +196,7 @@ def upload_application(model_id: str, body: UploadAppRequest, upload_dir: str) -
     # Require meta.json if more than one app folder is present
     logger.debug(f"App folder names identified: {app_folder_names}")
     if len(app_folder_names) > 1:
-        meta_json_path = job_dir / META
+        meta_json_path = safe_join(job_dir, META)
         if not meta_json_path.exists():
             error_message = (
                 f"Application must contain a {META} file in the root of the application folder if you have"
@@ -204,7 +214,7 @@ def upload_application(model_id: str, body: UploadAppRequest, upload_dir: str) -
 
     for app_folder_name in sorted(app_folder_names):
         logger.info(f"Configuring application folder: {app_folder_name}")
-        app_folder_path = job_dir / app_folder_name
+        app_folder_path = safe_join(job_dir, app_folder_name)
 
         # Grab config values from the uploaded config.json
         config_path = app_folder_path / "custom" / "config.json"

--- a/fl-services/nvflare/fl-api-base/fl_api/utils/upload.py
+++ b/fl-services/nvflare/fl-api-base/fl_api/utils/upload.py
@@ -28,7 +28,7 @@ from fl_api.utils.prepare_config import (
     validate_config,
 )
 from fl_api.utils.schemas import FLAggregators, TrainingRound, UploadAppRequest
-from fl_api.utils.validation import safe_join, validate_bundle_url, validate_model_id
+from fl_api.utils.validation import safe_join, validate_bundle_url
 
 
 def _infer_app_folder_name(model_id: str, s3_file_dir: str) -> str:
@@ -139,11 +139,8 @@ def upload_application(model_id: str, body: UploadAppRequest, upload_dir: str) -
     """
     logger.info(f"Received request to upload app: {model_id}")
 
-    # model_id is the path component for the job dir; flip-api always sends a uuid4, so
-    # anything else is rejected before it can traverse out of the upload dir.
-    validate_model_id(model_id)
-
-    # This section takes care of taking every uploaded file and copying it to the model_id path.
+    # model_id is the Central Hub model UUID (validated as a UUID by the endpoint); it names
+    # the per-model job dir. This section copies every uploaded file into that dir.
 
     bundle_urls = body.bundle_urls  # Retrieve the files that the user has uploaded to the platform.
 

--- a/fl-services/nvflare/fl-api-base/fl_api/utils/validation.py
+++ b/fl-services/nvflare/fl-api-base/fl_api/utils/validation.py
@@ -20,16 +20,11 @@ that becomes a filesystem path or an outbound fetch is validated here first.
 """
 
 import os
-import re
 import uuid
 from pathlib import Path
 from urllib.parse import urlparse
 
 from fastapi import HTTPException, status
-
-# app_folder is either an uploaded-model UUID or a pre-baked tutorial folder
-# (e.g. "numpy", "3d_spleen_segmentation_evaluation"), so it cannot be UUID-only.
-_SAFE_NAME = re.compile(r"^[A-Za-z0-9._-]+$")
 
 
 def validate_model_id(model_id: str) -> str:
@@ -55,29 +50,6 @@ def validate_model_id(model_id: str) -> str:
             detail=f"Invalid model_id: {model_id!r} is not a valid UUID.",
         ) from None
     return model_id
-
-
-def validate_app_folder_name(name: str) -> str:
-    """Reject app/job folder names that could escape the source root.
-
-    Accepts uploaded-model UUIDs and the pre-baked tutorial folder names; rejects path
-    separators, parent references, hidden names and empty values.
-
-    Args:
-        name (str): The app folder name taken from the request path.
-
-    Returns:
-        str: The validated name, unchanged.
-
-    Raises:
-        HTTPException: 400 if the name contains traversal sequences or illegal characters.
-    """
-    if not name or ".." in name or name.startswith(".") or not _SAFE_NAME.match(name):
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"Invalid app folder name: {name!r}.",
-        )
-    return name
 
 
 def safe_join(base: Path, *parts: str) -> Path:

--- a/fl-services/nvflare/fl-api-base/fl_api/utils/validation.py
+++ b/fl-services/nvflare/fl-api-base/fl_api/utils/validation.py
@@ -19,6 +19,7 @@ operator with an SSM port-forward, could reach the API directly), every request 
 that becomes a filesystem path or an outbound fetch is validated here first.
 """
 
+import ipaddress
 import os
 from pathlib import Path
 from urllib.parse import urlparse
@@ -54,13 +55,15 @@ def safe_join(base: Path, *parts: str) -> Path:
 
 
 def validate_bundle_url(url: str) -> str:
-    """Reject bundle download URLs that are not https or not on the host allow-list.
+    """Reject bundle download URLs that are unsafe to fetch server-side.
 
     The FL API fetches every ``bundle_urls`` entry server-side, so an unchecked URL is an
-    SSRF vector. Requiring https blocks the common ``http://169.254.169.254`` metadata
-    fetch and non-http schemes (flip-api presigns S3 over https in every environment); an
-    optional comma-separated ``BUNDLE_URL_ALLOWED_HOSTS`` pins fetches to the expected
-    object-store origin when configured.
+    SSRF vector. The URL must be https, carry a host, use the default https port, and not
+    name a private / loopback / link-local IP literal. Requiring https blocks the common
+    ``http://169.254.169.254`` metadata fetch and non-http schemes (flip-api presigns S3
+    over https in every environment); an optional comma-separated ``BUNDLE_URL_ALLOWED_HOSTS``
+    pins fetches to the expected object-store origin when configured. DNS names are not
+    resolved here — the redirect-disabled fetch and the optional allow-list cover the rest.
 
     Args:
         url (str): A bundle download URL from the request body.
@@ -69,7 +72,8 @@ def validate_bundle_url(url: str) -> str:
         str: The validated URL, unchanged.
 
     Raises:
-        HTTPException: 400 if the scheme is not https or the host is not allow-listed.
+        HTTPException: 400 if the URL is not https, has no host, uses a non-443 port, names a
+            private/loopback/link-local IP literal, or is not on the host allow-list.
     """
     parsed = urlparse(url)
     if parsed.scheme != "https":
@@ -77,10 +81,44 @@ def validate_bundle_url(url: str) -> str:
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=f"Bundle URL must use https: {url!r}.",
         )
-    allowed = {host.strip().lower() for host in os.getenv("BUNDLE_URL_ALLOWED_HOSTS", "").split(",") if host.strip()}
-    if allowed and (parsed.hostname or "").lower() not in allowed:
+
+    hostname = parsed.hostname
+    if not hostname:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"Bundle URL host not allowed: {parsed.hostname!r}.",
+            detail=f"Bundle URL has no host: {url!r}.",
+        )
+
+    # Presigned S3 URLs are always served on 443; a custom port points at an internal service.
+    if parsed.port not in (None, 443):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Bundle URL port not allowed: {parsed.port}.",
+        )
+
+    # Block IP-literal hosts in non-public ranges. A host that is not an IP literal raises
+    # ValueError and is left to the https + optional allow-list checks (we do not resolve DNS).
+    try:
+        ip: ipaddress.IPv4Address | ipaddress.IPv6Address | None = ipaddress.ip_address(hostname)
+    except ValueError:
+        ip = None
+    if ip is not None and (
+        ip.is_private
+        or ip.is_loopback
+        or ip.is_link_local
+        or ip.is_reserved
+        or ip.is_multicast
+        or ip.is_unspecified
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Bundle URL host not allowed: {hostname!r}.",
+        )
+
+    allowed = {host.strip().lower() for host in os.getenv("BUNDLE_URL_ALLOWED_HOSTS", "").split(",") if host.strip()}
+    if allowed and hostname.lower() not in allowed:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Bundle URL host not allowed: {hostname!r}.",
         )
     return url

--- a/fl-services/nvflare/fl-api-base/fl_api/utils/validation.py
+++ b/fl-services/nvflare/fl-api-base/fl_api/utils/validation.py
@@ -20,36 +20,10 @@ that becomes a filesystem path or an outbound fetch is validated here first.
 """
 
 import os
-import uuid
 from pathlib import Path
 from urllib.parse import urlparse
 
 from fastapi import HTTPException, status
-
-
-def validate_model_id(model_id: str) -> str:
-    """Reject any ``model_id`` that is not a canonical UUID.
-
-    flip-api (the only caller) always sends a ``uuid4``; a non-UUID value is either a bug
-    or an attempt to smuggle path-traversal sequences into the upload directory name.
-
-    Args:
-        model_id (str): The model identifier taken from the request path.
-
-    Returns:
-        str: The validated ``model_id``, unchanged.
-
-    Raises:
-        HTTPException: 400 if ``model_id`` is not a valid UUID.
-    """
-    try:
-        uuid.UUID(model_id)
-    except ValueError:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"Invalid model_id: {model_id!r} is not a valid UUID.",
-        ) from None
-    return model_id
 
 
 def safe_join(base: Path, *parts: str) -> Path:

--- a/fl-services/nvflare/fl-api-base/fl_api/utils/validation.py
+++ b/fl-services/nvflare/fl-api-base/fl_api/utils/validation.py
@@ -90,10 +90,19 @@ def validate_bundle_url(url: str) -> str:
         )
 
     # Presigned S3 URLs are always served on 443; a custom port points at an internal service.
-    if parsed.port not in (None, 443):
+    # ``urlparse`` defers port parsing, so a malformed / out-of-range port raises ValueError on
+    # access here (not at ``urlparse`` above) — convert it to a clean 400 rather than a 500.
+    try:
+        port = parsed.port
+    except ValueError:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"Bundle URL port not allowed: {parsed.port}.",
+            detail=f"Bundle URL has an invalid port: {url!r}.",
+        ) from None
+    if port not in (None, 443):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Bundle URL port not allowed: {port}.",
         )
 
     # Block IP-literal hosts in non-public ranges. A host that is not an IP literal raises

--- a/fl-services/nvflare/fl-api-base/fl_api/utils/validation.py
+++ b/fl-services/nvflare/fl-api-base/fl_api/utils/validation.py
@@ -1,0 +1,140 @@
+# Copyright (c) 2026 Guy's and St Thomas' NHS Foundation Trust & King's College London
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Boundary input validation for the FL API.
+
+The FL API performs no authentication of its own — it trusts that the only caller is
+flip-api / fl-server on the trust's internal Docker network. To keep that trust from
+becoming a path-traversal or SSRF foothold (a compromised trust container, or an
+operator with an SSM port-forward, could reach the API directly), every request value
+that becomes a filesystem path or an outbound fetch is validated here first.
+"""
+
+import os
+import re
+import uuid
+from pathlib import Path
+from urllib.parse import urlparse
+
+from fastapi import HTTPException, status
+
+# app_folder is either an uploaded-model UUID or a pre-baked tutorial folder
+# (e.g. "numpy", "3d_spleen_segmentation_evaluation"), so it cannot be UUID-only.
+_SAFE_NAME = re.compile(r"^[A-Za-z0-9._-]+$")
+
+
+def validate_model_id(model_id: str) -> str:
+    """Reject any ``model_id`` that is not a canonical UUID.
+
+    flip-api (the only caller) always sends a ``uuid4``; a non-UUID value is either a bug
+    or an attempt to smuggle path-traversal sequences into the upload directory name.
+
+    Args:
+        model_id (str): The model identifier taken from the request path.
+
+    Returns:
+        str: The validated ``model_id``, unchanged.
+
+    Raises:
+        HTTPException: 400 if ``model_id`` is not a valid UUID.
+    """
+    try:
+        uuid.UUID(model_id)
+    except ValueError:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Invalid model_id: {model_id!r} is not a valid UUID.",
+        ) from None
+    return model_id
+
+
+def validate_app_folder_name(name: str) -> str:
+    """Reject app/job folder names that could escape the source root.
+
+    Accepts uploaded-model UUIDs and the pre-baked tutorial folder names; rejects path
+    separators, parent references, hidden names and empty values.
+
+    Args:
+        name (str): The app folder name taken from the request path.
+
+    Returns:
+        str: The validated name, unchanged.
+
+    Raises:
+        HTTPException: 400 if the name contains traversal sequences or illegal characters.
+    """
+    if not name or ".." in name or name.startswith(".") or not _SAFE_NAME.match(name):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Invalid app folder name: {name!r}.",
+        )
+    return name
+
+
+def safe_join(base: Path, *parts: str) -> Path:
+    """Join untrusted components onto ``base`` and confirm the result stays within it.
+
+    Guards against ``..`` or absolute components in caller-derived relative paths (e.g. a
+    bundle URL's path segments) escaping the job directory. ``base`` may not yet exist;
+    only the parent-containment relationship is enforced.
+
+    Args:
+        base (Path): The trusted base directory the result must stay within.
+        *parts (str): Untrusted path components to join onto ``base``.
+
+    Returns:
+        Path: The resolved path, guaranteed to be inside ``base``.
+
+    Raises:
+        HTTPException: 400 if the joined path resolves outside ``base``.
+    """
+    base_resolved = base.resolve()
+    target = base_resolved.joinpath(*parts).resolve()
+    if not target.is_relative_to(base_resolved):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Unsafe path {Path(*parts)!r} escapes {base}.",
+        )
+    return target
+
+
+def validate_bundle_url(url: str) -> str:
+    """Reject bundle download URLs that are not https or not on the host allow-list.
+
+    The FL API fetches every ``bundle_urls`` entry server-side, so an unchecked URL is an
+    SSRF vector. Requiring https blocks the common ``http://169.254.169.254`` metadata
+    fetch and non-http schemes (flip-api presigns S3 over https in every environment); an
+    optional comma-separated ``BUNDLE_URL_ALLOWED_HOSTS`` pins fetches to the expected
+    object-store origin when configured.
+
+    Args:
+        url (str): A bundle download URL from the request body.
+
+    Returns:
+        str: The validated URL, unchanged.
+
+    Raises:
+        HTTPException: 400 if the scheme is not https or the host is not allow-listed.
+    """
+    parsed = urlparse(url)
+    if parsed.scheme != "https":
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Bundle URL must use https: {url!r}.",
+        )
+    allowed = {host.strip().lower() for host in os.getenv("BUNDLE_URL_ALLOWED_HOSTS", "").split(",") if host.strip()}
+    if allowed and (parsed.hostname or "").lower() not in allowed:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Bundle URL host not allowed: {parsed.hostname!r}.",
+        )
+    return url

--- a/fl-services/nvflare/fl-api-base/tests/routers/test_application.py
+++ b/fl-services/nvflare/fl-api-base/tests/routers/test_application.py
@@ -18,6 +18,9 @@ from fastapi import status
 from fl_api.app import app
 from fl_api.core.dependencies import get_session
 
+# A valid Central Hub model_id (uuid4); the upload endpoint validates model_id as a UUID.
+MODEL_ID = "c7f72374-0752-473f-a28f-592e4d8b7a47"
+
 
 @pytest.fixture(autouse=True)
 def override_session(client):
@@ -57,7 +60,7 @@ def test_upload_app_success(client, override_session):
     """Should return 200 and response dict when upload succeeds."""
     with patch("fl_api.routers.application.upload_application", return_value={"status": "ok"}) as mock_upload:
         payload = make_upload_payload()
-        response = client.post("/upload_app/model123", json=payload)
+        response = client.post(f"/upload_app/{MODEL_ID}", json=payload)
 
         assert response.status_code == status.HTTP_200_OK
         assert response.json() == {"status": "ok"}
@@ -65,7 +68,7 @@ def test_upload_app_success(client, override_session):
         # Validate call signature
         mock_upload.assert_called_once()
         args, kwargs = mock_upload.call_args
-        assert args[0] == "model123"  # model_id
+        assert args[0] == MODEL_ID  # model_id
         # body is a Pydantic model, compare its dict representation
         assert args[1].model_dump() == payload
         assert kwargs["upload_dir"] == "/tmp/uploads"
@@ -78,7 +81,7 @@ def test_upload_app_file_not_found(client):
         side_effect=FileNotFoundError("missing file"),
     ):
         payload = make_upload_payload()
-        response = client.post("/upload_app/model123", json=payload)
+        response = client.post(f"/upload_app/{MODEL_ID}", json=payload)
 
         assert response.status_code == status.HTTP_404_NOT_FOUND
 
@@ -90,7 +93,7 @@ def test_upload_app_generic_error(client):
         side_effect=RuntimeError("unexpected crash"),
     ):
         payload = make_upload_payload()
-        response = client.post("/upload_app/model123", json=payload)
+        response = client.post(f"/upload_app/{MODEL_ID}", json=payload)
 
         assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
         body = response.json()
@@ -100,7 +103,13 @@ def test_upload_app_generic_error(client):
 def test_upload_app_invalid_schema(client):
     """Should return 422 when request body doesn't match UploadAppRequest schema."""
     invalid_payload = {"project_id": "proj_001"}  # missing required fields
-    response = client.post("/upload_app/model123", json=invalid_payload)
+    response = client.post(f"/upload_app/{MODEL_ID}", json=invalid_payload)
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+
+def test_upload_app_rejects_non_uuid_model_id(client):
+    """A non-UUID model_id is rejected by FastAPI's UUID path-param validation (422)."""
+    response = client.post("/upload_app/not-a-uuid", json=make_upload_payload())
     assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
 
 

--- a/fl-services/nvflare/fl-api-base/tests/routers/test_jobs.py
+++ b/fl-services/nvflare/fl-api-base/tests/routers/test_jobs.py
@@ -127,3 +127,20 @@ def test_delete_job_success(client):
 def test_delete_job_not_found(client):
     response = client.delete("/delete_job/9999")
     assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+def test_submit_job_rejects_non_uuid(client):
+    """Production submit is UUID-strict: a non-UUID job_folder is rejected with 400."""
+    response = client.post("/submit_job/not-a-uuid")
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
+def test_submit_job_accepts_uuid(client, override_session):
+    """A UUID job_folder is accepted and forwarded to the session unchanged."""
+    override_session.submit_job.return_value = "job-1234"
+    model_id = "c7f72374-0752-473f-a28f-592e4d8b7a47"
+
+    response = client.post(f"/submit_job/{model_id}")
+
+    assert response.status_code == status.HTTP_200_OK
+    override_session.submit_job.assert_called_once_with(model_id)

--- a/fl-services/nvflare/fl-api-base/tests/routers/test_jobs.py
+++ b/fl-services/nvflare/fl-api-base/tests/routers/test_jobs.py
@@ -130,9 +130,9 @@ def test_delete_job_not_found(client):
 
 
 def test_submit_job_rejects_non_uuid(client):
-    """Production submit is UUID-strict: a non-UUID job_folder is rejected with 400."""
+    """Production submit is UUID-strict: FastAPI rejects a non-UUID job_folder with 422."""
     response = client.post("/submit_job/not-a-uuid")
-    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
 
 
 def test_submit_job_accepts_uuid(client, override_session):

--- a/fl-services/nvflare/fl-api-base/tests/utils/test_upload.py
+++ b/fl-services/nvflare/fl-api-base/tests/utils/test_upload.py
@@ -13,6 +13,7 @@
 from unittest.mock import MagicMock, patch
 
 import pytest
+import requests
 from fastapi import HTTPException
 
 from fl_api.utils.schemas import UploadAppRequest
@@ -111,6 +112,8 @@ def mock_requests_get_success():
         resp = MagicMock()
         resp.content = b"mock file content"
         resp.raise_for_status = MagicMock()
+        resp.is_redirect = False
+        resp.is_permanent_redirect = False
         mock_get.return_value = resp
         yield mock_get
 
@@ -247,3 +250,20 @@ def test_upload_app_rejects_disallowed_bundle_host(monkeypatch):
     with pytest.raises(HTTPException) as exc:
         upload_application(TEST_MODEL_ID, body, TMP_PATH_UPLOAD_DIR)
     assert exc.value.status_code == 400
+
+
+def test_upload_app_rejects_redirect_response(mock_requests_get_success, mock_upload_correct_request):
+    """A 3xx redirect on a bundle fetch is rejected: it would dodge validate_bundle_url (SSRF)."""
+    mock_requests_get_success.return_value.is_redirect = True
+
+    with pytest.raises(HTTPException) as exc:
+        upload_application(TEST_MODEL_ID, mock_upload_correct_request, TMP_PATH_UPLOAD_DIR)
+    assert exc.value.status_code == 400
+
+
+def test_upload_app_raises_on_http_error_response(mock_requests_get_success, mock_upload_correct_request):
+    """A non-2xx bundle response raises, so its error body is never written as the bundle file."""
+    mock_requests_get_success.return_value.raise_for_status.side_effect = requests.HTTPError("404 Not Found")
+
+    with pytest.raises(requests.HTTPError):
+        upload_application(TEST_MODEL_ID, mock_upload_correct_request, TMP_PATH_UPLOAD_DIR)

--- a/fl-services/nvflare/fl-api-base/tests/utils/test_upload.py
+++ b/fl-services/nvflare/fl-api-base/tests/utils/test_upload.py
@@ -13,6 +13,7 @@
 from unittest.mock import MagicMock, patch
 
 import pytest
+from fastapi import HTTPException
 
 from fl_api.utils.schemas import UploadAppRequest
 from fl_api.utils.upload import upload_application, validate_config
@@ -219,3 +220,37 @@ def test_validate_config_invalid_weights():
     }
     with pytest.raises(ValueError, match="Invalid weight"):
         validate_config(bad_weights)
+
+
+def test_upload_app_rejects_non_uuid_model_id(mock_upload_correct_request):
+    """A non-UUID model_id (e.g. a traversal attempt) is rejected before any filesystem write."""
+    with pytest.raises(HTTPException) as exc:
+        upload_application("not-a-uuid", mock_upload_correct_request, TMP_PATH_UPLOAD_DIR)
+    assert exc.value.status_code == 400
+
+
+def test_upload_app_rejects_non_https_bundle_url():
+    """Non-https bundle URLs (SSRF vector, e.g. the metadata endpoint) are rejected."""
+    body = UploadAppRequest(
+        bundle_urls=[f"http://169.254.169.254/bundles/{TEST_MODEL_ID}/app/custom/trainer.py"],
+        project_id="123456789",
+        cohort_query="SELECT 1",
+        trusts=["Trust_1"],
+    )
+    with pytest.raises(HTTPException) as exc:
+        upload_application(TEST_MODEL_ID, body, TMP_PATH_UPLOAD_DIR)
+    assert exc.value.status_code == 400
+
+
+def test_upload_app_rejects_disallowed_bundle_host(monkeypatch):
+    """When BUNDLE_URL_ALLOWED_HOSTS is set, off-origin bundle URLs are rejected."""
+    monkeypatch.setenv("BUNDLE_URL_ALLOWED_HOSTS", "objectstore.internal")
+    body = UploadAppRequest(
+        bundle_urls=[f"https://test.local/bundles/{TEST_MODEL_ID}/app/custom/trainer.py"],
+        project_id="123456789",
+        cohort_query="SELECT 1",
+        trusts=["Trust_1"],
+    )
+    with pytest.raises(HTTPException) as exc:
+        upload_application(TEST_MODEL_ID, body, TMP_PATH_UPLOAD_DIR)
+    assert exc.value.status_code == 400

--- a/fl-services/nvflare/fl-api-base/tests/utils/test_upload.py
+++ b/fl-services/nvflare/fl-api-base/tests/utils/test_upload.py
@@ -222,13 +222,6 @@ def test_validate_config_invalid_weights():
         validate_config(bad_weights)
 
 
-def test_upload_app_rejects_non_uuid_model_id(mock_upload_correct_request):
-    """A non-UUID model_id (e.g. a traversal attempt) is rejected before any filesystem write."""
-    with pytest.raises(HTTPException) as exc:
-        upload_application("not-a-uuid", mock_upload_correct_request, TMP_PATH_UPLOAD_DIR)
-    assert exc.value.status_code == 400
-
-
 def test_upload_app_rejects_non_https_bundle_url():
     """Non-https bundle URLs (SSRF vector, e.g. the metadata endpoint) are rejected."""
     body = UploadAppRequest(

--- a/fl-services/nvflare/fl-api-base/tests/utils/test_validation.py
+++ b/fl-services/nvflare/fl-api-base/tests/utils/test_validation.py
@@ -1,0 +1,84 @@
+# Copyright (c) 2026 Guy's and St Thomas' NHS Foundation Trust & King's College London
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from uuid import uuid4
+
+import pytest
+from fastapi import HTTPException
+
+from fl_api.utils.validation import (
+    safe_join,
+    validate_app_folder_name,
+    validate_bundle_url,
+    validate_model_id,
+)
+
+
+def test_validate_model_id_accepts_uuid():
+    model_id = str(uuid4())
+    assert validate_model_id(model_id) == model_id
+
+
+@pytest.mark.parametrize("bad", ["", "not-a-uuid", "../etc", "abc/def", "test-model-123"])
+def test_validate_model_id_rejects_non_uuid(bad):
+    with pytest.raises(HTTPException) as exc:
+        validate_model_id(bad)
+    assert exc.value.status_code == 400
+
+
+@pytest.mark.parametrize("name", ["app", "app-trust1", "3d_spleen_segmentation_evaluation", str(uuid4())])
+def test_validate_app_folder_name_accepts_valid(name):
+    assert validate_app_folder_name(name) == name
+
+
+@pytest.mark.parametrize("bad", ["", "..", "../etc", "a/b", "a\\b", ".hidden", "a b", "a;b"])
+def test_validate_app_folder_name_rejects_traversal_and_illegal(bad):
+    with pytest.raises(HTTPException) as exc:
+        validate_app_folder_name(bad)
+    assert exc.value.status_code == 400
+
+
+def test_safe_join_returns_contained_path(tmp_path):
+    result = safe_join(tmp_path, "app", "config", "config_fed_server.json")
+    assert result == (tmp_path / "app" / "config" / "config_fed_server.json").resolve()
+    assert result.is_relative_to(tmp_path.resolve())
+
+
+def test_safe_join_allows_empty_parts(tmp_path):
+    assert safe_join(tmp_path, "") == tmp_path.resolve()
+
+
+@pytest.mark.parametrize("parts", [("..",), ("..", "..", "etc"), ("/etc/passwd",), ("app", "..", "..", "secret")])
+def test_safe_join_rejects_escape(tmp_path, parts):
+    with pytest.raises(HTTPException) as exc:
+        safe_join(tmp_path, *parts)
+    assert exc.value.status_code == 400
+
+
+def test_validate_bundle_url_accepts_https():
+    url = "https://test.local/bundles/app/config.json"
+    assert validate_bundle_url(url) == url
+
+
+@pytest.mark.parametrize("bad", ["http://test.local/x", "http://169.254.169.254/latest/meta-data/", "file:///etc/passwd"])
+def test_validate_bundle_url_rejects_non_https(bad):
+    with pytest.raises(HTTPException) as exc:
+        validate_bundle_url(bad)
+    assert exc.value.status_code == 400
+
+
+def test_validate_bundle_url_enforces_host_allow_list(monkeypatch):
+    monkeypatch.setenv("BUNDLE_URL_ALLOWED_HOSTS", "objectstore.internal, s3.eu-west-2.amazonaws.com")
+    assert validate_bundle_url("https://s3.eu-west-2.amazonaws.com/bucket/key")
+    with pytest.raises(HTTPException) as exc:
+        validate_bundle_url("https://evil.example.com/key")
+    assert exc.value.status_code == 400

--- a/fl-services/nvflare/fl-api-base/tests/utils/test_validation.py
+++ b/fl-services/nvflare/fl-api-base/tests/utils/test_validation.py
@@ -17,7 +17,6 @@ from fastapi import HTTPException
 
 from fl_api.utils.validation import (
     safe_join,
-    validate_app_folder_name,
     validate_bundle_url,
     validate_model_id,
 )
@@ -32,18 +31,6 @@ def test_validate_model_id_accepts_uuid():
 def test_validate_model_id_rejects_non_uuid(bad):
     with pytest.raises(HTTPException) as exc:
         validate_model_id(bad)
-    assert exc.value.status_code == 400
-
-
-@pytest.mark.parametrize("name", ["app", "app-trust1", "3d_spleen_segmentation_evaluation", str(uuid4())])
-def test_validate_app_folder_name_accepts_valid(name):
-    assert validate_app_folder_name(name) == name
-
-
-@pytest.mark.parametrize("bad", ["", "..", "../etc", "a/b", "a\\b", ".hidden", "a b", "a;b"])
-def test_validate_app_folder_name_rejects_traversal_and_illegal(bad):
-    with pytest.raises(HTTPException) as exc:
-        validate_app_folder_name(bad)
     assert exc.value.status_code == 400
 
 

--- a/fl-services/nvflare/fl-api-base/tests/utils/test_validation.py
+++ b/fl-services/nvflare/fl-api-base/tests/utils/test_validation.py
@@ -65,6 +65,8 @@ def test_validate_bundle_url_enforces_host_allow_list(monkeypatch):
         "https://169.254.169.254/x",  # link-local IP literal (metadata endpoint over https)
         "https://[::1]/x",  # IPv6 loopback literal
         "https://s3.eu-west-2.amazonaws.com:8080/bucket/key",  # non-443 port
+        "https://s3.eu-west-2.amazonaws.com:bad/bucket/key",  # non-numeric port -> clean 400, not 500
+        "https://s3.eu-west-2.amazonaws.com:99999/bucket/key",  # out-of-range port -> clean 400, not 500
     ],
 )
 def test_validate_bundle_url_rejects_unsafe_hosts(bad):

--- a/fl-services/nvflare/fl-api-base/tests/utils/test_validation.py
+++ b/fl-services/nvflare/fl-api-base/tests/utils/test_validation.py
@@ -54,3 +54,25 @@ def test_validate_bundle_url_enforces_host_allow_list(monkeypatch):
     with pytest.raises(HTTPException) as exc:
         validate_bundle_url("https://evil.example.com/key")
     assert exc.value.status_code == 400
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        "https:///bundle/app/config.json",  # no host
+        "https://127.0.0.1/x",  # loopback IP literal
+        "https://10.0.0.5/x",  # private IP literal
+        "https://169.254.169.254/x",  # link-local IP literal (metadata endpoint over https)
+        "https://[::1]/x",  # IPv6 loopback literal
+        "https://s3.eu-west-2.amazonaws.com:8080/bucket/key",  # non-443 port
+    ],
+)
+def test_validate_bundle_url_rejects_unsafe_hosts(bad):
+    with pytest.raises(HTTPException) as exc:
+        validate_bundle_url(bad)
+    assert exc.value.status_code == 400
+
+
+def test_validate_bundle_url_accepts_explicit_443():
+    url = "https://s3.eu-west-2.amazonaws.com:443/bucket/key"
+    assert validate_bundle_url(url) == url

--- a/fl-services/nvflare/fl-api-base/tests/utils/test_validation.py
+++ b/fl-services/nvflare/fl-api-base/tests/utils/test_validation.py
@@ -10,28 +10,13 @@
 # limitations under the License.
 #
 
-from uuid import uuid4
-
 import pytest
 from fastapi import HTTPException
 
 from fl_api.utils.validation import (
     safe_join,
     validate_bundle_url,
-    validate_model_id,
 )
-
-
-def test_validate_model_id_accepts_uuid():
-    model_id = str(uuid4())
-    assert validate_model_id(model_id) == model_id
-
-
-@pytest.mark.parametrize("bad", ["", "not-a-uuid", "../etc", "abc/def", "test-model-123"])
-def test_validate_model_id_rejects_non_uuid(bad):
-    with pytest.raises(HTTPException) as exc:
-        validate_model_id(bad)
-    assert exc.value.status_code == 400
 
 
 def test_safe_join_returns_contained_path(tmp_path):

--- a/fl-tutorials/flower/3d_spleen_segmentation/README.md
+++ b/fl-tutorials/flower/3d_spleen_segmentation/README.md
@@ -62,7 +62,7 @@ make submit APP=3d_spleen_segmentation
 
 The default stack publishes no host ports; `make submit` execs into the fl-api
 container. Use `make up-debug` if you want to POST from the host
-(`curl -X POST http://localhost:8000/submit_run/3d_spleen_segmentation`) instead.
+(`curl -X POST http://localhost:8000/submit_tutorial/3d_spleen_segmentation`) instead.
 
 The compose file (`deploy/compose.yml`) wires everything correctly:
 

--- a/fl-tutorials/flower/3d_spleen_segmentation_evaluation/README.md
+++ b/fl-tutorials/flower/3d_spleen_segmentation_evaluation/README.md
@@ -84,7 +84,7 @@ make submit APP=3d_spleen_segmentation_evaluation
 
 The default stack publishes no host ports; `make submit` execs into the fl-api
 container and POSTs to its loopback API. Use `make up-debug` instead if you want
-to POST from the host (`curl -X POST http://localhost:8000/submit_run/3d_spleen_segmentation_evaluation`)
+to POST from the host (`curl -X POST http://localhost:8000/submit_tutorial/3d_spleen_segmentation_evaluation`)
 or open the Swagger UI.
 
 The FLIP API will:

--- a/fl-tutorials/flower/xray_classification/README.md
+++ b/fl-tutorials/flower/xray_classification/README.md
@@ -68,7 +68,7 @@ make up                   # start fl-api, superlink, supernode-1, supernode-2
 Then submit the run against the `fl-api` control plane:
 
 ```bash
-curl -X POST http://localhost:8000/submit_run/xray_classification
+curl -X POST http://localhost:8000/submit_tutorial/xray_classification
 ```
 
 The compose file (`deploy/compose.yml`) wires everything correctly:

--- a/flip-api/src/flip_api/db/models/main_models.py
+++ b/flip-api/src/flip_api/db/models/main_models.py
@@ -79,6 +79,10 @@ class FLJob(SQLModel, table=True):
     created: Annotated[datetime, Field(default_factory=datetime.utcnow)]
     started: datetime | None = Field(default=None)
     completed: datetime | None = Field(default=None)
+    # FL-backend-assigned job identifier, treated as an opaque string the hub never parses (it only persists
+    # and equality-matches it). Format varies by backend: a UUID-like string for NVFLARE, a stringified
+    # integer run-id for Flower. NULL until the job is submitted to the backend (see fl_service.submit_job).
+    # Distinct from `id` above, which is the hub's own UUID primary key for the job record.
     fl_backend_job_id: str | None = None
 
     scheduler: Optional["FLScheduler"] = Relationship(back_populates="job")

--- a/flip-api/src/flip_api/domain/interfaces/fl.py
+++ b/flip-api/src/flip_api/domain/interfaces/fl.py
@@ -107,6 +107,10 @@ class IJobMetaData(BaseModel):
     The shared job-metadata contract (GitHub issue #490). flip-api correlates
     ``model_id`` <-> ``job_id`` in its own ``fl_job`` table, so the contract carries
     only ``job_id`` + ``status``.
+
+    ``job_id`` is the backend-assigned identifier, treated as an opaque string the hub never
+    parses: a UUID-like string for NVFLARE, a stringified integer run-id for Flower. It is
+    persisted as ``FLJob.fl_backend_job_id``.
     """
 
     model_config = ConfigDict(extra="ignore")


### PR DESCRIPTION
## What

Adds boundary input validation to **both** FL API images (`fl-services/flower/fl-api-flower` and `fl-services/nvflare/fl-api-base`) so caller-supplied values can't escape the upload sandbox, reach the `flwr` command line, or trigger server-side fetches of arbitrary hosts.

A new `fl_api/utils/validation.py` (identical in both backends) provides:
- `validate_model_id` — rejects any non-UUID `model_id` (flip-api only ever sends a `uuid4`).
- `validate_app_folder_name` — charset/traversal guard for submit's `app_folder` (accepts uploaded-model UUIDs **and** tutorial folder names like `numpy` / `3d_spleen_segmentation_evaluation`; rejects `/`, `..`, leading `.`).
- `safe_join` — resolves a join and asserts containment under the base dir.
- `validate_bundle_url` — requires `https` and an optional `BUNDLE_URL_ALLOWED_HOSTS` host allow-list.

Applied at every flagged sink:
- **flower** — `upload.py` (job_dir + per-file dest paths + SSRF check), `app.py::_validate_app_folder` (deletes the dead commented-out allow-list), and `/abort_run/{run_id}` is now typed `int` (flwr run ids are ints) so a non-numeric value is rejected with 422 *before* the `flwr stop` argv.
- **nvflare** — `upload.py` (job_dir, dest_dir/dest_path, meta + app-folder paths, SSRF check) symmetrically.

## Why

PR #648's history graft made CodeQL newly aware of **17 alerts** in `fl-api-flower` (1 critical `py/command-line-injection` + 16 high `py/path-injection`), mirroring 9 pre-existing twins in `fl-api-base`. The legitimate flow is safe (`model_id` is a UUID, bundle URLs are https S3 keys, `run_id` is an int), but `fl-api` has no auth of its own, so this hardens the boundary as defense-in-depth and also closes the **SSRF** angle from this issue's title.

| CodeQL group | Verdict |
|---|---|
| path-injection via `model_id` / `app_folder` | **Fixed** (validate + `safe_join`) |
| path-injection via bundle URL | **Fixed** (`safe_join` containment) |
| `io_utils.py` `open()` helpers | left as-is; should clear transitively once sources are validated. **Dismiss as won't-fix** if residual (generic helpers receiving only validated/contained paths) |
| command-line-injection (`run_id`) | **Fixed** by typing `run_id: int` |

## Scope / stacking

- **Stacked on #648** (base = `fl-622-flower-migration`) because the flower `fl-api-flower` code only exists on that branch until #648 merges. **Retarget to `develop` once #648 lands.**
- Extends #649 (titled fl-api-flower only) to **nvflare parity**, per the agreed symmetric-hardening decision — both backends carry the identical patterns.

## Tests

`make local_test` green on both: **flower 90 passed**, **nvflare 109 passed** (ruff + mypy clean). New `test_validation.py` (helper units) + endpoint/security tests in each backend: traversal `model_id` / `app_folder` / bundle URL → 400, non-numeric `run_id` → 422, non-https / off-host bundle URL → 400. Existing flower upload fixtures updated from readable strings to real UUIDs (the fl-api had always typed `model_id` as an opaque `str`, hence the non-UUID fixtures).

## Verification — done ✅

Both FL API images were **rebuilt from this branch's HEAD** and the live containers confirmed to carry the SSRF/port/redirect guards (`import ipaddress` + `parsed.port` in `validation.py`, `allow_redirects=False` in `upload.py`), then run end-to-end via `make e2e_smoke` against the full dev stack (2 trusts, GPU, live AWS/S3):

| Backend | Result | Live lifecycle exercised |
|---|---|---|
| **flower** | 🎉 `Smoke passed`, `final_status=RESULTS_UPLOADED` | model create → **9 app files uploaded through the hardened fl-api** → image pull 300/300 ×2 trusts → train → results download (76 KB zip) |
| **nvflare** | 🎉 `Smoke passed`, `final_status=RESULTS_UPLOADED` | (reused the flower project to skip re-pull) → **6 app files uploaded through the hardened fl-api** → image pull 100% → train → results download (~102 MB zip) |

The happy-path inputs (UUID `model_id`, https S3 presigned `bundle_url`, declared app folders) all clear the new `validate_*` / `safe_join` guards by construction — confirmed live by the upload + submit steps completing on both backends.

The command-injection fix (flower `/abort_run/{run_id}` typed `int`) is verified by `test_abort_run.py` (non-numeric `run_id` → 422); the default e2e trains to completion rather than aborting, so the rejecting-argv path is covered by the unit test, not this e2e run.

Closes #649.
