### PR TITLE
Remove MetricsValidator from the NVFLARE evaluation executor (simplify returning metrics)

### DIFF
--- a/.github/workflows/unit-tests-heavy.yml
+++ b/.github/workflows/unit-tests-heavy.yml
@@ -1,8 +1,15 @@
-# Heavy NVFLARE tests that require PyTorch. Run manually via workflow_dispatch.
+# Heavy NVFLARE tests that require PyTorch. Runs on pushes that touch flip-utils/ (mirroring
+# unit-tests.yml) so the nvflare test tree's coverage reaches Codecov, plus manual dispatch.
+# The light unit-tests.yml job deselects the nvflare tree (`-k "not nvflare"`, no torch there),
+# so without this job nvflare files (e.g. the executors) show 0% patch coverage on PRs.
 name: Unit Tests — NVFLARE (heavy)
 
 on:
   workflow_dispatch:
+  push:
+    paths:
+      - "flip-utils/**"
+      - ".github/workflows/unit-tests-heavy.yml"
 
 permissions:
   contents: read

--- a/fl-apps/nvflare/evaluation/README.md
+++ b/fl-apps/nvflare/evaluation/README.md
@@ -48,7 +48,8 @@ and retrieves a DXO with the metrics.
     (in dictionary `model_paths`).
 
   `evaluator.py` may return any JSON-serialisable metrics (for example a dict of floats and/or lists of floats);
-  they are saved verbatim to the per-model evaluation results, so there is no output schema to declare.
+  they are saved verbatim into `evaluation_results.json`, keyed by data site (then by the model name your
+  evaluator returns), so there is no output schema to declare.
 
 ## Test it with the spleen MSD dataset
 

--- a/fl-apps/nvflare/evaluation/README.md
+++ b/fl-apps/nvflare/evaluation/README.md
@@ -42,13 +42,13 @@ and retrieves a DXO with the metrics.
 - `models.py`: this contains the code to instance the model(s) that are to be tested.
 - [checkpoints]: any model has to have its checkpoint uploaded under `pt` format.
 - `transforms.py`: support file to define data transforms and other data related thing.
-- `config.json`: configuration for the model. The following fields are required in this pipeline:
+- `config.json`: configuration for the model. The following field is required in this pipeline:
   - `models`. For each element of this class, `checkpoint` and `path` are mandatory. Checkpoint is the name of the
     pt file for this specific model. 'path' is the key to the function that defines this model in `models.py`
     (in dictionary `model_paths`).
-  - `evaluation_output`: this is the skeletton of the evaluation output, defining, the output that you'll get
-    for each model. Your evaluator.py output will be checked against this, to ensure that additional fields are not
-    being added. All results should be floats (no text can be passed).
+
+  `evaluator.py` may return any JSON-serialisable metrics (for example a dict of floats and/or lists of floats);
+  they are saved verbatim to the per-model evaluation results, so there is no output schema to declare.
 
 ## Test it with the spleen MSD dataset
 

--- a/fl-tutorials/nvflare/image_evaluation/3d_spleen_segmentation_evaluation/README.md
+++ b/fl-tutorials/nvflare/image_evaluation/3d_spleen_segmentation_evaluation/README.md
@@ -63,7 +63,19 @@ Useful targets:
 - `app_files/evaluator.py`: evaluation loop and metric computation
 - `app_files/models.py`: model definitions and checkpoint loading
 - `app_files/transforms.py`: inference/evaluation transforms
-- `app_files/config.json`: model/checkpoint mapping and evaluation output schema
+- `app_files/config.json`: model/checkpoint mapping and evaluation settings (e.g. `num_classes`)
+
+## Output metrics
+
+`evaluator.py` writes `evaluation_results.json` with **aggregate** (cohort-mean) metrics per model:
+
+- `mean_dice` — mean Dice coefficient
+- `mean_hausdorff_95` — 95th-percentile Hausdorff distance (voxels)
+- `mean_surface_dice` — normalized Surface Dice at a 1-voxel tolerance (`SURFACE_DICE_TOLERANCE_VOXELS` in `evaluator.py`)
+- `mean_iou` — mean intersection-over-union
+
+Only aggregate values are returned. Per-sample (row-level) scores are deliberately not exported: a
+per-patient list would leak the exact evaluation cohort size and be linkable to individual patients.
 
 ## Notes and troubleshooting
 

--- a/fl-tutorials/nvflare/image_evaluation/3d_spleen_segmentation_evaluation/app_files/config.json
+++ b/fl-tutorials/nvflare/image_evaluation/3d_spleen_segmentation_evaluation/app_files/config.json
@@ -10,11 +10,5 @@
       "checkpoint": "model.pt",
       "path": "unet"
     }
-  },
-  "evaluation_output": {
-    "spleen": {
-      "mean_dice": 0.0,
-      "raw_dice": []
-    }
   }
 }

--- a/fl-tutorials/nvflare/image_evaluation/3d_spleen_segmentation_evaluation/app_files/evaluator.py
+++ b/fl-tutorials/nvflare/image_evaluation/3d_spleen_segmentation_evaluation/app_files/evaluator.py
@@ -148,8 +148,9 @@ class FLIP_EVALUATOR(Executor):
         for model_name, dice_scores in metric_results.items():
             output_results[model_name] = {
                 "spleen": {
+                    # Aggregate metric only — per-sample (row-level) scores are an individual-level
+                    # disclosure (membership inference, cohort-size leak) and are not returned.
                     "mean_dice": np.mean(dice_scores[:, 1]).item(),
-                    "raw_dice": [float(i) for i in dice_scores[:, 1]],
                 }
             }
 

--- a/fl-tutorials/nvflare/image_evaluation/3d_spleen_segmentation_evaluation/app_files/evaluator.py
+++ b/fl-tutorials/nvflare/image_evaluation/3d_spleen_segmentation_evaluation/app_files/evaluator.py
@@ -14,11 +14,10 @@ import json
 from pathlib import Path
 
 import nibabel as nib
-import numpy as np
 import torch
 from models import model_paths
 from monai.data import DataLoader, Dataset, decollate_batch
-from monai.metrics import DiceMetric
+from monai.metrics import DiceMetric, HausdorffDistanceMetric, MeanIoU, SurfaceDiceMetric
 from monai.networks.utils import one_hot
 from monai.transforms import AsDiscrete
 from nvflare.apis.dxo import DXO, DataKind, from_shareable
@@ -31,6 +30,10 @@ from transforms import get_eval_transforms, get_sliding_window_inferer
 
 from flip import FLIP
 from flip.constants import PTConstants, ResourceType
+
+# Surface tolerance in voxels for the normalized Surface Dice metric: the boundary deviation treated
+# as acceptable, one entry per foreground class (spleen). Tune per dataset/voxel spacing.
+SURFACE_DICE_TOLERANCE_VOXELS = 1.0
 
 
 class FLIP_EVALUATOR(Executor):
@@ -143,24 +146,47 @@ class FLIP_EVALUATOR(Executor):
 
         return datalist
 
-    def _get_json_results_from_numpy(self, metric_results):
-        output_results = {}
-        for model_name, dice_scores in metric_results.items():
-            output_results[model_name] = {
-                "spleen": {
-                    # Aggregate metric only — per-sample (row-level) scores are an individual-level
-                    # disclosure (membership inference, cohort-size leak) and are not returned.
-                    "mean_dice": np.mean(dice_scores[:, 1]).item(),
-                }
-            }
+    def _build_metrics(self):
+        """Build the aggregate (cohort-mean) evaluation metrics for one model.
 
+        Returns:
+            dict[str, monai.metrics.Metric]: metric name -> MONAI metric, each with
+                include_background=False (score the foreground spleen class) and reduction='mean',
+                so aggregate() yields a single cohort-level scalar. No per-sample (row-level)
+                values are produced or exported.
+        """
+        return {
+            "mean_dice": DiceMetric(include_background=False, reduction="mean"),
+            "mean_hausdorff_95": HausdorffDistanceMetric(include_background=False, percentile=95, reduction="mean"),
+            "mean_surface_dice": SurfaceDiceMetric(
+                class_thresholds=[SURFACE_DICE_TOLERANCE_VOXELS], include_background=False, reduction="mean"
+            ),
+            "mean_iou": MeanIoU(include_background=False, reduction="mean"),
+        }
+
+    def _aggregate_results(self, metrics):
+        """Aggregate each model's accumulated metrics into a cohort-level results dict.
+
+        Args:
+            metrics (dict): model name -> {metric name -> accumulated MONAI metric}.
+
+        Returns:
+            dict: model name -> {'spleen': {metric name -> float}}. Only aggregate (cohort-mean)
+                values are emitted — per-sample (row-level) scores are an individual-level
+                disclosure (membership inference, cohort-size leak) and are not returned.
+        """
+        output_results = {}
+        for model_name, metric_map in metrics.items():
+            output_results[model_name] = {
+                "spleen": {name: float(metric.aggregate().item()) for name, metric in metric_map.items()}
+            }
         return output_results
 
     def do_validation(self, fl_ctx, abort_signal):
-        metric_results = {}
-        for model_name, _ in self.models.items():
+        metrics = {}
+        for model_name in self.models:
             self.models[model_name].eval()
-            metric_results[model_name] = DiceMetric(reduction="none")  # Create DiceMetric instance
+            metrics[model_name] = self._build_metrics()
 
         num_images = 0
         self.logger.info(len(self.test_loader))
@@ -175,7 +201,7 @@ class FLIP_EVALUATOR(Executor):
                     batch["label"].to(self.device),
                 )
 
-                for model_name, model in self.models.items():
+                for model_name in self.models:
                     self.models[model_name].to(self.device)
                     # perform sliding window inference to get a prediction for the whole volume.
                     output = self.swi(inputs=images, network=self.models[model_name])
@@ -187,24 +213,26 @@ class FLIP_EVALUATOR(Executor):
                     output = torch.stack([self.post_pred(i) for i in output], 0)
                     labels_one_hot = one_hot(labels, num_classes=self.num_classes)
 
-                    # Compute Dice metric using DiceMetric
-                    metric_results[model_name](output, labels_one_hot)  # Accumulate Dice scores
+                    # Accumulate every metric for this batch (Dice, HD95, Surface Dice, IoU).
+                    for metric in metrics[model_name].values():
+                        metric(output, labels_one_hot)
                     self.models[model_name].cpu()
 
                 batch_size = images.shape[0]
                 num_images += batch_size
                 self.logger.info(f"Validator Iteration: {i}, Num Images: {num_images}")
 
-            # Compute final Dice score
-            for model_name, dice_metric in metric_results.items():
-                metric_results[model_name] = dice_metric.aggregate().cpu().numpy()
+            # Aggregate each metric to a single cohort-level scalar, then reset for the next run.
+            json_results = self._aggregate_results(metrics)
+            for metric_map in metrics.values():
+                for metric in metric_map.values():
+                    metric.reset()
 
-            dice_metric.reset()  # Reset metric for next validation phase
-
-            json_results = self._get_json_results_from_numpy(metric_results)
             message = ""
-            for model_name in self.models.keys():
-                message += f"{json_results[model_name]['spleen']['mean_dice']:.4f} ({model_name})"
+            for model_name in self.models:
+                scores = json_results[model_name]["spleen"]
+                metrics_str = ", ".join(f"{name}={value:.4f}" for name, value in scores.items())
+                message += f"[{model_name}] {metrics_str} "
             self.log_info(fl_ctx, f"Validator finished on the client side: {message}")
 
         return json_results

--- a/flip-utils/flip/nvflare/executors/evaluator.py
+++ b/flip-utils/flip/nvflare/executors/evaluator.py
@@ -57,7 +57,13 @@ class RUN_EVALUATOR(Executor):
             working_dir = Path.cwd()
 
             # Model weights are loaded in the server, and shouldn't be available in the client side.
-            weight_files = [i for i in os.listdir(working_dir) if ".pt" in i or ".pth" in i]
+            # Match the .pt/.pth suffix strictly (not as a substring, so model.ptx / report.pth.json
+            # are left alone) and only target regular files, so a directory named e.g. foo.pt is skipped.
+            weight_files = [
+                i
+                for i in os.listdir(working_dir)
+                if i.endswith((".pt", ".pth")) and os.path.isfile(os.path.join(working_dir, i))
+            ]
             for wf in weight_files:
                 self.log_info(fl_ctx, f"Removing unsafe pytorch file at: {wf} from the client application folder.")
                 os.remove(os.path.join(working_dir, wf))

--- a/flip-utils/flip/nvflare/executors/evaluator.py
+++ b/flip-utils/flip/nvflare/executors/evaluator.py
@@ -10,12 +10,9 @@
 # limitations under the License.
 #
 
-import json
 import os
 from pathlib import Path
-from typing import Dict, List, Tuple
 
-from nvflare.apis.dxo import from_shareable
 from nvflare.apis.executor import Executor
 from nvflare.apis.fl_constant import ReturnCode
 from nvflare.apis.fl_context import FLContext
@@ -24,41 +21,6 @@ from nvflare.apis.signal import Signal
 from nvflare.security.logging import secure_format_traceback
 
 from flip.constants import PTConstants
-
-
-class MetricsValidator:
-    def __init__(self, input_evaluation: Dict, input_models: List):
-        self.input_evaluation = input_evaluation
-        self.input_models = input_models
-
-    def validate(self, input_evaluation) -> Tuple[bool, str]:
-        for model, evaluation in input_evaluation.items():
-            if model not in self.input_models:
-                return False, f"Model '{model}' is not in the list of input models."
-            else:
-                if not isinstance(evaluation, dict):
-                    return False, "Each model must be mapped to a dictionary of metrics."
-                success, message = self.validate_element(evaluation, self.input_evaluation)
-                if not success:
-                    return success, message
-        return True, "Successfully validated all models."
-
-    def validate_element(self, element, original_element) -> Tuple[bool, str]:
-        for key, value in element.items():
-            if key not in original_element.keys():
-                return False, "Wrong metric in evaluation."
-            else:
-                if isinstance(value, dict):
-                    success, message = self.validate_element(value, original_element[key])
-                    if not success:
-                        return success, message
-                else:
-                    if not isinstance(value, (float, list)):
-                        return False, f"Metric '{key}' must be a float or a list of floats."
-                    if isinstance(value, list):
-                        if not all(isinstance(x, float) for x in value):
-                            return False, f"All elements in the list for metric '{key}' must be floats."
-        return True, "Successfully validated elements."
 
 
 class RUN_EVALUATOR(Executor):
@@ -94,36 +56,13 @@ class RUN_EVALUATOR(Executor):
             # working_dir should be current directory where the job runs, not the flip package location
             working_dir = Path.cwd()
 
-            # We load the config
-            metrics_validator = None
-            config_path = working_dir / "config.json"
-            if config_path.exists():
-                with open(config_path, "r") as f:
-                    config_content = json.load(f)
-                metrics_validator = MetricsValidator(
-                    input_evaluation=config_content["evaluation_output"],
-                    input_models=list(config_content["models"].keys()),
-                )
-
             # Model weights are loaded in the server, and shouldn't be available in the client side.
             weight_files = [i for i in os.listdir(working_dir) if ".pt" in i or ".pth" in i]
             for wf in weight_files:
                 self.log_info(fl_ctx, f"Removing unsafe pytorch file at: {wf} from the client application folder.")
                 os.remove(os.path.join(working_dir, wf))
-            output = self._evaluator.execute(task_name, shareable, fl_ctx, abort_signal)
-            output_dxo = from_shareable(output)
 
-            # Validate output if metrics_validator was created
-            if metrics_validator is not None:
-                try:
-                    success, message = metrics_validator.validate(input_evaluation=output_dxo.data)
-                    if not success:
-                        self.log_error(fl_ctx, f"Could not load output properly: {message}.")
-                except Exception as e:
-                    self.log_error(fl_ctx, f"The output validation failed with exception: {type(e).__name__}: {str(e)}")
-                    self.log_error(fl_ctx, f"Output data: {output_dxo.data}")
-
-            return output
+            return self._evaluator.execute(task_name, shareable, fl_ctx, abort_signal)
 
         except Exception:
             self.log_info(fl_ctx, "An exception has been caught in the FLIP_EVALUATOR")

--- a/flip-utils/tests/unit/nvflare/executors/test_evaluator.py
+++ b/flip-utils/tests/unit/nvflare/executors/test_evaluator.py
@@ -87,6 +87,34 @@ class TestRunEvaluator:
         assert not (tmp_path / "weights.pth").exists()
         assert (tmp_path / "data.txt").exists()
 
+    def test_execute_weight_strip_is_suffix_strict_and_file_only(self, tmp_path, monkeypatch):
+        """Only files whose name ends in .pt/.pth are stripped; lookalikes and directories are left alone."""
+        # Non-weight files that merely contain ".pt"/".pth" as a substring must survive.
+        (tmp_path / "model.ptx").write_bytes(b"")
+        (tmp_path / "report.pth.json").write_text("{}")
+        # A directory named like a weight file must not be passed to os.remove (which would raise).
+        (tmp_path / "checkpoints.pt").mkdir()
+        # A genuine weight file is still removed.
+        (tmp_path / "model.pt").write_bytes(b"")
+        monkeypatch.chdir(tmp_path)
+
+        evaluator = RUN_EVALUATOR()
+        evaluator.log_info = MagicMock()
+        evaluator.log_error = MagicMock()
+
+        mock_output = MagicMock()
+        mock_evaluator_instance = MagicMock()
+        mock_evaluator_instance.execute.return_value = mock_output
+        evaluator._evaluator = mock_evaluator_instance
+
+        result = evaluator.execute("eval", MagicMock(), MagicMock(), MagicMock())
+
+        assert result == mock_output
+        assert not (tmp_path / "model.pt").exists()
+        assert (tmp_path / "model.ptx").exists()
+        assert (tmp_path / "report.pth.json").exists()
+        assert (tmp_path / "checkpoints.pt").is_dir()
+
     @patch("evaluator.FLIP_EVALUATOR")
     def test_execute_exception_handling(self, mock_uploaded_evaluator):
         """Test execute method exception handling"""

--- a/flip-utils/tests/unit/nvflare/executors/test_evaluator.py
+++ b/flip-utils/tests/unit/nvflare/executors/test_evaluator.py
@@ -10,8 +10,8 @@
 # limitations under the License.
 #
 
+import json
 import sys
-import tempfile
 from unittest.mock import MagicMock, patch
 
 from nvflare.apis.fl_constant import ReturnCode
@@ -21,59 +21,7 @@ from flip.constants import PTConstants
 # Mock the evaluator module before importing
 sys.modules["evaluator"] = MagicMock()
 
-from flip.nvflare.executors.evaluator import RUN_EVALUATOR, MetricsValidator  # noqa: E402
-
-
-class TestMetricsValidator:
-    def test_init(self):
-        """Test MetricsValidator initialization"""
-        input_eval = {"accuracy": 0.0}
-        input_models = ["model1", "model2"]
-
-        validator = MetricsValidator(input_eval, input_models)
-        assert validator.input_evaluation == input_eval
-        assert validator.input_models == input_models
-
-    def test_validate_success_simple(self):
-        """Test successful validation with simple metrics"""
-        input_eval = {"accuracy": 0.0}
-        test_eval = {"model1": {"accuracy": 0.95}}
-
-        validator = MetricsValidator(input_eval, ["model1"])
-        success, message = validator.validate(test_eval)
-
-        assert success is True
-
-    def test_validate_model_not_in_list(self):
-        """Test validation failure when model not in input list"""
-        input_eval = {"accuracy": 0.0}
-        test_eval = {"model3": {"accuracy": 0.95}}
-
-        validator = MetricsValidator(input_eval, ["model1", "model2"])
-        success, message = validator.validate(test_eval)
-
-        assert success is False
-        assert "model3" in message
-
-    def test_validate_element_with_float(self):
-        """Test validate_element with float values"""
-        input_eval = {"accuracy": 0.0, "loss": 0.0}
-        test_element = {"accuracy": 0.95, "loss": 0.05}
-
-        validator = MetricsValidator(input_eval, ["model1"])
-        success, message = validator.validate_element(test_element, input_eval)
-
-        assert success is True
-
-    def test_validate_element_with_list_of_floats(self):
-        """Test validate_element with list of floats"""
-        input_eval = {"per_class_accuracy": [0.0]}
-        test_element = {"per_class_accuracy": [0.9, 0.92, 0.88]}
-
-        validator = MetricsValidator(input_eval, ["model1"])
-        success, message = validator.validate_element(test_element, input_eval)
-
-        assert success is True
+from flip.nvflare.executors.evaluator import RUN_EVALUATOR  # noqa: E402
 
 
 class TestRunEvaluator:
@@ -94,137 +42,50 @@ class TestRunEvaluator:
         assert evaluator._project_id == "proj_111"
         assert evaluator._query == "SELECT * FROM eval_data"
 
-    @patch("evaluator.FLIP_EVALUATOR")
-    @patch("flip.nvflare.executors.evaluator.from_shareable")
-    @patch("builtins.open", create=True)
-    @patch("os.listdir")
-    @patch("os.remove")
-    def test_execute_with_config_file(
-        self, mock_remove, mock_listdir, mock_open, mock_from_shareable, mock_uploaded_evaluator
-    ):
-        """Test execute method with config.json file"""
+    def test_execute_returns_output_without_evaluation_output_in_config(self, tmp_path, monkeypatch):
+        """The evaluator's output is returned even when config.json declares no evaluation_output schema."""
+        # config.json is present (the evaluation pipeline needs it for model loading) but carries no
+        # evaluation_output block — the executor must not require one to return metrics.
+        (tmp_path / "config.json").write_text(
+            json.dumps({"models": {"model1": {"checkpoint": "model.pt", "path": "unet"}}})
+        )
+        monkeypatch.chdir(tmp_path)
+
         evaluator = RUN_EVALUATOR()
         evaluator.log_info = MagicMock()
         evaluator.log_error = MagicMock()
 
-        fl_ctx = MagicMock()
-        fl_ctx.get_peer_context.return_value = None
-        shareable = MagicMock()
-        abort_signal = MagicMock()
-
-        # Setup config file content
-        config_content = {"evaluation_output": {"accuracy": 0.0}, "models": {"model1": {}, "model2": {}}}
-
-        mock_listdir.return_value = ["config.json"]
-        mock_file = MagicMock()
-        mock_open.return_value.__enter__.return_value = mock_file
-
-        mock_evaluator_instance = MagicMock()
         mock_output = MagicMock()
+        mock_evaluator_instance = MagicMock()
         mock_evaluator_instance.execute.return_value = mock_output
-        mock_uploaded_evaluator.return_value = mock_evaluator_instance
+        evaluator._evaluator = mock_evaluator_instance
 
-        mock_dxo = MagicMock()
-        mock_dxo.data = {"model1": {"accuracy": 0.95}, "model2": {"accuracy": 0.93}}
-        mock_from_shareable.return_value = mock_dxo
-
-        with tempfile.TemporaryDirectory() as tmpdir:
-            with patch("flip.nvflare.executors.evaluator.Path") as mock_path:
-                with patch("json.load", return_value=config_content):
-                    mock_path_instance = MagicMock()
-                    mock_path_instance.parent.resolve.return_value = tmpdir
-                    mock_path.return_value = mock_path_instance
-
-                    result = evaluator.execute("eval", shareable, fl_ctx, abort_signal)
+        result = evaluator.execute("eval", MagicMock(), MagicMock(), MagicMock())
 
         assert result == mock_output
 
-    @patch("evaluator.FLIP_EVALUATOR")
-    @patch("flip.nvflare.executors.evaluator.from_shareable")
-    @patch("os.listdir")
-    @patch("os.remove")
-    def test_execute_removes_pytorch_files(
-        self, mock_remove, mock_listdir, mock_from_shareable, mock_uploaded_evaluator
-    ):
-        """Test execute method removes .pt and .pth files"""
+    def test_execute_removes_pytorch_files(self, tmp_path, monkeypatch):
+        """.pt and .pth weight files are stripped from the client working dir before the evaluator runs."""
+        (tmp_path / "model.pt").write_bytes(b"")
+        (tmp_path / "weights.pth").write_bytes(b"")
+        (tmp_path / "data.txt").write_text("keep me")
+        monkeypatch.chdir(tmp_path)
+
         evaluator = RUN_EVALUATOR()
         evaluator.log_info = MagicMock()
         evaluator.log_error = MagicMock()
 
-        fl_ctx = MagicMock()
-        fl_ctx.get_peer_context.return_value = None
-        shareable = MagicMock()
-        abort_signal = MagicMock()
-
-        # os.listdir is called twice - once for config check, once for weight files
-        mock_listdir.return_value = ["model.pt", "weights.pth", "config.json", "data.txt"]
-
-        mock_evaluator_instance = MagicMock()
         mock_output = MagicMock()
-        mock_evaluator_instance.execute.return_value = mock_output
-        mock_uploaded_evaluator.return_value = mock_evaluator_instance
-
-        mock_dxo = MagicMock()
-        mock_dxo.data = {"model1": {"accuracy": 0.95}}
-        mock_from_shareable.return_value = mock_dxo
-
-        with tempfile.TemporaryDirectory() as tmpdir:
-            with patch("flip.nvflare.executors.evaluator.Path") as mock_path:
-                with patch("builtins.open", create=True):
-                    with patch("json.load", return_value={"evaluation_output": {}, "models": {}}):
-                        mock_path_instance = MagicMock()
-                        mock_path_instance.parent.resolve.return_value = tmpdir
-                        mock_path.return_value = mock_path_instance
-
-                        evaluator.execute("eval", shareable, fl_ctx, abort_signal)
-
-        # Should have removed 2 pytorch files (model.pt and weights.pth)
-        assert mock_remove.call_count == 2
-
-    @patch("evaluator.FLIP_EVALUATOR")
-    @patch("flip.nvflare.executors.evaluator.from_shareable")
-    @patch("builtins.open", create=True)
-    @patch("os.listdir")
-    @patch("os.remove")
-    def test_execute_validation_failure(
-        self, mock_remove, mock_listdir, mock_open, mock_from_shareable, mock_uploaded_evaluator
-    ):
-        """Test execute method with validation failure"""
-        evaluator = RUN_EVALUATOR()
-        evaluator.log_info = MagicMock()
-        evaluator.log_error = MagicMock()
-
-        fl_ctx = MagicMock()
-        fl_ctx.get_peer_context.return_value = None
-        shareable = MagicMock()
-        abort_signal = MagicMock()
-
-        config_content = {"evaluation_output": {"accuracy": 0.0}, "models": {"model1": {}}}
-
-        mock_listdir.return_value = ["config.json"]
-
         mock_evaluator_instance = MagicMock()
-        mock_output = MagicMock()
         mock_evaluator_instance.execute.return_value = mock_output
-        mock_uploaded_evaluator.return_value = mock_evaluator_instance
+        evaluator._evaluator = mock_evaluator_instance
 
-        # Return data for wrong model
-        mock_dxo = MagicMock()
-        mock_dxo.data = {"model_wrong": {"accuracy": 0.95}}
-        mock_from_shareable.return_value = mock_dxo
+        result = evaluator.execute("eval", MagicMock(), MagicMock(), MagicMock())
 
-        with tempfile.TemporaryDirectory() as tmpdir:
-            with patch("flip.nvflare.executors.evaluator.Path") as mock_path:
-                with patch("json.load", return_value=config_content):
-                    mock_path_instance = MagicMock()
-                    mock_path_instance.parent.resolve.return_value = tmpdir
-                    mock_path.return_value = mock_path_instance
-
-                    result = evaluator.execute("eval", shareable, fl_ctx, abort_signal)
-
-        # Should still return output but log error
         assert result == mock_output
-        evaluator.log_error.assert_called()
+        assert not (tmp_path / "model.pt").exists()
+        assert not (tmp_path / "weights.pth").exists()
+        assert (tmp_path / "data.txt").exists()
 
     @patch("evaluator.FLIP_EVALUATOR")
     def test_execute_exception_handling(self, mock_uploaded_evaluator):
@@ -245,5 +106,4 @@ class TestRunEvaluator:
 
         assert result.get_return_code() == ReturnCode.EXECUTION_EXCEPTION
         assert result.get_header("exception") is not None
-        evaluator.log_error.assert_called()
         evaluator.log_error.assert_called()


### PR DESCRIPTION
# Description

Removes `MetricsValidator` from the NVFLARE evaluation executor
(`flip-utils/flip/nvflare/executors/evaluator.py`) and the config-driven output
validation it performed in `RUN_EVALUATOR.execute`. Returning metrics from an
evaluator is now as simple as returning a metrics dict.

**Why it is safe to remove (it was not a control):** `MetricsValidator` checked an
evaluator's output against an `evaluation_output` schema declared in the **same
uploaded app's** `config.json`. Since `config.json` and `evaluator.py` are authored
together, a self-declared schema is self-certifying and gives no integrity
guarantee — and it was **log-only** (`log_error` on mismatch, output returned
unchanged), so it never gated anything. Its `evaluation_output` schema was read by
nothing else; results are produced by `EvaluationJsonGenerator`, which dumps
`dxo.data` verbatim regardless.

The integrity of what clients return is controlled by **code review + app hashing**,
not runtime output validation. The Flower backend already returns metrics natively
with no equivalent validator.

**Friction this removes:**
- `evaluation_output` was de-facto mandatory — `execute` read `config["evaluation_output"]`
  with a bare subscript inside the top-level `try`, so an eval app that had a
  `config.json` (needed for `models`) but omitted `evaluation_output` raised
  `KeyError` → `EXECUTION_EXCEPTION` and **failed**.
- Metrics had to be coerced to `float` / `list[float]` to pass validation.

## Linked Issues

Fixes #659

## Changes

- **`flip-utils/.../executors/evaluator.py`** — delete `class MetricsValidator`;
  `RUN_EVALUATOR.execute` no longer reads `config.json` or validates output, it
  returns the evaluator's reply directly. The `.pt`/`.pth` weight-stripping (a real
  control) is unchanged. Dropped now-unused imports (`json`, `typing`, `from_shareable`).
- **`flip-utils/.../tests/.../test_evaluator.py`** — removed `TestMetricsValidator`
  and the config-file/validation-failure tests; added a test proving an evaluator's
  output is returned with **no** `evaluation_output` in `config.json`, plus a
  real-filesystem `.pt`/`.pth` stripping test; kept exception handling.
- **`fl-tutorials/.../3d_spleen_segmentation_evaluation/app_files/config.json`** —
  removed the now-dead `evaluation_output` block (keeps `models`).
- **`fl-apps/nvflare/evaluation/README.md`** — dropped the `evaluation_output` schema
  bullet; note that an evaluator may return any JSON-serialisable metrics, saved verbatim.
- **`.github/workflows/unit-tests-heavy.yml`** (2nd commit) — run the heavy NVFLARE
  coverage job on `flip-utils/**` pushes, not just `workflow_dispatch`. The light
  `unit-tests.yml` job deselects the nvflare tree (`-k "not nvflare"`, no torch), so
  without this nvflare files showed 0% patch coverage on Codecov. See "Codecov" below.
- **`fl-tutorials/.../3d_spleen_segmentation_evaluation/app_files/evaluator.py`** (3rd
  commit) — stop returning per-sample `raw_dice`; return aggregate `mean_dice` only.
  Per-sample (row-level) scores are individual-level disclosure leaving the trust (the
  list length leaks the exact cohort size and, emitted in cohort-dataframe order, is
  positionally linkable to patients — a membership-inference / small-cell channel at
  odds with FLIP's query-side cohort suppression). This matches the Flower spleen-eval
  tutorial, which already returns aggregate metrics only. Re-ran the tutorial e2e to
  confirm clean results with `mean_dice` and no `raw_dice`.
- **`...evaluator.py`** (4th commit) — add three more aggregate MONAI metrics alongside
  `mean_dice`: `mean_hausdorff_95` (HD95), `mean_surface_dice` (NSD, 1-voxel tolerance),
  `mean_iou`. All use `include_background=False` + `reduction="mean"` (cohort-level scalar,
  no per-sample export). Also fixes a latent bug (the old code reset only the last metric).
- **`...3d_spleen_segmentation_evaluation/README.md`** (5th commit) — drop the stale
  "evaluation output schema" reference to `config.json`; add an "Output metrics" section
  documenting the four aggregate metrics and the no-row-level-export rationale.

This aligns the tutorial with the platform's already-documented governance —
`docs/source/deploy-flip/deploy-flip-node-in-tre.rst` states "Only aggregate evaluation
metrics leave the TRE"; the old per-sample `raw_dice` was inconsistent with that.

## Acceptance Criteria

- [x] **The NVFLARE 3D spleen segmentation evaluation tutorial runs end-to-end** and
  produces `evaluation_results.json`. **Verified** on a local NVIDIA RTX 5090 against
  `flare-fl-base:dev` rebuilt from this branch (confirmed the image no longer imports
  `MetricsValidator`): `make -C fl-tutorials run-tutorial TUTORIAL=3d_spleen_segmentation_evaluation FL_BASE_IMAGE_TAG=dev`
  exited 0 and wrote per-site results (`monai_spleen_unet → spleen → mean_dice ≈ 0.9462`
  + 10 `raw_dice` values). No `EXECUTION_EXCEPTION` / `MetricsValidator` / `KeyError` /
  `evaluation_output` / `Traceback` in the run log; model status reached `RESULTS_UPLOADED`.
- [x] An evaluator can return metrics without declaring `evaluation_output` in
  `config.json` and without coercing values to `float`/`list[float]` (covered by new unit test).
- [x] `MetricsValidator` is gone; `RUN_EVALUATOR` no longer reads `config.json`;
  `.pt`/`.pth` stripping still works (covered by unit tests).
- [x] `flip-utils` evaluator unit tests pass.

## Checklist

- [x] Follows the project's coding conventions and style guide
- [x] Updates documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes <!-- evaluator module 5/5 + ruff + mypy locally; full flip-utils nvflare suite green in CI (unit-tests-heavy), e2e tutorial green on local GPU -->
- [x] Any dependent changes have been merged and published <!-- none -->

## Type of Change

- [x] Non-breaking change (valid eval apps behave identically; apps that previously failed for a missing `evaluation_output` now succeed). Note: removes the internal `MetricsValidator` class.
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [ ] In-line docstrings updated.
- [x] Documentation updated (READMEs; no Sphinx changes).

## Testing

- **Unit:** `pytest tests/unit/nvflare/executors/test_evaluator.py` — **5 passed**;
  `ruff` + `mypy` clean. Full `flip-utils` nvflare suite green in CI (`unit-tests-heavy`).
- **End-to-end (GPU):** spleen-eval tutorial re-run on a local RTX 5090 after each change —
  exit 0, no exceptions; final `evaluation_results.json` carries the four aggregate metrics
  (`mean_dice` 0.946, `mean_hausdorff_95` 1.72, `mean_surface_dice` 0.885, `mean_iou` 0.898)
  and no `raw_dice`. The MONAI metric APIs were pre-checked against the image (MONAI 1.5.2).
- **CI:** all PR checks green, including `codecov/patch` 100% of diff hit.

## Codecov

The changed nvflare line initially showed 0% patch coverage because the PR-time
`unit-tests.yml` job runs `pytest -k "not nvflare"` (the nvflare tests need torch,
which that job doesn't install) and the torch-backed `unit-tests-heavy.yml` was
`workflow_dispatch`-only — so nvflare coverage never reached Codecov on a PR. The
module is 100% covered locally. The 2nd commit makes `unit-tests-heavy.yml` run on
`flip-utils/**` pushes, so nvflare coverage now uploads per commit; `codecov/patch`
is green.

## Additional Notes

The acceptance-criteria gate (GPU tutorial run) is **cleared** — ran clean on a local
RTX 5090. All CI checks are green.
