### PR TITLE
fix(xnat): harden trust XNAT against bulk-import event-bus livelock

### DIFF
--- a/.github/workflows/docker_build_xnat_web.yml
+++ b/.github/workflows/docker_build_xnat_web.yml
@@ -116,7 +116,10 @@ jobs:
         run: aws s3 cp s3://${{ env.FLIP_ARTIFACTS_BUCKET_NAME }}/xnat/xnat-web-1.9.3.war build-artifacts/xnat-web-1.9.3.war
 
       - name: Download XNAT plugins
-        run: aws s3 sync s3://${{ env.FLIP_ARTIFACTS_BUCKET_NAME }}/xnat/plugins/ plugins/
+        # Exclude ohif-viewer: FLIP never opens the viewer, and its per-session
+        # metadata-rebuild listener is the dominant load on XNAT's Reactor
+        # EventBus (FLIP#662). Keep this in sync with scripts/ensure_plugins.sh.
+        run: aws s3 sync s3://${{ env.FLIP_ARTIFACTS_BUCKET_NAME }}/xnat/plugins/ plugins/ --exclude "ohif-viewer-*"
 
       - name: Build Docker image
         env:

--- a/trust/xnat/.env
+++ b/trust/xnat/.env
@@ -7,8 +7,11 @@
 # Guy's and St Thomas' NHS Foundation Trust & King's College London
 
 XNAT_VERSION=1.9.3
-XNAT_MIN_HEAP=1024m
-XNAT_MAX_HEAP=3072m
+# Heap raised from 1024m/3072m: bulk DQR imports drove G1 GC pressure that, with
+# the Reactor EventBus back-pressure livelock, helped wedge large cohort pulls
+# (FLIP#662). Trust hosts have ample RAM; 2g/8g gives GC headroom for big imports.
+XNAT_MIN_HEAP=2048m
+XNAT_MAX_HEAP=8192m
 XNAT_SMTP_ENABLED=false
 XNAT_SMTP_HOSTNAME=fake.fake
 XNAT_SMTP_PORT=

--- a/trust/xnat/docker-compose-stack.yml
+++ b/trust/xnat/docker-compose-stack.yml
@@ -33,6 +33,16 @@ services:
 
   xnat-db:
     image: ${DOCKER_REGISTRY}xnat-db:${XNAT_TAG}
+    # Raise max_connections above the Postgres default (100). During a bulk DQR
+    # import XNAT opens many concurrent build connections, and an xnat-web restart
+    # briefly doubles the count (the old task's connections linger until reaped),
+    # which exhausted the pool and locked out even admin queries (FLIP#662).
+    command:
+      - postgres
+      - -c
+      - max_connections=300
+      - -c
+      - shared_buffers=512MB
     deploy:
       replicas: 1
       restart_policy:

--- a/trust/xnat/scripts/ensure_plugins.sh
+++ b/trust/xnat/scripts/ensure_plugins.sh
@@ -15,11 +15,15 @@ if [[ -z "${PLUGIN_DIR}" || -z "${S3_BUCKET}" ]]; then
   exit 1
 fi
 
+# NOTE: ohif-viewer is intentionally NOT installed. FLIP uses XNAT purely as a
+# DICOM store for FL training and never opens the OHIF viewer, but the plugin's
+# per-session metadata-rebuild event listener is the dominant load on XNAT's
+# Reactor EventBus and materially drives the back-pressure livelock that wedges
+# bulk cohort imports (FLIP#662). It is excluded from the S3 sync below.
 required_prefixes=(
   "batch-launch-"
   "container-service-"
   "dicom-query-retrieve-"
-  "ohif-viewer-"
 )
 expected_prefixes="$(printf '%s, ' "${required_prefixes[@]}")"
 expected_prefixes="${expected_prefixes%, }"
@@ -52,7 +56,11 @@ else
 
   echo "⬇️ Missing plugin families locally: ${missing_prefixes//$'\n'/ }"
   echo "📦 Syncing plugins from S3..."
-  aws s3 sync "s3://${S3_BUCKET}/xnat/plugins/" "${PLUGIN_DIR}/" --delete --exclude "*" --include "*.jar"
+  # Exclude ohif-viewer: the trailing --exclude wins over --include for matching
+  # keys, so it is neither downloaded nor (with --delete) kept locally. See the
+  # required_prefixes note above (FLIP#662).
+  aws s3 sync "s3://${S3_BUCKET}/xnat/plugins/" "${PLUGIN_DIR}/" --delete \
+    --exclude "*" --include "*.jar" --exclude "ohif-viewer-*"
 fi
 
 missing_prefixes="$(find_missing_prefixes)"

--- a/trust/xnat/xnat/make-xnat-config.sh
+++ b/trust/xnat/xnat/make-xnat-config.sh
@@ -29,9 +29,24 @@ EOF
 fi
 
 
-if [ ! -z "$XNAT_EMAIL" ]; then
-  cat > $XNAT_HOME/config/prefs-init.ini << EOF
+# Initialise site preferences. The JMS listener concurrency caps bound XNAT's
+# directArchive build pool: at the default (max 40) a bulk DQR cohort import
+# spawns ~40 build threads that each publish events synchronously, saturating the
+# Reactor EventBus ring buffer until it deadlocks — the import wedges permanently
+# with everything stuck PROCESSING (FLIP#662). Capping concurrency keeps the
+# event-bus producers under the buffer capacity so large imports flow steadily.
+# NOTE: prefs-init.ini is applied at XNAT initialisation; for an already-running
+# instance set these via the admin UI / xapi siteConfig (or DB) and restart.
+cat > $XNAT_HOME/config/prefs-init.ini << EOF
 [siteConfig]
+defaultJmsListenerMinConcurrency=2
+defaultJmsListenerMaxConcurrency=8
+prearchiveOperationJmsListenerMinConcurrency=2
+prearchiveOperationJmsListenerMaxConcurrency=8
+EOF
+
+if [ ! -z "$XNAT_EMAIL" ]; then
+  cat >> $XNAT_HOME/config/prefs-init.ini << EOF
 adminEmail=$XNAT_EMAIL
 EOF
 fi

--- a/trust/xnat/xnat/make-xnat-config.sh
+++ b/trust/xnat/xnat/make-xnat-config.sh
@@ -40,9 +40,9 @@ fi
 cat > $XNAT_HOME/config/prefs-init.ini << EOF
 [siteConfig]
 defaultJmsListenerMinConcurrency=2
-defaultJmsListenerMaxConcurrency=8
+defaultJmsListenerMaxConcurrency=4
 prearchiveOperationJmsListenerMinConcurrency=2
-prearchiveOperationJmsListenerMaxConcurrency=8
+prearchiveOperationJmsListenerMaxConcurrency=4
 EOF
 
 if [ ! -z "$XNAT_EMAIL" ]; then


### PR DESCRIPTION
## Summary

Harden the trust XNAT against the **bulk-import event-bus livelock** diagnosed in #662. Large DQR cohort pulls wedge XNAT permanently: the Reactor `EventBus` ring buffer saturates (the OHIF-viewer per-session metadata listener is the dominant load), directArchive build threads convoy on a global lock, and the pipeline halts with everything stuck `PROCESSING` / `0 FAILED`. A plain restart clears the livelock but strands in-flight directArchive sessions and triggered a Postgres connection storm.

Observed on the GSTT prod-attached trust importing a 1910-study cohort — stalled at 843/1910.

## Changes

- **Drop the `ohif-viewer` plugin** (`scripts/ensure_plugins.sh`): removed from the required set and excluded from the S3 sync. FLIP uses XNAT purely as a DICOM store for FL training and never opens the OHIF viewer; its metadata-rebuild event listener is the dominant event-bus load driving the livelock.
- **Raise JVM heap** (`.env`): `1024m/3072m` → `2048m/8192m` for GC headroom on large pulls.
- **Postgres `max_connections=300`** + `shared_buffers=512MB` (`docker-compose-stack.yml`): a bulk import opens many concurrent build connections, and an xnat-web restart briefly doubles the count (old task's connections linger until reaped), which exhausted the default-100 pool and locked out even admin queries.

## Deploy notes

- Heap + `max_connections` apply on `docker stack deploy` (**no rebuild**).
- The OHIF removal requires a **`xnat-web` image rebuild** (`make build` / `docker_build_xnat_web.yml`), since plugins are baked into the image.

## Not included (follow-ups in #662)

- Persistent ActiveMQ + startup re-scan so restarts don't strand directArchive sessions.
- imaging-api import throttle (bounded batches) — the belt-and-suspenders guarantee independent of XNAT internals.

## Testing

- `bash -n` clean on `ensure_plugins.sh`; `aws s3 sync` filter order verified (trailing `--exclude "ohif-viewer-*"` wins over `--include "*.jar"`).
- Compose change is config-only.

Refs #662.
