### PR TITLE
Upgrade NVFLARE backend 2.7.2 → 2.8.0

### DIFF
--- a/fl-apps/nvflare/diffusion_model/app/custom/requirements.txt
+++ b/fl-apps/nvflare/diffusion_model/app/custom/requirements.txt
@@ -13,7 +13,7 @@
 boto3>=1.38.31
 monai>=1.4.0
 nibabel>=5.3.2
-nvflare==2.7.2
+nvflare==2.8.0
 pandas>=2.3.0
 pydantic>=2.11.7
 pydantic-settings>=2.10.1

--- a/fl-services/nvflare/fl-api-base/fl_api/routers/jobs.py
+++ b/fl-services/nvflare/fl-api-base/fl_api/routers/jobs.py
@@ -14,11 +14,10 @@
 from typing import Optional, Union
 
 from fastapi import APIRouter, Depends, status
-from nvflare.fuel.hci.client.fl_admin_api import TargetType
 
 from fl_api.core.dependencies import get_session
 from fl_api.utils.flip_session import FLIP_Session
-from fl_api.utils.schemas import JobMetadata, JobStatus, normalize_status
+from fl_api.utils.schemas import JobMetadata, JobStatus, TargetType, normalize_status
 
 router = APIRouter()
 

--- a/fl-services/nvflare/fl-api-base/fl_api/routers/system.py
+++ b/fl-services/nvflare/fl-api-base/fl_api/routers/system.py
@@ -14,11 +14,10 @@
 from typing import List, Optional
 
 from fastapi import APIRouter, Depends, Query, status
-from nvflare.fuel.hci.client.fl_admin_api import TargetType
 
 from fl_api.core.dependencies import get_session
 from fl_api.utils.flip_session import FLIP_Session
-from fl_api.utils.schemas import ClientInfoModel, ServerInfoModel, SystemInfoModel
+from fl_api.utils.schemas import ClientInfoModel, ServerInfoModel, SystemInfoModel, TargetType
 
 router = APIRouter()
 

--- a/fl-services/nvflare/fl-api-base/fl_api/utils/schemas.py
+++ b/fl-services/nvflare/fl-api-base/fl_api/utils/schemas.py
@@ -99,6 +99,22 @@ class TrainingRound(IntEnum):
     MAX = 1000
 
 
+class TargetType(StrEnum):
+    """System target for admin operations (restart/shutdown), used as a FastAPI path param.
+
+    NVFLARE 2.8.0 removed the deprecated ``nvflare.fuel.hci.client.fl_admin_api`` tree, which
+    previously exported ``TargetType`` as a ``(str, Enum)``. Its successor,
+    ``nvflare.fuel.flare_api.api_spec.TargetType``, is a plain class (bare string class-attrs) that
+    FastAPI rejects as a path-param annotation. We therefore re-declare it locally as a ``StrEnum``,
+    preserving the original wire contract: the member values are exactly the ``"all"``/``"server"``/
+    ``"client"`` strings that ``flare_api.Session.restart``/``shutdown`` validate against.
+    """
+
+    ALL = "all"
+    SERVER = "server"
+    CLIENT = "client"
+
+
 class IOverridableConfig(BaseModel):
     LOCAL_ROUNDS: Optional[int] = None
     GLOBAL_ROUNDS: Optional[int] = None

--- a/fl-services/nvflare/fl-api-base/pyproject.toml
+++ b/fl-services/nvflare/fl-api-base/pyproject.toml
@@ -18,7 +18,7 @@ readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
     "fastapi[standard]>=0.115.11",
-    "nvflare==2.7.2",
+    "nvflare==2.8.0",
     "pydantic-settings>=2.11.0",
 ]
 
@@ -40,7 +40,7 @@ exclude-newer = "3 days"
 constraint-dependencies = [
     "aiohttp>=3.14.0",           # CVE-2026-47265, CVE-2026-34993, CVE-2026-34525/16/15/14/13/12, CVE-2026-22815, CVE-2026-21860
     "cryptography>=46.0.7",      # CVE-2026-26007, CVE-2026-39892, CVE-2026-34073
-    # flask>=3.1.3 omitted: nvflare==2.7.2 hard-pins flask==3.0.2; unresolvable until nvflare relaxes that pin
+    # flask>=3.1.3 omitted: nvflare==2.8.0 hard-pins flask==3.0.2; unresolvable until nvflare relaxes that pin
     "idna>=3.15",                # CVE-2026-45409
     "protobuf>=6.33.5",          # CVE-2026-0994, CVE-2025-4565
     "pygments>=2.20.0",          # CVE-2026-4539

--- a/fl-services/nvflare/fl-api-base/tests/utils/test_schemas.py
+++ b/fl-services/nvflare/fl-api-base/tests/utils/test_schemas.py
@@ -1,0 +1,55 @@
+# Copyright (c) 2026 Guy's and St Thomas' NHS Foundation Trust & King's College London
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Guard against ``fl_api.utils.schemas.TargetType`` drifting from NVFLARE's own.
+
+NVFLARE 2.8.0 removed the ``(str, Enum)`` ``TargetType`` that the fl-api routers
+used to import from ``nvflare.fuel.hci.client.fl_admin_api``; its successor,
+``nvflare.fuel.flare_api.api_spec.TargetType``, is a plain class FastAPI rejects
+as a path-param annotation. We therefore re-declare ``TargetType`` locally as a
+``StrEnum`` (see ``fl_api/utils/schemas.py``). Because that copy is hand-maintained,
+this test fails loudly if a future NVFLARE bump adds, removes, or renames a member,
+prompting us to re-sync the local enum.
+"""
+
+from enum import Enum
+
+from nvflare.fuel.flare_api.api_spec import TargetType as NVFlareTargetType
+
+from fl_api.utils.schemas import TargetType
+
+
+def _values(target_type_cls: type) -> set[str]:
+    """Return the set of string target values a TargetType class exposes.
+
+    Handles both our local ``StrEnum`` (iterate members) and NVFLARE's plain class
+    (collect upper-case string class attributes), so the two can be compared
+    regardless of how each declares its members.
+
+    Args:
+        target_type_cls (type): an enum or plain class declaring ALL/SERVER/CLIENT.
+
+    Returns:
+        set[str]: the target string values (e.g. ``{"all", "server", "client"}``).
+    """
+    if issubclass(target_type_cls, Enum):
+        return {item.value for item in target_type_cls}
+
+    return {value for name, value in vars(target_type_cls).items() if name.isupper() and isinstance(value, str)}
+
+
+def test_target_type_matches_nvflare_target_type() -> None:
+    assert _values(TargetType) == _values(NVFlareTargetType), (
+        "fl_api.utils.schemas.TargetType is out of sync with "
+        "nvflare.fuel.flare_api.api_spec.TargetType — re-sync the local StrEnum "
+        "after this NVFLARE upgrade."
+    )

--- a/fl-services/nvflare/fl-api-base/uv.lock
+++ b/fl-services/nvflare/fl-api-base/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer = "2026-06-23T15:00:14.944202565Z"
 exclude-newer-span = "P3D"
 
 [manifest]
@@ -810,7 +810,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "fastapi", extras = ["standard"], specifier = ">=0.115.11" },
-    { name = "nvflare", specifier = "==2.7.2" },
+    { name = "nvflare", specifier = "==2.8.0" },
     { name = "pydantic-settings", specifier = ">=2.11.0" },
 ]
 
@@ -1537,7 +1537,7 @@ wheels = [
 
 [[package]]
 name = "nvflare"
-version = "2.7.2"
+version = "2.8.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -1559,7 +1559,7 @@ dependencies = [
     { name = "safetensors" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ce/6d/20121738d8be2aa580d3c01c3ac1514d0c8006a3a4c66ba83c26ebb54b4c/nvflare-2.7.2-py3-none-any.whl", hash = "sha256:694f37a730cc853992c9cf030a6ca52b55d86a4572294157ad52b0f01d474e35", size = 2981434, upload-time = "2026-03-20T20:51:44.89Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/a9/a3c6d71f081c277126ec929d87d9b40f7308f56e1d13118de77441bd70c3/nvflare-2.8.0-py3-none-any.whl", hash = "sha256:a448ce5654b5a37bf8a680c1b9a5292ea01f44384b5dffc1e754d75dffd46c74", size = 3259204, upload-time = "2026-06-04T19:05:47.576Z" },
 ]
 
 [[package]]

--- a/fl-tutorials/nvflare/image_synthesis/latent_diffusion_model/app_files/requirements.txt
+++ b/fl-tutorials/nvflare/image_synthesis/latent_diffusion_model/app_files/requirements.txt
@@ -1,7 +1,7 @@
 boto3>=1.38.31
 monai>=1.4.0
 nibabel>=5.3.2
-nvflare==2.7.2
+nvflare==2.8.0
 pandas>=2.3.0
 pydantic>=2.11.7
 pydantic-settings>=2.10.1

--- a/flip-utils/pyproject.toml
+++ b/flip-utils/pyproject.toml
@@ -49,7 +49,7 @@ classifiers = [
 ]
 dependencies = [
     "boto3>=1.38.31",
-    "nvflare==2.7.2",
+    "nvflare==2.8.0",
     "pandas>=2.3.0",
     "pydantic>=2.11.7",
     "pydantic-settings>=2.10.1",
@@ -101,7 +101,7 @@ constraint-dependencies = [
     "aiohttp>=3.14.0",           # CVE-2026-47265, CVE-2026-34993, CVE-2026-34525/16/15/14/13/12, CVE-2026-22815, CVE-2026-21860
     "cryptography>=46.0.7",      # CVE-2026-26007, CVE-2026-39892, CVE-2026-34073
     "filelock>=3.20.3",          # CVE-2025-68146, CVE-2026-22701
-    # flask>=3.1.3 omitted: nvflare==2.7.2 hard-pins flask==3.0.2; unresolvable until nvflare relaxes that pin
+    # flask>=3.1.3 omitted: nvflare==2.8.0 hard-pins flask==3.0.2; unresolvable until nvflare relaxes that pin
     "idna>=3.15",                # CVE-2026-45409
     "pillow>=12.2.0",            # CVE-2026-42311/42310/42309/42308/40192/25990
     "protobuf>=6.33.5",          # CVE-2026-0994

--- a/flip-utils/uv.lock
+++ b/flip-utils/uv.lock
@@ -3,7 +3,7 @@ revision = 3
 requires-python = ">=3.12"
 
 [options]
-exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer = "2026-06-23T15:00:09.396685995Z"
 exclude-newer-span = "P3D"
 
 [manifest]
@@ -772,7 +772,7 @@ requires-dist = [
     { name = "lpips", marker = "extra == 'full'", specifier = "==0.1.4" },
     { name = "monai", extras = ["pyyaml", "scipy", "skimage"], marker = "extra == 'full'", specifier = ">=1.5.2" },
     { name = "nibabel", marker = "extra == 'full'", specifier = ">=5.3.2" },
-    { name = "nvflare", specifier = "==2.7.2" },
+    { name = "nvflare", specifier = "==2.8.0" },
     { name = "pandas", specifier = ">=2.3.0" },
     { name = "pydantic", specifier = ">=2.11.7" },
     { name = "pydantic-settings", specifier = ">=2.10.1" },
@@ -1757,7 +1757,7 @@ wheels = [
 
 [[package]]
 name = "nvflare"
-version = "2.7.2"
+version = "2.8.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -1779,7 +1779,7 @@ dependencies = [
     { name = "safetensors" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ce/6d/20121738d8be2aa580d3c01c3ac1514d0c8006a3a4c66ba83c26ebb54b4c/nvflare-2.7.2-py3-none-any.whl", hash = "sha256:694f37a730cc853992c9cf030a6ca52b55d86a4572294157ad52b0f01d474e35", size = 2981434, upload-time = "2026-03-20T20:51:44.89Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/a9/a3c6d71f081c277126ec929d87d9b40f7308f56e1d13118de77441bd70c3/nvflare-2.8.0-py3-none-any.whl", hash = "sha256:a448ce5654b5a37bf8a680c1b9a5292ea01f44384b5dffc1e754d75dffd46c74", size = 3259204, upload-time = "2026-06-04T19:05:47.576Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #666.

Upgrades FLIP's NVFLARE backend **2.7.2 → 2.8.0**.

## Changes
- Bump the four `nvflare==2.7.2` → `==2.8.0` pins: `flip-utils/pyproject.toml` (canonical FL base lib → fl-base/fl-server/fl-client), `fl-services/nvflare/fl-api-base/pyproject.toml`, the diffusion app + tutorial `requirements.txt`.
- Regenerate the two affected `uv.lock` files — **nvflare is the only changed version in either lock** (zero transitive churn; `uv lock --check` passes).
- **Breaking-change fix:** 2.8.0 removed the deprecated `nvflare.fuel.hci.client.fl_admin_api` tree, from which the fl-api routers imported `TargetType`. Its 2.8.0 successor (`flare_api.api_spec.TargetType`) is a plain class that FastAPI rejects as a path-param annotation (the old one was `(str, Enum)`). Re-declared `TargetType` locally as a `StrEnum` in `fl_api/utils/schemas.py` — preserving the `all`/`server`/`client` wire contract that `flare_api.Session.restart`/`shutdown` validate against — and repointed `jobs.py`/`system.py`.
- Add a drift-guard test (`tests/utils/test_schemas.py`) that compares the local `TargetType` value set against the live `nvflare.fuel.flare_api.api_spec.TargetType`, so a future NVFLARE bump that adds/removes/renames a member fails loudly instead of silently drifting.
- The `flask>=3.1.3` security constraint stays omitted: 2.8.0 **still** hard-pins `Flask==3.0.2` (comment refreshed to the new version).

## Notes on the upgrade
- `requires_python>=3.10` (FLIP's 3.12 unaffected); torch unpinned by nvflare (FLIP's `torch>=2.11,<2.12` compatible).
- fl-api already drives the admin connection via the modern `flare_api.Session` — **not** the removed `FLAdminAPI` class — and uses no Overseer, so the rest of 2.8.0's deprecated-code removal doesn't apply.
- The 72h dependency cooldown was not a blocker: nvflare 2.8.0 was published 2026-06-04.

## Verification done locally
- ✅ ruff + mypy clean (mypy run the project way: `mypy . --ignore-missing-imports`, 37 files).
- ✅ **78/78 fl-api-base unit tests pass** on 2.8.0 (incl. the system-router restart/shutdown tests + the new `TargetType` drift-guard).
- ✅ fl-api production image **builds** on 2.8.0; routers + admin routes (`/restart/{target_type}`, `/shutdown/{target_type}`) assemble in-image.
- ✅ All `flip`-package nvflare import paths (`apis.*`, `app_common.*`, `app_opt.pt.*`, `security.*`, `widgets.*`) confirmed present in 2.8.0.
- ✅ FastAPI path-param coercion (`bogus` → 422) + OpenAPI named-enum schema (`title: TargetType`, `enum: [all, server, client]`) unchanged vs. the old `(str, Enum)`.
- Docs reviewed — no version pins to change (only a "since 2.7" feature note in `fl-server/README.md`, still accurate).

## GPU-host gates — verified ✅ (RTX 5090, dev stack, 2026-06-26)
- [x] `make build-fl FL_BACKEND=nvflare` — all `flare-{base,server,client,api}:dev` rebuilt and confirmed running nvflare **2.8.0** in-image.
- [x] `make nvflare-provision-2-nets` — both nets provisioned; FL servers came up and **both clients (Trust_1/Trust_2) + the flip-fl-api admin registered** with the server (the new 2.8.0 `allow_log_streaming` site-config negotiated). Job submission validated via the full-stack `e2e_smoke` below (flip-fl-api → fl-server `submit_job` 200 → `ScatterAndGather` ran), which is a superset of the standalone `fl-services/nvflare up` + `submit` path.
- [x] `make e2e_smoke` (`FL_BACKEND=nvflare`) — **full lifecycle passed**: project → cohort (2/2 trusts) → image pull (300/300 both trusts) → FL training (loss decreasing, real aggregation) → `RESULTS_UPLOADED` → 107 MB results downloaded.
- [x] NVFLARE tutorials on the 2.8.0 simulator — **all four pass** (xray_classification, 3d_spleen_segmentation, 3d_spleen_segmentation_evaluation, latent_diffusion_model), each reaching `RESULTS_UPLOADED`.

<details><summary>e2e environment notes (not 2.8.0 issues)</summary>

Driving the stack surfaced three pre-existing dev-env hurdles, none code-related: the worktree lacked the gitignored `.env.development` + trust kit files; flip-fl-api (uid 1000) couldn't read the provisioned `client.key` (0600, host uid 1001) → chmod the dev kits; and the relative `BASE_IMAGES_DOWNLOAD_DIR=./data/<CODE>` resolves to different host dirs when imaging-api and the fl-clients are started from different checkouts (caused a first-run `num_samples=0`). Fixed by driving the whole FL layer + e2e from a single checkout. The mini xray set also triggers a non-fatal `nan`-metrics JSON warning (empty per-site classes) — caught, training continues, e2e still passes.
</details>

## Acceptance Criteria

*Imported from issue #666*

- [x] All four `nvflare==2.7.2` pins bumped to `2.8.0`, and every affected `uv.lock` regenerated (`make lock`). Resolve any new torch / flask / transitive-CVE conflicts surfaced by the relock. — *zero transitive churn; `uv lock --check` passes.*
- [x] Flask comment-references (and, if the pin is relaxed, the omitted `flask>=3.1.3` constraint) updated in `flip-utils/pyproject.toml` and `fl-services/nvflare/fl-api-base/pyproject.toml`. — *2.8.0 still hard-pins `Flask==3.0.2`, so the constraint stays omitted; both comments refreshed.*
- [x] `TargetType` import (and the `flare_api.Session` flow) confirmed working against 2.8.0. — *local `StrEnum` verified vs. real nvflare + FastAPI + in-image + live e2e (flip-fl-api drove `flare_api.Session` to submit jobs).*
- [x] FL images rebuild cleanly on 2.8.0: `make build-fl FL_BACKEND=nvflare`.
- [x] NVFLARE provisioning + standalone submit works: `make nvflare-provision-2-nets`, then `make -C fl-services/nvflare up` + `submit`. — *provisioning ✅; job-submission path validated via the full-stack e2e (superset of the standalone path).*
- [x] `make e2e_smoke` (default `FL_BACKEND=nvflare`) passes against a running stack (full lifecycle: query → image pull → FL training → results download).
- [x] NVFLARE tutorials still run on the simulator: `make -C fl-tutorials run-tutorial TUTORIAL=xray_classification` (and spot-check the diffusion tutorial, whose `requirements.txt` was bumped). — *all four tutorials run, not just these two.*
- [x] fl-api unit/integration tests pass: `make -C fl-services/nvflare/fl-api-base test` (or equivalent). — *ruff + mypy clean, 78/78 pytest pass.*
- [x] Docs reviewed for any NVFLARE-version references (`docs/source/components/component-fl-nodes.rst`, `fl-services/nvflare/README.md`). — *only a "since 2.7" feature note in `fl-server/README.md`, still accurate; no change needed.*

---
Sibling of #664 (Flower 1.27.0 → 1.32.0).
