### PR TITLE
Make CI workflows fork-friendly for contributor pushes

### DIFF
--- a/.github/workflows/docker_build_flip_api.yml
+++ b/.github/workflows/docker_build_flip_api.yml
@@ -31,9 +31,12 @@ jobs:
   build-and-push:
     # Only publish when the upstream test run passed. workflow_dispatch (manual)
     # has no workflow_run context, so allow it through unconditionally.
+    # The repository guard skips publishing on forks, which cannot push to
+    # ghcr.io/londonaicentre and would otherwise show a spurious CI failure.
     if: >-
-      github.event_name == 'workflow_dispatch' ||
-      github.event.workflow_run.conclusion == 'success'
+      (github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'success') &&
+      github.repository == 'londonaicentre/FLIP'
     runs-on: ubuntu-latest
     permissions: # override top-level read-only default to allow GHCR push
       contents: read

--- a/.github/workflows/docker_build_orthanc.yml
+++ b/.github/workflows/docker_build_orthanc.yml
@@ -25,6 +25,10 @@ permissions:
 
 jobs:
   build-and-push:
+    # Skip on forks: they cannot push to ghcr.io/londonaicentre, so this whole
+    # build-and-publish job would otherwise show a spurious CI failure on fork
+    # pushes. Upstream main/develop publishing is unchanged.
+    if: github.repository == 'londonaicentre/FLIP'
     runs-on: ubuntu-latest
     permissions: # override top-level read-only default to allow GHCR push
       contents: read

--- a/.github/workflows/docker_build_trust_data_access_api.yml
+++ b/.github/workflows/docker_build_trust_data_access_api.yml
@@ -32,9 +32,12 @@ jobs:
   build-and-push:
     # Only publish when the upstream test run passed. workflow_dispatch (manual)
     # has no workflow_run context, so allow it through unconditionally.
+    # The repository guard skips publishing on forks, which cannot push to
+    # ghcr.io/londonaicentre and would otherwise show a spurious CI failure.
     if: >-
-      github.event_name == 'workflow_dispatch' ||
-      github.event.workflow_run.conclusion == 'success'
+      (github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'success') &&
+      github.repository == 'londonaicentre/FLIP'
     runs-on: ubuntu-latest
     permissions: # override top-level read-only default to allow GHCR push
       contents: read

--- a/.github/workflows/docker_build_trust_imaging_api.yml
+++ b/.github/workflows/docker_build_trust_imaging_api.yml
@@ -30,9 +30,12 @@ jobs:
   build-and-push:
     # Only publish when the upstream test run passed. workflow_dispatch (manual)
     # has no workflow_run context, so allow it through unconditionally.
+    # The repository guard skips publishing on forks, which cannot push to
+    # ghcr.io/londonaicentre and would otherwise show a spurious CI failure.
     if: >-
-      github.event_name == 'workflow_dispatch' ||
-      github.event.workflow_run.conclusion == 'success'
+      (github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'success') &&
+      github.repository == 'londonaicentre/FLIP'
     runs-on: ubuntu-latest
     permissions: # override top-level read-only default to allow GHCR push
       contents: read

--- a/.github/workflows/docker_build_trust_trust_api.yml
+++ b/.github/workflows/docker_build_trust_trust_api.yml
@@ -31,9 +31,12 @@ jobs:
   build-and-push:
     # Only publish when the upstream test run passed. workflow_dispatch (manual)
     # has no workflow_run context, so allow it through unconditionally.
+    # The repository guard skips publishing on forks, which cannot push to
+    # ghcr.io/londonaicentre and would otherwise show a spurious CI failure.
     if: >-
-      github.event_name == 'workflow_dispatch' ||
-      github.event.workflow_run.conclusion == 'success'
+      (github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'success') &&
+      github.repository == 'londonaicentre/FLIP'
     runs-on: ubuntu-latest
     permissions: # override top-level read-only default to allow GHCR push
       contents: read

--- a/.github/workflows/docker_build_xnat_db.yml
+++ b/.github/workflows/docker_build_xnat_db.yml
@@ -25,6 +25,10 @@ permissions:
 
 jobs:
   build-and-push:
+    # Skip on forks: they cannot push to ghcr.io/londonaicentre, so this whole
+    # build-and-publish job would otherwise show a spurious CI failure on fork
+    # pushes. Upstream main/develop publishing is unchanged.
+    if: github.repository == 'londonaicentre/FLIP'
     runs-on: ubuntu-latest
     permissions: # override top-level read-only default to allow GHCR push
       contents: read

--- a/.github/workflows/docker_build_xnat_nginx.yml
+++ b/.github/workflows/docker_build_xnat_nginx.yml
@@ -25,6 +25,10 @@ permissions:
 
 jobs:
   build-and-push:
+    # Skip on forks: they cannot push to ghcr.io/londonaicentre, so this whole
+    # build-and-publish job would otherwise show a spurious CI failure on fork
+    # pushes. Upstream main/develop publishing is unchanged.
+    if: github.repository == 'londonaicentre/FLIP'
     runs-on: ubuntu-latest
     permissions: # override top-level read-only default to allow GHCR push
       contents: read

--- a/.github/workflows/docker_build_xnat_web.yml
+++ b/.github/workflows/docker_build_xnat_web.yml
@@ -25,6 +25,10 @@ permissions:
 
 jobs:
   build-and-push:
+    # Skip on forks: they cannot assume the upstream AWS OIDC role or push to
+    # ghcr.io/londonaicentre, so this whole build-and-publish job would otherwise
+    # show a spurious CI failure on fork pushes. Upstream publishing is unchanged.
+    if: github.repository == 'londonaicentre/FLIP'
     runs-on: ubuntu-latest
     permissions: # override top-level read-only default to allow GHCR push
       id-token: write # required for OIDC

--- a/.github/workflows/fl-apps-push-s3-dev-flower.yml
+++ b/.github/workflows/fl-apps-push-s3-dev-flower.yml
@@ -26,6 +26,10 @@ permissions:
 
 jobs:
   sync:
+    # Skip on forks: they cannot assume the upstream AWS OIDC role to sync to S3,
+    # so this job would otherwise show a spurious CI failure on fork pushes.
+    # Upstream develop/main S3 publishing is unchanged.
+    if: github.repository == 'londonaicentre/FLIP'
     runs-on: ubuntu-latest
     environment: flip
     env:

--- a/.github/workflows/fl-apps-push-s3-dev.yml
+++ b/.github/workflows/fl-apps-push-s3-dev.yml
@@ -26,6 +26,10 @@ permissions:
 
 jobs:
   sync:
+    # Skip on forks: they cannot assume the upstream AWS OIDC role to sync to S3,
+    # so this job would otherwise show a spurious CI failure on fork pushes.
+    # Upstream develop/main S3 publishing is unchanged.
+    if: github.repository == 'londonaicentre/FLIP'
     runs-on: ubuntu-latest
     environment: flip
     env:

--- a/.github/workflows/fl-apps-push-s3-prod-flower.yml
+++ b/.github/workflows/fl-apps-push-s3-prod-flower.yml
@@ -26,6 +26,10 @@ permissions:
 
 jobs:
   sync:
+    # Skip on forks: they cannot assume the upstream AWS OIDC role to sync to S3,
+    # so this job would otherwise show a spurious CI failure on fork pushes.
+    # Upstream develop/main S3 publishing is unchanged.
+    if: github.repository == 'londonaicentre/FLIP'
     runs-on: ubuntu-latest
     environment: flip
     env:

--- a/.github/workflows/fl-apps-push-s3-prod.yml
+++ b/.github/workflows/fl-apps-push-s3-prod.yml
@@ -26,6 +26,10 @@ permissions:
 
 jobs:
   sync:
+    # Skip on forks: they cannot assume the upstream AWS OIDC role to sync to S3,
+    # so this job would otherwise show a spurious CI failure on fork pushes.
+    # Upstream develop/main S3 publishing is unchanged.
+    if: github.repository == 'londonaicentre/FLIP'
     runs-on: ubuntu-latest
     environment: flip
     env:

--- a/.github/workflows/fl-apps-push-s3-stag-flower.yml
+++ b/.github/workflows/fl-apps-push-s3-stag-flower.yml
@@ -26,6 +26,10 @@ permissions:
 
 jobs:
   sync:
+    # Skip on forks: they cannot assume the upstream AWS OIDC role to sync to S3,
+    # so this job would otherwise show a spurious CI failure on fork pushes.
+    # Upstream develop/main S3 publishing is unchanged.
+    if: github.repository == 'londonaicentre/FLIP'
     runs-on: ubuntu-latest
     environment: flip
     env:

--- a/.github/workflows/fl-apps-push-s3-stag.yml
+++ b/.github/workflows/fl-apps-push-s3-stag.yml
@@ -26,6 +26,10 @@ permissions:
 
 jobs:
   sync:
+    # Skip on forks: they cannot assume the upstream AWS OIDC role to sync to S3,
+    # so this job would otherwise show a spurious CI failure on fork pushes.
+    # Upstream develop/main S3 publishing is unchanged.
+    if: github.repository == 'londonaicentre/FLIP'
     runs-on: ubuntu-latest
     environment: flip
     env:

--- a/.github/workflows/fl-docker-build-flower.yml
+++ b/.github/workflows/fl-docker-build-flower.yml
@@ -25,6 +25,10 @@ on:
 
 jobs:
   build-and-push:
+    # Skip on forks: they cannot push to ghcr.io/londonaicentre, so this whole
+    # build-and-publish job would otherwise show a spurious CI failure on fork
+    # pushes. Upstream main/develop publishing is unchanged.
+    if: github.repository == 'londonaicentre/FLIP'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/fl-docker-build-nvflare.yml
+++ b/.github/workflows/fl-docker-build-nvflare.yml
@@ -23,6 +23,10 @@ on:
 
 jobs:
   build-and-push:
+    # Skip on forks: they cannot push to ghcr.io/londonaicentre, so this whole
+    # build-and-publish job would otherwise show a spurious CI failure on fork
+    # pushes. Upstream main/develop publishing is unchanged.
+    if: github.repository == 'londonaicentre/FLIP'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -23,6 +23,10 @@ permissions:
 
 jobs:
   release:
+    # Skip on forks: they cannot publish to PyPI (OIDC trusted publishing), push
+    # tags, or create releases in the upstream repo, so this job would otherwise
+    # show a spurious CI failure on a fork's main push. Upstream is unchanged.
+    if: github.repository == 'londonaicentre/FLIP'
     runs-on: ubuntu-latest
     environment: flip
     defaults:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,10 @@ permissions:
 jobs:
     release:
         name: Tag and Create GitHub Release
+        # Skip on forks: they cannot push tags or create releases in the upstream
+        # repo, so this job would otherwise show a spurious CI failure on a fork's
+        # main push. Upstream main release behaviour is unchanged.
+        if: github.repository == 'londonaicentre/FLIP'
         runs-on: ubuntu-latest
         permissions: # override top-level read-only default to allow tag/release creation
             contents: write

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -59,7 +59,10 @@ jobs:
               with:
                   files: ./coverage.xml
                   flags: flip
-                  fail_ci_if_error: true
+                  # Non-blocking: forks have no CODECOV_TOKEN (upstream secrets are
+                  # not shared), so a failed upload must not fail otherwise-green CI.
+                  # Matches every other test workflow in this repo.
+                  fail_ci_if_error: false
               env:
                   CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
@@ -100,6 +103,9 @@ jobs:
               with:
                   files: ./coverage.xml
                   flags: api
-                  fail_ci_if_error: true
+                  # Non-blocking: forks have no CODECOV_TOKEN (upstream secrets are
+                  # not shared), so a failed upload must not fail otherwise-green CI.
+                  # Matches every other test workflow in this repo.
+                  fail_ci_if_error: false
               env:
                   CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -269,6 +269,24 @@ make ci
 
 This runs all jobs defined in `.github/workflows/` locally.
 
+### CI checks on forks
+
+Contributors work from a [fork](#the-contribution-process), and a fork's CI runs with the fork's own `GITHUB_TOKEN`
+and **without** the upstream repository secrets. Workflows that **publish or deploy** therefore cannot run on a fork —
+they would only ever fail trying to reach `londonaicentre`-owned resources — so each is guarded with
+`if: github.repository == 'londonaicentre/FLIP'` and shows up as **skipped** (neutral, not a red failure) on fork
+pushes. These are:
+
+- **Image publishing** — `Build and Push NVFLARE/Flower FL Docker Images`, and the `orthanc`, `xnat-*`, `flip-api`,
+  and `trust-*` GHCR build-and-push workflows.
+- **S3 sync** — the `fl-apps-push-s3-*` workflows (AWS OIDC into the upstream account).
+- **Releases** — `release.yml` and `release-pypi.yml` (git tags, GitHub releases, PyPI publishing).
+
+Everything that **validates** your change still runs on your fork, and a red result there is a real failure to fix:
+lint, type-checking, unit and integration tests, docs, Terraform validation, Helm tests, and secret scanning.
+Coverage upload to Codecov is non-blocking (`fail_ci_if_error: false`), so a missing `CODECOV_TOKEN` on your fork
+never fails an otherwise-green job.
+
 ### Running the stack (pull vs. build)
 
 In development (`PROD` unset), `make up` **pulls** the repo-built service images


### PR DESCRIPTION
## Summary

Fork CI runs with the fork's own `GITHUB_TOKEN` and **without** upstream repository/environment secrets. Every workflow that **publishes or deploys** therefore failed on contributor fork pushes — even when the contributor's code was fine — producing spurious red checks (the four named in #668, plus more).

This PR guards every publish/deploy job with `if: github.repository == 'londonaicentre/FLIP'` so it is **skipped** (neutral, not failed) on forks, and makes the `unit-tests.yml` Codecov upload non-blocking to match the rest of the repo. Upstream `main`/`develop` behaviour is unchanged — the guard is always true upstream.

## What changed

Beyond the four checks listed in the issue, an audit of all 45 workflows found **16 that fail on forks**. All are now guarded:

**GHCR image publishing** (job-level guard)
- `fl-docker-build-nvflare.yml`, `fl-docker-build-flower.yml` *(named in #668)*
- `docker_build_orthanc.yml`, `docker_build_xnat_{db,nginx,web}.yml`
- `docker_build_flip_api.yml`, `docker_build_trust_{trust,imaging,data-access}-api.yml` — these are `workflow_run`-triggered and already had an `if:` on test-conclusion, so the repo guard is ANDed into it.

**AWS S3 sync** (job-level guard)
- `fl-apps-push-s3-{dev,stag,prod}.yml` and their `-flower` variants (6 files) — OIDC into the upstream AWS account.

**Releases** (job-level guard)
- `release.yml`, `release-pypi.yml` — git tags, GitHub releases, PyPI trusted publishing.

**Codecov**
- `unit-tests.yml` *(named in #668)* — `fail_ci_if_error: true → false` on both jobs (every other test workflow already uses `false`). This was the one workflow with no branch filter, so it fired on *any* fork branch push.

**Docs**
- `CONTRIBUTING.md` — new "CI checks on forks" subsection listing what is skipped vs. what still validates.

Already fork-safe (no change needed): the four `fl-apps-*-pr-s3*` workflows already guard on `head.repo.fork == false`; `docker_build_flip_ui.yml` is build-only; the `test_*` workflows already use non-blocking Codecov; `unit-tests-heavy.yml` is already non-blocking.

## How forks behave now

| | Fork push | Upstream push |
|---|---|---|
| Publish / deploy jobs | skipped (neutral) | run (unchanged) |
| Lint / tests / type-check / docs / TF / Helm / secret-scan | run — real failures stay red | run |
| Codecov upload | non-blocking | non-blocking |

## Verification

- `yaml.safe_load` over all 45 workflows — all parse cleanly after the edits.
- Guard expressions reviewed: simple jobs use `if: github.repository == 'londonaicentre/FLIP'`; the `workflow_run` builds use `(github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success') && github.repository == 'londonaicentre/FLIP'`.
- No `fail_ci_if_error: true` remains in the tree.
- The guard is true in the upstream repo, so upstream `main`/`develop` publishing is unchanged.

Fixes #668

## Acceptance Criteria

- [x] Fork pushes no longer fail solely because they cannot publish to `ghcr.io/londonaicentre/...` — the GHCR build-and-push jobs are skipped on forks.
- [x] Fork pushes no longer fail solely because upstream secrets such as `CODECOV_TOKEN` are unavailable — Codecov upload is non-blocking, and the AWS / PyPI / release jobs are skipped on forks.
- [x] Test/lint failures remain visible as real failures — all validation jobs still run on forks.
- [x] Upstream `main`/`develop` publish behaviour remains unchanged — the guard (`github.repository == 'londonaicentre/FLIP'`) is always true upstream.
