### PR TITLE
ci: finish Node 24 migration — bump configure-aws-credentials off node20 + add timeout-minutes to S3-sync jobs

### DIFF
--- a/.github/workflows/check-package-metadata.yml
+++ b/.github/workflows/check-package-metadata.yml
@@ -31,7 +31,7 @@ jobs:
                 working-directory: ./flip-utils
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
 
             - name: Set up Python
               uses: actions/setup-python@v5

--- a/.github/workflows/check-version-bump.yml
+++ b/.github/workflows/check-version-bump.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0 # required to fetch all tags for comparison
 

--- a/.github/workflows/docker_build_xnat_web.yml
+++ b/.github/workflows/docker_build_xnat_web.yml
@@ -57,7 +57,7 @@ jobs:
           ref: ${{ github.event.workflow_run.head_sha }}
 
       - name: Configure AWS credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@v4.2.1
+        uses: aws-actions/configure-aws-credentials@v6.2.1
         with:
           role-to-assume: ${{ vars.AWS_ROLE_TO_ASSUME }}
           role-session-name: ${{ vars.AWS_ROLE_SESSION_NAME }}

--- a/.github/workflows/fl-api-test-flower.yml
+++ b/.github/workflows/fl-api-test-flower.yml
@@ -36,7 +36,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/fl-api-test-nvflare.yml
+++ b/.github/workflows/fl-api-test-nvflare.yml
@@ -36,7 +36,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/fl-apps-check-required-files.yml
+++ b/.github/workflows/fl-apps-check-required-files.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Regenerate per-backend required_files manifests
         run: bash fl-apps/check_required_files.sh
       - name: Fail if committed manifests are stale

--- a/.github/workflows/fl-apps-check-tutorial-sync.yml
+++ b/.github/workflows/fl-apps-check-tutorial-sync.yml
@@ -38,6 +38,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Run check_tutorial_sync.sh
         run: bash scripts/check_tutorial_sync.sh

--- a/.github/workflows/fl-apps-cleanup-pr-s3-flower.yml
+++ b/.github/workflows/fl-apps-cleanup-pr-s3-flower.yml
@@ -28,6 +28,7 @@ jobs:
   cleanup-pr:
     name: Delete PR-scoped S3 path if merged
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     environment: flip
     env:
       FL_BACKEND: flower
@@ -36,7 +37,7 @@ jobs:
 
     steps:
       - name: Configure AWS credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@v4.2.1
+        uses: aws-actions/configure-aws-credentials@v6.2.1
         with:
           role-to-assume: ${{ vars.AWS_DEV_ROLE_TO_ASSUME }}
           role-session-name: ${{ vars.AWS_ROLE_SESSION_NAME }}

--- a/.github/workflows/fl-apps-cleanup-pr-s3.yml
+++ b/.github/workflows/fl-apps-cleanup-pr-s3.yml
@@ -28,6 +28,7 @@ jobs:
   cleanup-pr:
     name: Delete PR-scoped S3 path if merged
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     environment: flip
     env:
       FL_BACKEND: nvflare
@@ -36,7 +37,7 @@ jobs:
 
     steps:
       - name: Configure AWS credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@v4.2.1
+        uses: aws-actions/configure-aws-credentials@v6.2.1
         with:
           role-to-assume: ${{ vars.AWS_DEV_ROLE_TO_ASSUME }}
           role-session-name: ${{ vars.AWS_ROLE_SESSION_NAME }}

--- a/.github/workflows/fl-apps-push-pr-s3-flower.yml
+++ b/.github/workflows/fl-apps-push-pr-s3-flower.yml
@@ -31,6 +31,7 @@ jobs:
   sync-pr:
     name: Sync fl-apps/flower/ to PR-scoped S3 path (branch head)
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     # Skip PRs from forks to avoid missing creds (no secrets/OIDC by default).
     if: ${{ github.event.pull_request.head.repo.fork == false }}
     environment: flip
@@ -39,10 +40,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Configure AWS credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@v4.2.1
+        uses: aws-actions/configure-aws-credentials@v6.2.1
         with:
           role-to-assume: ${{ vars.AWS_DEV_ROLE_TO_ASSUME }}
           role-session-name: ${{ vars.AWS_ROLE_SESSION_NAME }}

--- a/.github/workflows/fl-apps-push-pr-s3.yml
+++ b/.github/workflows/fl-apps-push-pr-s3.yml
@@ -31,6 +31,7 @@ jobs:
   sync-pr:
     name: Sync fl-apps/ to PR-scoped S3 path (branch head)
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     # Skip PRs from forks to avoid missing creds (no secrets/OIDC by default).
     if: ${{ github.event.pull_request.head.repo.fork == false }}
     environment: flip
@@ -39,10 +40,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Configure AWS credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@v4.2.1
+        uses: aws-actions/configure-aws-credentials@v6.2.1
         with:
           role-to-assume: ${{ vars.AWS_DEV_ROLE_TO_ASSUME }}
           role-session-name: ${{ vars.AWS_ROLE_SESSION_NAME }}

--- a/.github/workflows/fl-apps-push-s3-dev-flower.yml
+++ b/.github/workflows/fl-apps-push-s3-dev-flower.yml
@@ -27,16 +27,17 @@ permissions:
 jobs:
   sync:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     environment: flip
     env:
       FL_BACKEND: flower
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Configure AWS credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@v4.2.1
+        uses: aws-actions/configure-aws-credentials@v6.2.1
         with:
           role-to-assume: ${{ vars.AWS_DEV_ROLE_TO_ASSUME }}
           role-session-name: ${{ vars.AWS_ROLE_SESSION_NAME }}

--- a/.github/workflows/fl-apps-push-s3-dev.yml
+++ b/.github/workflows/fl-apps-push-s3-dev.yml
@@ -27,16 +27,17 @@ permissions:
 jobs:
   sync:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     environment: flip
     env:
       FL_BACKEND: nvflare
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Configure AWS credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@v4.2.1
+        uses: aws-actions/configure-aws-credentials@v6.2.1
         with:
           role-to-assume: ${{ vars.AWS_DEV_ROLE_TO_ASSUME }}
           role-session-name: ${{ vars.AWS_ROLE_SESSION_NAME }}

--- a/.github/workflows/fl-apps-push-s3-prod-flower.yml
+++ b/.github/workflows/fl-apps-push-s3-prod-flower.yml
@@ -27,16 +27,17 @@ permissions:
 jobs:
   sync:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     environment: flip
     env:
       FL_BACKEND: flower
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Configure AWS credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@v4.2.1
+        uses: aws-actions/configure-aws-credentials@v6.2.1
         with:
           role-to-assume: ${{ vars.AWS_PROD_ROLE_TO_ASSUME }}
           role-session-name: ${{ vars.AWS_ROLE_SESSION_NAME }}

--- a/.github/workflows/fl-apps-push-s3-prod.yml
+++ b/.github/workflows/fl-apps-push-s3-prod.yml
@@ -27,16 +27,17 @@ permissions:
 jobs:
   sync:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     environment: flip
     env:
       FL_BACKEND: nvflare
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Configure AWS credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@v4.2.1
+        uses: aws-actions/configure-aws-credentials@v6.2.1
         with:
           role-to-assume: ${{ vars.AWS_PROD_ROLE_TO_ASSUME }}
           role-session-name: ${{ vars.AWS_ROLE_SESSION_NAME }}

--- a/.github/workflows/fl-apps-push-s3-stag-flower.yml
+++ b/.github/workflows/fl-apps-push-s3-stag-flower.yml
@@ -27,16 +27,17 @@ permissions:
 jobs:
   sync:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     environment: flip
     env:
       FL_BACKEND: flower
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Configure AWS credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@v4.2.1
+        uses: aws-actions/configure-aws-credentials@v6.2.1
         with:
           role-to-assume: ${{ vars.AWS_STAG_ROLE_TO_ASSUME }}
           role-session-name: ${{ vars.AWS_ROLE_SESSION_NAME }}

--- a/.github/workflows/fl-apps-push-s3-stag.yml
+++ b/.github/workflows/fl-apps-push-s3-stag.yml
@@ -27,16 +27,17 @@ permissions:
 jobs:
   sync:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     environment: flip
     env:
       FL_BACKEND: nvflare
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Configure AWS credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@v4.2.1
+        uses: aws-actions/configure-aws-credentials@v6.2.1
         with:
           role-to-assume: ${{ vars.AWS_STAG_ROLE_TO_ASSUME }}
           role-session-name: ${{ vars.AWS_ROLE_SESSION_NAME }}

--- a/.github/workflows/fl-docker-build-flower.yml
+++ b/.github/workflows/fl-docker-build-flower.yml
@@ -45,7 +45,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Determine image tags
         id: tags

--- a/.github/workflows/fl-docker-build-nvflare.yml
+++ b/.github/workflows/fl-docker-build-nvflare.yml
@@ -43,7 +43,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Determine image tags
         id: tags

--- a/.github/workflows/pr-release-notes-preview.yml
+++ b/.github/workflows/pr-release-notes-preview.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0 # required to resolve previous release tag

--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0 # full history + all tags required for tag existence check
 

--- a/.github/workflows/test_helm_chart.yml
+++ b/.github/workflows/test_helm_chart.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -51,7 +51,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Helm
         uses: azure/setup-helm@v4
@@ -66,7 +66,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Helm
         uses: azure/setup-helm@v4
@@ -107,7 +107,7 @@ jobs:
     needs: [helm-lint, helm-template]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Helm
         uses: azure/setup-helm@v4

--- a/.github/workflows/test_trust_xnat_anon.yml
+++ b/.github/workflows/test_trust_xnat_anon.yml
@@ -38,7 +38,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/unit-tests-heavy.yml
+++ b/.github/workflows/unit-tests-heavy.yml
@@ -24,7 +24,7 @@ jobs:
         working-directory: ./flip-utils
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Python 3.12
         uses: actions/setup-python@v5

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -33,7 +33,7 @@ jobs:
 
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
 
             - name: Set up Python 3.12
               uses: actions/setup-python@v5
@@ -73,7 +73,7 @@ jobs:
 
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
 
             - name: Set up Python 3.12
               uses: actions/setup-python@v5


### PR DESCRIPTION
## What & why

The `fl-apps-push-s3-stag` workflow [hung for 13+ minutes](https://github.com/londonaicentre/FLIP/actions/runs/28359623717) on the **"Configure AWS credentials (OIDC)"** step (normal runtime ~20s). The hang itself was a **transient OIDC/STS round-trip** — cancel + re-run cleared it in ~20s — but it exposed two latent gaps this PR closes:

1. **No `timeout-minutes`** on the S3-sync jobs, so a transient hang sits up to the **6h job limit** instead of failing fast.
2. The `configure-aws-credentials` action still ran on **Node 20** (deprecated), emitting the deprecation banner on every run.

This **finishes the Node 24 runner migration** already started in `3fef7ae1` / `6356eb5d` — that pass bumped `checkout`/`setup-node`/`codecov` in the core CI/build/test workflows but left the `fl-apps`/`fl-*`/`unit-tests`/`check-*` family and `configure-aws-credentials` on node20.

## Changes (25 workflow files, mechanical)

| Change | Action | Count |
|---|---|---|
| **Node 24 bump** | `aws-actions/configure-aws-credentials@v4.2.1` → `@v6.2.1` | 11 usages |
| **Node 24 bump** | `actions/checkout@v4` → `@v5` | 22 workflows |
| **Resilience** | `timeout-minutes: 10` on the fl-apps S3 sync/cleanup jobs | 10 jobs |

### Notes for review

- **`configure-aws-credentials` is a major bump (v4 → v6)** — `v4` *and* `v5` are both still node20; **v6** is the first node24 line (latest `v6.2.1`). Verified the three inputs we use (`role-to-assume`, `role-session-name`, `aws-region`) are unchanged in v6, and we consume no action outputs.
- **`timeout-minutes` — not the version bump — is the actual incident mitigation.** It's scoped to the lightweight S3 jobs only; `docker_build_xnat_web` (also bumped to v6) is deliberately left without a 10-min cap since image builds legitimately run longer.
- Root-causing the *hang* itself is AWS/GitHub-side; no repo change prevents it — `timeout-minutes` just bounds the blast radius.
- `.github/workflows/**` only — no Docker image rebuild, no app code.

## Verification

- `grep` confirms **0** remaining `configure-aws-credentials@v4.2.1` and **0** remaining `actions/checkout@v4`.
- All 25 changed files parse as valid YAML; each of the 10 timeout jobs has exactly one job-level `timeout-minutes`.

Closes #675


## Acceptance Criteria

*Imported from issue #675*

- [ ] `configure-aws-credentials@v4.2.1` → `@v6.x` across all 11 files; a stag/dev S3-sync run goes green with **no** Node 20 deprecation banner.
- [ ] `timeout-minutes` added to the S3 sync/cleanup jobs (dev/stag/prod/pr + flower variants + cleanup).
- [ ] (Optional) remaining `checkout@v4` → `@v5` in the fl-apps/fl-*/unit-tests/check-* workflows.