### PR TITLE
Lazy-load route chunks + split charts off the login payload (#586)

### DIFF
--- a/flip-ui/src/App.vue
+++ b/flip-ui/src/App.vue
@@ -12,6 +12,7 @@
 -->
 
 <template>
+    <AiRouteProgress />
     <router-view />
     <AiSnackbar />
 </template>
@@ -21,6 +22,7 @@ import { useDark } from "@vueuse/core";
 import useSWRV from "swrv";
 import { watch } from "vue";
 
+import AiRouteProgress from "@/components/AiRouteProgress/AiRouteProgress.vue";
 import AiSnackbar from "@/components/AiSnackbar/AiSnackbar.vue";
 
 import { getHealth } from "./services/health-service";

--- a/flip-ui/src/components/AiRouteProgress/AiRouteProgress.vue
+++ b/flip-ui/src/components/AiRouteProgress/AiRouteProgress.vue
@@ -1,0 +1,33 @@
+<!--
+    Copyright (c) 2026 Guy's and St Thomas' NHS Foundation Trust & King's College London
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+        http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+
+<!--
+    Thin top-of-page loading bar shown while a lazy route chunk is being
+    fetched. State lives in @/router/progress and is driven by the router
+    guards; this component only renders it. Decorative/non-interactive, so it
+    is hidden from the accessibility tree.
+-->
+<template>
+    <div
+        v-show="routeProgress.visible"
+        class="fixed top-0 left-0 z-[100] h-0.5 bg-primary-500 dark:bg-primary-300 transition-[width] duration-200 ease-out"
+        :style="{ width: `${routeProgress.width}%` }"
+        role="presentation"
+        aria-hidden="true"
+        data-test="route-progress"
+    />
+</template>
+
+<script setup lang="ts">
+import { routeProgress } from "@/router/progress";
+</script>

--- a/flip-ui/src/router/__tests__/progress.spec.ts
+++ b/flip-ui/src/router/__tests__/progress.spec.ts
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2026 Guy's and St Thomas' NHS Foundation Trust & King's College London
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { doneRouteProgress, routeProgress, startRouteProgress } from "@/router/progress";
+
+describe("route progress", () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+        // reset shared state between tests
+        doneRouteProgress();
+        vi.runAllTimers();
+        routeProgress.visible = false;
+        routeProgress.width = 0;
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it("does not flash for navigations that resolve within the start delay", () => {
+        startRouteProgress();
+        // resolve before the 150ms reveal delay
+        vi.advanceTimersByTime(100);
+        doneRouteProgress();
+
+        expect(routeProgress.visible).toBe(false);
+        expect(routeProgress.width).toBe(0);
+    });
+
+    it("reveals and creeps the bar while a slow navigation is in flight", () => {
+        startRouteProgress();
+        vi.advanceTimersByTime(150); // reveal
+        expect(routeProgress.visible).toBe(true);
+        expect(routeProgress.width).toBe(8);
+
+        const before = routeProgress.width;
+        vi.advanceTimersByTime(200); // one creep tick
+        expect(routeProgress.width).toBeGreaterThan(before);
+        expect(routeProgress.width).toBeLessThanOrEqual(90);
+    });
+
+    it("completes then hides the bar when navigation finishes", () => {
+        startRouteProgress();
+        vi.advanceTimersByTime(150);
+        expect(routeProgress.visible).toBe(true);
+
+        doneRouteProgress();
+        expect(routeProgress.width).toBe(100);
+
+        vi.advanceTimersByTime(200); // finish delay
+        expect(routeProgress.visible).toBe(false);
+        expect(routeProgress.width).toBe(0);
+    });
+});

--- a/flip-ui/src/router/index.ts
+++ b/flip-ui/src/router/index.ts
@@ -21,7 +21,12 @@ import { createRouter, createWebHistory } from "vue-router";
 const routes = setupLayouts(generatedRoutes);
 
 // import { routes } from "@/router/routes";
+import { doneRouteProgress, startRouteProgress } from "@/router/progress";
 import { authCheck } from "@/utils/auth";
+
+// Guards a one-time reload when a lazy route chunk fails to load (see onError).
+const CHUNK_RELOAD_KEY = "flip:chunk-reload";
+
 const router = createRouter({
     history: createWebHistory(),
     routes,
@@ -35,8 +40,35 @@ const router = createRouter({
 });
 
 router.beforeEach((to, from, next) => {
+    startRouteProgress();
     /** Ensure the user is logged in */
     authCheck(to, from, next);
+});
+
+router.afterEach((_to, _from, failure) => {
+    doneRouteProgress();
+    // A clean navigation means the current chunks resolve, so re-arm the
+    // stale-chunk reload guard for any future deploy.
+    if (!failure) {
+        sessionStorage.removeItem(CHUNK_RELOAD_KEY);
+    }
+});
+
+// When a lazy route chunk fails to load — almost always because a new deploy
+// has replaced the hashed chunk files this still-open tab references — recover
+// by doing a single full reload to fetch the fresh index.html (and its current
+// chunk manifest). The sessionStorage flag stops this looping if the failure
+// is something other than a stale deploy.
+router.onError((error, to) => {
+    doneRouteProgress();
+    const message = error instanceof Error ? error.message : String(error);
+    const isChunkLoadError = /failed to fetch dynamically imported module/i.test(message)
+        || /error loading dynamically imported module/i.test(message)
+        || /importing a module script failed/i.test(message);
+    if (isChunkLoadError && !sessionStorage.getItem(CHUNK_RELOAD_KEY)) {
+        sessionStorage.setItem(CHUNK_RELOAD_KEY, "1");
+        window.location.assign(to.fullPath);
+    }
 });
 
 

--- a/flip-ui/src/router/progress.ts
+++ b/flip-ui/src/router/progress.ts
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2026 Guy's and St Thomas' NHS Foundation Trust & King's College London
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { reactive } from "vue";
+
+/**
+ * Top-of-page navigation progress bar state.
+ *
+ * With lazy route loading (`importMode: "async"`), navigating to a route the
+ * user hasn't visited triggers a dynamic-import chunk fetch. While that is in
+ * flight the previous view stays mounted, so without feedback a slow chunk
+ * load looks like an unresponsive click. This drives a thin progress bar
+ * rendered by `AiRouteProgress.vue`, started/finished from the router guards.
+ *
+ * A short start delay means navigations that resolve instantly — a cached
+ * chunk, or staying on the same route — never flash the bar.
+ */
+const DELAY_MS = 150;
+const CREEP_MS = 200;
+const FINISH_MS = 200;
+
+export const routeProgress = reactive({
+    visible: false,
+    width: 0
+});
+
+let delayTimer: ReturnType<typeof setTimeout> | undefined;
+let creepTimer: ReturnType<typeof setInterval> | undefined;
+let finishTimer: ReturnType<typeof setTimeout> | undefined;
+
+/** Begin a navigation: after a short delay, reveal the bar and creep it toward 90%. */
+export function startRouteProgress(): void {
+    clearTimeout(delayTimer);
+    clearTimeout(finishTimer);
+    delayTimer = setTimeout(() => {
+        routeProgress.visible = true;
+        routeProgress.width = 8;
+        creepTimer = setInterval(() => {
+            // Ease toward 90% while the chunk is in flight; never reach 100%
+            // until the navigation actually completes.
+            routeProgress.width = Math.min(routeProgress.width + (90 - routeProgress.width) * 0.1, 90);
+        }, CREEP_MS);
+    }, DELAY_MS);
+}
+
+/** Finish a navigation: complete the bar to 100%, then hide it. No-op if never shown. */
+export function doneRouteProgress(): void {
+    clearTimeout(delayTimer);
+    clearInterval(creepTimer);
+    if (!routeProgress.visible) {
+        routeProgress.width = 0;
+
+        return;
+    }
+    routeProgress.width = 100;
+    finishTimer = setTimeout(() => {
+        routeProgress.visible = false;
+        routeProgress.width = 0;
+    }, FINISH_MS);
+}

--- a/flip-ui/vite.config.mts
+++ b/flip-ui/vite.config.mts
@@ -64,7 +64,12 @@ export default defineConfig(({ mode, command }) => {
                 resolvers: IconsResolver({ prefix: "icon" })
             }),
             svgLoader(),
-            Pages({ importMode: "sync" }),
+            // Lazy-load route components: each page becomes its own `() => import()`
+            // chunk fetched on navigation, instead of being eagerly bundled into the
+            // entry. This stops the public /auth/login route from shipping the entire
+            // authenticated app. Pairs with the `charts` manualChunk split below — see
+            // the router's onError handler for stale-chunk recovery.
+            Pages({ importMode: "async" }),
             Layouts({ defaultLayout: "MainLayout" })
         ],
         server: {
@@ -72,8 +77,8 @@ export default defineConfig(({ mode, command }) => {
             host: true,
             allowedHosts: [
                 "app.flip.aicentre.co.uk",
-                "stag.flip.aicentre.co.uk",
-            ],
+                "stag.flip.aicentre.co.uk"
+            ]
         },
         resolve: {
             alias: [
@@ -100,7 +105,12 @@ export default defineConfig(({ mode, command }) => {
                     manualChunks: (id) => {
                         if (id.includes("/node_modules/vue/") || id.includes("/node_modules/vue-router/")) return "app";
                         if (id.includes("/node_modules/aws-amplify/")) return "aws";
-                        if (id.includes("/node_modules/axios/") || id.includes("/node_modules/echarts/") || id.includes("/node_modules/vee-validate/")) return "misc";
+                        // echarts (+ its zrender renderer) is only used by the
+                        // authenticated metrics/cohort charts. Keep it in its own
+                        // chunk so the login route — which needs vee-validate, also
+                        // in `misc` — doesn't drag the charting library along with it.
+                        if (id.includes("/node_modules/echarts/") || id.includes("/node_modules/zrender/")) return "charts";
+                        if (id.includes("/node_modules/axios/") || id.includes("/node_modules/vee-validate/")) return "misc";
                     }
                 }
             }


### PR DESCRIPTION
# Description

Addresses the Tier 3 *"Reduce unused first-party JavaScript"* item (`unused-javascript`) from the Lighthouse audit in #586. The public `/auth/login` route was downloading almost the entire authenticated app — including `echarts`, which only the metrics/cohort charts use.

## The problem

Routes were bundled eagerly (`Pages({ importMode: "sync" })`), so the entry `index` chunk contained every page. On top of that, `manualChunks` grouped `echarts` together with `vee-validate` in a shared `misc` chunk — and since the login form imports `vee-validate`, login pulled the whole `misc` chunk including the charting library it never renders.

## The fix (two parts — either alone leaves echarts on login)

1. **`importMode: "sync"` → `"async"`** — each route component becomes its own `() => import()` chunk fetched on navigation, splitting ~660 KB of route code out of the entry into lazy per-route chunks (`projects`, `_modelId_`, `cohort-query`, `users`, …).
2. **Split `echarts` (+ `zrender`) out of `misc` into its own `charts` chunk** — so the auth-needed libs (`vee-validate`/`axios`) don't drag the charting library along.

## Result — bytes on the initial (login) load, uncompressed

| | index | app | aws | misc | other | **total** |
|---|---|---|---|---|---|---|
| **before** | 2.02 MB | 84 KB | 79 KB | 645 KB (incl. echarts) | — | **~2.82 MB** |
| **after** | 1.34 MB | 84 KB | 79 KB | 78 KB | api 72 KB + runtime/error ~21 KB | **~1.67 MB** |

**~1.15 MB (~41%) less on the pre-auth load**, with the 566 KB `charts` chunk confirmed *not* preloaded in `dist/index.html` anymore. (The remaining `index` weight is global plugins eagerly registered in `main.ts` — CodeMirror, highlight.js, etc. — a separate, larger optimisation left out of scope here.)

## Supporting robustness for lazy loading

- **`AiRouteProgress.vue` + `router/progress.ts`** — a thin top-of-page progress bar driven from the router guards, with a 150 ms start delay so instant (cached-chunk) navigations don't flash it. No new dependency.
- **`router.onError`** — when a lazy chunk fails to load (almost always a still-open tab after a redeploy replaced the hashed files), do a single guarded full reload to fetch the fresh `index.html` + chunk manifest. A `sessionStorage` flag prevents reload loops.

## Linked Issues

Addresses part of #586 (Tier 3 `unused-javascript`).

## Checklist

- [x] Follows the project's coding conventions and style guide
- [ ] Updates documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Type of Change

- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make -C docs/ docs`.

## Testing

- [x] `vite build` succeeds; verified `dist/index.html` no longer preloads the `charts` chunk and the initial chunk set drops to ~1.67 MB.
- [x] ESLint clean on all changed/new files.
- [x] Full UI unit suite green — **764 passing**, 1 skipped, incl. new `router/progress` tests.

## Additional Notes

This is app-wide in effect (every route now lazy-loads), so it's intentionally a **separate PR** from the login a11y/contrast work in #686. Worth a manual smoke of in-app navigation (the progress bar on a throttled connection) and a deep-link load before merge. No new dependencies were added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CJ2c81NVfgresfJXBFBgKq)_