### PR TITLE
NVFLARE Client-API tutorials fail via `make run-tutorial` — app_files not staged into job custom/ (No module named 'models')

### DIFF
--- a/fl-tutorials/nvflare/image_classification/xray_classification_client_api/.env.app
+++ b/fl-tutorials/nvflare/image_classification/xray_classification_client_api/.env.app
@@ -1,5 +1,5 @@
 JOB_TYPE=standard_client_api
-DEV_IMAGES_DIR=../data/xrays_mini_300/accession-resources/
-DEV_DATAFRAME=../data/xrays_mini_300/dataframe.csv
+DEV_IMAGES_DIR=../../data/xrays_mini_300/accession-resources/
+DEV_DATAFRAME=../../data/xrays_mini_300/dataframe.csv
 FLIP_PROJECT_ID=
 FLIP_QUERY=

--- a/fl-tutorials/nvflare/image_classification/xray_classification_client_api/Makefile
+++ b/fl-tutorials/nvflare/image_classification/xray_classification_client_api/Makefile
@@ -9,6 +9,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+APP_DIR := $(CURDIR)
+
+# Run job.py in the flip-utils environment with the `full` ML extra — the same package set the
+# flare-fl-base FL image installs (`uv sync --extra full`), so a local SimEnv run matches the deployed
+# image. A bare `uv run` would resolve to the repo-root venv, which has no torch/nvflare/monai.
+FLIP_UTILS := $(abspath $(APP_DIR)/../../../../flip-utils)
+UV_RUN := uv run --project $(FLIP_UTILS) --extra full
+
 # --- Load app-specific env ---
 ifneq ("$(wildcard .env.app)","")
 include ./.env.app
@@ -28,7 +36,7 @@ run: sim
 # app/config/, and app/custom/ (bundled flip/ package + staged app_files/).
 # FLIP-specific values (project_id, query) are injected via environment variables.
 export:
-	uv run --no-sync python job.py \
+	$(UV_RUN) python job.py \
 		--export \
 		--export-dir ./fl_job \
 		--n_clients 2 \
@@ -38,8 +46,12 @@ export:
 # Runs the job under the NVFLARE simulator. Requires a GPU and the reference
 # dataset (run `make -C fl-tutorials download-xray-data` first).
 # FLIP-specific values are read from FLIP_PROJECT_ID and FLIP_QUERY env vars.
+# DEV_IMAGES_DIR/DEV_DATAFRAME are resolved to absolute paths so the simulator's client workers
+# (which run from the workspace dir, not here) find the LOCAL_DEV dataset.
 sim:
-	uv run --no-sync python job.py \
+	DEV_IMAGES_DIR="$(abspath $(DEV_IMAGES_DIR))" \
+	DEV_DATAFRAME="$(abspath $(DEV_DATAFRAME))" \
+	$(UV_RUN) python job.py \
 		--n_clients 2 \
 		--num_rounds 3
 

--- a/fl-tutorials/nvflare/image_classification/xray_classification_client_api/README.md
+++ b/fl-tutorials/nvflare/image_classification/xray_classification_client_api/README.md
@@ -52,10 +52,13 @@ Produces a complete NVFLARE job directory under `./fl_job/flip_fedavg/` includin
 make export
 ```
 
-or equivalently:
+or equivalently — the Makefile runs `job.py` in the **flip-utils** environment with the `full` ML
+extra (the same package set the `flare-fl-base` FL image installs via `uv sync --extra full`), so a
+local run matches the deployed image and a bare `uv run` (repo-root venv, no torch/nvflare/monai) is
+avoided:
 
 ```bash
-uv run --no-sync python job.py --export --export-dir ./fl_job --n_clients 2 --num_rounds 3
+uv run --project ../../../../flip-utils --extra full python job.py --export --export-dir ./fl_job --n_clients 2 --num_rounds 3
 ```
 
 > **Note:** `make run` (invoked by the tutorial harness `run-tutorial`/`run-all-tutorials`)

--- a/fl-tutorials/nvflare/image_classification/xray_classification_client_api/job.py
+++ b/fl-tutorials/nvflare/image_classification/xray_classification_client_api/job.py
@@ -28,6 +28,10 @@ It supports two execution modes:
     ``FLIP_QUERY``) rather than CLI flags because SQL queries contain spaces that
     don't survive argparse whitespace-splitting.
 
+Both modes go through NVFLARE's :meth:`Recipe.execute`, which consumes ``--export``/``--export-dir``
+from ``sys.argv`` itself (it strips them before this script's own ``argparse`` runs) and
+exports-or-runs accordingly — so there is no separate ``--export`` branch here.
+
 Usage:
     # Export job config for review or Docker deployment (no GPU needed)
     python job.py --export --export-dir ./fl_job --n_clients 2 --num_rounds 3
@@ -40,7 +44,6 @@ from __future__ import annotations
 
 import argparse
 import os
-import shutil
 import sys
 from pathlib import Path
 
@@ -51,26 +54,27 @@ if str(_APP_FILES_DIR) not in sys.path:
     sys.path.insert(0, str(_APP_FILES_DIR))
 
 from flip.nvflare.recipes import FlipFedAvgRecipe  # noqa: E402
+from nvflare import FedJob  # noqa: E402
 from nvflare.recipe import SimEnv  # noqa: E402
 
 
-def stage_app_files(job_root: str) -> None:
-    """Copy every file in app_files/ into <job_root>/flip_fedavg/app/custom/.
+def stage_app_files(job: FedJob) -> None:
+    """Bundle every file in ``app_files/`` into the job's server + client ``custom/`` directories.
 
-    The recipe's :meth:`export` auto-bundles the ``flip/`` package into
-    ``app/custom/flip/`` but does not include the user-supplied app files
-    (trainer.py, config.json, models.py, data_utils.py, loss_and_metrics.py).
-    This function completes the job by staging those files alongside the
-    bundled ``flip/`` package.
+    The recipe wires only the NVFLARE components; the user-supplied app files (``trainer.py``,
+    ``models.py``, ``config.json``, ``data_utils.py``, ``loss_and_metrics.py``) must be added to the job
+    explicitly so they land in every site's ``app/custom/``. ``FedJob.add_file_to_{server,clients}``
+    registers them with the job's file sources, so they are bundled for **both** the SimEnv/simulator run
+    (``recipe.execute``) and ``--export`` — unlike a post-export filesystem copy, which the SimEnv path
+    never triggered.
 
     Args:
-        job_root: The export-dir passed to :meth:`export` (e.g. ``./fl_job``).
+        job: The recipe's underlying :class:`~nvflare.job_config.api.FedJob` (``recipe.job``).
     """
-    custom_dir = Path(job_root) / "flip_fedavg" / "app" / "custom"
-    app_files_dir = Path(__file__).parent / "app_files"
-    for src in app_files_dir.iterdir():
+    for src in sorted(_APP_FILES_DIR.iterdir()):
         if src.is_file():
-            shutil.copy2(src, custom_dir / src.name)
+            job.add_file_to_server(str(src))
+            job.add_file_to_clients(str(src))
 
 
 def main() -> None:
@@ -83,13 +87,8 @@ def main() -> None:
         default="/tmp/nvflare/xray_client_api",
         help="SimEnv workspace root",
     )
-    parser.add_argument("--export", action="store_true", help="Export job config instead of running SimEnv")
-    parser.add_argument(
-        "--export-dir",
-        type=str,
-        default="./fl_job",
-        help="Directory to write the exported job (default: ./fl_job)",
-    )
+    # NOTE: ``--export``/``--export-dir`` are handled by NVFLARE's ``Recipe.execute`` (it strips them
+    # from ``sys.argv`` before this parser runs), so they are intentionally not declared here.
     args = parser.parse_args()
 
     # ------------------------------------------------------------------
@@ -112,22 +111,22 @@ def main() -> None:
         query=query,
     )
 
-    if args.export:
-        recipe.export(args.export_dir)
-        stage_app_files(args.export_dir)
-        print(f"Exported complete job to: {Path(args.export_dir).resolve() / 'flip_fedavg'}")
-    else:
-        env = SimEnv(
-            num_clients=args.n_clients,
-            num_threads=args.n_clients,
-            workspace_root=args.workspace,
-        )
-        run = recipe.execute(env)
+    # Stage the user app files into the job's custom/ dirs *before* execute() — this is what makes the
+    # exported/simulated job self-contained (the recipe only wires components). execute() then either
+    # exports (when --export is on sys.argv, exiting afterwards) or runs the SimEnv simulation.
+    stage_app_files(recipe.job)
 
-        print()
-        print(f"Job status:  {run.get_status()}")
-        print(f"Job results: {run.get_result()}")
-        print()
+    env = SimEnv(
+        num_clients=args.n_clients,
+        num_threads=args.n_clients,
+        workspace_root=args.workspace,
+    )
+    run = recipe.execute(env)
+
+    print()
+    print(f"Job status:  {run.get_status()}")
+    print(f"Job results: {run.get_result()}")
+    print()
 
 
 if __name__ == "__main__":

--- a/fl-tutorials/nvflare/image_evaluation/3d_spleen_segmentation_evaluation_client_api/.env.app
+++ b/fl-tutorials/nvflare/image_evaluation/3d_spleen_segmentation_evaluation_client_api/.env.app
@@ -1,6 +1,6 @@
 JOB_TYPE=evaluation_client_api
-DEV_IMAGES_DIR=../data/spleen/images
-DEV_DATAFRAME=../data/spleen/dataframe.csv
+DEV_IMAGES_DIR=../../data/spleen/images
+DEV_DATAFRAME=../../data/spleen/dataframe.csv
 FLIP_PROJECT_ID=
 FLIP_QUERY=
 MODEL_CHECKPOINT_URL=https://huggingface.co/aicentreflip/tutorials-evaluation-3d-seg-model/resolve/main/model.pt

--- a/fl-tutorials/nvflare/image_evaluation/3d_spleen_segmentation_evaluation_client_api/Makefile
+++ b/fl-tutorials/nvflare/image_evaluation/3d_spleen_segmentation_evaluation_client_api/Makefile
@@ -11,6 +11,12 @@
 
 APP_DIR := $(CURDIR)
 
+# Run job.py in the flip-utils environment with the `full` ML extra — the same package set the
+# flare-fl-base FL image installs (`uv sync --extra full`), so a local SimEnv run matches the deployed
+# image. A bare `uv run` would resolve to the repo-root venv, which has no torch/nvflare/monai.
+FLIP_UTILS := $(abspath $(APP_DIR)/../../../../flip-utils)
+UV_RUN := uv run --project $(FLIP_UTILS) --extra full
+
 # --- Load app-specific env ---
 ifneq ("$(wildcard .env.app)","")
 include ./.env.app
@@ -44,7 +50,7 @@ run: download-checkpoints sim
 # Builds a complete NVFLARE job under ./fl_job/flip_evaluation/ including meta.json, app/config/, and
 # app/custom/ (bundled flip/ package + staged app_files/ incl. the model.pt checkpoint).
 export: download-checkpoints
-	uv run --no-sync python job.py \
+	$(UV_RUN) python job.py \
 		--export \
 		--export-dir ./fl_job \
 		--n_clients 2
@@ -53,8 +59,12 @@ export: download-checkpoints
 # Runs the job under the NVFLARE simulator. Requires a GPU and the reference dataset
 # (run `make -C fl-tutorials download-spleen-data` first).
 # FLIP-specific values are read from FLIP_PROJECT_ID and FLIP_QUERY env vars.
+# DEV_IMAGES_DIR/DEV_DATAFRAME are resolved to absolute paths so the simulator's client workers
+# (which run from the workspace dir, not here) find the LOCAL_DEV dataset.
 sim:
-	uv run --no-sync python job.py \
+	DEV_IMAGES_DIR="$(abspath $(DEV_IMAGES_DIR))" \
+	DEV_DATAFRAME="$(abspath $(DEV_DATAFRAME))" \
+	$(UV_RUN) python job.py \
 		--n_clients 2
 
 clean:

--- a/fl-tutorials/nvflare/image_evaluation/3d_spleen_segmentation_evaluation_client_api/README.md
+++ b/fl-tutorials/nvflare/image_evaluation/3d_spleen_segmentation_evaluation_client_api/README.md
@@ -43,11 +43,18 @@ The checkpoint URL is configured in `.env.app` as `MODEL_CHECKPOINT_URL`.
 Default local development settings are in `.env.app`:
 
 - `JOB_TYPE=evaluation_client_api`
-- `DEV_IMAGES_DIR=../data/spleen/images`
-- `DEV_DATAFRAME=../data/spleen/dataframe.csv`
+- `DEV_IMAGES_DIR=../../data/spleen/images`
+- `DEV_DATAFRAME=../../data/spleen/dataframe.csv`
 - `MODEL_CHECKPOINT_URL=https://huggingface.co/aicentreflip/tutorials-evaluation-3d-seg-model/resolve/main/model.pt`
 
-Evaluation settings (e.g. `num_classes`, the `models` checkpoint mapping) are in `app_files/config.json`.
+The `DEV_*` paths point at the shared, gitignored `fl-tutorials/nvflare/data/spleen` dataset produced by
+`make -C fl-tutorials download-spleen-data`; `make sim` resolves them to absolute paths so the
+simulator's client workers find the data. Evaluation settings (e.g. `num_classes`, the `models`
+checkpoint mapping) are in `app_files/config.json`.
+
+`make sim`/`make export`/`make run` run `job.py` in the **flip-utils** environment with the `full` ML
+extra — the same package set the `flare-fl-base` FL image installs (`uv sync --extra full`) — so a local
+run matches the deployed image.
 
 ## Run the tutorial
 

--- a/fl-tutorials/nvflare/image_evaluation/3d_spleen_segmentation_evaluation_client_api/job.py
+++ b/fl-tutorials/nvflare/image_evaluation/3d_spleen_segmentation_evaluation_client_api/job.py
@@ -26,6 +26,10 @@ execution modes:
     (``make -C fl-tutorials download-spleen-data``), and the checkpoint (``make download-checkpoints``).
     FLIP-specific values are injected via environment variables (``FLIP_PROJECT_ID``, ``FLIP_QUERY``).
 
+Both modes go through NVFLARE's :meth:`Recipe.execute`, which consumes ``--export``/``--export-dir`` from
+``sys.argv`` itself (it strips them before this script's own ``argparse`` runs) and exports-or-runs
+accordingly — so there is no separate ``--export`` branch here.
+
 Usage:
     # Export job config for review or Docker deployment (no GPU needed)
     python job.py --export --export-dir ./fl_job --n_clients 2
@@ -38,7 +42,6 @@ from __future__ import annotations
 
 import argparse
 import os
-import shutil
 import sys
 from pathlib import Path
 
@@ -49,24 +52,27 @@ if str(_APP_FILES_DIR) not in sys.path:
     sys.path.insert(0, str(_APP_FILES_DIR))
 
 from flip.nvflare.recipes import FlipEvalRecipe  # noqa: E402
+from nvflare import FedJob  # noqa: E402
 from nvflare.recipe import SimEnv  # noqa: E402
 
 
-def stage_app_files(job_root: str) -> None:
-    """Copy every file in app_files/ into <job_root>/flip_evaluation/app/custom/.
+def stage_app_files(job: FedJob) -> None:
+    """Bundle every file in ``app_files/`` into the job's server + client ``custom/`` directories.
 
-    The recipe's :meth:`export` auto-bundles the ``flip/`` package into ``app/custom/flip/`` but does
-    not include the user-supplied app files (evaluator.py, config.json, models.py, transforms.py and the
-    ``model.pt`` checkpoint). This function completes the job by staging those alongside the bundled
-    ``flip/`` package.
+    The recipe wires only the NVFLARE components; the user-supplied app files (``evaluator.py``,
+    ``models.py``, ``transforms.py``, ``config.json`` and the ``model.pt`` checkpoint) must be added to
+    the job explicitly so they land in every site's ``app/custom/``. ``FedJob.add_file_to_{server,clients}``
+    registers them with the job's file sources, so they are bundled for **both** the SimEnv/simulator run
+    (``recipe.execute``) and ``--export`` — unlike a post-export filesystem copy, which the SimEnv path
+    never triggered.
 
     Args:
-        job_root: The export-dir passed to :meth:`export` (e.g. ``./fl_job``).
+        job: The recipe's underlying :class:`~nvflare.job_config.api.FedJob` (``recipe.job``).
     """
-    custom_dir = Path(job_root) / "flip_evaluation" / "app" / "custom"
-    for src in _APP_FILES_DIR.iterdir():
+    for src in sorted(_APP_FILES_DIR.iterdir()):
         if src.is_file():
-            shutil.copy2(src, custom_dir / src.name)
+            job.add_file_to_server(str(src))
+            job.add_file_to_clients(str(src))
 
 
 def main() -> None:
@@ -78,13 +84,8 @@ def main() -> None:
         default="/tmp/nvflare/spleen_eval_client_api",
         help="SimEnv workspace root",
     )
-    parser.add_argument("--export", action="store_true", help="Export job config instead of running SimEnv")
-    parser.add_argument(
-        "--export-dir",
-        type=str,
-        default="./fl_job",
-        help="Directory to write the exported job (default: ./fl_job)",
-    )
+    # NOTE: ``--export``/``--export-dir`` are handled by NVFLARE's ``Recipe.execute`` (it strips them
+    # from ``sys.argv`` before this parser runs), so they are intentionally not declared here.
     args = parser.parse_args()
 
     # FLIP-specific values are read from environment variables rather than CLI flags: SQL queries
@@ -102,22 +103,22 @@ def main() -> None:
         query=query,
     )
 
-    if args.export:
-        recipe.export(args.export_dir)
-        stage_app_files(args.export_dir)
-        print(f"Exported complete job to: {Path(args.export_dir).resolve() / 'flip_evaluation'}")
-    else:
-        env = SimEnv(
-            num_clients=args.n_clients,
-            num_threads=args.n_clients,
-            workspace_root=args.workspace,
-        )
-        run = recipe.execute(env)
+    # Stage the user app files into the job's custom/ dirs *before* execute() — this is what makes the
+    # exported/simulated job self-contained (the recipe only wires components). execute() then either
+    # exports (when --export is on sys.argv, exiting afterwards) or runs the SimEnv simulation.
+    stage_app_files(recipe.job)
 
-        print()
-        print(f"Job status:  {run.get_status()}")
-        print(f"Job results: {run.get_result()}")
-        print()
+    env = SimEnv(
+        num_clients=args.n_clients,
+        num_threads=args.n_clients,
+        workspace_root=args.workspace,
+    )
+    run = recipe.execute(env)
+
+    print()
+    print(f"Job status:  {run.get_status()}")
+    print(f"Job results: {run.get_result()}")
+    print()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Fixes #690: the NVFLARE Client-API tutorials could not be run via their documented
`make -C fl-tutorials run-tutorial TUTORIAL=<name>` path (simulator failed at server-config load with
`No module named 'models'`). Both `xray_classification_client_api` and
`3d_spleen_segmentation_evaluation_client_api` now run green under the NVFLARE simulator.

Three compounding issues, all fixed:

1. **app_files not staged into the job.** The recipe's `FedJob` only wires NVFLARE components, and
   `job.py`'s `stage_app_files()` was dead code — NVFLARE 2.8's `nvflare.recipe` import strips
   `--export`/`--export-dir` from `sys.argv` before `job.py`'s own `argparse`, so the `if args.export`
   branch never ran and nothing staged the user files. Now staged via
   `FedJob.add_file_to_{server,clients}` **before** `execute()`, so they are bundled for both the SimEnv
   run and `--export`. The dead `--export` branch is removed (`Recipe.execute` handles `--export`).

2. **Run environment had no FL deps.** `make sim`/`make export` used `uv run --no-sync`, which resolves
   to the repo-root venv (no torch/nvflare/monai). They now run `job.py` in the **flip-utils** environment
   with the `full` extra — the same package set the `flare-fl-base` FL image installs
   (`uv sync --extra full`), so a local run matches the deployed image.

3. **Dataset paths.** `.env.app` `DEV_*` pointed at `../data` (one level short of the canonical, gitignored
   `fl-tutorials/nvflare/data`) and were relative; now `../../data`, resolved to absolute paths in the
   `sim` target so the simulator's client workers find the `LOCAL_DEV` dataset.

## Verification

`make -C fl-tutorials run-tutorial TUTORIAL=<name>` runs green under the NVFLARE simulator
(RTX 5090, 2 clients) for both tutorials:

- **eval** — 10 spleen volumes/client scored → aggregate-only metrics into `evaluation_results.json`
  (`mean_dice≈0.946`, `mean_hausdorff_95≈1.72`, `mean_surface_dice≈0.885`, `mean_iou≈0.898`).
- **xray** — FedAvg over 3 rounds, `TEST_LOSS` converging (0.82 → 0.41), clean `END_RUN`.

`make export` produces a complete self-contained job (app_files + bundled `flip/`). `ruff` clean on both
`job.py`.

## Base branch

Targets `688-spleen-eval-client-api` (the branch that introduced the eval tutorial), not `develop`, so the
fix rides along with #689.

Closes #690

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Acceptance Criteria

### From issue #690

- [ ] `make -C fl-tutorials run-tutorial TUTORIAL=xray_classification_client_api` runs green on the NVFLARE simulator (server + clients start, job completes).
- [ ] `make -C fl-tutorials run-tutorial TUTORIAL=3d_spleen_segmentation_evaluation_client_api` runs green (produces `evaluation_results.json` with aggregate-only metrics).
- [ ] The tutorial's `app_files/` (`models.py`, `evaluator.py`/`trainer.py`, `transforms.py`, `config.json`, checkpoint) are staged into the job's `app/custom/` for **both** the SimEnv run path and `job.py --export`.
- [ ] Remove or fix the now-dead `stage_app_files()` / `if args.export:` branch in the client-API `job.py`s (NVFLARE 2.8 consumes `--export` from `sys.argv`).
- [ ] `make -C fl-tutorials run-all-tutorials` no longer errors on the two client-API tutorials.

---
_Found while verifying PR #689 (issue #688). Data note: `make download-spleen-data` writes to the
gitignored `fl-tutorials/nvflare/data/spleen`; the client-API eval tutorial's `.env.app`
`DEV_IMAGES_DIR=../data/spleen/images` is authored relative to the `fl-tutorials/nvflare/testing/`
harness dir, not the tutorial dir._

### From issue #690

- [ ] `make -C fl-tutorials run-tutorial TUTORIAL=xray_classification_client_api` runs green on the NVFLARE simulator (server + clients start, job completes).
- [ ] `make -C fl-tutorials run-tutorial TUTORIAL=3d_spleen_segmentation_evaluation_client_api` runs green (produces `evaluation_results.json` with aggregate-only metrics).
- [ ] The tutorial's `app_files/` (`models.py`, `evaluator.py`/`trainer.py`, `transforms.py`, `config.json`, checkpoint) are staged into the job's `app/custom/` for **both** the SimEnv run path and `job.py --export`.
- [ ] Remove or fix the now-dead `stage_app_files()` / `if args.export:` branch in the client-API `job.py`s (NVFLARE 2.8 consumes `--export` from `sys.argv`).
- [ ] `make -C fl-tutorials run-all-tutorials` no longer errors on the two client-API tutorials.

---
_Found while verifying PR #689 (issue #688). Data note: `make download-spleen-data` writes to the
gitignored `fl-tutorials/nvflare/data/spleen`; the client-API eval tutorial's `.env.app`
`DEV_IMAGES_DIR=../data/spleen/images` is authored relative to the `fl-tutorials/nvflare/testing/`
harness dir, not the tutorial dir._

