### PR TITLE
Remove unused ECR VPC endpoints

### DIFF
--- a/deploy/providers/AWS/README.md
+++ b/deploy/providers/AWS/README.md
@@ -48,7 +48,7 @@ Your AWS IAM role/user needs the following permissions for provisioning infrastr
 - **Secrets Manager**: Full access for storing database credentials and API secrets
 - **IAM**: Create and manage roles for EC2 instances and ECS task execution / task roles
 - **Application + Network Load Balancers**: Create and manage both the ALB (HTTPS API traffic) and the NLB (FL server TCP/gRPC traffic)
-- **ECS / Fargate**: `ecs:*` (cluster, task definitions, services). Task images come from **GHCR** (`ghcr.io/londonaicentre/...`) — no AWS-side image registry permissions needed (no ECR mirror). The ECR API/DKR VPC endpoints in `vpc_endpoints.tf` are kept only for the bootstrap EFS-provisioning job (`amazon/aws-cli`, pulled from ECR Public).
+- **ECS / Fargate**: `ecs:*` (cluster, task definitions, services). Task images come from **GHCR** (`ghcr.io/londonaicentre/...`) — no AWS-side image registry permissions needed (no ECR mirror). The bootstrap EFS-provisioning image (`amazon/aws-cli`) comes from Docker Hub and is also fetched through the NAT gateway, so private ECR API/DKR endpoints are not required.
 - **EFS**: `elasticfilesystem:*` for the shared workspace volumes mounted into FL Fargate tasks
 - **CloudFront + WAFv2**: Create and manage the UI distribution and the WebACL attached to it
 - **ACM**: Issue / import certificates in both `eu-west-2` (ALB origin) and `us-east-1` (CloudFront viewer)
@@ -328,7 +328,7 @@ deploy/providers/AWS/
 ├── iam_ecs.tf                  # IAM execution + task roles for ECS Fargate tasks
 ├── parameter_store.tf          # SSM Parameter Store entries consumed by ECS tasks (bucket URIs, internal URL, etc.)
 ├── service_discovery.tf        # Cloud Map private DNS namespace (flip.local) for ECS task-to-task resolution
-├── vpc_endpoints.tf            # Interface endpoints (Secrets Manager, SSM, CloudWatch Logs, ECR API + DKR) + S3 gateway endpoint
+├── vpc_endpoints.tf            # Interface endpoints (Secrets Manager, SSM, CloudWatch Logs) + S3 gateway endpoint
 ├── dhcp.tf                     # VPC DHCP option set
 ├── locals.tf                   # Shared locals
 ├── cloudfront.tf               # CloudFront distribution for flip-ui + attached WAFv2 WebACL

--- a/deploy/providers/AWS/check_status.py
+++ b/deploy/providers/AWS/check_status.py
@@ -452,10 +452,10 @@ def check_ecs_cluster() -> None:
 
 
 def check_vpc_endpoints() -> None:
-    """Verify essential VPC interface endpoints are AVAILABLE.
+    """Verify configured AWS VPC interface endpoints are AVAILABLE.
 
-    Detects: missing or broken endpoints that would block ECS Fargate tasks
-    from pulling images (ECR), reading secrets (Secrets Manager), or logging.
+    Detects broken endpoints that would block ECS Fargate tasks from reading
+    parameters or secrets, or from writing logs.
     """
     print_status("INFO", "Checking VPC endpoints...")
     success, output = run_aws_command([
@@ -478,19 +478,10 @@ def check_vpc_endpoints() -> None:
         print_status("WARN", "Could not parse VPC endpoint data")
         return
 
-    essential_prefixes = [
-        "com.amazonaws.",
-        ".ecr.dkr",
-        ".ecr.api",
-        ".ssm",
-        ".secretsmanager",
-        ".logs",
-    ]
     for ep in endpoints:
         name = ep.get("Name", "")
         state = ep.get("State", "?")
-        is_essential = any(p in name for p in essential_prefixes)
-        if is_essential:
+        if name.startswith("com.amazonaws."):
             if state == "available":
                 print_status("PASS", f"VPC endpoint {name.split('.')[-1]} is {state}")
             else:

--- a/deploy/providers/AWS/variables.tf
+++ b/deploy/providers/AWS/variables.tf
@@ -179,7 +179,7 @@ variable "enable_efs" {
 }
 
 variable "enable_ecs_endpoints" {
-  description = "Enable VPC interface endpoints (SSM, Secrets, Logs, ECR) for ECS Fargate"
+  description = "Enable VPC interface endpoints (SSM, Secrets Manager, CloudWatch Logs) for ECS Fargate"
   type        = bool
   default     = true
 }

--- a/deploy/providers/AWS/vpc_endpoints.tf
+++ b/deploy/providers/AWS/vpc_endpoints.tf
@@ -12,14 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# VPC endpoints let Fargate tasks pull images, read SSM parameters, fetch
-# secrets, and write logs without traversing the NAT gateway. Required because
-# Fargate tasks in private subnets need outbound access to AWS APIs at task
-# launch — without these, image pulls and secret reads silently hang.
+# VPC endpoints let Fargate tasks read SSM parameters, fetch secrets, and write
+# logs without traversing the NAT gateway. Container images are hosted on GHCR,
+# and the EFS-provisioning image is hosted on Docker Hub; both are fetched
+# through the NAT gateway, so private ECR endpoints are not used.
 #
-# Gated behind enable_ecs_endpoints: creating 5 interface endpoints costs
-# ~$73/month in idle ENI hourly charges. Until PR 2 deploys ECS services
-# that consume them, existing EC2 traffic uses the NAT gateway just fine.
+# Gated behind enable_ecs_endpoints because each interface endpoint incurs an
+# hourly charge for an ENI in every configured availability zone.
 # The S3 gateway endpoint is always created (no hourly charge).
 
 ############################
@@ -79,8 +78,6 @@ locals {
     "secretsmanager",
     "ssm",
     "logs",
-    "ecr.api",
-    "ecr.dkr",
   ])
 }
 


### PR DESCRIPTION
## Summary

- remove the unused `ecr.api` and `ecr.dkr` interface endpoints while retaining Secrets Manager, SSM, CloudWatch Logs, and the S3 gateway endpoint
- update the endpoint variable, deployment documentation, and status-check wording to match the deployed services
- correct the AWS README: the EFS bootstrap task uses the Docker Hub image `amazon/aws-cli:2.22.35`, not ECR Public

## Why

FLIP application images are hosted on GHCR, and the EFS bootstrap image is hosted on Docker Hub. Both public registry paths use the NAT gateway; the private ECR endpoints route neither workload. Terraform was therefore creating two unused interface endpoints, each with an ENI in every private-subnet availability zone.

## Impact

The next `terraform apply` will destroy the managed ECR API/DKR endpoints. The three AWS API interface endpoints used by Fargate and the no-hourly-charge S3 gateway endpoint remain unchanged. Image pulls continue through the existing NAT path.

## Validation

- `make -C deploy/providers/AWS prettier`
- `terraform -chdir=deploy/providers/AWS fmt -check -recursive -diff`
- `terraform -chdir=deploy/providers/AWS validate -no-color` (passes with existing `failure_threshold` deprecation warnings)
- `ruff check --ignore E501 deploy/providers/AWS/check_status.py`
- Python AST parse of `deploy/providers/AWS/check_status.py`
- `git diff --check`

A full Ruff check still reports the two pre-existing E501 violations at `check_status.py:1152` and `check_status.py:1177`; this change does not touch those lines.

Closes #504