### PR TITLE
Add Codex agent guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,404 @@
+# AGENTS.md — FLIP
+
+## Project Overview
+
+FLIP (Federated Learning Interoperability Platform) — open-source platform for federated training and evaluation of
+medical imaging AI models across healthcare institutions while preserving data privacy.
+
+**License**: Apache 2.0 — all source files must include the copyright header.
+
+## Repository Structure
+
+```
+FLIP/
+├── flip-api/           # Central Hub API (Python/FastAPI)
+├── flip-ui/            # Frontend UI (Vue 3 / TypeScript / TailwindCSS)
+├── flip-utils/         # FLIP Python library (pip-installable flip-utils)
+├── fl-services/        # FL Docker services + network provisioning, per backend (Makefile owns build/provision/up/down/submit; flower also up-secure): fl-services/nvflare/{fl-base,fl-server,fl-client,fl-api-base, provision/{net-*_project_*.yml, scripts/, workspace-{dev,stag,prod}/ gitignored}}, fl-services/flower/{fl-base,superlink,supernode,fl-api-flower, provision/{scripts/, creds/ gitignored}} (#622)
+├── fl-apps/            # FL app templates per backend: fl-apps/nvflare/{standard,fed_opt,evaluation,diffusion_model}, fl-apps/flower/{standard,evaluation} + check_required_files.sh (cross-backend CI validator at root)
+├── fl-tutorials/       # FL tutorials per backend: fl-tutorials/nvflare/{image_*,testing}, fl-tutorials/flower/{xray_classification,3d_spleen_segmentation*,numpy} (root Makefile forwards by FL_BACKEND); xray classification, spleen seg/eval, diffusion
+├── trust/
+│   ├── trust-api/      # Trust API gateway (Python/FastAPI)
+│   ├── data-access-api/# OMOP database queries (Python/FastAPI)
+│   ├── imaging-api/    # DICOM image retrieval (Python/FastAPI)
+│   ├── omop-db/        # Mocked OMOP database (PostgreSQL)
+│   ├── orthanc/        # Mocked PACS server
+│   └── xnat/           # Mocked XNAT neuroimaging service
+├── deploy/             # Docker Compose files (dev/prod, flower/nvflare); FL network provisioning now lives under fl-services/<backend>/, not here
+│   └── providers/
+│       ├── AWS/        # Terraform/OpenTofu IaC + Ansible for AWS deployment
+│       ├── kubernetes/ # Helm chart for Kubernetes trust deployment
+│       └── local/      # Ansible playbooks for on-premises trust deployment
+├── docs/               # Sphinx documentation (ReadTheDocs)
+└── scripts/            # Utility scripts (incl. check-fl-provisioned.sh — the `make up` FL-kit guard)
+```
+
+Service-specific details are in `flip-api/AGENTS.md`, `trust/AGENTS.md`, `trust/*/AGENTS.md`, and `deploy/providers/AWS/AGENTS.md`.
+
+The `flip-utils/`, `fl-services/`, `fl-apps/`, and `fl-tutorials/` trees hold the FL base library, Docker services,
+app templates, and tutorials for both NVFLARE and Flower. Both
+backends are also provisioned in-tree (gitignored): `deploy/fl_backend.mk` points `FL_PROVISIONED_DIR` per-backend at
+`fl-services/nvflare/provision/workspace-dev` (nvflare) or `fl-services/flower/provision/creds` (flower) — see
+[`README.md#federated-learning-setup`](README.md#federated-learning-setup).
+
+## Tech Stack
+
+| Layer | Technology |
+| ------- | ----------- |
+| Backend APIs | Python 3.12+, FastAPI, SQLAlchemy/SQLModel, Pydantic |
+| Frontend | Vue 3, TypeScript, Vite, TailwindCSS, Pinia |
+| Database | PostgreSQL (asyncpg) |
+| Package mgmt (Python) | UV (`uv sync`, `uv add`) |
+| Package mgmt (JS) | npm |
+| Testing | pytest (unit + integration), Vitest (frontend unit), Cypress (frontend e2e) |
+| Linters/Formatters | Ruff (Python), MyPy (Python), ESLint (JS/TS) |
+| Containers | Docker, Docker Compose, Docker Swarm (XNAT) |
+| Infrastructure | Terraform/OpenTofu (AWS), Ansible (EC2 + on-prem provisioning) |
+| FL frameworks | NVIDIA FLARE, Flower |
+| Auth | AWS Cognito |
+| Storage | AWS S3 |
+| CI/CD | GitHub Actions |
+
+## Common Commands
+
+### Running Services
+
+```bash
+make up                    # Start all services (requires AWS access) — pulls images from GHCR
+make up BUILD=true         # Same, but rebuild repo-built services from local source instead of pulling
+make up-no-trust           # Start central hub only
+make up-trusts             # Start trust services only
+make down                  # Stop all services
+make restart               # Stop and restart all
+make build                 # Build all Docker images (standalone, --no-cache; does not start)
+make lock                  # Regenerate every uv.lock from its pyproject.toml
+make ui                    # Start UI only
+make clean                 # Remove all stopped containers, networks, and images
+make ci                    # Run CI pipeline locally using act
+make central-hub           # Start flip-api + database (no UI)
+make debug SERVICE=<name>  # Restart service in debug mode (port 5678)
+make debug-off SERVICE=<name>
+make debug-all             # Debug all API services
+make debug-off-all         # Remove all debug modes
+```
+
+#### Dev image sourcing: pull-by-default
+
+In development (`PROD` unset), `make up` **pulls** the repo-built services
+(`flip-api`, `trust-api`, `imaging-api`, `data-access-api`, `orthanc`) from GHCR
+rather than building them — they carry `image:` + `pull_policy: always` in the dev
+compose, with local `src/` bind-mounted on top so live reload still runs your
+working copy. Pass `BUILD=true` (e.g. `make up BUILD=true`) to rebuild from source
+instead — required after a dependency (`uv.lock`/`pyproject.toml`) or Dockerfile
+change, since those live in the image layer, not the mounted `src/`.
+
+- **Prerequisite:** be logged into GHCR (`docker login ghcr.io`) and have the
+  `${DOCKER_TAG}` tag published (dev defaults to `:stag`, the `develop` build).
+  A failed pull no longer silently falls back to a build.
+- **`flip-ui` is the exception** — it has no published GHCR image, so it always
+  builds locally. `make build` remains the standalone `--no-cache` builder.
+- Stag/prod are unchanged: `PROD=stag|true` selects the prod compose (baked
+  `image:`-only services, no mounts).
+
+### Testing
+
+```bash
+make unit_test             # All unit tests across all services (from root)
+make integration_test      # flip-api + trust integration tests (from root)
+make tests                 # flip-ui unit + e2e tests, then flip-api test suite (from root)
+make e2e_smoke             # End-to-end smoke against a running stack (see below)
+# From a service directory (e.g., flip-api/):
+make test                  # ruff + mypy + pytest (unit + integration)
+make unit_test             # Unit tests only
+make integration_test      # Integration tests only (also available from root and trust/)
+make local_test            # Tests without Docker
+```
+
+### End-to-End Smoke Test
+
+`make e2e_smoke` (from root) drives a full project lifecycle against an **already-running stack**: create project → submit cohort query → wait for image pull → run FL training → download results. It is the scripted form of the manual UI sanity-check and is **not run in CI**. Long-running (image pull + FL training) — run it in the background.
+
+Prerequisites:
+- Stack up via `make up` (central hub + trusts + XNAT) with trusts registered; Orthanc PACS seeded with DICOM data so image pull has something to pull.
+- The tutorial files are in-tree at `fl-tutorials/<backend>/` (NVFLARE and Flower both migrated from the legacy fl-base repos).
+
+Defaults track `FL_BACKEND` (default `nvflare`): `MODEL_FILES_DIR` and `QUERY_FILE` point at `fl-tutorials/nvflare/image_classification/xray_classification/`. For Flower, they point at the in-tree `fl-tutorials/flower/xray_classification/`. Common overrides:
+
+```bash
+make e2e_smoke FL_BACKEND=flower                               # use the Flower tutorial
+make e2e_smoke MODEL_FILES_DIR=/path/app QUERY_FILE=/path/q.sql
+make e2e_smoke EXTRA_ARGS="--abort-midway"                     # exercise the FL stop-training path
+make e2e_smoke EXTRA_ARGS="--image-pull-threshold 0.5 --image-pull-timeout 1200"
+make e2e_smoke EXTRA_ARGS="--project-id <UUID>"               # reuse an approved project (see below)
+```
+
+The `--project-id <UUID>` override (printed as `project_id=<UUID>` at the start of any run) reuses an
+existing approved project: it skips cohort submission + approval and jumps straight to model
+create → upload → train → download. The image-pull wait still runs but returns immediately when the
+studies are already pulled — so it lets you iterate on training/app code (and re-run after an upload
+or fl-api change) without re-creating the project and re-pulling DICOM (~6 min/backend) each time.
+
+**Testing a change on BOTH FL backends in one sitting (the backend switch).** The pulled DICOM lives in
+each trust's Orthanc/XNAT, which `make restart-fl` leaves untouched — so you can pull once on the first
+backend and *reuse the same project* for the second, skipping the second image pull entirely:
+
+```bash
+# 0. Rebuild the fl-api image(s) from your branch first — the running stack serves PUBLISHED images,
+#    not your code. Full: `make build-fl FL_BACKEND=<backend>`; fl-api-only fast path:
+#    DOCKER_GID=$(id -g) docker compose -f fl-services/<backend>/compose.dev.yml build <fl-api|flip-fl-api>
+make e2e_smoke FL_BACKEND=flower                                          # note the printed project_id=<UUID>
+make restart-fl FL_BACKEND=nvflare DOCKER_FL_REGISTRY= DOCKER_FL_TAG=dev  # switch backend onto rebuilt :dev images
+make e2e_smoke FL_BACKEND=nvflare EXTRA_ARGS="--project-id <UUID>"        # reuse project → skip cohort + re-pull
+```
+
+Before trusting either run, confirm the live container actually carries your code (the stack silently
+runs old images otherwise): `docker exec flip-fl-api-net-1 cat fl_api/utils/upload.py`. See
+[Running FL Tutorials Locally](#running-fl-tutorials-locally) for `make build-fl` / `:dev` image details.
+
+### Running FL Tutorials Locally
+
+The NVFLARE tutorials live in `fl-tutorials/` and run on the local NVFLARE simulator (needs a GPU +
+the `flare-fl-base` image). Each tutorial carries a `.env.app` and delegates to the shared harness in
+`fl-tutorials/nvflare/testing/`. From the repo root:
+
+```bash
+make -C fl-tutorials list-tutorials
+make -C fl-tutorials download-xray-data                  # xray dataset (HF); spleen: download-spleen-data
+make -C fl-tutorials run-tutorial TUTORIAL=xray_classification
+make -C fl-tutorials run-all-tutorials                   # all four (heavy; stops on first failure)
+make -C fl-tutorials test-template TEMPLATE=fed_opt      # smoke-test a template that has no tutorial
+```
+
+The simulator GPU id defaults to `0`; override with `SIM_GPU` in `fl-tutorials/nvflare/testing/.env.testing`.
+To iterate on the FL images, `make build-fl` builds them locally as `:dev` (see `fl-services/nvflare/README.md`);
+run the stack on them with `make up DOCKER_FL_REGISTRY= DOCKER_FL_TAG=dev`.
+
+### Linting & Type Checking
+
+```bash
+uv run ruff check . --fix  # Lint with auto-fix
+uv run mypy .              # Static type checking
+```
+
+### Debugging
+
+```bash
+make debug SERVICE=flip-api        # Start a service in debug mode
+make debug SERVICE=trust-api       # Available: flip-api, trust-api, imaging-api, data-access-api
+make debug-off SERVICE=flip-api    # Stop debug mode
+```
+
+### Test Data
+
+```bash
+make -C flip-api create_testing_projects   # Create test projects
+make -C flip-api delete_testing_projects   # Clean up test data
+```
+
+### Database migrations (flip-api)
+
+flip-api's PostgreSQL schema is owned by **Alembic** (`flip-api/src/flip_api/db/migrations/`), not `SQLModel.metadata.create_all`. The flip-api entrypoint runs `alembic upgrade head` before seeding at boot (fail-fast). Any schema-affecting change to `flip-api/src/flip_api/db/models/*.py` **must** ship a revision in the same PR — the integration drift guard (`flip-api/tests/integration/test_migrations.py`) fails otherwise.
+
+```bash
+make -C flip-api migration MESSAGE="..."   # autogenerate a revision (flip-db must be up); then review it
+make -C flip-api migrate                   # alembic upgrade head
+make -C flip-api migration_current         # show current revision
+```
+
+### Docker Swarm Commands
+
+```bash
+docker swarm init                          # Initialize Swarm mode
+docker network rm deploy_trust-network-1   # Remove trust network
+docker network rm deploy_trust-network-2   # Remove trust network
+make create-networks                       # Create all networks
+docker compose -f deploy/compose.development.yml exec <service> <command>
+docker compose -f deploy/compose.development.yml run --rm <service>
+```
+
+### Trust Registration & Key Setup
+
+```bash
+make new-trust TRUST_CODE=<CODE> TRUST_NAME="..."  # Scaffold trust/.env.<CODE>.<env>
+make register-trusts                  # Register the shipped dev roster (trust/.env.*.development.example)
+make register-trust KIT=<CODE>        # Register one trust + fill its kit (creds + hub-shared block)
+make sync-trust-kit KIT=<CODE> PROD=<env>  # Rotation only: refresh hub-shared values in trust/.env.<CODE>.<env>
+make sync-trust-kits                  # Refresh every locally-present kit file
+make generate-internal-service-key    # Generate fl-server-to-hub key
+```
+
+## Workflow Requirements
+
+### Always Use Make Commands
+
+When a Makefile target exists, always use it instead of raw commands. Make targets encapsulate correct flags, environment setup, and command sequences:
+
+- `make test` instead of raw ruff + mypy + pytest
+- `make build` instead of raw docker compose build
+- `make up`/`make down` instead of raw docker compose
+
+### Always Verify Changes
+
+After code changes, run verification before committing:
+
+1. Identify affected services.
+2. Run service-level test: `make test` (or `make unit_test` if no Docker).
+3. For cross-service changes, run root-level: `make unit_test`.
+4. For frontend changes: `cd flip-ui && npm run lint && npm run test:unit`
+5. Fix all failures before committing.
+
+### Documentation Check
+
+After changes, evaluate if docs need updating:
+
+| Change Type | Documentation to Review |
+|-------------|------------------------|
+| New service/component | `README.md`, `CONTRIBUTING.md`, `docs/source/components.rst` |
+| New API endpoints | `docs/source/api-reference.rst`, service `README.md` |
+| Changed env vars | `.env.development.example`, `CONTRIBUTING.md`, `docs/source/sys-admin.rst` |
+| New dependencies | `CONTRIBUTING.md`, service `README.md` |
+| Changed deployment config | `deploy/README.md`, `docs/source/sys-admin.rst` |
+| New Make targets | `README.md`, this file |
+| User-facing workflow changes | `docs/source/user-guides.rst` |
+| FL framework features | `docs/source/components/component-fl-nodes.rst` |
+| Trust service changes | `trust/README.md`, relevant `trust/*/README.md` |
+| Auth/role changes | `docs/source/sys-admin/admin-user-roles.rst` |
+
+## Code Style & Conventions
+
+### Python
+
+- Line length: 120. Linter: Ruff (`select = ['I', 'F', 'E', 'W', 'PT', 'UP006', 'UP007', 'UP035', 'UP042', 'UP045']`; `UP042` enforces `StrEnum` over the legacy `(str, Enum)` pattern). Type checker: mypy.
+- Docstrings: Google style. Naming: snake_case. Imports: alphabetically sorted.
+- Source layout: `src/[service_name]/`. Tests: `tests/unit/`, `tests/integration/`.
+- Test placement: a test goes in `tests/integration/` if and only if it touches a real backing service (Postgres via `session` fixture, real AWS, a running sibling API, real Orthanc/XNAT/OMOP). If every external dependency is mocked, it's a unit test in `tests/unit/`. FastAPI `TestClient` alone does not make a test "integration". See `CONTRIBUTING.md` ("Where does my test go?") for the canonical rule.
+- Dependency injection: FastAPI `Depends()`. Async DB: asyncpg with async context managers.
+
+### JavaScript/TypeScript (flip-ui)
+
+- Line length: 120. Linter: ESLint + TypeScript + Vue plugins.
+- Components: PascalCase in `src/partials/` (reusable) and `src/pages/`.
+- State: Pinia stores in `src/stores/`. Icons: Heroicons.
+
+### General
+
+- All files include Apache 2.0 copyright header.
+- Commits must be signed off (DCO): `git commit -s`
+- PRs target `develop`. Branch naming: `[ticket_id]-[task_name]`.
+
+## Environment Setup
+
+1. `cp .env.development.example .env.development`
+2. Per service: `cd <service-dir> && uv sync`
+3. UI: `cd flip-ui && npm install`
+4. AWS: `aws configure sso` (required for flip-api and `make up`)
+5. Install AWS Session Manager plugin
+6. `make create-networks`
+
+### Key Environment Variables
+
+- `FL_BACKEND` — `nvflare` (default) or `flower`. Two roles: (1) deploy layer — selects which fl-* images run (compose/Makefile); (2) flip-api — sets the `FLNets.fl_backend` column at seed time. The seeded value is **canonical**: flip-api reads `FL_BACKEND` only at seeding and never reconciles it at runtime. To switch frameworks, `make restart-fl FL_BACKEND=...` recreates flip-api so its startup seeding re-applies the backend onto every net.
+- `FL_PROVISIONED_DIR` — path to the in-tree provisioned FL artifacts, derived per-backend by `deploy/fl_backend.mk` from `FL_BACKEND`: `fl-services/nvflare/provision/workspace-dev` (nvflare startup kits) or `fl-services/flower/provision/creds` (flower per-net TLS certs + SuperNode keys). Both gitignored. Read only by the dev compose overlays for the cert/workspace volume mounts; override at the CLI for a one-off (`make up FL_PROVISIONED_DIR=...`). FL Makefiles are **per-backend** — each `fl-services/<backend>/Makefile` owns that backend's `build`/`provision`/`up`/`down`/`submit` (flower also `up-secure`); the root Makefile forwards only `build-fl` by `FL_BACKEND`. Each backend's `fl-services/<backend>/Makefile` also owns its network provisioning (NVFLARE adds `provision`/`provision-2-nets`/`provision-stag`/`provision-prod`/`upload-kits-to-s3`; the project YAMLs, `scripts/`, and gitignored `workspace-{dev,stag,prod}/` output live under `provision/`). Provision with `make -C fl-services/nvflare provision-2-nets` (nvflare) or `make -C fl-services/flower provision NET_NUMBER=<N>` (flower). To run a backend standalone + submit without the full stack: `make -C fl-services/<backend> up` (or `up-secure`) then `make -C fl-services/<backend> submit APP=<job>`.
+- `PROD` — `true` (production), `stag` (staging), unset (development)
+- `AES_KEY_BASE64` — encryption key for trust communication
+- A remote trust operator only needs their kit file (`trust/.env.<KIT>`) — no hub `.env.<env>` needed on trust hosts.
+  See `trust/README.md` for the standalone-operator quick-start.
+- `TRUST_API_KEY` — single per-trust plaintext API key, lives only in that trust's kit file (`trust/.env.<CODE>.<env>`), never on the hub
+- `INTERNAL_SERVICE_KEY_HEADER` — HTTP header name for internal service auth
+- `INTERNAL_SERVICE_KEY` — internal service key for fl-server-to-hub auth (Central Hub only)
+- `INTERNAL_SERVICE_KEY_HASH` — hub-side SHA-256 hash of the internal service key
+- `TRUST_INTERNAL_SERVICE_KEY_HEADER` — HTTP header name for trust-internal service auth, sent by every caller (trust-api, imaging-api, fl-client) on every call to imaging-api or data-access-api. Default `X-Trust-Internal-Service-Key`.
+- `TRUST_INTERNAL_SERVICE_KEY` — per-trust plaintext key carried in the trust's kit file (`trust/.env.<CODE>.<env>`), minted by `register_trust`. Read by every trust-internal container; used by trust-api / imaging-api / data-access-api / fl-client to authenticate one another inside the trust. Each trust uses a distinct key — see the **Trust-internal Service Authentication** section below for the threat model. Distinct from the hub's `INTERNAL_SERVICE_KEY*`: per-trust scope, never sent to or stored on the hub.
+- Trusts are NOT enumerated in the hub env file. The kit files (`trust/.env.<CODE>.<env>`) ARE the roster: `make new-trust TRUST_CODE=<CODE> TRUST_NAME="..."` scaffolds one, `make register-trust KIT=<CODE>` registers it. The old `TRUST_<n>_NAME` / `TRUST_<n>_CODE` / `TRUST_<n>_REGION` / `TRUST_<n>_HOST` deploy vars and `register-trust-<n>` targets are removed.
+- `CENTRAL_HUB_API_URL` — public base URL of flip-api (with `/api`); read by flip-ui and trust-api. In prod this is the CloudFront URL.
+- `FLIP_API_INTERNAL_URL` — Central-Hub-internal base URL of flip-api (with `/api`); read **only** by fl-server. Must resolve over the Docker network (e.g. `http://flip-api:8000/api`), never the CloudFront URL — CloudFront strips `X-Internal-Service-Key` at the edge.
+- Database auth — In production (`ENV=production`) flip-api authenticates to Postgres through **RDS Proxy** using a short-lived AWS IAM auth token minted per-connection by a SQLAlchemy `do_connect` hook in `flip_api/db/database.py` (passwordless engine URL, `sslmode=require`, `pool_pre_ping` + `pool_recycle`). The proxy reaches RDS with the rotating RDS-managed master secret it re-reads natively, so the app holds no static DB credential and secret rotation no longer causes an outage (FLIP#556). Dev (`ENV=development`) uses the static `POSTGRES_PASSWORD` from the environment. There is no separate toggle — the path is selected by `ENV`.
+- `ENFORCE_MFA` — `true` (the `Settings` default; do **not** set in `.env*` files for stag/prod) gates every authenticated route on TOTP enrolment via the app-layer MFA check in `verify_token`. The dev override lives in `deploy/compose.development.yml` (`ENFORCE_MFA=false`) so local development doesn't force enrolment on a burner authenticator app. Production compose (`compose.production.yml`) passes `ENFORCE_MFA=${ENFORCE_MFA:-true}` so the env var can be overridden from `.env.stag`/`.env.prod` for testing, but falls back to the secure `true` default when unset. Intentionally not in `.env.development.example` or AWS Secrets Manager — the Settings default (`true`) is the canonical secure anchor. The UI mirrors this flag from `/users/me/mfa/status` and skips the enrolment redirect when it's false.
+- `MAX_MODEL_FILE_BYTES` — Hard cap on the file size of a single model-file upload, in bytes. Bound on the presigned POST policy so S3 rejects oversized payloads at the edge — the hub never sees them. Default `104857600` (100 MiB). The S3 policy condition allows a small fixed overhead above this for multipart/form-data framing (see `_MULTIPART_OVERHEAD_BUFFER_BYTES` in `flip_api/utils/s3_client.py`); the UI guard at `flip-ui/src/utils/file.ts` compares against this raw value so a file at exactly the cap is accepted on both sides.
+- `PRE_SIGNED_URL_EXPIRATION_SECONDS` — Setting default for the model-file presigned POST policy TTL, in seconds. The hub silently clamps to the 1800s (30 min) security ceiling encoded as `MAX_PUT_PRESIGNED_URL_TTL_SECONDS` in `flip_api/utils/s3_client.py` (a leaked policy is a writable capability against the upload bucket, so the leak window must stay tight). The ceiling is 1800s rather than the original 600s to give larger uploads (up to the `MAX_MODEL_FILE_BYTES` cap) enough time to complete. Setting default is `3600`; effective ceiling 1800. Over-ceiling callers leave a warning in the logs.
+
+## Deployment Architecture
+
+- **Cloud-Only**: Central Hub (ECS Fargate) + Trust (EC2) on AWS
+- **Hybrid**: Central Hub on AWS + Trust on local/on-prem host
+- Trusts poll Central Hub over HTTPS (outbound only). No inbound ports on trust hosts.
+- SSH access via AWS SSM Session Manager only (no port 22 open).
+
+## CI/CD
+
+GitHub Actions: `test_flip_api.yml`, `test_flip_ui.yml`, `test_trust_*.yml`, `docker_build_*.yml`, `validate_terraform.yml`, `secret-scanning.yml`, `docs.yml`, `pr_acceptance_criteria.yml`. Run locally: `make ci` (uses `act`).
+
+### Docker image builds: gated on tests, manual trigger for branches
+
+**The application `docker_build_*.yml` workflows (`flip_api`, `trust_trust_api`, `trust_imaging_api`, `trust_data_access_api`) auto-publish to GHCR only after their service's test workflow passes on `develop` or `main`.** They trigger via `workflow_run` on the matching test workflow (`FLIP API CI`, `Trust - Trust API CI`, etc.) and a job-level `if` gates on `workflow_run.conclusion == 'success'` — a red test suite never publishes. Path filtering is inherited from the test workflow, so a build still only fires when that service changed. (`orthanc`, `xnat_*` keep their direct push trigger — they have no test suite to gate on; `flip-ui` is a CI smoke test that never publishes.)
+
+> **Note:** `workflow_run` triggers only take effect once these workflow files are on the repo's **default branch**. The first merge that introduces them won't retroactively publish; subsequent qualifying pushes will.
+
+Branch pushes do NOT build images. If you pin a branch-named tag in a compose file (e.g. `ghcr.io/londonaicentre/flip-api:my-feature-branch`) for prod testing, manually trigger the relevant build workflow via `workflow_dispatch` (which bypasses the test gate):
+
+```bash
+gh workflow run docker_build_flip_api.yml --ref <branch-name>
+gh workflow run docker_build_flip_ui.yml --ref <branch-name>          # only if UI image is consumed; deploy-ui builds locally
+gh workflow run docker_build_trust_trust_api.yml --ref <branch-name>
+# ...one per service whose image you've pinned
+```
+
+Wait for green completion (`gh run list --workflow=docker_build_flip_api.yml --branch <branch>`) before redeploying. The `flip-ui` is rebuilt locally by `make deploy-ui` and does not consume GHCR; the rest do.
+
+## Pre-commit Hooks
+
+TruffleHog, detect-secrets, large file check (max 1000KB), merge conflict markers, YAML validation, private key detection, env var validation, fl-apps required-files generation (`fl-apps-required-files` — regenerates each `fl-apps/<backend>/required_files.json` from its per-template arrays via `fl-apps/check_required_files.sh`; rewrites-and-fails on drift like `prettier`, so re-stage and commit again — backstopped by the `check-required-files` CI workflow. The aggregate is `linguist-generated` in `.gitattributes`; never hand-edit it — edit the per-template `required_files.json`), uv lockfile sync (`uv-lock`, one entry per uv project). Install: `pre-commit install`.
+
+## Security Rules
+
+- Never commit secrets/credentials (pre-commit hooks enforce this).
+- SSH-over-SSM mandatory (no port 22 exposed).
+- Never bypass TLS (`curl -k` prohibited).
+- Use `AES_KEY_BASE64` for trust communication encryption.
+- AWS Cognito for hub auth, per-trust API keys for trust-to-hub auth.
+- Internal service key for fl-server-to-hub auth (separate from trust keys).
+- Trust-internal service key for trust-api / imaging-api / fl-client → imaging-api / data-access-api auth (per-trust, never leaves trust env). See **Trust-internal Service Authentication** below.
+- FL clients intentionally have no Central Hub credentials.
+- Do not hardcode env values in Dockerfiles or compose files.
+- 72-hour supply-chain cooldown on Python/npm package installs — enforced by uv `exclude-newer` (`[tool.uv]` in every `pyproject.toml`) and npm `min-release-age` (`flip-ui/.npmrc`, requires npm >= 11.10 which Node 24 LTS ships), backstopped by a `uv lock --check` CI gate in `secret-scanning.yml`. See CONTRIBUTING.md ("Dependency cooldown").
+
+## Trust-internal Service Authentication
+
+**Threat.** Imaging-api proxies privileged XNAT operations using a service account; data-access-api executes arbitrary SQL against OMOP using a service account. Without caller authentication on these APIs, any container on the trust Docker network — or any operator with SSM port-forward access — can drive XNAT-admin operations and run unrestricted OMOP queries. Both surfaces sit behind no inbound firewall on the trust host (everything is internal to the Docker network) and neither used to validate the caller's identity.
+
+**Mitigation.** Every trust-internal call carries a shared-secret header. The header name comes from `TRUST_INTERNAL_SERVICE_KEY_HEADER` (default `X-Trust-Internal-Service-Key`), the value is the per-trust `TRUST_INTERNAL_SERVICE_KEY` from the trust's kit file (`trust/.env.<CODE>.<env>`). Receivers (imaging-api, data-access-api) compare the header against their own copy of the key with `hmac.compare_digest` (constant-time, defeats timing side-channels). Senders are trust-api, imaging-api (when calling data-access-api `/cohort/accession-ids`), and fl-client. The same key is held in plaintext by every trust-internal container — the trust boundary is the trust itself, not individual service-pairs within it. `/health` stays unauthenticated so liveness probes keep working.
+
+**Per-trust scope.** Each trust gets a distinct key. A leak in Trust_1 cannot drive operations on Trust_2's APIs. The hub never sees these keys — they live only in trust-side env: `register_trust` writes `TRUST_INTERNAL_SERVICE_KEY` into the trust's kit file (`trust/.env.<CODE>.<env>`), which `trust/Makefile` `-include`s so every trust-internal container inherits it. This is deliberately distinct from the hub's `INTERNAL_SERVICE_KEY` (which protects fl-server → flip-api on the Central Hub).
+
+**Generating keys.** The key is minted by `register_trust` (`make register-trusts`), which writes `TRUST_INTERNAL_SERVICE_KEY` into the trust's kit file. Re-register to rotate.
+
+**Per-service code.** The auth check lives in each receiving service's `utils/internal_auth.py`:
+
+- `trust/imaging-api/imaging_api/utils/internal_auth.py` — applied at the router level on every imaging-api router except `/health`.
+- `trust/data-access-api/data_access_api/utils/internal_auth.py` — applied at the router level on `/cohort` (covers `/cohort`, `/cohort/dataframe`, `/cohort/accession-ids`).
+
+The senders construct the header inline at call sites:
+
+- `trust-api/trust_api/services/task_handlers.py::_trust_internal_headers()` — used on outbound imaging-api and data-access-api calls.
+- `imaging-api/imaging_api/services_external/data_access.py` — used on the outbound `/cohort/accession-ids` call.
+- The `flip` Python package — lives at [`flip-utils/flip/`](flip-utils/flip/) in this mono-repo, consumed by both the NVFLARE and Flower fl-client / fl-server images built from `fl-services/`. Wraps every fl-client call to imaging-api (`flip.get_by_accession_number`, etc.) and data-access-api (`flip.get_dataframe`). The package reads `TRUST_INTERNAL_SERVICE_KEY` from `os.environ` and forwards it on every request. **User-uploaded training code (`client_app.py`, `server_app.py`, anything under `tutorials/`) does not deal with the header directly** — it calls `flip.*` and the package handles transport-level auth.
+
+## Code Modification Rules
+
+1. Follow existing code style and conventions.
+2. Add/update tests covering new functionality.
+3. Run `make test` or `make unit_test` before committing.
+4. Update documentation as needed.
+5. Commit with clear messages. All commits signed off by human author alone (`git commit -s`).
+6. Add new deps to `pyproject.toml` or `package.json`, document in service README.
+7. Use SOLID principles. Aim for high test coverage on critical paths.
+
+## Documentation Files
+
+Key docs (read on demand):
+
+- Auth/deployment: `docs/source/sys-admin.rst`
+- Components: `docs/source/components.rst`
+- API reference: `docs/source/api-reference.rst`
+- User guides: `docs/source/user-guides.rst`
+- AWS deployment: `deploy/providers/AWS/README.md`

--- a/deploy/providers/AWS/AGENTS.md
+++ b/deploy/providers/AWS/AGENTS.md
@@ -1,0 +1,76 @@
+# AGENTS.md — AWS Deployment
+
+## Terraform Files
+
+| File | Resources |
+|------|-----------|
+| `main.tf` | Provider config, VPC, subnets, IGW, NAT, route tables, RDS instance, Secrets Manager, SES |
+| `services.tf` | S3 buckets, Cognito |
+| `rds_proxy.tf` | RDS Proxy + IAM DB auth (proxy, IAM role/policy, SG, `rds-db:connect`) — see FLIP#556 |
+| `ecs.tf` | ECS cluster, ALB, target groups, listeners |
+| `ecs_services.tf` | ECS Fargate services (flip-api, FL services) |
+| `ecs_tasks.tf` | ECS task definitions for Central Hub services (flip-api + FL) |
+| `ecs_efs_provision.tf` | EFS access points + ECS provisioning task for FL workspace |
+| `ecs_sg.tf` | ECS security groups |
+| `certificate.tf` | ACM certificates (ALB + CloudFront) |
+| `cloudfront.tf` | CloudFront distribution for flip-ui |
+| `iam_ecs.tf` | IAM roles, instance profiles, SSM policies |
+| `parameter_store.tf` | SSM Parameter Store entries |
+| `backend.tf` | S3 backend + DynamoDB lock |
+| `variables.tf` | All Terraform variables with defaults |
+
+## AWS Profiles
+
+| Alias | Environment | Account |
+| ------- | ------------- | --------- |
+| `stag` | Staging | `flipstag` |
+| `prod` | Production | `flipprod` |
+| `FlipDeveloperAccess-080369786334` | Developer access | — |
+
+## Key Deploy Commands
+
+```bash
+make full-deploy PROD=stag                   # Full staging deploy
+make full-deploy PROD=true                    # Full prod deploy
+make full-deploy-hybrid PROD=<stag|true> [LOCAL_TRUST_IP=<ip>]  # Hybrid with on-prem trust
+make init/plan/apply                          # Terraform workflow
+make deploy-centralhub                        # ECS force-redeploy + CloudFront UI
+make deploy-trust                             # Deploy trust stack to EC2
+make deploy-ui                                # Build + sync UI to S3 + invalidate CloudFront
+make status                                   # Health checks
+make ssh-config                               # Generate SSH config with SSM ProxyCommand
+make forward-trust                            # SSM port forward all trust UIs
+make provision-local-trust                     # Provision an on-prem trust host (run ON the host)
+make allow-local-trust-nlb LOCAL_TRUST_IP=<ip>  # Open the FL-server NLB to a trust's reported IP
+make package-onprem-trust-kit KIT=<CODE>      # Tarball a filled-in trust/.env.<CODE>.<env> + FL kit slice for an on-prem operator
+make delete-trust NAME=<name>                 # Hard-delete a trust on the hub (frees the slot)
+make destroy                                  # Selective destroy (preserves Cognito, Secrets, S3)
+make aws-login                                # AWS SSO login
+```
+
+## Infrastructure
+
+- **VPC**: 10.0.0.0/16, 2 AZs, public + private subnets
+- **ECS Fargate**: Central Hub services (flip-api, fl-api-net-1, fl-server-net-1)
+- **EC2**: Trust host (t3.xlarge, private subnet, SSM-only access)
+- **RDS**: PostgreSQL in private subnets. In production flip-api connects through **RDS Proxy** using **IAM auth** (short-lived per-connection tokens); the proxy uses the RDS-managed master secret to reach the DB, so secret rotation no longer takes flip-api down (FLIP#556). No `rds_iam` Postgres grant is needed.
+- **ALB**: Internal (`internal = true`, private subnets); HTTPS termination for `/api/*` reached via CloudFront VPC origin (no public IP)
+- **NLB**: gRPC for FL server traffic
+- **CloudFront + S3**: flip-ui static hosting
+- **Secrets Manager**: `FLIP_API` secret (AES key, DB password, key hashes)
+- **Cognito**: `flip-user-pool` with email auth
+- **Container registry**: **GHCR** (`ghcr.io/londonaicentre/`) for every FLIP image (flip-api, flare-fl-api, flare-fl-server, flower-superlink, trust-api, imaging-api, data-access-api, orthanc, omop-db, XNAT). ECS Fargate task definitions pull directly from GHCR — `var.docker_registry` in `variables.tf` defaults to it; trust EC2 / on-prem hosts do too. **There is no ECR mirror.** A surgical centralhub redeploy (per `project_prod_ecs_deploy.md` — don't `make apply` for prod) is: GH workflow `workflow_dispatch` to build the branch image to GHCR → `aws ecs register-task-definition` with the branch tag → `aws ecs update-service --force-new-deployment`. The flip-ui bundle ships separately via `make deploy-ui` (it's static assets in S3, not a container image).
+
+## Verifying a Central-Hub FL redeploy
+
+A surgical FL redeploy is `aws ecs update-service --force-new-deployment` on `fl-server-net-1` / `fl-api-net-1` (Fargate re-pulls the `:stag`/`:prod` tag on every task start — no task-def revision needed). To confirm the new image is actually running, compare the task's image digest to the GHCR tag — **but select the container by name, not by array index**:
+
+- `aws ecs describe-tasks` returns `containers` as an array, and the **GuardDuty Runtime Monitoring sidecar** (`aws-guardduty-agent-*`) usually sorts first. Querying `containers[0].imageDigest` reads the *agent's* digest, not the FL container's.
+- The GuardDuty agent image lives in an AWS-internal ECR, **never GHCR**, so its digest returns **HTTP 404** when looked up in `ghcr.io`. A 404 digest is the sidecar — not a stale FL image. (This burned a full investigation on 2026-06-24: `66446df3…` was the GuardDuty agent; the real `fl-server-net-1` digest `29b10362…` matched `:stag` exactly. Both `flare-fl-server:stag` and `flare-fl-api:stag` were rebuilt by the #624 FL-deps merge, configs created `15:54–15:55Z`.)
+- Always query `tasks[0].containers[?name=='fl-server-net-1'].imageDigest`. Full verification recipe (GHCR token, manifest digest, config `created` timestamp) is in [`TROUBLESHOOTING.md` §1.9](TROUBLESHOOTING.md).
+
+## State Management
+
+- Remote state in S3 (`FLIP_TFSTATE_BUCKET_NAME`) with DynamoDB locking
+- Persistent resources (S3, Secrets, Cognito) preserved during destroy
+- `make import-persistent` to import pre-existing resources

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,0 +1,37 @@
+# AGENTS.md — FLIP Documentation
+
+## Documentation Index (read on demand)
+
+| File | Topic |
+|------|-------|
+| `source/overview.rst` | Project overview, architecture, motivation |
+| `source/components.rst` | Component descriptions (API, UI, trust services, FL nodes) |
+| `source/sys-admin.rst` | System administration, deployment, auth configuration |
+| `source/user-guides.rst` | User-facing workflows and guides |
+| `source/api-reference.rst` | REST API endpoint reference |
+| `source/deploy-flip.rst` | Deployment instructions (central hub, TRE, on-prem) |
+| `source/working-with-flip-apps.rst` | Building FL apps (NVFLARE / Flower) |
+| `source/flip-workflow.rst` | End-to-end FLIP workflow |
+| `source/faqs.rst` | Frequently asked questions |
+| `source/glossary.rst` | Terminology definitions |
+
+## Sub-docs
+
+| Directory | Topic |
+|-----------|-------|
+| `source/components/` | Per-component deep dives (FL nodes, XNAT, OMOP, logging stack, architecture overview) |
+| `source/sys-admin/` | Admin tasks (user roles, project/user management, platform support) |
+| `source/user-guides/` | User guide files |
+| `source/deploy-flip/` | Per-target deployment guides (central hub, TRE, on-prem) |
+| `source/working-with-flip-apps/` | Step-by-step FLARE / Flower app authoring |
+
+## How to Read
+
+When implementing a feature that touches documentation, read the relevant `.rst` file(s) above. These are ReStructuredText format used by Sphinx for ReadTheDocs builds.
+
+## Build Commands
+
+```bash
+cd docs && make clean    # Clean built docs
+cd docs && make docs     # Build Sphinx HTML documentation
+```

--- a/flip-api/AGENTS.md
+++ b/flip-api/AGENTS.md
@@ -1,0 +1,68 @@
+# AGENTS.md — flip-api (Central Hub API)
+
+## Service Overview
+
+Central Hub REST API. FastAPI + asyncpg + SQLModel. Handles user auth (Cognito), project management, trust coordination, FL run orchestration, cohort queries, file management, and scheduling.
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `src/flip_api/main.py` | FastAPI app factory, middleware, router registration |
+| `src/flip_api/config.py` | Pydantic settings, env var loading |
+| `src/flip_api/db/database.py` | asyncpg async session, DB connection |
+| `src/flip_api/db/models/main_models.py` | SQLModel ORM: Project, Trust, Model, File, etc. |
+| `src/flip_api/db/models/user_models.py` | User, Role, Permission models |
+| `src/flip_api/db/seed/` | DB seed data: roles, permissions, FL kit slots, FL scheduler, banners |
+| `src/flip_api/db/migrations/` | Alembic migrations (`env.py`, `versions/`); `alembic.ini` at the service root. **Alembic owns the schema** |
+| `src/flip_api/domain/schemas/` | Pydantic request/response schemas |
+| `src/flip_api/domain/interfaces/` | Repository interfaces (Dependency Inversion) |
+| `src/flip_api/auth/` | Cognito JWT verification, auth middleware |
+| `src/flip_api/scripts/` | Trust registration CLI (register_trust.py), internal-service-key generation, env utils |
+
+## Service Modules
+
+| Module | Purpose |
+| -------- | --------- |
+| `user_services/` | Register, authenticate, update/delete users, roles, permissions |
+| `project_services/` | Project CRUD, approval workflows |
+| `model_services/` | ML model management, metrics, logs, approvals |
+| `fl_services/` | FL training initiation, status, stop, file pull |
+| `trusts_services/` | Trust registration, health checks, imaging creation |
+| `cohort_services/` | Cohort query submission, results retrieval |
+| `step_functions_services/` | Step function orchestration (register user, approve, cohort) |
+| `file_services/` | S3 file upload/download |
+| `private_services/` | Trust-to-hub internal endpoints (tasks, cohort results) |
+| `site_services/` | Site configuration, details |
+| `role_services/` | Role CRUD |
+| `scheduler/` | APScheduler background jobs (FL scheduling, trust polling) |
+| `shared/` | Shared utilities, middleware |
+
+## Commands (from `flip-api/`)
+
+```bash
+make test          # ruff + mypy + pytest (unit + integration)
+make unit_test     # ruff + mypy + pytest unit + step function tests (--skip-client)
+make integration_test  # Integration tests only
+make local_test    # Tests without Docker (--skip-client --skip-db)
+make lint          # ruff check --fix (in Docker)
+make mypy          # mypy type check (in Docker)
+make build         # docker compose build
+make up            # Start flip-db then flip-api
+make down          # Stop flip-api then flip-db
+make debug         # Restart in debug mode (port 5678)
+make migrate       # alembic upgrade head (apply migrations)
+make migration MESSAGE="..."   # autogenerate a revision from the model diff (flip-db must be up)
+make migration_downgrade       # alembic downgrade -1
+make migration_history         # alembic history
+make migration_current         # alembic current
+```
+
+## Conventions
+
+- FastAPI `Depends()` for DI. Repository pattern in `domain/interfaces/`.
+- asyncpg connections via async context managers from `db/database.py`.
+- DB schema is owned by **Alembic** (`db/migrations/`), not `SQLModel.metadata.create_all`. The entrypoint runs `alembic upgrade head` before seeding at boot (fail-fast). Every schema-affecting change to `db/models/*.py` must ship a revision — the integration drift guard (`tests/integration/test_migrations.py`) enforces it. Native-PG-enum gotcha: `ALTER TYPE … ADD VALUE` needs `op.get_context().autocommit_block()`, and downgrades dropping an enum-typed table must `DROP TYPE`.
+- pytest + factory_boy for test data. Fixtures in `conftest.py`.
+- Ruff config: line-length 120, select I/F/E/W/PT + UP006/UP007/UP035/UP042/UP045 (`UP042` enforces `StrEnum` over the legacy `(str, Enum)` pattern).
+- All tests in `tests/unit/` and `tests/integration/`.

--- a/trust/AGENTS.md
+++ b/trust/AGENTS.md
@@ -1,0 +1,132 @@
+# AGENTS.md — Trust Services
+
+## Architecture
+
+Trust services run at each healthcare institution (cloud EC2 or on-prem). All trust communication is outbound — trusts poll the Central Hub; no inbound ports needed.
+
+| Service | Port | Purpose |
+| --------- | ------ | --------- |
+| trust-api | 8020 | API gateway, polls hub for tasks, orchestrates trust |
+| imaging-api | 8001 | DICOM image retrieval from PACS |
+| data-access-api | 8010 | OMOP database queries for cohort analysis |
+| fl-client | — | FL participant (connects outbound to FL server via NLB) |
+| omop-db | 5432 | Mocked OMOP patient database (PostgreSQL) |
+| orthanc | 8042 | Mocked DICOM PACS server (UI/REST; DICOM port 4242 is internal to the trust network and not bound to the host) |
+| xnat | 8104 | Mocked neuroimaging platform |
+| observability | 3000/3100 | Grafana + Loki monitoring stack |
+
+## Kit file structure
+
+Each `trust/.env.<CODE>.<env>` carries the trust's host-local profile,
+trust-local credentials, and kit credentials. **Hub-shared vars have one source
+per environment** — there is no copy to drift:
+
+- **Dev:** the kit's Hub-shared block is **commented out** (inert). The values
+  are inherited from the hub's `.env.development` (the single source) —
+  `trust/Makefile` `-include`s it (dev only) and the root `make up` also exports
+  it. So you edit a hub-shared var (e.g. `DOCKER_FL_TAG`, `AES_KEY_BASE64`) in
+  `.env.development` and `make up`; no re-register, no stale kit copy.
+- **Prod:** the kit carries the Hub-shared block **live** — a remote operator
+  has no hub `.env`, so the kit is their only source. `trust/Makefile` stays
+  kit-only in prod (no hub `.env` include); a stale/missing value fails loud.
+
+Four sections, in order (the dev `.env.<CODE>.development.example` templates show
+the commented dev form):
+
+| Section | Owner | Touched by |
+|---------|-------|-----------|
+| Host-local profile | Operator | hand-edit (ports, bind dirs) |
+| Trust-local credentials | Operator | hand-edit (passwords, service URLs) |
+| Hub-shared (managed) | Hub admin | `register-trust KIT=<CODE>` (live in prod, commented in dev) / `sync-trust-kit KIT=<CODE>` (prod refresh) |
+| Kit credentials (managed) | Hub | `register-trust` only — write-once; hub keeps only the hash |
+
+The Hub-shared block is delimited by a sentinel comment
+(`# ── Hub-shared (managed by register-trust / sync-trust-kits — do not edit) ──`)
+that `scripts/distribute-trust-kits.sh` and `scripts/sync_trust_kit.py`
+match byte-for-byte. The exact key set is the `HUB_SHARED_ENV_KEYS` tuple in
+`flip_api/scripts/register_trust.py` (`AES_KEY_BASE64`,
+`CENTRAL_HUB_API_URL`, `TRUST_API_KEY_HEADER`, `FL_BACKEND`,
+`FLOWER_KIT_DATE`, `FLARE_KIT_DATE`, `DOCKER_TAG`, `DOCKER_REGISTRY`,
+`DOCKER_FL_TAG`, `DOCKER_FL_REGISTRY`, `NLB_SUBDOMAIN`, `FL_SERVER_PORT`).
+`UPLOADED_FEDERATED_DATA_BUCKET` is hub-only (fl-server uploads aggregated
+results to S3); `DOCKER_FL_CLIENT_NAME` is derived from `FL_BACKEND` by
+`deploy/fl_backend.mk` (trust/Makefile includes it).
+
+`make sync-trust-kit KIT=<CODE> PROD=<env>` refreshes the Hub-shared block in
+`trust/.env.<CODE>.<env>` from the admin's local `$(MAIN_ENV_FILE)` without
+rotating credentials. Implemented by `scripts/sync_trust_kit.py` (uv
+PEP 723 script — stdlib only, no docker/jq/ECS round-trip). Works
+identically across dev/stag/prod — the root Makefile's `include
+$(MAIN_ENV_FILE)` + `export` populates os.environ before the script
+runs, so `PROD=true` simply selects which env file to read. Run after
+rotating `AES_KEY_BASE64`, bumping `DOCKER_TAG`, switching `FL_BACKEND`,
+etc., then re-transmit the refreshed kit file to the remote operator
+(out-of-band, same as initial distribution — SCP-via-SSM for EC2;
+encrypted channel for on-prem).
+
+For the on-prem flow, the admin scaffolds and fills the kit on their
+workstation in two commands (prod AWS creds required):
+
+1. `make new-trust TRUST_CODE=<CODE> TRUST_NAME="..." PROD=true`
+   — scaffolds `trust/.env.<CODE>.production` from the base template
+   (`trust/.env.example`).
+2. `make register-trust KIT=<CODE> PROD=true` — registers on the prod hub and
+   fills BOTH the Kit credentials AND the Hub-shared block in one step
+   (replaces the old "paste 5 UI lines + separate `sync-trust-kit`").
+
+Then `make -C deploy/providers/AWS package-onprem-trust-kit KIT=<CODE> PROD=true`
+tarballs the populated kit file as-is + the operator's slice of the FL
+participant kit S3 bucket into
+`deploy/providers/AWS/build/trust-kits/flip-trust-kit-<slot>-<date>.tar.gz`.
+The packager does NOT edit the kit file.
+
+The operator extracts, copies `.env.<CODE>.production` into their checkout,
+edits only the Host-local profile (sets `FL_KIT_DIR`, ports/dirs) and rotates
+the Trust-local passwords, runs `make onboard-onprem-trust KIT=<CODE> PROD=true`
+for the readiness checklist (kit present, swarm active, Hub-shared + Kit
+credentials populated, FL_KIT_DIR exists + has the expected files), then
+`make up-onprem-trust KIT=<CODE> PROD=true`.
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `Makefile` | Trust stack orchestration (parameterized `up-trust KIT=<name>`) |
+| `deploy/compose_trust.development.yml` | Dev Docker Compose (builds from source) |
+| `deploy/compose_trust.production.yml` | Prod Docker Compose (GHCR images; declares the `trust-local-{loki,grafana}-data` named volumes as defaults) |
+| `deploy/compose_trust.{env}.{flower\|nvflare}.yml` | FL backend variants |
+| `deploy/compose_trust.{env}.gpu.yml` | GPU passthrough overlay — added by `up-trust` / `up-fl-clients-kit` via `GPU_OVERRIDE` only when the kit's `NUM_AVAILABLE_GPUS > 0`; reserves host NVIDIA GPU(s) for the fl-client. `up-trust-ec2` never applies it (the EC2 t3.xlarge is GPU-less, so the fl-client is CPU-only there regardless of the kit) |
+| `deploy/compose_trust-1_override.yml` | Dev trust-1 host-port bindings |
+| `.env.<CODE>.<env>` | Per-trust kit file, e.g. `.env.GSTT.development`, `.env.<CODE>.production` (TRUST_API_KEY, TRUST_INTERNAL_SERVICE_KEY, FL_KIT_SLOT, FL_KIT_SLOT_NUMBER, EXPECTED_TRUST_ID, host-local ports/dirs, **FL_KIT_DIR** — root of the FL participant kit, default `/opt/flip/fl-kit` matching the Ansible-staged EC2 path); gitignored. Templates: per-trust dev examples `.env.GSTT.development.example` / `.env.KCH.development.example`; the generic scaffold base `.env.example`, consumed by `make new-trust`. Same kit-file schema everywhere — `make -C trust up-trust KIT=<CODE> PROD=<env>` is the only dispatch |
+
+## Commands (from `trust/`)
+
+```bash
+make up                        # Start the shipped dev trust stacks (GSTT + KCH)
+make down                      # Stop all trusts
+make up-trust KIT=GSTT         # Start one trust stack (also brings up its XNAT)
+make down-trust KIT=GSTT       # Stop one trust stack
+make restart-trust KIT=GSTT    # Restart one trust stack
+make up-trust-ec2 KIT=GSTT     # Start one trust stack on a cloud EC2 host
+make up-trust KIT=<CODE> PROD=true  # Start a trust pointing at a remote hub (e.g. on-prem)
+make debug                     # Trust-1 in debug mode
+make debug-trust-api           # Debug trust-api only
+make debug-imaging-api         # Debug imaging-api only
+make debug-data-access-api     # Debug data-access-api only
+make tests                     # Run tests on all 3 API services
+make build                     # Build all trust Docker images
+make create-networks           # Create Docker overlay networks
+make update-omop-data          # Download/extract mock OMOP data (both trusts)
+make update-omop-data TRUST=1  # Trust_1 only
+make update-orthanc-data       # Download/extract mock DICOM data (both trusts)
+make update-orthanc-data TRUST=1  # Trust_1 only
+```
+
+## Environment
+
+- All runtime config comes from the kit file (`trust/.env.<KIT>`); no hub `.env.*` is included by `trust/Makefile` or `trust/xnat/Makefile`. `PROD` still selects the compose-file suffix (development / production) but no longer drives an env-file include.
+- Trust identity: `TRUST_API_KEY` (per-trust, from the kit file `trust/.env.<CODE>.<env>`); optional `EXPECTED_TRUST_ID` self-check. The hub identifies the trust by API key alone.
+- Encryption: `AES_KEY_BASE64` for trust-to-hub payload encryption (hub-shared; synced into the kit file).
+- `DEBUG` is no longer inherited from a hub env file. `make debug` / `make debug-off` set it explicitly; `make up-trust` without an explicit `DEBUG=true` runs services in non-debug mode.
+- The two shipped dev trusts (GSTT, KCH) have separate ports, networks, and data dirs. Their FL kit *slots* are still named `Trust_1` / `Trust_2` — those are the pre-provisioned FL participant-kit identities (cert CN for NVFLARE, supernode number for Flower), assigned to a trust by the hub at registration. A trust (GSTT) claims a slot (Trust_1); they are different things.
+- Local trust uses `trust-local` project name to avoid port collisions

--- a/trust/data-access-api/AGENTS.md
+++ b/trust/data-access-api/AGENTS.md
@@ -1,0 +1,18 @@
+# AGENTS.md — data-access-api (OMOP Queries)
+
+## Service Overview
+
+FastAPI service for querying the OMOP Common Data Model database. Receives cohort query requests from trust-api, translates them to SQL, executes against omop-db, and returns results.
+
+## Key Patterns
+
+- Connects to omop-db (PostgreSQL port 5432) on the trust network
+- Only receives internal requests from trust-api (not directly exposed)
+- OMOP CDM query translation layer
+
+## Commands
+
+```bash
+make test        # ruff + mypy + pytest (unit + integration)
+make unit_test   # Unit tests only
+```

--- a/trust/imaging-api/AGENTS.md
+++ b/trust/imaging-api/AGENTS.md
@@ -1,0 +1,18 @@
+# AGENTS.md — imaging-api (DICOM Retrieval)
+
+## Service Overview
+
+FastAPI service for DICOM image retrieval from PACS (Orthanc/XNAT). Receives requests from trust-api, queries PACS, retrieves images, and returns results.
+
+## Key Patterns
+
+- Communicates with Orthanc (port 4242) and XNAT (port 8104) on the trust network
+- Only receives internal requests from trust-api (not directly exposed)
+- DICOM-to-NIfTI conversion support
+
+## Commands
+
+```bash
+make test        # ruff + mypy + pytest (unit only — no integration target)
+make unit_test   # Unit tests only
+```

--- a/trust/trust-api/AGENTS.md
+++ b/trust/trust-api/AGENTS.md
@@ -1,0 +1,20 @@
+# AGENTS.md — trust-api (Trust Gateway)
+
+## Service Overview
+
+FastAPI gateway running on each trust. Polls the Central Hub for tasks (FL training, cohort queries, imaging requests), dispatches to imaging-api or data-access-api, encrypts results with AES_KEY_BASE64, posts back to hub.
+
+## Key Patterns
+
+- Outbound-only communication: trust-api initiates all connections to the Central Hub via `CENTRAL_HUB_API_URL`
+- Polling loop checks hub for pending tasks at regular intervals
+- Encrypts payloads with `AES_KEY_BASE64` before sending to hub
+- Communicates with sibling services (imaging-api, data-access-api) on the trust Docker network
+
+## Commands
+
+```bash
+make test        # ruff + mypy + pytest (unit + integration)
+make unit_test   # Unit tests only (alias for local_test)
+make up/down     # Docker compose start/stop
+```


### PR DESCRIPTION
## Summary

- add Codex `AGENTS.md` guidance at the repository root and in each directory that currently has scoped `CLAUDE.md` guidance
- preserve the existing instruction content and hierarchy
- translate internal `CLAUDE.md` references and headings to `AGENTS.md`

## Why

Codex discovers repository-specific instructions through `AGENTS.md`. Mirroring the existing scoped guidance gives Codex the same project, service, documentation, trust, and AWS deployment context without changing the Claude instruction files.

## Impact

Documentation and agent configuration only. There are no runtime or build changes.

## Validation

- compared each of the eight `AGENTS.md` files byte-for-byte with its sibling `CLAUDE.md` after applying the expected `CLAUDE.md` to `AGENTS.md` filename translation
- confirmed no generated `AGENTS.md` file retains a `CLAUDE.md` reference
- `git diff --cached --check`

The unrelated `PLAN-arkplus-review-fixes.md` remains untracked and is not included in this PR.