### PR TITLE
Improve Lighthouse scores on the login page (accessibility, SEO, best practices, performance)

### DIFF
--- a/.github/workflows/lighthouse_flip_ui.yml
+++ b/.github/workflows/lighthouse_flip_ui.yml
@@ -1,0 +1,124 @@
+# Copyright (c) Guy's and St Thomas' NHS Foundation Trust & King's College London
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Re-runs the Lighthouse audit behind #586 in a clean, repeatable environment
+# (headless Chrome on the runner, no browser extensions) — the "clean re-run"
+# the issue's acceptance criteria asks for. Scoped to the pre-auth /auth/login
+# route, which needs only the built UI (no API / trust / FL stack); config +
+# rationale live in flip-ui/lighthouserc.cjs.
+#
+# Informational by design: the lhci assertions are all `warn`, so this job
+# never blocks a PR — it publishes a Lighthouse report artifact and surfaces
+# score regressions as warnings. Promote it to a required check (and flip the
+# a11y/seo assertions to `error` in lighthouserc.cjs) once a green baseline is
+# trusted.
+name: Lighthouse - FLIP UI
+
+on:
+  push:
+    branches: [main, develop]
+    paths:
+      - "flip-ui/**"
+      - ".github/workflows/lighthouse_flip_ui.yml"
+  pull_request:
+    branches: [main, develop]
+    paths:
+      - "flip-ui/**"
+      - ".github/workflows/lighthouse_flip_ui.yml"
+  # Manual trigger so the audit can be re-run on demand against any branch.
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# One run per ref; a new push cancels the in-flight run for the same branch/PR.
+concurrency:
+  group: lighthouse-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lighthouse:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: ./flip-ui
+
+    env:
+      # Never build the auth-bypassing bundle (checked by prebuild:deploy).
+      VITE_LOCAL: "false"
+      # Dummy Cognito/API config so generate-window-js emits a populated
+      # public/js/window.js and the SPA boots to render the login form. These
+      # match the stub values the Cypress job uses; the login page never calls
+      # the API, and Amplify's pre-auth session probe just fails closed (which
+      # is itself one of the findings, #702) — none of it blocks the audit.
+      CENTRAL_HUB_API_URL: "http://localhost:8080"
+      AWS_COGNITO_USER_POOL_ID: "eu-west-2_DUMMY1234"
+      AWS_COGNITO_APP_CLIENT_ID: "dummyclientid1234567890ab"
+      AWS_REGION: "eu-west-2"
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Set Node.js version
+        uses: actions/setup-node@v5
+        with:
+          # Node 24 LTS bundles npm >=11.10 so .npmrc min-release-age (the
+          # supply-chain cooldown) is enforced on `npm ci`, matching the other
+          # flip-ui jobs.
+          node-version: "24"
+          cache: npm
+          cache-dependency-path: flip-ui/package-lock.json
+
+      - name: Install dependencies
+        # Cypress desktop binary isn't needed here; skip its flaky CDN download.
+        env:
+          CYPRESS_INSTALL_BINARY: "0"
+        run: npm ci
+
+      - name: Stub flip-ui/.env.development
+        # Vite's loadEnv reads this file for import.meta.env at build time;
+        # the job-level env block covers generate-window-js's shell reads.
+        # Mirrors the Cypress job's stub, minus the E2E test seams — we want a
+        # production-representative bundle, not the auth-bypassing E2E build.
+        run: |
+          cat > .env.development <<'EOF'
+          VITE_LOCAL=false
+          CENTRAL_HUB_API_URL=http://localhost:8080
+          AWS_COGNITO_USER_POOL_ID=eu-west-2_DUMMY1234
+          AWS_COGNITO_APP_CLIENT_ID=dummyclientid1234567890ab
+          AWS_REGION=eu-west-2
+          EOF
+
+      - name: Build production bundle
+        # build:deploy = `vite build` (skips vue-tsc, which has pre-existing
+        # root type errors unrelated to this audit). Perf / unused-JS metrics
+        # are only meaningful on the built, code-split, minified bundle — never
+        # on the dev server.
+        run: npm run build:deploy
+
+      - name: Run Lighthouse CI
+        # Pinned, well-aged @lhci/cli run via npx so it stays out of the app's
+        # package-lock (CI-only tool). autorun reads flip-ui/lighthouserc.cjs:
+        # it starts `vite preview`, audits /auth/login, asserts (warn-only),
+        # and writes reports to ./.lighthouseci.
+        run: npx --yes @lhci/cli@0.14.0 autorun
+
+      - name: Upload Lighthouse reports
+        if: always()
+        uses: actions/upload-artifact@v5
+        with:
+          name: lighthouse-report
+          path: flip-ui/.lighthouseci
+          if-no-files-found: warn
+          retention-days: 30

--- a/flip-ui/.gitignore
+++ b/flip-ui/.gitignore
@@ -14,6 +14,9 @@
 node_modules
 /dist
 
+# Lighthouse CI reports (written by `lhci autorun`; uploaded as a CI artifact)
+/.lighthouseci
+
 # Generated at dev-start / deploy-time by scripts/generate-window-js.sh —
 # never hand-edited. See public/js/window.js.example for the shape.
 /public/js/window.js

--- a/flip-ui/lighthouserc.cjs
+++ b/flip-ui/lighthouserc.cjs
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2026 Guy's and St Thomas' NHS Foundation Trust & King's College London
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Lighthouse CI config for the FLIP UI, driven by the `lighthouse_flip_ui`
+// workflow. It re-runs the audit behind issue #586 in a clean, repeatable
+// environment (headless Chrome on a CI runner, no browser extensions) —
+// which is exactly what the original prod capture lacked.
+//
+// Scope: the pre-auth `/auth/login` route only. That page talks to AWS
+// Cognito (Amplify), never to flip-api, so no backend / trust / FL stack is
+// needed — a production `vite build` served by `vite preview` is enough.
+// `staticDistDir` is deliberately NOT used: it can't do SPA history fallback,
+// so a deep link to /auth/login would 404. `vite preview` serves the built
+// bundle *and* falls back to index.html, matching how CloudFront serves prod.
+//
+// NOTE: CSP and source-map findings (issues #703 / the deferred source-maps
+// item on #586) depend on CloudFront response headers, which `vite preview`
+// does not emit — those can only be validated against a real deployment, not
+// here.
+module.exports = {
+    ci: {
+        collect: {
+            // Serve the already-built dist/ (the workflow runs `build:deploy`
+            // first). `vite preview` gives SPA history fallback so the deep
+            // link to /auth/login resolves to the app rather than a 404.
+            startServerCommand: "npm run serve -- --port 4173 --strictPort",
+            startServerReadyPattern: "Local:",
+            startServerReadyTimeout: 30000,
+            url: ["http://localhost:4173/auth/login"],
+            // Median of 3 runs — smooths the timing-based performance metrics;
+            // the accessibility / SEO audits are deterministic regardless.
+            numberOfRuns: 3,
+            settings: {
+                // Match the original audit (Lighthouse v13, desktop form factor).
+                preset: "desktop",
+                // Chrome on CI runners needs --no-sandbox; --disable-gpu avoids
+                // headless GPU flakiness. --disable-extensions keeps the profile
+                // clean (the whole point of re-running — the prod capture was
+                // polluted by ad-blocker extension scripts).
+                chromeFlags: "--no-sandbox --disable-gpu --disable-extensions",
+            },
+        },
+        assert: {
+            // All `warn` for now: this job is informational until a green
+            // baseline is observed on a few runs. Once the numbers are trusted,
+            // promote accessibility + seo to `error` (they're audit-based and
+            // deterministic) to turn the #586 target into an enforced gate.
+            // Leave best-practices at `warn`: it's dinged by the known-deferred
+            // console 401s (#702) and CSP (#703). Leave performance at `warn`:
+            // it's timing-based and varies run-to-run on shared CI runners.
+            assertions: {
+                "categories:accessibility": ["warn", { minScore: 0.95 }],
+                "categories:seo": ["warn", { minScore: 0.95 }],
+                "categories:best-practices": ["warn", { minScore: 0.9 }],
+                "categories:performance": ["warn", { minScore: 0.9 }],
+            },
+        },
+        upload: {
+            // Keep reports inside GitHub (uploaded as a build artifact by the
+            // workflow) rather than pushing to a third-party public bucket.
+            target: "filesystem",
+            outputDir: "./.lighthouseci",
+        },
+    },
+};


### PR DESCRIPTION
## Description

Adds a **Lighthouse CI** audit of the login page, closing the last open acceptance-criterion on #586 — *"a clean Lighthouse re-run (no browser extensions / via CI) confirms the gains."* The original audit was captured in a browser with ad-blocker extensions, which polluted the numbers; this runs it in a clean, repeatable environment (headless Chrome on a CI runner) on every flip-ui change.

### Scope: `/auth/login` only — no backend needed
The login route talks to **AWS Cognito** (Amplify), never to flip-api, so no API / trust / FL stack is required. The workflow builds the production bundle and serves it with `vite preview` (which does SPA history-fallback, so the deep link to `/auth/login` resolves rather than 404s).

> Perf / unused-JS metrics are only meaningful on the **built, code-split, minified** bundle — never the dev server — so the workflow audits `build:deploy` output.

## Files

- **`flip-ui/lighthouserc.cjs`** — lhci config: desktop preset (matches the original), median of 3 runs, reports to `./.lighthouseci`, assertions on the four categories.
- **`.github/workflows/lighthouse_flip_ui.yml`** — build (dummy Cognito env → populated `window.js`) → `lhci autorun` (pinned via npx, kept out of `package-lock`) → upload the report as an artifact. Triggers on flip-ui PRs/pushes + `workflow_dispatch`.
- **`flip-ui/.gitignore`** — ignore `.lighthouseci`.

## Informational by design (for now)

All lhci assertions are **`warn`**, so this job **never blocks a PR** — it publishes a Lighthouse report artifact and surfaces regressions as warnings. Rationale:
- **accessibility / seo** — target `minScore 0.95` (the #586 goal). `warn` until a green baseline is observed over a few runs, then promote to `error` (these audits are deterministic) to make it an enforced gate.
- **best-practices** — `warn`: dinged by the known-deferred console 401s (**#702**) and CSP (**#703**).
- **performance** — `warn`: timing-based, varies on shared CI runners.

**Caveat:** CSP (#703) and source-map findings depend on **CloudFront response headers**, which `vite preview` doesn't emit — those can only be validated against a real deployment, not this job.

## Testing

- [x] `lighthouserc.cjs` loads as valid CommonJS; workflow YAML parses.
- [x] Locally verified the full pre-Chrome path: `build:deploy` (with the workflow's dummy-Cognito env) succeeds and generates `window.js`; `vite preview --port 4173 --strictPort` boots and prints the `Local:` readiness line; `GET /auth/login` → **200** returning the SPA index (`id="app"`, `/js/window.js`, module script); `GET /js/window.js` → 200.
- [ ] The headless-Chrome `lhci autorun` step runs only on the CI runner (no Chrome in the dev sandbox) — validated by this PR's own Lighthouse job.

## Linked Issues

Closes the "clean Lighthouse re-run" acceptance criterion of #586. Complements #686 (the fixes) and the follow-ups #702 / #703.

## Type of Change

- [x] Non-breaking change (CI-only; adds a workflow + config, no app code).
