### PR TITLE
feat(project): surface read-only DICOM-to-NIfTI setting in Edit Project drawer

### DIFF
--- a/flip-api/src/flip_api/domain/interfaces/project.py
+++ b/flip-api/src/flip_api/domain/interfaces/project.py
@@ -148,6 +148,10 @@ class IProject(BaseModel):  # Base for IProject to avoid repetition
 class IReturnedProject(IProject):  # Extends IProject
     owner_email: EmailStr = Field(..., alias="ownerEmail")
     users: list[CognitoUser]
+    # Surfaced read-only so the edit form can display the project's
+    # DICOM->NIfTI setting. Fixed at creation and immutable afterwards (the
+    # edit endpoint ignores it), so the UI renders the toggle disabled.
+    dicom_to_nifti: bool = Field(default=True)
     model_config = ConfigDict(populate_by_name=True)
 
 

--- a/flip-api/src/flip_api/project_services/get_project.py
+++ b/flip-api/src/flip_api/project_services/get_project.py
@@ -173,6 +173,7 @@ def get_project_details_endpoint(
         creation_timestamp=project_db.creation_timestamp.isoformat(timespec="milliseconds") + "Z",
         staged_at=staged_at_map.get(project_db.id),
         owner_id=project_db.owner_id,
+        dicom_to_nifti=project_db.dicom_to_nifti,
     )  # type: ignore[call-arg]
 
     logger.info(f"Successfully retrieved details for project {project_id}")

--- a/flip-ui/src/pages/project/[projectId]/index.vue
+++ b/flip-ui/src/pages/project/[projectId]/index.vue
@@ -128,6 +128,7 @@
             :users="project.users"
             :project-unstaged="isProjectUnstaged() && !isViewer"
             :description="project.description"
+            :dicom-to-nifti="project.dicom_to_nifti ?? true"
             :updating="projectUpdating"
             :owner-id="project.ownerId"
             @close="closeEditProjectDrawer"

--- a/flip-ui/src/partials/projects/EditProjectDrawer.vue
+++ b/flip-ui/src/partials/projects/EditProjectDrawer.vue
@@ -41,6 +41,7 @@
                         <div class="w-screen max-w-4xl">
                             <Form
                                 :validation-schema="schema"
+                                :initial-values="{ dicom_to_nifti: dicomToNifti ? 'true' : undefined }"
                                 class="flex flex-col h-full bg-white divide-y divide-gray-100 shadow-xl dark:bg-gray-800 dark:divide-gray-700 dark:ring-1 dark:ring-white/20"
                                 @submit="updateProject"
                             >
@@ -99,6 +100,30 @@
                                                         disabled: !projectUnstaged,
                                                         readonly: !projectUnstaged
                                                     }"
+                                                />
+                                            </div>
+                                            <div>
+                                                <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                                                    Convert DICOMs to NIfTI
+                                                </label>
+                                                <p class="text-xs text-gray-500 dark:text-gray-400 mb-1">
+                                                    Automatically convert DICOM scans to NIfTI format when images are imported from PACS into XNAT.
+                                                </p>
+                                                <p class="text-xs text-gray-500 dark:text-gray-400 mb-1">
+                                                    When enabled, NIfTI files can be requested using the ResourceType parameter.
+                                                </p>
+                                                <p class="text-xs text-gray-500 dark:text-gray-400 mb-1">
+                                                    Disable this if you will be working with DICOM files directly.
+                                                </p>
+                                                <p class="text-xs italic text-gray-400 dark:text-gray-500 mb-2">
+                                                    This option is set when the project is created and cannot be changed.
+                                                </p>
+                                                <AiSwitch
+                                                    name="dicom_to_nifti"
+                                                    value="true"
+                                                    :disabled="true"
+                                                    :label="{ enabled: 'Enabled', disabled: 'Disabled' }"
+                                                    data-test="dicom-to-nifti-toggle"
                                                 />
                                             </div>
                                         </div>
@@ -181,6 +206,7 @@ import AiAlert from "@/components/AiAlert/AiAlert.vue";
 import AiButton from "@/components/AiButton/AiButton.vue";
 import AiDialogOverlay from "@/components/AiDialogOverlay/AiDialogOverlay.vue";
 import AiConfirmModal from "@/components/AiModal/AiConfirmModal.vue";
+import AiSwitch from "@/components/AiSwitch/AiSwitch.vue";
 import router from "@/router";
 import { deleteProject, IProjectUser } from "@/services/project-service";
 import { useAuthStore } from "@/store/auth";
@@ -205,6 +231,9 @@ interface IEditProjectDrawerProps {
     updating: boolean;
     users: IProjectUser[];
     ownerId: string;
+    // Current DICOM-to-NIfTI setting, shown read-only. It's fixed at project
+    // creation and cannot be edited, so the toggle is always disabled.
+    dicomToNifti: boolean;
 }
 
 const schema = projectSchema;
@@ -228,8 +257,14 @@ const closeDrawer = () => {
 };
 
 const updateProject = (values: unknown) => {
+    // Only name/description are editable; users comes from the ProjectUsers
+    // child. dicom_to_nifti is intentionally excluded — it's read-only and
+    // immutable after creation (the edit endpoint ignores it regardless).
+    const { name, description } = values as IEditProject;
+
     emit("save", {
-        ...values as IEditProject,
+        name,
+        description,
         users: userList
     });
 };

--- a/flip-ui/src/partials/projects/__tests__/EditProjectDrawer.confirm-slot.spec.ts
+++ b/flip-ui/src/partials/projects/__tests__/EditProjectDrawer.confirm-slot.spec.ts
@@ -48,7 +48,8 @@ describe("EditProjectDrawer delete-confirmation slot", () => {
         projectUnstaged: true,
         updating: false,
         users: [],
-        ownerId: "owner-1"
+        ownerId: "owner-1",
+        dicomToNifti: true
     };
 
     it("renders the delete-project warning markup in the confirmation slot", () => {
@@ -85,5 +86,57 @@ describe("EditProjectDrawer delete-confirmation slot", () => {
         expect(slot.exists()).toBe(true);
         expect(slot.find("img").exists()).toBe(false);
         expect(slot.html()).toContain("&lt;img");
+    });
+});
+
+describe("EditProjectDrawer DICOM-to-NIfTI read-only field", () => {
+    const baseProps = {
+        show: true,
+        name: "Acme",
+        id: "proj-1",
+        description: "desc",
+        projectUnstaged: true,
+        updating: false,
+        users: [],
+        ownerId: "owner-1",
+        dicomToNifti: true
+    };
+
+    const mountDrawer = (dicomToNifti: boolean) =>
+        mountComponent(EditProjectDrawer, {
+            global: {
+                renderStubDefaultSlot: true,
+                stubs: { AiConfirmModal: confirmModalStub }
+            },
+            props: {
+                ...baseProps,
+                dicomToNifti
+            }
+        });
+
+    it("renders the DICOM-to-NIfTI section with the immutability hint", () => {
+        const html = mountDrawer(true).html();
+
+        expect(html).toContain("Convert DICOMs to NIfTI");
+        expect(html).toContain("cannot be changed");
+    });
+
+    it("renders the toggle as read-only (the interactive switch is hidden while disabled)", () => {
+        const wrapper = mountDrawer(true);
+
+        expect(wrapper.find("[data-test=dicom-to-nifti-toggle]").exists()).toBe(false);
+    });
+
+    it("shows 'Enabled' when the project's dicom_to_nifti is on", () => {
+        expect(mountDrawer(true).text()).toContain("Enabled");
+    });
+
+    it("shows 'Disabled' when the project's dicom_to_nifti is off", () => {
+        const text = mountDrawer(false).text();
+
+        expect(text).toContain("Disabled");
+        // The capitalised "Enabled" label only renders when the toggle is on;
+        // the descriptive copy uses lowercase "enabled", so this stays exact.
+        expect(text).not.toContain("Enabled");
     });
 });

--- a/flip-ui/src/services/project-service.ts
+++ b/flip-ui/src/services/project-service.ts
@@ -79,6 +79,10 @@ export type IProject = {
     approvedTrusts?: IProjectTrust[];
     users: IProjectUser[]
     status: ProjectStatus
+    // Whether DICOMs are converted to NIfTI on import. Set at creation and
+    // immutable thereafter. Only the project-detail endpoint surfaces it, so
+    // it's optional (the list endpoint omits it).
+    dicom_to_nifti?: boolean;
 }
 
 export interface IProjectCreate {


### PR DESCRIPTION
## What

A project's `dicom_to_nifti` flag is set at creation and immutable afterwards, but it wasn't surfaced anywhere after that — the only way to check it was a direct DB query. This adds it to the project-detail response and renders it, read-only, in the Edit Project drawer.

- `IReturnedProject.dicom_to_nifti` — new field (default `True`, matching the DB column's default), populated in `get_project.py` from the existing `project_db.dicom_to_nifti` column. No migration: the column already exists on `main_models.py`/`IProjectResponse`, this just plumbs it onto the *other* project-response model that the detail endpoint uses.
- `EditProjectDrawer.vue` — renders a disabled `AiSwitch` ("Convert DICOMs to NIfTI") with explanatory copy and an "cannot be changed" note; wired through `index.vue` → `dicomToNifti` prop.
- `project-service.ts` — `IProject.dicom_to_nifti?: boolean` (optional: only the detail endpoint returns it, the list endpoint doesn't).

## Testing

- Extended `EditProjectDrawer.confirm-slot.spec.ts` with 4 new cases (renders the section + hint, toggle is non-interactive, "Enabled"/"Disabled" label text) — 6/6 pass.
- `flip-api` `make local_test`: no change in pass/fail counts vs. a clean `develop` checkout (same 13 pre-existing failures on both, unrelated to this change — cohort/seed/run_jobs/paging/s3 log-message assertions).
- `ruff check` clean on the two changed Python files.
- `eslint` on the changed UI files: 0 errors (pre-existing `max-len` warnings only, consistent with this file's existing long descriptive-text lines; the lint script has no `--max-warnings` gate).