### PR TITLE
Refactor: de-fork flip/nvflare — subclass stock NVFLARE instead of vendoring copies

### DIFF
--- a/flip-utils/flip/nvflare/components/custom_percentile_privacy.py
+++ b/flip-utils/flip/nvflare/components/custom_percentile_privacy.py
@@ -10,102 +10,52 @@
 # limitations under the License.
 #
 
-# Copyright (c) 2021, NVIDIA CORPORATION.  All rights reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-
-import numpy as np
-
-# from dxo_filter import DXOFilter
-from nvflare.apis.dxo import DXO, DataKind, MetaKey
-from nvflare.apis.dxo_filter import DXOFilter
+from nvflare.apis.dxo import DXO
 from nvflare.apis.fl_context import FLContext
 from nvflare.apis.shareable import Shareable
+from nvflare.app_common.filters.percentile_privacy import PercentilePrivacy as NVFlarePercentilePrivacy
 
 
-class PercentilePrivacy(DXOFilter):
+class PercentilePrivacy(NVFlarePercentilePrivacy):
+    """Stock NVFLARE ``PercentilePrivacy`` differential-privacy filter plus an ``off`` toggle.
+
+    Subclasses ``nvflare.app_common.filters.percentile_privacy.PercentilePrivacy`` so the
+    percentile/gamma filtering maths (Shokri and Shmatikov, "Privacy-preserving deep learning",
+    CCS '15) tracks upstream instead of drifting from a vendored copy. The sole FLIP addition is
+    ``off``: it lets the filter stay wired into ``config_fed_client.json``'s result-filter chain
+    while being switched on/off from config (e.g. running DP-on vs DP-off experiments) without
+    adding or removing the component.
+    """
+
     def __init__(self, percentile=10, gamma=0.01, data_kinds: list[str] | None = None, off: bool = False):
-        """Implementation of "largest percentile to share" privacy preserving policy.
-
-        Shokri and Shmatikov, Privacy-preserving deep learning, CCS '15
+        """Initialise the filter.
 
         Args:
-            percentile (int, optional): Only abs diff greater than this percentile is updated.
-              Allowed range 0..100.  Defaults to 10.
-            gamma (float, optional): The upper limit to truncate abs values of weight diff. Defaults to 0.01.
-            Any weight diff with abs<gamma will become 0.
-            data_kinds: kinds of DXO to filter
-            off (bool, optional): If True, the filter is turned off. Defaults to False.
+            percentile (int): Only abs weight-diff greater than this percentile is shared.
+                Allowed range 0..100. Defaults to 10.
+            gamma (float): Upper limit to truncate abs values of the weight diff; any weight diff
+                with abs < gamma becomes 0. Defaults to 0.01.
+            data_kinds (list[str] | None): Kinds of DXO to filter. Defaults (via stock) to
+                ``[WEIGHT_DIFF, WEIGHTS]`` when None.
+            off (bool): If True the filter is a no-op — ``process_dxo`` returns the DXO unchanged.
+                Defaults to False.
         """
-        if not data_kinds:
-            data_kinds = [DataKind.WEIGHT_DIFF, DataKind.WEIGHTS]
-
-        super().__init__(supported_data_kinds=[DataKind.WEIGHTS, DataKind.WEIGHT_DIFF], data_kinds_to_filter=data_kinds)
-
-        # must be in 0..100, only update abs diff greater than percentile
-        self.percentile = percentile
-        # must be positive
-        self.gamma = gamma  # truncate absolute value of delta W
+        super().__init__(percentile=percentile, gamma=gamma, data_kinds=data_kinds)
         self.off = off
 
     def process_dxo(self, dxo: DXO, shareable: Shareable, fl_ctx: FLContext) -> None | DXO:
-        """Compute the percentile on the abs delta_W.
-
-        Only share the params where absolute delta_W greater than
-        the percentile value
+        """Return the DXO unchanged when ``off``; otherwise delegate to stock filtering.
 
         Args:
-            dxo: information from client
-            shareable: that the dxo belongs to
-            fl_ctx: context provided by workflow
+            dxo (DXO): Information from the client.
+            shareable (Shareable): The shareable the DXO belongs to.
+            fl_ctx (FLContext): Context provided by the workflow.
 
-        Returns: filtered dxo
+        Returns:
+            None | DXO: The unchanged DXO when off, else the stock-filtered DXO (or None if the
+            stock guard clauses reject it).
         """
         self.log_info(fl_ctx, f"Percentile filter is {'off' if self.off else 'on'}")
         if self.off:
             return dxo
-        self.logger.debug("check gamma")
-        if self.gamma <= 0:
-            self.log_debug(fl_ctx, "no partial model: gamma: {}".format(self.gamma))
-            return None
-        if self.percentile < 0 or self.percentile > 100:
-            self.log_debug(fl_ctx, "no partial model: percentile: {}".format(self.percentile))
-            return None  # do nothing
-
-        # invariant to local steps
-        model_diff = dxo.data
-        total_steps = dxo.get_meta_prop(MetaKey.NUM_STEPS_CURRENT_ROUND, 1)
-
-        delta_w = {name: model_diff[name] / total_steps for name in model_diff}
-        # abs delta
-        all_abs_values = np.concatenate([np.abs(delta_w[name].ravel()) for name in delta_w])
-        cutoff = np.percentile(a=all_abs_values, q=self.percentile, overwrite_input=False)
-        self.log_info(
-            fl_ctx,
-            f"Max abs delta_w: {np.max(all_abs_values)}, Min abs delta_w: {np.min(all_abs_values)},"
-            f"cutoff: {cutoff}, scale: {total_steps}.",
-        )
-
-        for name in delta_w:
-            diff_w = delta_w[name]
-            if np.ndim(diff_w) == 0:  # single scalar, no clipping
-                delta_w[name] = diff_w * total_steps
-                continue
-            selector = (diff_w > -cutoff) & (diff_w < cutoff)
-            diff_w[selector] = 0.0
-            diff_w = np.clip(diff_w, a_min=-self.gamma, a_max=self.gamma)
-            delta_w[name] = diff_w * total_steps
-
-        dxo.data = delta_w
-        return dxo
+        return super().process_dxo(dxo, shareable, fl_ctx)

--- a/flip-utils/flip/nvflare/components/evaluation_json_generator.py
+++ b/flip-utils/flip/nvflare/components/evaluation_json_generator.py
@@ -15,30 +15,40 @@ import os.path
 
 from nvflare.apis.dxo import DataKind, from_shareable
 from nvflare.apis.event_type import EventType
-from nvflare.apis.fl_component import FLComponent
 from nvflare.apis.fl_context import FLContext
 from nvflare.app_common.app_constant import AppConstants
 from nvflare.app_common.app_event_type import AppEventType
+from nvflare.app_common.utils.file_utils import resolve_path_under_root
+from nvflare.app_common.widgets.validation_json_generator import to_serializable
 
 from flip.constants import PTConstants
+from flip.nvflare.components.validation_json_generator import ValidationJsonGenerator
 
 
-class EvaluationJsonGenerator(FLComponent):
+class EvaluationJsonGenerator(ValidationJsonGenerator):
+    """Flat-shape evaluation results generator.
+
+    Deduped against FLIP's :class:`ValidationJsonGenerator`: it inherits the manual-dispatch
+    mechanism (the no-op ``handle_event`` — ServerEventHandler drives ``handle_evaluation_events``)
+    and the numpy-float JSON encoding / path-safe output. It differs only in shape — evaluation
+    records one aggregate metrics result per client (``_eval_results[data_client] = metrics``)
+    rather than a cross-validation matrix keyed by (data_client, model_owner) — and in the results
+    directory / file name.
+    """
+
     def __init__(self, results_dir=PTConstants.EvalDir, json_file_name=PTConstants.EvalResultsFilename):
-        """Handles EVALUATION_RESULT_RECEIVED event and generates a results.json containing accuracy of each
-        validated model.
+        """Initialise the evaluation results generator.
 
         Args:
-            results_dir (str, optional): Name of the results directory. Defaults to cross_site_eval
-            json_file_name (str, optional): Name of the json file. Defaults to evaluation_results.json
+            results_dir (str): Name of the results directory. Defaults to ``PTConstants.EvalDir``.
+            json_file_name (str): Name of the json file. Defaults to ``PTConstants.EvalResultsFilename``.
         """
-        super(EvaluationJsonGenerator, self).__init__()
-
-        self._results_dir = results_dir
-        self._eval_results = {}
-        self._json_file_name = json_file_name
+        super().__init__(results_dir=results_dir, json_file_name=json_file_name)
+        # Flat per-client store (not the base's nested self._val_results).
+        self._eval_results: dict = {}
 
     def handle_evaluation_events(self, event_type: str, fl_ctx: FLContext) -> None:
+        """FLIP integration point — ServerEventHandler dispatches events here, not via handle_event."""
         if event_type == EventType.START_RUN:
             self._eval_results.clear()
         elif event_type == AppEventType.VALIDATION_RESULT_RECEIVED:
@@ -53,27 +63,24 @@ class EvaluationJsonGenerator(FLComponent):
             if eval_results:
                 try:
                     dxo = from_shareable(eval_results)
-                    dxo.validate()
-
                     if dxo.data_kind == DataKind.METRICS:
-                        if data_client not in self._eval_results:
-                            self._eval_results[data_client] = {}
                         self._eval_results[data_client] = dxo.data
                     else:
                         self.log_error(
                             fl_ctx, f"Expected dxo of kind METRICS but got {dxo.data_kind} instead.", fire_event=False
                         )
                 except Exception:
-                    self.log_exception(fl_ctx, "Exception in handling validation result.", fire_event=False)
+                    self.log_exception(fl_ctx, "Exception in handling evaluation result.", fire_event=False)
             else:
-                self.log_error(fl_ctx, "Validation result not found.", fire_event=False)
+                self.log_error(fl_ctx, "Evaluation result not found.", fire_event=False)
         elif event_type == EventType.END_RUN:
             run_dir = fl_ctx.get_engine().get_workspace().get_run_dir(fl_ctx.get_job_id())
-            eval_res_dir = os.path.join(run_dir, self._results_dir)
+            res_file_path = resolve_path_under_root(
+                run_dir, os.path.join(self._results_dir, self._json_file_name), "evaluation results path"
+            )
+            eval_res_dir = os.path.dirname(res_file_path)
             if not os.path.exists(eval_res_dir):
                 self.log_info(fl_ctx, f"Creating evaluation results directory at {eval_res_dir}")
                 os.makedirs(eval_res_dir)
-
-            res_file_path = os.path.join(eval_res_dir, self._json_file_name)
             with open(res_file_path, "w") as f:
-                json.dump(self._eval_results, f, indent=4)
+                json.dump(self._eval_results, f, indent=4, default=to_serializable)

--- a/flip-utils/flip/nvflare/components/stage_percentile_privacy.py
+++ b/flip-utils/flip/nvflare/components/stage_percentile_privacy.py
@@ -10,69 +10,39 @@
 # limitations under the License.
 #
 
-# Copyright (c) 2021, NVIDIA CORPORATION.  All rights reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-
 import numpy as np
-
-# from dxo_filter import DXOFilter
-from nvflare.apis.dxo import DXO, DataKind, MetaKey
-from nvflare.apis.dxo_filter import DXOFilter
+from nvflare.apis.dxo import DXO, MetaKey
 from nvflare.apis.fl_context import FLContext
 from nvflare.apis.shareable import Shareable
 
 from flip.constants import FlipMetaKey
+from flip.nvflare.components.custom_percentile_privacy import PercentilePrivacy
 
 
-class StagePercentilePrivacy(DXOFilter):
-    def __init__(self, percentile=10, gamma=0.01, data_kinds: list[str] | None = None, off: bool = False):
-        """Implementation of "largest percentile to share" privacy preserving policy.
+class StagePercentilePrivacy(PercentilePrivacy):
+    """Percentile-privacy filter that groups parameters by training stage before filtering.
 
-        Shokri and Shmatikov, Privacy-preserving deep learning, CCS '15
-
-        Args:
-            percentile (int, optional): Only abs diff greater than this percentile is updated.
-              Allowed range 0..100.  Defaults to 10.
-            gamma (float, optional): The upper limit to truncate abs values of weight diff. Defaults to 0.01.
-            Any weight diff with abs<gamma will become 0.
-            data_kinds: kinds of DXO to filter
-            off (bool, optional): If True, the filter is turned off. Defaults to False.
-        """
-        if not data_kinds:
-            data_kinds = [DataKind.WEIGHT_DIFF, DataKind.WEIGHTS]
-
-        super().__init__(supported_data_kinds=[DataKind.WEIGHTS, DataKind.WEIGHT_DIFF], data_kinds_to_filter=data_kinds)
-
-        # must be in 0..100, only update abs diff greater than percentile
-        self.percentile = percentile
-        # must be positive
-        self.gamma = gamma  # truncate absolute value of delta W
-        self.off = off
+    Subclasses FLIP's :class:`PercentilePrivacy` to inherit its constructor (``percentile`` /
+    ``gamma`` / ``data_kinds`` / ``off``) and — transitively — stock NVFLARE's differential-privacy
+    maths. It overrides ``process_dxo`` to compute the percentile cutoff *per stage* (from
+    ``FlipMetaKey.STAGE``) rather than across all parameters at once, so each stage of a staged
+    model (e.g. autoencoder then diffusion model) is filtered independently.
+    """
 
     def process_dxo(self, dxo: DXO, shareable: Shareable, fl_ctx: FLContext) -> None | DXO:
-        """Compute the percentile on the abs delta_W.
+        """Compute the percentile on the abs delta_W, per stage.
 
-        Only share the params where absolute delta_W greater than
-        the percentile value
+        Only shares the params whose absolute delta_W is greater than the percentile value,
+        grouping parameters by the stages listed in ``FlipMetaKey.STAGE``.
 
         Args:
-            dxo: information from client
-            shareable: that the dxo belongs to
-            fl_ctx: context provided by workflow
+            dxo (DXO): Information from the client.
+            shareable (Shareable): The shareable the DXO belongs to.
+            fl_ctx (FLContext): Context provided by the workflow.
 
-        Returns: filtered dxo
+        Returns:
+            None | DXO: The filtered DXO, the unchanged DXO (off / no stage info), or None (invalid
+            gamma/percentile).
         """
         self.log_info(fl_ctx, f"Percentile filter is {'off' if self.off else 'on'}")
         if self.off:

--- a/flip-utils/flip/nvflare/components/validation_json_generator.py
+++ b/flip-utils/flip/nvflare/components/validation_json_generator.py
@@ -10,74 +10,34 @@
 # limitations under the License.
 #
 
-import json
-import os.path
-
-from nvflare.apis.dxo import DataKind, from_shareable
-from nvflare.apis.event_type import EventType
-from nvflare.apis.fl_component import FLComponent
 from nvflare.apis.fl_context import FLContext
-from nvflare.app_common.app_constant import AppConstants
-from nvflare.app_common.app_event_type import AppEventType
+from nvflare.app_common.widgets.validation_json_generator import (
+    ValidationJsonGenerator as NVFlareValidationJsonGenerator,
+)
 
-from flip.constants import PTConstants
 
+class ValidationJsonGenerator(NVFlareValidationJsonGenerator):
+    """Stock NVFLARE ``ValidationJsonGenerator``, dispatched manually by FLIP's ServerEventHandler.
 
-class ValidationJsonGenerator(FLComponent):
-    def __init__(self, results_dir=AppConstants.CROSS_VAL_DIR, json_file_name=PTConstants.CrossValResultsJsonFilename):
-        """Handles VALIDATION_RESULT_RECEIVED event and generates a results.json containing accuracy of each
-        validated model.
+    Subclasses ``nvflare.app_common.widgets.validation_json_generator.ValidationJsonGenerator`` so
+    the results accumulation (METRICS *and* COLLECTION / T2 leaf handling), numpy-float JSON
+    encoding and path-safe output track upstream instead of a drifting vendored copy (the fork had
+    only the METRICS branch and a plain ``json.dump``). The default ``results_dir`` /
+    ``json_file_name`` are identical to stock, so the constructor is inherited unchanged.
 
-        Args:
-            results_dir (str, optional): Name of the results directory. Defaults to cross_site_val
-            json_file_name (str, optional): Name of the json file. Defaults to cross_val_results.json
-        """
-        super(ValidationJsonGenerator, self).__init__()
+    The only FLIP-specific behaviour is dispatch. NVFLARE would auto-handle events through
+    ``handle_event``; FLIP instead routes them through ``ServerEventHandler``, which calls
+    ``handle_evaluation_events``. Because this component is still registered (so its
+    ``handle_event`` is auto-fired for every event), ``handle_event`` is suppressed here — otherwise
+    each validation result would be recorded twice — and the real work is delegated to stock's
+    implementation from ``handle_evaluation_events``.
+    """
 
-        self._results_dir = results_dir
-        self._val_results = {}
-        self._json_file_name = json_file_name
+    def handle_event(self, event_type: str, fl_ctx: FLContext) -> None:
+        # No-op: FLIP drives these events manually via handle_evaluation_events (ServerEventHandler),
+        # so the auto-dispatched path must not also process them.
+        pass
 
     def handle_evaluation_events(self, event_type: str, fl_ctx: FLContext) -> None:
-        if event_type == EventType.START_RUN:
-            self._val_results.clear()
-        elif event_type == AppEventType.VALIDATION_RESULT_RECEIVED:
-            model_owner = fl_ctx.get_prop(AppConstants.MODEL_OWNER, None)
-            data_client = fl_ctx.get_prop(AppConstants.DATA_CLIENT, None)
-            val_results = fl_ctx.get_prop(AppConstants.VALIDATION_RESULT, None)
-
-            if not model_owner:
-                self.log_error(
-                    fl_ctx, "model_owner unknown. Validation result will not be saved to json", fire_event=False
-                )
-            if not data_client:
-                self.log_error(
-                    fl_ctx, "data_client unknown. Validation result will not be saved to json", fire_event=False
-                )
-
-            if val_results:
-                try:
-                    dxo = from_shareable(val_results)
-                    dxo.validate()
-
-                    if dxo.data_kind == DataKind.METRICS:
-                        if data_client not in self._val_results:
-                            self._val_results[data_client] = {}
-                        self._val_results[data_client][model_owner] = dxo.data
-                    else:
-                        self.log_error(
-                            fl_ctx, f"Expected dxo of kind METRICS but got {dxo.data_kind} instead.", fire_event=False
-                        )
-                except Exception:
-                    self.log_exception(fl_ctx, "Exception in handling validation result.", fire_event=False)
-            else:
-                self.log_error(fl_ctx, "Validation result not found.", fire_event=False)
-        elif event_type == EventType.END_RUN:
-            run_dir = fl_ctx.get_engine().get_workspace().get_run_dir(fl_ctx.get_job_id())
-            cross_val_res_dir = os.path.join(run_dir, self._results_dir)
-            if not os.path.exists(cross_val_res_dir):
-                os.makedirs(cross_val_res_dir)
-
-            res_file_path = os.path.join(cross_val_res_dir, self._json_file_name)
-            with open(res_file_path, "w") as f:
-                json.dump(self._val_results, f)
+        """FLIP integration point — ServerEventHandler dispatches events here, not via handle_event."""
+        super().handle_event(event_type, fl_ctx)

--- a/flip-utils/flip/nvflare/controllers/cross_site_model_eval.py
+++ b/flip-utils/flip/nvflare/controllers/cross_site_model_eval.py
@@ -10,34 +10,37 @@
 # limitations under the License.
 #
 
-import logging
-import os
-import shutil
-import time
-from typing import Any
-
-from nvflare.apis.client import Client
-from nvflare.apis.controller_spec import ClientTask, Task
-from nvflare.apis.dxo import DXO, from_file, from_shareable
+from nvflare.apis.controller_spec import Task
 from nvflare.apis.fl_constant import ReturnCode
 from nvflare.apis.fl_context import FLContext
-from nvflare.apis.impl.controller import Controller
 from nvflare.apis.shareable import Shareable
 from nvflare.apis.signal import Signal
-from nvflare.apis.workspace import Workspace
-from nvflare.app_common.abstract.formatter import Formatter
-from nvflare.app_common.abstract.model_locator import ModelLocator
-from nvflare.app_common.app_constant import AppConstants, ModelName
-from nvflare.app_common.app_event_type import AppEventType
+from nvflare.app_common.app_constant import AppConstants
+from nvflare.app_common.workflows.cross_site_model_eval import CrossSiteModelEval as NVFlareCrossSiteModelEval
 from nvflare.security.logging import secure_format_exception
-from nvflare.widgets.info_collector import GroupInfoCollector, InfoCollector
 
 from flip import FLIP
 from flip.constants import FlipTasks
 from flip.nvflare.runtime import get_flip_model_id
 
 
-class CrossSiteModelEval(Controller):
+class CrossSiteModelEval(NVFlareCrossSiteModelEval):
+    """Stock NVFLARE cross-site model evaluation plus FLIP integration.
+
+    Subclasses ``nvflare.app_common.workflows.cross_site_model_eval.CrossSiteModelEval`` so the
+    evaluation orchestration, T2 multi-DXO handling (``get_leaf_dxos``) and run-dir path-safety
+    (``resolve_path_under_root``) track upstream instead of drifting from a vendored copy. FLIP
+    adds only:
+
+    * ``model_id`` — attributes any client execution exception reported back to the hub;
+    * a ``POST_VALIDATION`` cleanup task broadcast to clients once evaluation completes normally;
+    * reporting client execution exceptions to the hub via ``FLIP.send_handled_exception``.
+    """
+
+    # Declared for type-checkers: stock sets this in __init__ (as None then a client-name list);
+    # annotating it here lets subclasses (e.g. ModelEval) reassign it without a has-type error.
+    _participating_clients: list[str] | None
+
     def __init__(
         self,
         task_check_period=0.5,
@@ -52,221 +55,72 @@ class CrossSiteModelEval(Controller):
         participating_clients=None,
         wait_for_clients_timeout=300,
         cleanup_timeout=600,
-        fatal_error_delay=5,
         model_id="",
     ):
-        """Cross Site Model Validation workflow.
+        """Cross-site model evaluation workflow.
+
+        All arguments other than the two below are validated and stored by stock
+        ``CrossSiteModelEval``; see its docstring.
 
         Args:
-            task_check_period (float, optional): How often to check for new tasks or tasks being finished.
-                Defaults to 0.5.
-            cross_val_dir (str, optional): Path to cross site validation directory relative to run directory.
-                Defaults to "cross_site_val".
-            submit_model_timeout (int, optional): Timeout of submit_model_task. Defaults to 600 secs.
-            validation_timeout (int, optional): Timeout for validate_model task. Defaults to 6000 secs.
-            model_locator_id (str, optional): ID for model_locator component. Defaults to "".
-            formatter_id (str, optional): ID for formatter component. Defaults to "".
-            submit_model_task_name (str, optional): Name of submit_model task. Defaults to "".
-            validation_task_name (str, optional): Name of validate_model task. Defaults to "validate".
-            cleanup_models (bool, optional): Whether models should be deleted after run. Defaults to False.
-            participating_clients (list, optional): List of participating client names. If not provided, defaults
-                to all clients connected at start of controller.
-            wait_for_clients_timeout (int, optional): Timeout for clients to appear. Defaults to 300 secs
-            fatal_error_delay (int, optional): Time in seconds to delay before calling 'system_panic'
-                if a task returns an error result and ignore_result_error is set to false
-            model_id (str, required): ID of the model that the training is being performed under.
+            cleanup_timeout (int): Timeout in seconds for the POST_VALIDATION cleanup broadcast
+                that runs once evaluation completes. Defaults to 600.
+            model_id (str): ID of the model being evaluated, attached to any client execution
+                exception reported to the hub. Resolved lazily from the FL context, falling back
+                to this value.
         """
-        super(CrossSiteModelEval, self).__init__(task_check_period=task_check_period)
+        super().__init__(
+            task_check_period=task_check_period,
+            cross_val_dir=cross_val_dir,
+            submit_model_timeout=submit_model_timeout,
+            validation_timeout=validation_timeout,
+            model_locator_id=model_locator_id,
+            formatter_id=formatter_id,
+            submit_model_task_name=submit_model_task_name,
+            validation_task_name=validation_task_name,
+            cleanup_models=cleanup_models,
+            participating_clients=participating_clients,
+            wait_for_clients_timeout=wait_for_clients_timeout,
+        )
 
-        # flip
-        self.flip = FLIP()
-
-        if not isinstance(task_check_period, float):
-            raise TypeError("task_check_period must be float but got {}".format(type(task_check_period)))
-        if not isinstance(cross_val_dir, str):
-            raise TypeError("cross_val_dir must be a string but got {}".format(type(cross_val_dir)))
-        if not isinstance(submit_model_timeout, int):
-            raise TypeError("submit_model_timeout must be int but got {}".format(type(submit_model_timeout)))
-        if not isinstance(validation_timeout, int):
-            raise TypeError("validation_timeout must be int but got {}".format(type(validation_timeout)))
-        if not isinstance(model_locator_id, str):
-            raise TypeError("model_locator_id must be a string but got {}".format(type(model_locator_id)))
-        if not isinstance(formatter_id, str):
-            raise TypeError("formatter_id must be a string but got {}".format(type(formatter_id)))
-        if not isinstance(submit_model_task_name, str):
-            raise TypeError("submit_model_task_name must be a string but got {}".format(type(submit_model_task_name)))
-        if not isinstance(validation_task_name, str):
-            raise TypeError("validation_task_name must be a string but got {}".format(type(validation_task_name)))
-        if not isinstance(cleanup_models, bool):
-            raise TypeError("cleanup_models must be bool but got {}".format(type(cleanup_models)))
-        if participating_clients:
-            if not isinstance(participating_clients, list):
-                raise TypeError("participating_clients must be a list but got {}".format(type(participating_clients)))
-            if not all(isinstance(x, str) for x in participating_clients):
-                raise TypeError("participating_clients must be strings")
-
-        if submit_model_timeout < 0:
-            raise ValueError("submit_model_timeout must be greater than or equal to 0.")
-        if validation_timeout < 0:
-            raise ValueError("model_validate_timeout must be greater than or equal to 0.")
-        if wait_for_clients_timeout < 0:
-            raise ValueError("wait_for_clients_timeout must be greater than or equal to 0.")
+        if not isinstance(cleanup_timeout, int):
+            raise TypeError("cleanup_timeout must be int but got {}".format(type(cleanup_timeout)))
         if cleanup_timeout < 0:
             raise ValueError("cleanup_timeout must be greater than or equal to 0.")
 
-        self._cross_val_dir = cross_val_dir
-        self._model_locator_id = model_locator_id
-        self._formatter_id = formatter_id
-        self._submit_model_task_name = submit_model_task_name
-        self._validation_task_name = validation_task_name
-        self._submit_model_timeout = submit_model_timeout
-        self._validation_timeout = validation_timeout
-        self._wait_for_clients_timeout = wait_for_clients_timeout
-        self._cleanup_models = cleanup_models
-        self._participating_clients = participating_clients
-
-        self._val_results: dict[str, Any] = {}
-        self._server_models: dict[str, Any] = {}
-        self._client_models: dict[str, Any] = {}
-
-        self._formatter = None
-        self._cross_val_models_dir: str = ""
-        self._cross_val_results_dir: str = ""
-        self._model_locator: Any = None
+        self.flip = FLIP()
         self._cleanup_timeout = cleanup_timeout
-        self._fatal_error_delay = fatal_error_delay
         self._model_id_fallback = model_id
         self._model_id: str | None = None
 
-        # Set logger level
-        self.logger.setLevel(logging.INFO)
-
     def _resolve_model_id(self, fl_ctx: FLContext) -> str:
+        """Lazily resolve the FLIP model id from the FL context, falling back to the ctor value."""
         if self._model_id is None:
             self._model_id = get_flip_model_id(fl_ctx, fallback=self._model_id_fallback)
         return self._model_id
 
-    def start_controller(self, fl_ctx: FLContext):
-        engine = fl_ctx.get_engine()
-        if not engine:
-            self.system_panic("Engine not found. Workflow exiting.", fl_ctx)
+    def control_flow(self, abort_signal: Signal, fl_ctx: FLContext):
+        """Run stock cross-site evaluation, then broadcast a POST_VALIDATION cleanup task.
+
+        Stock ``control_flow`` returns early on every abort/failure path, and ``system_panic``
+        synchronously triggers ``abort_signal`` (via the server runner's FATAL_SYSTEM_ERROR
+        handler). Guarding the cleanup on ``abort_signal.triggered`` therefore keeps it from
+        running after an abort or a fatal error — a naive ``super() + append`` would wrongly run
+        it post-abort. An empty participating-clients list means stock quit before evaluating, so
+        there is nothing to clean up.
+        """
+        super().control_flow(abort_signal, fl_ctx)
+
+        if abort_signal.triggered:
+            self.log_info(fl_ctx, "Abort signal triggered - skipping post-validation cleanup.")
+            return
+        if not self._participating_clients:
+            self.log_info(fl_ctx, "No participating clients - skipping post-validation cleanup.")
             return
 
-        # If the list of participating clients is not provided, include all clients currently available.
-        if not self._participating_clients:
-            clients = engine.get_clients()
-            self._participating_clients = [c.name for c in clients]
-
-        # Create shareable dirs for models and results
-        workspace: Workspace = engine.get_workspace()
-        run_dir = workspace.get_run_dir(fl_ctx.get_job_id())
-        cross_val_path = os.path.join(run_dir, self._cross_val_dir)
-        self._cross_val_models_dir = os.path.join(cross_val_path, AppConstants.CROSS_VAL_MODEL_DIR_NAME)
-        self._cross_val_results_dir = os.path.join(cross_val_path, AppConstants.CROSS_VAL_RESULTS_DIR_NAME)
-
-        # Fire the init event.
-        fl_ctx.set_prop(AppConstants.CROSS_VAL_MODEL_PATH, self._cross_val_models_dir)
-        fl_ctx.set_prop(AppConstants.CROSS_VAL_RESULTS_PATH, self._cross_val_results_dir)
-        self.fire_event(AppEventType.CROSS_VAL_INIT, fl_ctx)
-
-        # Cleanup/create the cross val models and results directories
-        if os.path.exists(self._cross_val_models_dir):
-            shutil.rmtree(self._cross_val_models_dir)
-        if os.path.exists(self._cross_val_results_dir):
-            shutil.rmtree(self._cross_val_results_dir)
-
-        # Recreate new directories.
-        os.makedirs(self._cross_val_models_dir)
-        os.makedirs(self._cross_val_results_dir)
-
-        # Get components
-        if self._model_locator_id:
-            self._model_locator = engine.get_component(self._model_locator_id)
-            if not isinstance(self._model_locator, ModelLocator):
-                self.system_panic(
-                    reason="bad model locator {}: expect ModelLocator but got {}".format(
-                        self._model_locator_id, type(self._model_locator)
-                    ),
-                    fl_ctx=fl_ctx,
-                )
-                return
-
-        if self._formatter_id:
-            self._formatter = engine.get_component(self._formatter_id)
-            if not isinstance(self._formatter, Formatter):
-                self.system_panic(
-                    reason=f"formatter {self._formatter_id} is not an instance of Formatter.", fl_ctx=fl_ctx
-                )
-                return
-
-        if not self._formatter:
-            self.log_info(fl_ctx, "Formatter not found. Stats will not be printed.")
-
-        for c_name in self._participating_clients:
-            self._client_models[c_name] = None
-            self._val_results[c_name] = {}
-
-    def control_flow(self, abort_signal: Signal, fl_ctx: FLContext):
         try:
-            # wait until there are some clients
-            engine = fl_ctx.get_engine()
-            start_time = time.time()
-            while not self._participating_clients:
-                self._participating_clients = engine.get_clients()
-                if time.time() - start_time > self._wait_for_clients_timeout:
-                    self.log_info(fl_ctx, "No clients available - quit model validation.")
-                    return
-
-                self.log_info(fl_ctx, "No clients available - waiting ...")
-                time.sleep(2.0)
-                if abort_signal.triggered:
-                    self.log_info(fl_ctx, "Abort signal triggered. Finishing model validation.")
-                    return
-
-            self.log_info(fl_ctx, f"Beginning model validation with clients: {self._participating_clients}.")
-
-            if self._submit_model_task_name:
-                shareable = Shareable()
-                shareable.set_header(AppConstants.SUBMIT_MODEL_NAME, ModelName.BEST_MODEL)
-                submit_model_task = Task(
-                    name=self._submit_model_task_name,
-                    data=shareable,
-                    result_received_cb=self._receive_local_model_cb,
-                    timeout=self._submit_model_timeout,
-                )
-                self.broadcast(
-                    task=submit_model_task,
-                    targets=self._participating_clients,
-                    fl_ctx=fl_ctx,
-                    min_responses=len(self._participating_clients),
-                )
-
-            if abort_signal.triggered:
-                self.log_info(fl_ctx, "Abort signal triggered. Finishing model validation.")
-                return
-
-            # Load server models and assign those tasks
-            if self._model_locator:
-                success = self._locate_server_models(fl_ctx)
-                if not success:
-                    return
-
-                for server_model in self._server_models:
-                    self._send_validation_task(server_model, fl_ctx)
-            else:
-                self.log_info(fl_ctx, "ModelLocator not present. No server models will be included.")
-
-            while self.get_num_standing_tasks():
-                if abort_signal.triggered:
-                    self.log_info(fl_ctx, "Abort signal triggered. Finishing cross site validation.")
-                    return
-                self.log_debug(fl_ctx, "Checking standing tasks to see if cross site validation finished.")
-                time.sleep(self._task_check_period)
-
             self.log_info(fl_ctx, "Beginning post validation cleanup task...")
-
             cleanup_task = Task(name=FlipTasks.POST_VALIDATION.value, data=Shareable(), timeout=self._cleanup_timeout)
-
             self.broadcast_and_wait(
                 task=cleanup_task,
                 min_responses=len(self._participating_clients),
@@ -274,323 +128,40 @@ class CrossSiteModelEval(Controller):
                 fl_ctx=fl_ctx,
                 abort_signal=abort_signal,
             )
-
             self.log_info(fl_ctx, "Post validation cleanup completed")
-
-        except BaseException as e:
-            error_msg = f"Exception in cross site validator control_flow: {secure_format_exception(e)}"
+        except Exception as e:
+            error_msg = f"Exception in post-validation cleanup: {secure_format_exception(e)}"
             self.log_exception(fl_ctx, error_msg)
             self.system_panic(error_msg, fl_ctx)
 
-    def stop_controller(self, fl_ctx: FLContext):
-        self.cancel_all_tasks(fl_ctx=fl_ctx)
-
-        if self._cleanup_models:
-            self.log_info(fl_ctx, "Removing local models kept for validation.")
-            for model_name, model_path in self._server_models.items():
-                if model_path and os.path.isfile(model_path):
-                    os.remove(model_path)
-                    self.log_debug(fl_ctx, f"Removing server model {model_name} at {model_path}.")
-            for model_name, model_path in self._client_models.items():
-                if model_path and os.path.isfile(model_path):
-                    os.remove(model_path)
-                    self.log_debug(fl_ctx, f"Removing client {model_name}'s model at {model_path}.")
-
-    def _receive_local_model_cb(self, client_task: ClientTask, fl_ctx: FLContext):
-        client_name = client_task.client.name
-        result: Shareable = client_task.result
-
-        self._accept_local_model(client_name=client_name, result=result, fl_ctx=fl_ctx)
-
-        # Cleanup task result
-        client_task.result = None
-
-    def _before_send_validate_task_cb(self, client_task: ClientTask, fl_ctx: FLContext):
-        model_name = client_task.task.props[AppConstants.MODEL_OWNER]
-
-        try:
-            model_dxo: DXO = self._load_validation_content(model_name, self._cross_val_models_dir, fl_ctx)
-        except ValueError as _:
-            reason = f"Error in loading model shareable for {model_name}. CrossSiteValidator exiting."
-            self.log_error(fl_ctx, reason)
-            self.system_panic(reason, fl_ctx)
-            return
-
-        if not model_dxo:
-            self.system_panic(
-                f"Model contents for {model_name} not found in {self._cross_val_models_dir}. "
-                "CrossSiteValidator exiting",
-                fl_ctx=fl_ctx,
-            )
-            return
-
-        model_shareable = model_dxo.to_shareable()
-        model_shareable.set_header(AppConstants.MODEL_OWNER, model_name)
-        model_shareable.add_cookie(AppConstants.MODEL_OWNER, model_name)
-        client_task.task.data = model_shareable
-
-        fl_ctx.set_prop(AppConstants.DATA_CLIENT, client_task.client, private=True, sticky=False)
-        fl_ctx.set_prop(AppConstants.MODEL_OWNER, model_name, private=True, sticky=False)
-        fl_ctx.set_prop(AppConstants.MODEL_TO_VALIDATE, model_shareable, private=True, sticky=False)
-        fl_ctx.set_prop(AppConstants.PARTICIPATING_CLIENTS, self._participating_clients, private=True, sticky=False)
-        self.fire_event(AppEventType.SEND_MODEL_FOR_VALIDATION, fl_ctx)
-
-    def _after_send_validate_task_cb(self, client_task: ClientTask, fl_ctx: FLContext):
-        # Once task is sent clear data to restore memory
-        client_task.task.data = None
-
-    def _receive_val_result_cb(self, client_task: ClientTask, fl_ctx: FLContext):
-        # Find name of the client sending this
-        result = client_task.result
-        client_name = client_task.client.name
-
-        self._accept_val_result(client_name=client_name, result=result, fl_ctx=fl_ctx)
-
-        client_task.result = None
-
-    def _locate_server_models(self, fl_ctx: FLContext) -> bool:
-        # Load models from model_locator
-        self.log_info(fl_ctx, "Locating server models.")
-        server_model_names = self._model_locator.get_model_names(fl_ctx)
-
-        unique_names = []
-        for name in server_model_names:
-            # Get the model
-            dxo = self._model_locator.locate_model(name, fl_ctx)
-            if not isinstance(dxo, DXO):
-                self.system_panic(f"ModelLocator produced invalid data: expect DXO but got {type(dxo)}.", fl_ctx)
-                return False
-
-            # Save to workspace
-            unique_name = "SRV_" + name
-            unique_names.append(unique_name)
-            try:
-                save_path = self._save_validation_content(unique_name, self._cross_val_models_dir, dxo, fl_ctx)
-            except Exception:
-                self.log_exception(fl_ctx, f"Unable to save shareable contents of server model {unique_name}")
-                self.system_panic(f"Unable to save shareable contents of server model {unique_name}", fl_ctx)
-                return False
-
-            self._server_models[unique_name] = save_path
-            self._val_results[unique_name] = {}
-
-        if unique_names:
-            self.log_info(fl_ctx, f"Server models loaded: {unique_names}.")
-        else:
-            self.log_info(fl_ctx, "no server models to validate!")
-        return True
-
     def _accept_local_model(self, client_name: str, result: Shareable, fl_ctx: FLContext):
-        fl_ctx.set_prop(AppConstants.RECEIVED_MODEL, result, private=False, sticky=False)
-        fl_ctx.set_prop(AppConstants.RECEIVED_MODEL_OWNER, client_name, private=False, sticky=False)
-        fl_ctx.set_prop(AppConstants.CROSS_VAL_DIR, self._cross_val_dir, private=False, sticky=False)
-        self.fire_event(AppEventType.RECEIVE_BEST_MODEL, fl_ctx)
-
-        # get return code
-        rc = result.get_return_code()
-        if rc and rc != ReturnCode.OK:
-            time.sleep(self._fatal_error_delay)
-            # Raise errors if bad peer context or execution exception.
-            if rc in [ReturnCode.MISSING_PEER_CONTEXT, ReturnCode.BAD_PEER_CONTEXT]:
-                self.log_error(fl_ctx, "Peer context is bad or missing. No model submitted for this client.")
-            elif rc in [ReturnCode.EXECUTION_EXCEPTION, ReturnCode.TASK_UNKNOWN]:
-                formatted_exception = result.get_header("exception")
-
-                if formatted_exception is not None:
-                    self.log_error(fl_ctx, formatted_exception)
-                    self.flip.send_handled_exception(
-                        formatted_exception=formatted_exception,
-                        client_name=client_name,
-                        model_id=self._resolve_model_id(fl_ctx),
-                    )
-
-                self.log_error(
-                    fl_ctx, "Execution Exception on client during model submission. No model submitted for this client."
-                )
-            # Ignore contribution if result invalid.
-            elif rc in [
-                ReturnCode.EXECUTION_RESULT_ERROR,
-                ReturnCode.TASK_DATA_FILTER_ERROR,
-                ReturnCode.TASK_RESULT_FILTER_ERROR,
-                ReturnCode.TASK_UNKNOWN,
-            ]:
-                self.log_error(fl_ctx, "Execution result is not a shareable. Model submission will be ignored.")
-            else:
-                self.log_error(fl_ctx, "Return code set. Model submission from client will be ignored.")
-        else:
-            # Save shareable in models directory.
-            try:
-                self.log_debug(fl_ctx, "Extracting DXO from shareable.")
-                dxo = from_shareable(result)
-                save_path = self._save_validation_content(client_name, self._cross_val_models_dir, dxo, fl_ctx)
-            except ValueError as v_e:
-                self.log_error(
-                    fl_ctx, f"Unable to save shareable contents of {client_name}'s model. Exception: {str(v_e)}"
-                )
-                self.log_warning(fl_ctx, f"Ignoring client {client_name}'s model.")
-                return
-
-            self.log_info(fl_ctx, f"Received local model from client {client_name}.")
-
-            self._client_models[client_name] = save_path
-
-            # Send a model to this client to validate
-            self._send_validation_task(client_name, fl_ctx)
-
-    def _send_validation_task(self, model_name: str, fl_ctx: FLContext):
-        self.log_info(fl_ctx, f"Sending {model_name} model to all participating clients for validation.")
-
-        # Create validation task and broadcast to all participating clients.
-        task = Task(
-            name=self._validation_task_name,
-            data=Shareable(),
-            before_task_sent_cb=self._before_send_validate_task_cb,
-            after_task_sent_cb=self._after_send_validate_task_cb,
-            result_received_cb=self._receive_val_result_cb,
-            timeout=self._validation_timeout,
-            props={AppConstants.MODEL_OWNER: model_name},
-        )
-
-        self.broadcast(
-            task=task,
-            fl_ctx=fl_ctx,
-            targets=self._participating_clients,
-            min_responses=len(self._participating_clients),
-            wait_time_after_min_received=0,
-        )
+        """Report any client execution exception to the hub, then delegate to stock handling."""
+        self._report_client_exception(client_name, result, fl_ctx)
+        super()._accept_local_model(client_name=client_name, result=result, fl_ctx=fl_ctx)
 
     def _accept_val_result(self, client_name: str, result: Shareable, fl_ctx: FLContext):
-        model_owner = result.get_cookie(AppConstants.MODEL_OWNER, "")
+        """Report any client execution exception to the hub, then delegate to stock handling."""
+        self._report_client_exception(client_name, result, fl_ctx)
+        super()._accept_val_result(client_name=client_name, result=result, fl_ctx=fl_ctx)
 
-        # Fire event. This needs to be a new local context per each client
-        fl_ctx.set_prop(AppConstants.MODEL_OWNER, model_owner, private=True, sticky=False)
-        fl_ctx.set_prop(AppConstants.DATA_CLIENT, client_name, private=True, sticky=False)
-        fl_ctx.set_prop(AppConstants.VALIDATION_RESULT, result, private=True, sticky=False)
-        self.fire_event(AppEventType.VALIDATION_RESULT_RECEIVED, fl_ctx)
+    def _report_client_exception(self, client_name: str, result: Shareable, fl_ctx: FLContext):
+        """Surface a client-side execution exception to the hub, if the result carries one.
 
+        Stock only logs execution exceptions; FLIP additionally forwards the client's formatted
+        traceback to the hub so it can be shown against the model run.
+
+        Args:
+            client_name (str): Name of the client that produced the result.
+            result (Shareable): The task result received from the client.
+            fl_ctx (FLContext): The current FL context.
+        """
         rc = result.get_return_code()
-        if rc and rc != ReturnCode.OK:
-            # Raise errors if bad peer context or execution exception.
-            if rc in [ReturnCode.MISSING_PEER_CONTEXT, ReturnCode.BAD_PEER_CONTEXT]:
-                self.log_error(fl_ctx, "Peer context is bad or missing.")
-            elif rc in [ReturnCode.EXECUTION_EXCEPTION, ReturnCode.TASK_UNKNOWN]:
-                formatted_exception = result.get_header("exception")
-
-                if formatted_exception is not None:
-                    self.log_error(fl_ctx, formatted_exception)
-                    self.flip.send_handled_exception(
-                        formatted_exception=formatted_exception,
-                        client_name=client_name,
-                        model_id=self._resolve_model_id(fl_ctx),
-                    )
-
-                self.log_error(fl_ctx, "Execution Exception in model validation.")
-            elif rc in [
-                ReturnCode.EXECUTION_RESULT_ERROR,
-                ReturnCode.TASK_DATA_FILTER_ERROR,
-                ReturnCode.TASK_RESULT_FILTER_ERROR,
-            ]:
-                self.log_error(fl_ctx, "Execution result is not a shareable. Validation results will be ignored.")
-            else:
-                self.log_error(
-                    fl_ctx,
-                    f"Client {client_name} sent results for validating {model_owner} model with return code set."
-                    " Logging empty results.",
+        if rc in (ReturnCode.EXECUTION_EXCEPTION, ReturnCode.TASK_UNKNOWN):
+            formatted_exception = result.get_header("exception")
+            if formatted_exception is not None:
+                self.log_error(fl_ctx, formatted_exception)
+                self.flip.send_handled_exception(
+                    formatted_exception=formatted_exception,
+                    client_name=client_name,
+                    model_id=self._resolve_model_id(fl_ctx),
                 )
-
-            self._val_results[client_name][model_owner] = {}
-        else:
-            save_file_name = client_name + "_" + model_owner
-
-            try:
-                dxo = from_shareable(result)
-                self._save_validation_content(save_file_name, self._cross_val_results_dir, dxo, fl_ctx)
-                self._val_results[client_name][model_owner] = os.path.join(self._cross_val_results_dir, save_file_name)
-
-                self.log_info(fl_ctx, f"Client {client_name} sent results for validating {model_owner} model.")
-            except ValueError as v_e:
-                reason = (
-                    f"Unable to save validation result from {client_name} of {model_owner}'s model. "
-                    f"Exception: {str(v_e)}"
-                )
-                self.log_exception(fl_ctx, reason)
-
-    def _save_validation_content(self, name: str, save_dir: str, dxo: DXO, fl_ctx: FLContext) -> str:
-        """Saves DXO to given directory within the app_dir.
-
-        Args:
-            name (str): Name of DXO file
-            save_dir (str): Relative path to directory in which to save
-            dxo (DXO): DXO object
-            fl_ctx (FLContext): FLContext object
-
-        Returns:
-            str: Path to the file saved.
-        """
-        # Save the model with name as the filename to shareable directory
-        data_filename = os.path.join(save_dir, name)
-
-        # Save contents to path
-        try:
-            dxo.to_file(data_filename)
-        except Exception as e:
-            error_message = f"Unable to save DXO contents to {data_filename}: {secure_format_exception(e)}"
-            self.log_exception(fl_ctx, error_message)
-            raise ValueError(error_message)
-
-        self.log_debug(fl_ctx, f"Saved cross validation result (model/metric) with name: {name}.")
-
-        return data_filename
-
-    def _load_validation_content(self, name: str, load_dir: str, fl_ctx: FLContext) -> DXO:
-        """Loads DXO from disk.
-
-        Args:
-            name (str): Name of file to load
-            load_dir (str): Directory from which to load
-            fl_ctx (FLContext): FLContext object
-
-        Returns:
-            DXO: Loaded DXO object
-        """
-        filename = os.path.join(load_dir, name)
-
-        try:
-            dxo = from_file(filename)
-        except Exception as e:
-            error_message = f"Exception in loading content from {name}: {secure_format_exception(e)}"
-            self.log_exception(fl_ctx, error_message)
-            raise ValueError(error_message)
-
-        self.log_debug(fl_ctx, f"Loaded cross validation content with name: {name}.")
-
-        return dxo
-
-    def handle_event(self, event_type: str, fl_ctx: FLContext):
-        super().handle_event(event_type=event_type, fl_ctx=fl_ctx)
-        if event_type == InfoCollector.EVENT_TYPE_GET_STATS:
-            if self._formatter:
-                collector = fl_ctx.get_prop(InfoCollector.CTX_KEY_STATS_COLLECTOR, None)
-                if collector:
-                    if not isinstance(collector, GroupInfoCollector):
-                        raise TypeError("collector must be GroupInfoCollector but got {}".format(type(collector)))
-
-                    fl_ctx.set_prop(AppConstants.VALIDATION_RESULT, self._val_results, private=True, sticky=False)
-                    val_info = self._formatter.format(fl_ctx)
-
-                    collector.add_info(
-                        group_name=self._name,
-                        info={"val_results": val_info},
-                    )
-            else:
-                self.log_warning(fl_ctx, "No formatter provided. Validation results can't be printed.")
-
-    def process_result_of_unknown_task(
-        self, client: Client, task_name: str, client_task_id: str, result: Shareable, fl_ctx: FLContext
-    ):
-        if task_name == self._submit_model_task_name:
-            self._accept_local_model(client_name=client.name, result=result, fl_ctx=fl_ctx)
-        elif task_name == self._validation_task_name:
-            self._accept_val_result(client_name=client.name, result=result, fl_ctx=fl_ctx)
-        else:
-            self.log_error(fl_ctx, "Ignoring result from unknown task.")

--- a/flip-utils/flip/nvflare/controllers/fed_evaluation.py
+++ b/flip-utils/flip/nvflare/controllers/fed_evaluation.py
@@ -14,9 +14,8 @@ import os
 import shutil
 import time
 
-from nvflare.apis.client import Client
 from nvflare.apis.controller_spec import ClientTask, Task
-from nvflare.apis.dxo import DXO, from_bytes
+from nvflare.apis.dxo import DXO
 from nvflare.apis.fl_constant import ReturnCode
 from nvflare.apis.fl_context import FLContext
 from nvflare.apis.impl.controller import Controller
@@ -30,12 +29,24 @@ from nvflare.app_common.app_event_type import AppEventType
 from nvflare.security.logging import secure_format_exception
 from nvflare.widgets.info_collector import GroupInfoCollector, InfoCollector
 
-from flip import FLIP
 from flip.constants import FlipTasks, PTConstants
-from flip.nvflare.runtime import get_flip_model_id
+from flip.nvflare.controllers.cross_site_model_eval import CrossSiteModelEval
 
 
-class ModelEval(Controller):
+class ModelEval(CrossSiteModelEval):
+    """FLIP model-collection evaluation: evaluate a set of server-provided models on every client.
+
+    Subclasses FLIP's :class:`CrossSiteModelEval` to share one FLIP eval base — model-id
+    resolution (``_resolve_model_id``) and hub exception reporting (``_report_client_exception``) —
+    and to inherit the stock scaffolding (constructor validation, unknown-task routing, stop
+    logic). Unlike cross-site validation, where each client's submitted model is validated by every
+    other client, evaluation loads a *collection* of models server-side and bundles them into a
+    single evaluation task broadcast to all clients.
+
+    Sharing the base also defines the ``_validation_task_name`` / ``_cross_val_dir`` attributes the
+    previous standalone fork referenced but never assigned.
+    """
+
     def __init__(
         self,
         task_check_period=0.5,
@@ -49,93 +60,37 @@ class ModelEval(Controller):
         participating_clients=None,
         wait_for_clients_timeout=300,
         cleanup_timeout=600,
-        fatal_error_delay=5,
         model_id="",
     ):
-        """Model Evaluation workflow.
+        """Model-collection evaluation workflow.
+
+        All arguments are validated and stored by the FLIP/stock base; the evaluation task is named
+        by ``evaluation_task_name``, which is also wired into the stock ``validation_task_name``
+        plumbing (so unknown-task routing works).
 
         Args:
-            task_check_period (float, optional): How often to check for new tasks or tasks being finished.
-                Defaults to 0.5.
-            submit_model_timeout (int, optional): Timeout of submit_model_task. Defaults to 600 secs.
-            validation_timeout (int, optional): Timeout for validate_model task. Defaults to 6000 secs.
-            model_locator_id (str, optional): ID for model_locator component. Defaults to "".
-            formatter_id (str, optional): ID for formatter component. Defaults to "".
-            submit_model_task_name (str, optional): Name of submit_model task. Defaults to "".
-            validation_task_name (str, optional): Name of validate_model task. Defaults to "validate".
-            cleanup_models (bool, optional): Whether models should be deleted after run. Defaults to False.
-            participating_clients (list, optional): List of participating client names. If not provided, defaults
-                to all clients connected at start of controller.
-            wait_for_clients_timeout (int, optional): Timeout for clients to appear. Defaults to 300 secs
-            fatal_error_delay (int, optional): Time in seconds to delay before calling 'system_panic'
-                if a task returns an error result and ignore_result_error is set to false
-            model_id (str, required): ID of the model that the training is being performed under.
+            evaluation_task_name (str): Name of the evaluation task broadcast to clients. Defaults
+                to ``PTConstants.EvalTaskName``.
         """
-        super(ModelEval, self).__init__(task_check_period=task_check_period)
+        super().__init__(
+            task_check_period=task_check_period,
+            submit_model_timeout=submit_model_timeout,
+            validation_timeout=validation_timeout,
+            model_locator_id=model_locator_id,
+            formatter_id=formatter_id,
+            submit_model_task_name=submit_model_task_name,
+            validation_task_name=evaluation_task_name,
+            cleanup_models=cleanup_models,
+            participating_clients=participating_clients,
+            wait_for_clients_timeout=wait_for_clients_timeout,
+            cleanup_timeout=cleanup_timeout,
+            model_id=model_id,
+        )
 
-        # flip
-        self.flip = FLIP()
-
-        if not isinstance(task_check_period, float):
-            raise TypeError("task_check_period must be float but got {}".format(type(task_check_period)))
-        if not isinstance(submit_model_timeout, int):
-            raise TypeError("submit_model_timeout must be int but got {}".format(type(submit_model_timeout)))
-        if not isinstance(validation_timeout, int):
-            raise TypeError("validation_timeout must be int but got {}".format(type(validation_timeout)))
-        if not isinstance(model_locator_id, str):
-            raise TypeError("model_locator_id must be a string but got {}".format(type(model_locator_id)))
-        if not isinstance(formatter_id, str):
-            raise TypeError("formatter_id must be a string but got {}".format(type(formatter_id)))
-        if not isinstance(submit_model_task_name, str):
-            raise TypeError("submit_model_task_name must be a string but got {}".format(type(submit_model_task_name)))
-        if not isinstance(evaluation_task_name, str):
-            raise TypeError("evaluation_task_name must be a string but got {}".format(type(evaluation_task_name)))
-        if not isinstance(cleanup_models, bool):
-            raise TypeError("cleanup_models must be bool but got {}".format(type(cleanup_models)))
-        if participating_clients:
-            if not isinstance(participating_clients, list):
-                raise TypeError("participating_clients must be a list but got {}".format(type(participating_clients)))
-            if not all(isinstance(x, str) for x in participating_clients):
-                raise TypeError("participating_clients must be strings")
-
-        if submit_model_timeout < 0:
-            raise ValueError("submit_model_timeout must be greater than or equal to 0.")
-        if validation_timeout < 0:
-            raise ValueError("model_validate_timeout must be greater than or equal to 0.")
-        if wait_for_clients_timeout < 0:
-            raise ValueError("wait_for_clients_timeout must be greater than or equal to 0.")
-        if cleanup_timeout < 0:
-            raise ValueError("cleanup_timeout must be greater than or equal to 0.")
-
-        self._eval_dir = PTConstants.EvalDir
-        self._model_locator_id = model_locator_id
-        self._formatter_id = formatter_id
-        self._submit_model_task_name = submit_model_task_name
-        # This stays VALIDATION for NVFLARE compatibility.
         self._evaluation_task_name = evaluation_task_name
-        self._submit_model_timeout = submit_model_timeout
-        self._validation_timeout = validation_timeout
-        self._wait_for_clients_timeout = wait_for_clients_timeout
-        self._cleanup_models = cleanup_models
-        self._participating_clients = participating_clients
-
-        self._eval_results = {}
-        self._models = {}
-        self._all_models_dxo = None
-        self._client_models = {}
-
-        self._formatter = None
         self._eval_results_dir = PTConstants.EvalDir
-        self._model_locator = None
-        self._cleanup_timeout = cleanup_timeout
-        self._fatal_error_delay = fatal_error_delay
-        self._model_id_fallback = model_id
-        self._model_id: str | None = None
-
-    def _resolve_model_id(self, fl_ctx: FLContext) -> str:
-        if self._model_id is None:
-            self._model_id = get_flip_model_id(fl_ctx, fallback=self._model_id_fallback)
-        return self._model_id
+        self._eval_results: dict = {}
+        self._all_models_dxo = None
 
     def start_controller(self, fl_ctx: FLContext):
         engine = fl_ctx.get_engine()
@@ -145,38 +100,21 @@ class ModelEval(Controller):
 
         # If the list of participating clients is not provided, include all clients currently available.
         if not self._participating_clients:
-            clients = engine.get_clients()
-            self._participating_clients = [c.name for c in clients]
+            self._participating_clients = [c.name for c in engine.get_clients()]
 
-        # Create shareable dirs for models and results
         workspace: Workspace = engine.get_workspace()
         run_dir = workspace.get_run_dir(fl_ctx.get_job_id())
-        eval_path = os.path.join(run_dir, self._eval_results_dir)
-        self._eval_results_dir = eval_path
-        # Initialise the model locator
-        if self._model_locator_id:
-            self._model_locator = engine.get_component(self._model_locator_id)
-            if not isinstance(self._model_locator, ModelLocator):
-                self.system_panic(
-                    reason="bad model locator {}: expect ModelLocator but got {}".format(
-                        self._model_locator_id, type(self._model_locator)
-                    ),
-                    fl_ctx=fl_ctx,
-                )
-                return
+        self._eval_results_dir = os.path.join(run_dir, self._eval_results_dir)
 
         # Fire the init event.
         fl_ctx.set_prop(AppConstants.CROSS_VAL_RESULTS_PATH, self._eval_results_dir)
         self.fire_event(AppEventType.CROSS_VAL_INIT, fl_ctx)
 
-        # Cleanup/create the cross val models and results directories
+        # Cleanup/create the evaluation results directory.
         if os.path.exists(self._eval_results_dir):
             shutil.rmtree(self._eval_results_dir)
-
-        # Recreate new directories.
         os.makedirs(self._eval_results_dir)
 
-        # Get components
         if self._model_locator_id:
             self._model_locator = engine.get_component(self._model_locator_id)
             if not isinstance(self._model_locator, ModelLocator):
@@ -205,32 +143,28 @@ class ModelEval(Controller):
 
     def control_flow(self, abort_signal: Signal, fl_ctx: FLContext):
         try:
-            # wait until there are some clients
             engine = fl_ctx.get_engine()
             start_time = time.time()
             while not self._participating_clients:
                 self._participating_clients = engine.get_clients()
                 if time.time() - start_time > self._wait_for_clients_timeout:
-                    self.log_info(fl_ctx, "No clients available - quit model validation.")
+                    self.log_info(fl_ctx, "No clients available - quit model evaluation.")
                     return
 
                 self.log_info(fl_ctx, "No clients available - waiting ...")
                 time.sleep(2.0)
                 if abort_signal.triggered:
-                    self.log_info(fl_ctx, "Abort signal triggered. Finishing model validation.")
+                    self.log_info(fl_ctx, "Abort signal triggered. Finishing model evaluation.")
                     return
 
-            self.log_info(fl_ctx, f"Beginning model validation with clients: {self._participating_clients}.")
+            self.log_info(fl_ctx, f"Beginning model evaluation with clients: {self._participating_clients}.")
 
-            # This loads models in the evaluation directory, and saves them in self._models.
+            # Load the collection of server models to evaluate into self._all_models_dxo.
             if self._model_locator:
-                success = self._locate_server_models(fl_ctx)
-                if not success:
+                if not self._locate_server_models(fl_ctx):
                     return
 
-            # Do the validation task
-
-            task = Task(
+            eval_task = Task(
                 name=self._evaluation_task_name,
                 data=Shareable(),
                 before_task_sent_cb=self._before_send_validate_task_cb,
@@ -238,9 +172,8 @@ class ModelEval(Controller):
                 result_received_cb=self._receive_val_result_cb,
                 timeout=self._validation_timeout,
             )
-
             self.broadcast(
-                task=task,
+                task=eval_task,
                 fl_ctx=fl_ctx,
                 targets=self._participating_clients,
                 min_responses=len(self._participating_clients),
@@ -253,15 +186,13 @@ class ModelEval(Controller):
 
             while self.get_num_standing_tasks():
                 if abort_signal.triggered:
-                    self.log_info(fl_ctx, "Abort signal triggered. Finishing cross site validation.")
+                    self.log_info(fl_ctx, "Abort signal triggered. Finishing model evaluation.")
                     return
-                self.log_debug(fl_ctx, "Checking standing tasks to see if cross site validation finished.")
+                self.log_debug(fl_ctx, "Checking standing tasks to see if model evaluation finished.")
                 time.sleep(self._task_check_period)
 
-            self.log_info(fl_ctx, "Beginning post validation cleanup task...")
-
+            self.log_info(fl_ctx, "Beginning post evaluation cleanup task...")
             cleanup_task = Task(name=FlipTasks.POST_TASK.value, data=Shareable(), timeout=self._cleanup_timeout)
-
             self.broadcast_and_wait(
                 task=cleanup_task,
                 min_responses=len(self._participating_clients),
@@ -269,64 +200,27 @@ class ModelEval(Controller):
                 fl_ctx=fl_ctx,
                 abort_signal=abort_signal,
             )
+            self.log_info(fl_ctx, "Post evaluation cleanup completed")
 
-            self.log_info(fl_ctx, "Post validation cleanup completed")
-
-        except BaseException as e:
-            error_msg = f"Exception in cross site validator control_flow: {secure_format_exception(e)}"
+        except Exception as e:
+            error_msg = f"Exception in model evaluation control_flow: {secure_format_exception(e)}"
             self.log_exception(fl_ctx, error_msg)
             self.system_panic(error_msg, fl_ctx)
 
-    def stop_controller(self, fl_ctx: FLContext):
-        self.cancel_all_tasks(fl_ctx=fl_ctx)
-
-        if self._cleanup_models:
-            self.log_info(fl_ctx, "Removing local models kept for validation.")
-            for model_name, model_path in self._models.items():
-                if model_path and os.path.isfile(model_path):
-                    os.remove(model_path)
-                    self.log_debug(fl_ctx, f"Removing server model {model_name} at {model_path}.")
-            for model_name, model_path in self._client_models.items():
-                if model_path and os.path.isfile(model_path):
-                    os.remove(model_path)
-                    self.log_debug(fl_ctx, f"Removing client {model_name}'s model at {model_path}.")
-
-    def _receive_local_model_cb(self, client_task: ClientTask, fl_ctx: FLContext):
-        client_name = client_task.client.name
-        result: Shareable = client_task.result
-
-        self._accept_local_model(client_name=client_name, result=result, fl_ctx=fl_ctx)
-
-        # Cleanup task result
-        client_task.result = None
-
-    def _after_send_validate_task_cb(self, client_task: ClientTask, fl_ctx: FLContext):
-        # Once task is sent clear data to restore memory
-        client_task.task.data = None
-
-    def _receive_val_result_cb(self, client_task: ClientTask, fl_ctx: FLContext):
-        # Find name of the client sending this
-        result = client_task.result
-        client_name = client_task.client.name
-
-        self.log_info(fl_ctx, f"Receiving validation result from client: {client_name}: {result}")
-        self._accept_val_result(client_name=client_name, result=result, fl_ctx=fl_ctx)
-
-        client_task.result = None
-
     def _locate_server_models(self, fl_ctx: FLContext) -> bool:
-        # Load models from model_locator
+        """Load the whole collection of models to evaluate from the model locator.
+
+        Unlike stock (one DXO located per model name), evaluation loads every model in a single
+        ``locate_model`` call and keeps the collection DXO to broadcast to clients.
+        """
         self.log_info(fl_ctx, "Locating server models.")
 
-        # Evaluation allows us to load a collection of models to test:
         all_models = self._model_locator.locate_model(fl_ctx)
-
         for name in self._model_locator.model_names:
             model_dxo = all_models.data.get(name)
             if not isinstance(model_dxo, DXO):
                 self.system_panic(f"ModelLocator gave a collection of models for which {name} is not a dxo.", fl_ctx)
                 return False
-
             self._eval_results[name] = {}
 
         if self._model_locator.model_names:
@@ -335,17 +229,12 @@ class ModelEval(Controller):
             self.log_info(fl_ctx, "no server models to validate!")
 
         self._all_models_dxo = all_models
-
         return True
 
     def _before_send_validate_task_cb(self, client_task: ClientTask, fl_ctx: FLContext):
-        """Before the evaluation task, we load all the models DXO into a Shareable that is sent to the clients."""
-
+        """Bundle the whole model collection into the task data sent to each client."""
         if not self._all_models_dxo:
-            self.system_panic(
-                "Model contents empty.",
-                fl_ctx=fl_ctx,
-            )
+            self.system_panic("Model contents empty.", fl_ctx=fl_ctx)
             return
 
         model_shareable = self._all_models_dxo.to_shareable()
@@ -356,130 +245,40 @@ class ModelEval(Controller):
         fl_ctx.set_prop(AppConstants.PARTICIPATING_CLIENTS, self._participating_clients, private=True, sticky=False)
         self.fire_event(AppEventType.SEND_MODEL_FOR_VALIDATION, fl_ctx)
 
-    def _accept_local_model(self, client_name: str, result: Shareable, fl_ctx: FLContext):
-        fl_ctx.set_prop(AppConstants.RECEIVED_MODEL, result, private=False, sticky=False)
-        fl_ctx.set_prop(AppConstants.CROSS_VAL_DIR, self._cross_val_dir, private=False, sticky=False)
-        self.fire_event(AppEventType.RECEIVE_BEST_MODEL, fl_ctx)
-
-        # get return code
-        rc = result.get_return_code()
-        if rc and rc != ReturnCode.OK:
-            time.sleep(self._fatal_error_delay)
-            # Raise errors if bad peer context or execution exception.
-            if rc in [ReturnCode.MISSING_PEER_CONTEXT, ReturnCode.BAD_PEER_CONTEXT]:
-                self.log_error(fl_ctx, "Peer context is bad or missing. No model submitted for this client.")
-            elif rc in [ReturnCode.EXECUTION_EXCEPTION, ReturnCode.TASK_UNKNOWN]:
-                formatted_exception = result.get_header("exception")
-
-                if formatted_exception is not None:
-                    self.log_error(fl_ctx, formatted_exception)
-                    self.flip.send_handled_exception(
-                        formatted_exception=formatted_exception,
-                        client_name=client_name,
-                        model_id=self._resolve_model_id(fl_ctx),
-                    )
-
-                self.log_error(
-                    fl_ctx, "Execution Exception on client during model submission. No model submitted for this client."
-                )
-            # Ignore contribution if result invalid.
-            elif rc in [
-                ReturnCode.EXECUTION_RESULT_ERROR,
-                ReturnCode.TASK_DATA_FILTER_ERROR,
-                ReturnCode.TASK_RESULT_FILTER_ERROR,
-                ReturnCode.TASK_UNKNOWN,
-            ]:
-                self.log_error(fl_ctx, "Execution result is not a shareable. Model submission will be ignored.")
-            else:
-                self.log_error(fl_ctx, "Return code set. Model submission from client will be ignored.")
-        else:
-            # Save shareable in models directory.
-            # try:
-            #    self.log_debug(fl_ctx, "Extracting DXO from shareable.")
-            #    dxo = from_shareable(result)
-            #    save_path = self._save_validation_content(client_name, self._cross_val_models_dir, dxo, fl_ctx)
-            # except ValueError as v_e:
-            #    self.log_error(
-            #        fl_ctx, f"Unable to save shareable contents of {client_name}'s model. Exception: {str(v_e)}"
-            #    )
-            #    self.log_warning(fl_ctx, f"Ignoring client {client_name}'s model.")
-            #    return
-
-            self.log_info(fl_ctx, f"Received local model from client {client_name}.")
-
-            # self._client_models[client_name] = save_path
-
-            # Send a model to this client to validate
-            self._send_validation_task(client_name, fl_ctx)
-
     def _accept_val_result(self, client_name: str, result: Shareable, fl_ctx: FLContext):
-        # Fire event. This needs to be a new local context per each client
-
+        """Record each client's evaluation result, keyed flatly by client, reporting exceptions."""
         fl_ctx.set_prop(AppConstants.DATA_CLIENT, client_name, private=True, sticky=False)
         fl_ctx.set_prop(AppConstants.VALIDATION_RESULT, result, private=True, sticky=False)
         self.fire_event(AppEventType.VALIDATION_RESULT_RECEIVED, fl_ctx)
 
+        self._report_client_exception(client_name, result, fl_ctx)
+
         rc = result.get_return_code()
         if rc and rc != ReturnCode.OK:
-            # Raise errors if bad peer context or execution exception.
-            if rc in [ReturnCode.MISSING_PEER_CONTEXT, ReturnCode.BAD_PEER_CONTEXT]:
+            if rc in (ReturnCode.MISSING_PEER_CONTEXT, ReturnCode.BAD_PEER_CONTEXT):
                 self.log_error(fl_ctx, "Peer context is bad or missing.")
-            elif rc in [ReturnCode.EXECUTION_EXCEPTION, ReturnCode.TASK_UNKNOWN]:
-                formatted_exception = result.get_header("exception")
-
-                if formatted_exception is not None:
-                    self.log_error(fl_ctx, formatted_exception)
-                    self.flip.send_handled_exception(
-                        formatted_exception=formatted_exception,
-                        client_name=client_name,
-                        model_id=self._resolve_model_id(fl_ctx),
-                    )
-
-                self.log_error(fl_ctx, "Execution Exception in model validation.")
-            elif rc in [
+            elif rc in (ReturnCode.EXECUTION_EXCEPTION, ReturnCode.TASK_UNKNOWN):
+                self.log_error(fl_ctx, "Execution Exception in model evaluation.")
+            elif rc in (
                 ReturnCode.EXECUTION_RESULT_ERROR,
                 ReturnCode.TASK_DATA_FILTER_ERROR,
                 ReturnCode.TASK_RESULT_FILTER_ERROR,
-            ]:
+            ):
                 self.log_error(fl_ctx, "Execution result is not a shareable. Validation results will be ignored.")
             else:
                 self.log_error(
-                    fl_ctx,
-                    f"Client {client_name} sent results with return code set. Logging empty results.",
+                    fl_ctx, f"Client {client_name} sent results with return code set. Logging empty results."
                 )
-
             self._eval_results[client_name] = {}
         else:
-            save_file_name = client_name
-
-            try:
-                self._eval_results[client_name] = os.path.join(self._eval_results_dir, save_file_name)
-
-                self.log_info(fl_ctx, f"Client {client_name} sent results for validating model.")
-            except ValueError as v_e:
-                reason = f"Unable to save validation result from {client_name}. Exception: {str(v_e)}"
-                self.log_exception(fl_ctx, reason)
-
-    def _load_validation_content(self, name: str, load_dir: str, fl_ctx: FLContext) -> DXO | None:
-        # Load shareable from disk
-        shareable_filename = os.path.join(load_dir, name)
-        dxo: DXO = None
-
-        # load shareable
-        try:
-            with open(shareable_filename, "rb") as f:
-                data = f.read()
-
-            dxo: DXO = from_bytes(data)
-
-            self.log_debug(fl_ctx, f"Loading cross validation shareable content with name: {name}.")
-        except Exception as e:
-            raise ValueError(f"Exception in loading shareable content for {name}: {secure_format_exception(e)}")
-
-        return dxo
+            self._eval_results[client_name] = os.path.join(self._eval_results_dir, client_name)
+            self.log_info(fl_ctx, f"Client {client_name} sent results for validating model.")
 
     def handle_event(self, event_type: str, fl_ctx: FLContext):
-        super().handle_event(event_type=event_type, fl_ctx=fl_ctx)
+        # Bypass stock CrossSiteModelEval.handle_event (it reports the unused, nested
+        # self._val_results); run the base controller event handling, then report ModelEval's own
+        # flat self._eval_results to the stats collector.
+        Controller.handle_event(self, event_type=event_type, fl_ctx=fl_ctx)
         if event_type == InfoCollector.EVENT_TYPE_GET_STATS:
             if self._formatter:
                 collector = fl_ctx.get_prop(InfoCollector.CTX_KEY_STATS_COLLECTOR, None)
@@ -490,19 +289,6 @@ class ModelEval(Controller):
                     fl_ctx.set_prop(AppConstants.VALIDATION_RESULT, self._eval_results, private=True, sticky=False)
                     val_info = self._formatter.format(fl_ctx)
 
-                    collector.add_info(
-                        group_name=self._name,
-                        info={"val_results": val_info},
-                    )
+                    collector.add_info(group_name=self._name, info={"val_results": val_info})
             else:
                 self.log_warning(fl_ctx, "No formatter provided. Validation results can't be printed.")
-
-    def process_result_of_unknown_task(
-        self, client: Client, task_name: str, client_task_id: str, result: Shareable, fl_ctx: FLContext
-    ):
-        if task_name == self._submit_model_task_name:
-            self._accept_local_model(client_name=client.name, result=result, fl_ctx=fl_ctx)
-        elif task_name == self._validation_task_name:
-            self._accept_val_result(client_name=client.name, result=result, fl_ctx=fl_ctx)
-        else:
-            self.log_error(fl_ctx, "Ignoring result from unknown task.")

--- a/flip-utils/flip/nvflare/controllers/scatter_and_gather.py
+++ b/flip-utils/flip/nvflare/controllers/scatter_and_gather.py
@@ -46,12 +46,19 @@ class ScatterAndGather(NVFlareScatterAndGather):
         ``PersistToS3AndCleanup``) can persist results on an aborted run.
     """
 
-    def __init__(self, model_id: str = "", **kwargs) -> None:
+    def __init__(self, *args, model_id: str = "", **kwargs) -> None:
+        # ``*args`` is load-bearing, not dead: NVFLARE's FedJob/recipe serialisation
+        # (``get_component_init_parameters``) only walks a thin subclass's base class to capture
+        # stock's __init__ args (persistor_id, aggregator_id, num_rounds, …) when the subclass
+        # declares BOTH ``*args`` and ``**kwargs``. With ``**kwargs`` alone, only ``model_id`` is
+        # serialised, so a recipe's ScatterAndGather loses its persistor and broadcasts an empty
+        # round-0 model. Do not remove ``*args`` (guarded by TestFedJobSerialisation).
+        #
         # FLIP has never snapshotted components each round; keep that off by default so a large-model
         # job does not re-serialise the full global model every round (see the class docstring). Left
         # in kwargs so an explicit config value still wins.
         kwargs.setdefault("snapshot_every_n_rounds", 0)
-        super().__init__(**kwargs)
+        super().__init__(*args, **kwargs)
         self._model_id_fallback = model_id
         self._model_id: str | None = None
         self.flip = FLIP()
@@ -119,6 +126,12 @@ class ScatterAndGather(NVFlareScatterAndGather):
             event_data = fl_ctx.get_prop(FLContextKey.EVENT_DATA, None)
             if event_data is None:
                 self.log_error(fl_ctx, "Metrics Error: metrics result event was fired but no data found")
+                return
+            if self._current_round is None:
+                # SEND_RESULT is broadcast to every controller. In a multi-phase job (e.g. the
+                # diffusion AE/DM split) a controller whose control_flow has not started yet still
+                # has _current_round is None (as stock initialises it); it must not relay another
+                # controller's metric with a None round. The active controller relays it.
                 return
             handle_metrics_event(event_data, self._current_round, self._resolve_model_id(fl_ctx), flip=self.flip)
 

--- a/flip-utils/tests/unit/nvflare/components/test_custom_percentile_privacy.py
+++ b/flip-utils/tests/unit/nvflare/components/test_custom_percentile_privacy.py
@@ -14,215 +14,96 @@ from unittest.mock import MagicMock
 
 import numpy as np
 from nvflare.apis.dxo import DXO, DataKind, MetaKey
+from nvflare.app_common.filters.percentile_privacy import PercentilePrivacy as NVFlarePercentilePrivacy
 
 from flip.nvflare.components.custom_percentile_privacy import PercentilePrivacy
 
 
 class TestPercentilePrivacy:
+    """FLIP's PercentilePrivacy is a thin subclass of stock NVFLARE's PercentilePrivacy.
+
+    Its only FLIP-specific behaviour is the ``off`` toggle; when the filter is on it must
+    delegate to stock unchanged. These tests pin that contract (and that it stays a subclass
+    so it tracks upstream), not stock's percentile/gamma maths, which NVFLARE owns and tests.
+    """
+
     def setup_method(self):
-        """Setup test fixtures"""
         self.fl_ctx = MagicMock()
         self.fl_ctx.get_peer_context.return_value = None
         self.shareable = MagicMock()
 
+    @staticmethod
+    def _weight_diff_dxo(data: dict, total_steps: int = 1) -> DXO:
+        dxo = DXO(data_kind=DataKind.WEIGHT_DIFF, data={k: v.copy() for k, v in data.items()})
+        dxo.set_meta_prop(MetaKey.NUM_STEPS_CURRENT_ROUND, total_steps)
+        return dxo
+
+    def test_subclasses_stock_percentile_privacy(self):
+        """De-fork guard: FLIP's filter must subclass stock so it inherits upstream fixes."""
+        assert issubclass(PercentilePrivacy, NVFlarePercentilePrivacy)
+        assert isinstance(PercentilePrivacy(), NVFlarePercentilePrivacy)
+
     def test_init_default_values(self):
-        """Test initialization with default values"""
-        filter = PercentilePrivacy()
-        assert filter.percentile == 10
-        assert filter.gamma == 0.01
-        assert not filter.off
+        f = PercentilePrivacy()
+        assert f.percentile == 10
+        assert f.gamma == 0.01
+        assert f.off is False
 
     def test_init_custom_values(self):
-        """Test initialization with custom values"""
-        filter = PercentilePrivacy(percentile=20, gamma=0.05, off=True)
-        assert filter.percentile == 20
-        assert filter.gamma == 0.05
-        assert filter.off
+        f = PercentilePrivacy(percentile=20, gamma=0.05, off=True)
+        assert f.percentile == 20
+        assert f.gamma == 0.05
+        assert f.off is True
 
-    def test_process_dxo_when_off(self):
-        """Test that filter returns DXO unchanged when off=True"""
-        filter = PercentilePrivacy(off=True)
-
+    def test_process_dxo_when_off_returns_input_untouched(self):
+        """off=True short-circuits: the exact input DXO is returned, data unmodified."""
+        f = PercentilePrivacy(off=True)
         weights = {"layer1": np.array([1.0, 2.0, 3.0])}
-        dxo = DXO(data_kind=DataKind.WEIGHT_DIFF, data=weights)
+        dxo = self._weight_diff_dxo(weights)
 
-        result = filter.process_dxo(dxo, self.shareable, self.fl_ctx)
+        result = f.process_dxo(dxo, self.shareable, self.fl_ctx)
 
         assert result is dxo
         np.testing.assert_array_equal(result.data["layer1"], weights["layer1"])
 
-    def test_process_dxo_with_invalid_gamma(self):
-        """Test that filter returns None when gamma <= 0"""
-        filter = PercentilePrivacy(gamma=-0.01)
+    def test_process_dxo_when_on_applies_filtering(self):
+        """off=False (default) actually filters — sub-cutoff magnitudes are zeroed."""
+        f = PercentilePrivacy(percentile=50, gamma=1.0)
+        dxo = self._weight_diff_dxo({"layer1": np.array([-0.5, -0.2, 0.1, 0.3, 0.8])})
 
-        weights = {"layer1": np.array([1.0, 2.0, 3.0])}
-        dxo = DXO(data_kind=DataKind.WEIGHT_DIFF, data=weights)
-
-        result = filter.process_dxo(dxo, self.shareable, self.fl_ctx)
-
-        assert result is None
-
-    def test_process_dxo_with_invalid_percentile_low(self):
-        """Test that filter returns None when percentile < 0"""
-        filter = PercentilePrivacy(percentile=-10)
-
-        weights = {"layer1": np.array([1.0, 2.0, 3.0])}
-        dxo = DXO(data_kind=DataKind.WEIGHT_DIFF, data=weights)
-
-        result = filter.process_dxo(dxo, self.shareable, self.fl_ctx)
-
-        assert result is None
-
-    def test_process_dxo_with_invalid_percentile_high(self):
-        """Test that filter returns None when percentile > 100"""
-        filter = PercentilePrivacy(percentile=150)
-
-        weights = {"layer1": np.array([1.0, 2.0, 3.0])}
-        dxo = DXO(data_kind=DataKind.WEIGHT_DIFF, data=weights)
-
-        result = filter.process_dxo(dxo, self.shareable, self.fl_ctx)
-
-        assert result is None
-
-    def test_process_dxo_applies_percentile_filtering(self):
-        """Test that filter properly applies percentile filtering"""
-        filter = PercentilePrivacy(percentile=50, gamma=1.0)
-
-        # Create weight diff with known values
-        # Values: [-0.5, -0.2, 0.1, 0.3, 0.8]
-        # At 50th percentile, cutoff will be around 0.3
-        # Values with abs < cutoff should become 0
-        weights = {"layer1": np.array([-0.5, -0.2, 0.1, 0.3, 0.8])}
-        dxo = DXO(data_kind=DataKind.WEIGHT_DIFF, data=weights)
-        dxo.set_meta_prop(MetaKey.NUM_STEPS_CURRENT_ROUND, 1)
-
-        result = filter.process_dxo(dxo, self.shareable, self.fl_ctx)
+        result = f.process_dxo(dxo, self.shareable, self.fl_ctx)
 
         assert result is not None
-        # Check that some values were zeroed out
-        result_data = result.data["layer1"]
-        # At least some small values should be zeroed
-        assert np.any(result_data == 0.0) or len(result_data) == len(weights["layer1"])
+        assert np.any(result.data["layer1"] == 0.0)
 
-    def test_process_dxo_applies_gamma_clipping(self):
-        """Test that filter clips values to gamma range"""
-        filter = PercentilePrivacy(percentile=10, gamma=0.5)
+    def test_process_dxo_when_on_matches_stock_output_exactly(self):
+        """The whole point of the de-fork: when on, output is byte-identical to stock.
 
-        # Create weight diff with large values
-        weights = {"layer1": np.array([-2.0, -1.0, 0.0, 1.0, 2.0])}
-        dxo = DXO(data_kind=DataKind.WEIGHT_DIFF, data=weights)
-        dxo.set_meta_prop(MetaKey.NUM_STEPS_CURRENT_ROUND, 1)
-
-        result = filter.process_dxo(dxo, self.shareable, self.fl_ctx)
-
-        assert result is not None
-        result_data = result.data["layer1"]
-        # All values should be clipped to [-gamma, gamma] range
-        assert np.all(result_data >= -filter.gamma)
-        assert np.all(result_data <= filter.gamma)
-
-    def test_process_dxo_with_multiple_steps(self):
-        """Test that filter accounts for total_steps"""
-        filter = PercentilePrivacy(percentile=50, gamma=1.0)
-
-        total_steps = 5
-        weights = {"layer1": np.array([0.5, 1.0, 1.5, 2.0, 2.5])}
-        dxo = DXO(data_kind=DataKind.WEIGHT_DIFF, data=weights)
-        dxo.set_meta_prop(MetaKey.NUM_STEPS_CURRENT_ROUND, total_steps)
-
-        result = filter.process_dxo(dxo, self.shareable, self.fl_ctx)
-
-        assert result is not None
-        # Result should be scaled back by total_steps
-        result_data = result.data["layer1"]
-        assert result_data is not None
-
-    def test_process_dxo_with_scalar_value(self):
-        """Test that filter handles scalar values correctly"""
-        filter = PercentilePrivacy(percentile=50, gamma=1.0)
-
-        # Test with scalar (0-dimensional array)
-        weights = {"scalar_param": np.array(0.5)}
-        dxo = DXO(data_kind=DataKind.WEIGHT_DIFF, data=weights)
-        dxo.set_meta_prop(MetaKey.NUM_STEPS_CURRENT_ROUND, 1)
-
-        result = filter.process_dxo(dxo, self.shareable, self.fl_ctx)
-
-        assert result is not None
-        # Scalar should not be clipped, just scaled
-        result_data = result.data["scalar_param"]
-        assert np.ndim(result_data) == 0
-
-    def test_process_dxo_with_multiple_layers(self):
-        """Test that filter works with multiple layers"""
-        filter = PercentilePrivacy(percentile=30, gamma=0.5)
-
-        weights = {
-            "layer1": np.array([0.1, 0.2, 0.3, 0.4, 0.5]),
-            "layer2": np.array([-0.5, -0.3, 0.0, 0.3, 0.5]),
-            "layer3": np.array([0.01, 0.02, 0.03]),
+        Covers multiple layers, a scalar param, and total_steps scaling in one shot — this
+        replaces the fork's re-implemented percentile/gamma unit tests, which duplicated
+        NVFLARE's own coverage.
+        """
+        data = {
+            "layer1": np.array([-0.5, -0.2, 0.1, 0.3, 0.8]),
+            "layer2": np.array([[2.0, -2.0], [0.05, -0.4]]),
+            "scalar": np.array(0.5),
         }
-        dxo = DXO(data_kind=DataKind.WEIGHT_DIFF, data=weights)
-        dxo.set_meta_prop(MetaKey.NUM_STEPS_CURRENT_ROUND, 1)
+        flip_result = PercentilePrivacy(percentile=40, gamma=0.5).process_dxo(
+            self._weight_diff_dxo(data, total_steps=3), self.shareable, self.fl_ctx
+        )
+        stock_result = NVFlarePercentilePrivacy(percentile=40, gamma=0.5).process_dxo(
+            self._weight_diff_dxo(data, total_steps=3), self.shareable, self.fl_ctx
+        )
 
-        result = filter.process_dxo(dxo, self.shareable, self.fl_ctx)
+        assert flip_result is not None
+        assert stock_result is not None
+        assert flip_result.data.keys() == stock_result.data.keys()
+        for name in data:
+            np.testing.assert_array_equal(flip_result.data[name], stock_result.data[name])
 
-        assert result is not None
-        assert len(result.data) == 3
-        assert "layer1" in result.data
-        assert "layer2" in result.data
-        assert "layer3" in result.data
+    def test_process_dxo_when_on_returns_none_for_invalid_gamma(self):
+        """Delegation preserves stock's guard clauses (gamma <= 0 -> None)."""
+        f = PercentilePrivacy(gamma=-0.01)
+        dxo = self._weight_diff_dxo({"layer1": np.array([1.0, 2.0, 3.0])})
 
-    def test_process_dxo_with_zero_values(self):
-        """Test that filter handles arrays with zero values"""
-        filter = PercentilePrivacy(percentile=50, gamma=1.0)
-
-        weights = {"layer1": np.array([0.0, 0.0, 0.0, 0.1, 0.2])}
-        dxo = DXO(data_kind=DataKind.WEIGHT_DIFF, data=weights)
-        dxo.set_meta_prop(MetaKey.NUM_STEPS_CURRENT_ROUND, 1)
-
-        result = filter.process_dxo(dxo, self.shareable, self.fl_ctx)
-
-        assert result is not None
-        assert "layer1" in result.data
-
-    def test_process_dxo_preserves_shape(self):
-        """Test that filter preserves array shapes"""
-        filter = PercentilePrivacy(percentile=50, gamma=1.0)
-
-        # Create 2D array
-        original_shape = (3, 4)
-        weights = {"layer1": np.random.randn(*original_shape)}
-        dxo = DXO(data_kind=DataKind.WEIGHT_DIFF, data=weights)
-        dxo.set_meta_prop(MetaKey.NUM_STEPS_CURRENT_ROUND, 1)
-
-        result = filter.process_dxo(dxo, self.shareable, self.fl_ctx)
-
-        assert result is not None
-        assert result.data["layer1"].shape == original_shape
-
-    def test_process_dxo_extreme_percentile_0(self):
-        """Test filter with 0th percentile (most aggressive filtering)"""
-        filter = PercentilePrivacy(percentile=0, gamma=1.0)
-
-        weights = {"layer1": np.array([0.1, 0.2, 0.3, 0.4, 0.5])}
-        dxo = DXO(data_kind=DataKind.WEIGHT_DIFF, data=weights)
-        dxo.set_meta_prop(MetaKey.NUM_STEPS_CURRENT_ROUND, 1)
-
-        result = filter.process_dxo(dxo, self.shareable, self.fl_ctx)
-
-        assert result is not None
-        # With 0th percentile, cutoff is minimum, so most/all values should remain
-
-    def test_process_dxo_extreme_percentile_100(self):
-        """Test filter with 100th percentile (least aggressive filtering)"""
-        filter = PercentilePrivacy(percentile=100, gamma=1.0)
-
-        weights = {"layer1": np.array([0.1, 0.2, 0.3, 0.4, 0.5])}
-        dxo = DXO(data_kind=DataKind.WEIGHT_DIFF, data=weights)
-        dxo.set_meta_prop(MetaKey.NUM_STEPS_CURRENT_ROUND, 1)
-
-        result = filter.process_dxo(dxo, self.shareable, self.fl_ctx)
-
-        assert result is not None
-        # With 100th percentile, cutoff is maximum, so most values might be zeroed
+        assert f.process_dxo(dxo, self.shareable, self.fl_ctx) is None

--- a/flip-utils/tests/unit/nvflare/components/test_evaluation_json_generator.py
+++ b/flip-utils/tests/unit/nvflare/components/test_evaluation_json_generator.py
@@ -15,6 +15,7 @@ import os
 import tempfile
 from unittest.mock import MagicMock, Mock
 
+import numpy as np
 from nvflare.apis.dxo import DXO, DataKind
 from nvflare.apis.event_type import EventType
 from nvflare.app_common.app_constant import AppConstants
@@ -22,6 +23,7 @@ from nvflare.app_common.app_event_type import AppEventType
 
 from flip.constants import PTConstants
 from flip.nvflare.components.evaluation_json_generator import EvaluationJsonGenerator
+from flip.nvflare.components.validation_json_generator import ValidationJsonGenerator as FlipValidationJsonGenerator
 
 
 class TestEvaluationJsonGenerator:
@@ -201,3 +203,41 @@ class TestEvaluationJsonGenerator:
             assert client in self.generator._eval_results
             assert client in self.generator._eval_results
             assert client in self.generator._eval_results
+
+    # --- de-fork contract: deduped as a subclass of FLIP's ValidationJsonGenerator ---
+
+    def test_subclasses_flip_validation_json_generator(self):
+        """De-fork guard: shares FLIP's manual-dispatch base (no-op handle_event + numpy encoder)."""
+        assert issubclass(EvaluationJsonGenerator, FlipValidationJsonGenerator)
+        assert isinstance(EvaluationJsonGenerator(), FlipValidationJsonGenerator)
+
+    def test_handle_event_is_a_noop(self):
+        """Auto-dispatched handle_event must not process events; ServerEventHandler drives
+        handle_evaluation_events instead (else each result is recorded twice)."""
+        dxo = DXO(data_kind=DataKind.METRICS, data={"accuracy": 0.9})
+        self.fl_ctx.get_prop.side_effect = lambda key, default=None: {
+            AppConstants.DATA_CLIENT: "c",
+            AppConstants.VALIDATION_RESULT: dxo.to_shareable(),
+        }.get(key, default)
+
+        self.generator.handle_event(AppEventType.VALIDATION_RESULT_RECEIVED, self.fl_ctx)
+
+        assert self.generator._eval_results == {}
+
+    def test_handle_end_run_encodes_numpy_floats(self):
+        """Gained from the shared base: np.float32 metrics serialise (fork's json.dump raised)."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            run_dir = os.path.join(tmpdir, "run_1")
+            os.makedirs(run_dir)
+            mock_engine = Mock()
+            mock_engine.get_workspace.return_value.get_run_dir.return_value = run_dir
+            self.fl_ctx.get_engine.return_value = mock_engine
+            self.fl_ctx.get_job_id.return_value = "job_123"
+            self.generator._eval_results = {"client1": {"dice": np.float32(0.5)}}
+
+            self.generator.handle_evaluation_events(EventType.END_RUN, self.fl_ctx)
+
+            json_file = os.path.join(run_dir, self.generator._results_dir, self.generator._json_file_name)
+            with open(json_file) as f:
+                saved = json.load(f)
+            assert saved["client1"]["dice"] == 0.5

--- a/flip-utils/tests/unit/nvflare/components/test_stage_percentile_privacy.py
+++ b/flip-utils/tests/unit/nvflare/components/test_stage_percentile_privacy.py
@@ -18,6 +18,7 @@ import numpy as np
 from nvflare.apis.dxo import DXO, DataKind, MetaKey
 
 from flip.constants import FlipMetaKey
+from flip.nvflare.components.custom_percentile_privacy import PercentilePrivacy
 from flip.nvflare.components.stage_percentile_privacy import StagePercentilePrivacy
 
 
@@ -26,6 +27,12 @@ class TestStagePercentilePrivacy:
         self.fl_ctx = MagicMock()
         self.fl_ctx.get_peer_context.return_value = None
         self.shareable = MagicMock()
+
+    def test_subclasses_flip_percentile_privacy(self):
+        """De-fork guard: inherits FLIP's PercentilePrivacy __init__/off (and, transitively, stock)
+        while keeping its own per-stage process_dxo."""
+        assert issubclass(StagePercentilePrivacy, PercentilePrivacy)
+        assert isinstance(StagePercentilePrivacy(), PercentilePrivacy)
 
     def test_init_default_values(self):
         f = StagePercentilePrivacy()

--- a/flip-utils/tests/unit/nvflare/components/test_validation_json_generator.py
+++ b/flip-utils/tests/unit/nvflare/components/test_validation_json_generator.py
@@ -15,10 +15,14 @@ import os
 import tempfile
 from unittest.mock import MagicMock, Mock
 
+import numpy as np
 from nvflare.apis.dxo import DXO, DataKind
 from nvflare.apis.event_type import EventType
 from nvflare.app_common.app_constant import AppConstants
 from nvflare.app_common.app_event_type import AppEventType
+from nvflare.app_common.widgets.validation_json_generator import (
+    ValidationJsonGenerator as NVFlareValidationJsonGenerator,
+)
 
 from flip.nvflare.components.validation_json_generator import ValidationJsonGenerator
 
@@ -249,3 +253,60 @@ class TestValidationJsonGenerator:
         for model in models:
             assert model in self.generator._val_results[data_client]
             assert model in self.generator._val_results[data_client]
+
+    # --- de-fork contract: thin subclass of stock, dispatched manually ---
+
+    def test_subclasses_stock_validation_json_generator(self):
+        """De-fork guard: subclass stock so the COLLECTION/T2 branch + numpy encoder track upstream."""
+        assert issubclass(ValidationJsonGenerator, NVFlareValidationJsonGenerator)
+        assert isinstance(ValidationJsonGenerator(), NVFlareValidationJsonGenerator)
+
+    def test_handle_event_is_a_noop(self):
+        """FLIP dispatches manually via handle_evaluation_events (ServerEventHandler). The
+        auto-dispatched handle_event must NOT process events, or every result is counted twice."""
+        dxo = DXO(data_kind=DataKind.METRICS, data={"accuracy": 0.9})
+        self.fl_ctx.get_prop.side_effect = lambda key, default=None: {
+            AppConstants.MODEL_OWNER: "m",
+            AppConstants.DATA_CLIENT: "c",
+            AppConstants.VALIDATION_RESULT: dxo.to_shareable(),
+        }.get(key, default)
+
+        self.generator.handle_event(AppEventType.VALIDATION_RESULT_RECEIVED, self.fl_ctx)
+
+        assert self.generator._val_results == {}
+
+    def test_handle_evaluation_events_collection_dxo_unpacks_leaves(self):
+        """Gained from stock: a COLLECTION (T2) DXO unpacks each leaf metric (fork rejected it)."""
+        leaf = DXO(data_kind=DataKind.METRICS, data={"accuracy": 0.8})
+        collection = DXO(data_kind=DataKind.COLLECTION, data={"sub_client": leaf})
+        self.fl_ctx.get_prop.side_effect = lambda key, default=None: {
+            AppConstants.MODEL_OWNER: "model1",
+            AppConstants.DATA_CLIENT: "site1",
+            AppConstants.VALIDATION_RESULT: collection.to_shareable(),
+        }.get(key, default)
+
+        self.generator.handle_evaluation_events(AppEventType.VALIDATION_RESULT_RECEIVED, self.fl_ctx)
+
+        assert self.generator._val_results != {}, "COLLECTION dxo should be unpacked, not rejected"
+        recorded = [metric for client in self.generator._val_results.values() for metric in client.values()]
+        assert {"accuracy": 0.8} in recorded
+
+    def test_handle_end_run_encodes_numpy_floats(self):
+        """Gained from stock: np.float32 metrics serialise via the to_serializable encoder."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            run_dir = os.path.join(tmpdir, "run_1")
+            os.makedirs(run_dir)
+            mock_engine = Mock()
+            mock_engine.get_workspace.return_value.get_run_dir.return_value = run_dir
+            self.fl_ctx.get_engine.return_value = mock_engine
+            self.fl_ctx.get_job_id.return_value = "job_123"
+            # 0.5 is exactly representable in float32, so the round-trip is exact — the point is
+            # that np.float32 serialises at all (the fork's plain json.dump raised TypeError).
+            self.generator._val_results = {"site1": {"model1": {"accuracy": np.float32(0.5)}}}
+
+            self.generator.handle_evaluation_events(EventType.END_RUN, self.fl_ctx)
+
+            json_file = os.path.join(run_dir, self.generator._results_dir, self.generator._json_file_name)
+            with open(json_file) as f:
+                saved = json.load(f)
+            assert saved["site1"]["model1"]["accuracy"] == 0.5

--- a/flip-utils/tests/unit/nvflare/controllers/test_cross_site_model_eval.py
+++ b/flip-utils/tests/unit/nvflare/controllers/test_cross_site_model_eval.py
@@ -12,275 +12,153 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 from nvflare.apis.dxo import DXO, DataKind
 from nvflare.apis.fl_constant import ReturnCode
-from nvflare.apis.shareable import Shareable
-from nvflare.app_common.app_constant import AppConstants
+from nvflare.app_common.workflows.cross_site_model_eval import CrossSiteModelEval as NVFlareCrossSiteModelEval
 
+from flip.constants import FlipTasks
 from flip.nvflare.controllers.cross_site_model_eval import CrossSiteModelEval
+
+_MODEL_ID = "123e4567-e89b-12d3-a456-426614174000"
+
+
+def _make(**kwargs) -> CrossSiteModelEval:
+    kwargs.setdefault("model_id", _MODEL_ID)
+    controller = CrossSiteModelEval(**kwargs)
+    controller.flip = MagicMock()
+    for method in ("log_info", "log_debug", "log_error", "log_exception", "fire_event"):
+        setattr(controller, method, MagicMock())
+    return controller
+
+
+def _fl_ctx() -> MagicMock:
+    """MagicMock FLContext with the two lookups nvflare's log/event helpers validate."""
+    fl_ctx = MagicMock()
+    fl_ctx.get_peer_context.return_value = None
+    fl_ctx.get_prop.return_value = None
+    return fl_ctx
 
 
 class TestCrossSiteModelEval:
-    def test_init_stores_model_id_as_fallback(self):
-        """Construction stores model_id as fallback; _model_id cache starts as None."""
-        model_id = "123e4567-e89b-12d3-a456-426614174000"
-        controller = CrossSiteModelEval(model_id=model_id)
-        assert controller._model_id_fallback == model_id
+    """FLIP's CrossSiteModelEval subclasses stock and adds only: FLIP model-id resolution,
+    a POST_VALIDATION cleanup broadcast on normal completion, and reporting client execution
+    exceptions to the hub. Everything else (T2 multi-DXO handling, path-safety, saving/loading)
+    is inherited from stock rather than vendored.
+    """
+
+    def test_subclasses_stock_cross_site_model_eval(self):
+        """De-fork guard: must subclass stock so it inherits get_leaf_dxos + resolve_path_under_root."""
+        assert issubclass(CrossSiteModelEval, NVFlareCrossSiteModelEval)
+        assert isinstance(_make(), NVFlareCrossSiteModelEval)
+
+    def test_init_stores_flip_model_id_and_cleanup_timeout(self):
+        controller = _make(cleanup_timeout=42)
+        assert controller._model_id_fallback == _MODEL_ID
         assert controller._model_id is None
+        assert controller._cleanup_timeout == 42
+        assert controller.flip is not None
 
-    def test_resolve_model_id_uses_fallback_when_fl_ctx_has_no_custom_props(self):
-        """Lazy resolution returns the constructor UUID when fl_ctx has no custom_props."""
-        model_id = "123e4567-e89b-12d3-a456-426614174000"
-        controller = CrossSiteModelEval(model_id=model_id)
-        fl_ctx = MagicMock()
-        fl_ctx.get_prop.return_value = None
-        result = controller._resolve_model_id(fl_ctx)
-        assert result == model_id
-
-    def test_init_invalid_task_check_period(self):
+    def test_init_invalid_task_check_period_raises(self):
+        """Stock's type validation is inherited."""
         with pytest.raises(TypeError):
-            CrossSiteModelEval(task_check_period="not-a-float", model_id="123e4567-e89b-12d3-a456-426614174000")
+            CrossSiteModelEval(task_check_period="not-a-float", model_id=_MODEL_ID)
 
-    def test_start_controller_no_engine(self):
-        controller = CrossSiteModelEval(model_id="123e4567-e89b-12d3-a456-426614174000")
-        fl_ctx = MagicMock()
-        fl_ctx.get_peer_context.return_value = None
-        fl_ctx.get_engine.return_value = None
+    def test_resolve_model_id_uses_fallback_when_fl_ctx_has_no_props(self):
+        controller = _make()
+        fl_ctx = _fl_ctx()
+        assert controller._resolve_model_id(fl_ctx) == _MODEL_ID
 
-        controller.system_panic = MagicMock()
-        controller.start_controller(fl_ctx)
+    def test_accept_local_model_reports_execution_exception_to_hub(self):
+        controller = _make()
+        result = MagicMock()
+        result.get_return_code.return_value = ReturnCode.EXECUTION_EXCEPTION
+        result.get_header.return_value = "boom-traceback"
+        fl_ctx = _fl_ctx()
 
-        controller.system_panic.assert_called_once()
+        controller._accept_local_model(client_name="c1", result=result, fl_ctx=fl_ctx)
 
-    @patch("os.path.exists", return_value=True)
-    @patch("shutil.rmtree")
-    @patch("os.makedirs")
-    def test_start_controller_creates_dirs_and_sets_props(self, mock_makedirs, mock_rmtree, mock_exists):
-        controller = CrossSiteModelEval(model_id="123e4567-e89b-12d3-a456-426614174000")
+        controller.flip.send_handled_exception.assert_called_once()
+        kwargs = controller.flip.send_handled_exception.call_args.kwargs
+        assert kwargs["formatted_exception"] == "boom-traceback"
+        assert kwargs["client_name"] == "c1"
+        assert kwargs["model_id"] == _MODEL_ID
 
-        fl_ctx = MagicMock()
-        fl_ctx.get_peer_context.return_value = None
-        engine = MagicMock()
-        client1 = MagicMock()
-        client1.name = "c1"
-        engine.get_clients.return_value = [client1]
-        workspace = MagicMock()
-        workspace.get_run_dir.return_value = "/run"
-        engine.get_workspace.return_value = workspace
-        fl_ctx.get_engine.return_value = engine
-        fl_ctx.get_job_id.return_value = "job1"
+    def test_accept_val_result_reports_execution_exception_to_hub(self):
+        controller = _make()
+        result = MagicMock()
+        result.get_cookie.return_value = "SRV_best"
+        result.get_return_code.return_value = ReturnCode.EXECUTION_EXCEPTION
+        result.get_header.return_value = "val-boom"
+        fl_ctx = _fl_ctx()
 
-        controller.fire_event = MagicMock()
+        controller._accept_val_result(client_name="c1", result=result, fl_ctx=fl_ctx)
 
-        controller.start_controller(fl_ctx)
+        controller.flip.send_handled_exception.assert_called_once()
+        assert controller.flip.send_handled_exception.call_args.kwargs["formatted_exception"] == "val-boom"
 
-        # participating client set and event fired
-        assert "c1" in controller._participating_clients
-        controller.fire_event.assert_called()
-        mock_rmtree.assert_called()
-        mock_makedirs.assert_called()
+    def test_accept_local_model_ok_delegates_to_stock_save_and_sends_validation(self, tmp_path):
+        """OK path delegates to stock, which is T2-aware (get_leaf_dxos) and path-safe."""
+        controller = _make()
+        controller._cross_val_models_dir = str(tmp_path)
+        controller._send_validation_task = MagicMock()
 
-    @patch("os.path.exists", return_value=True)
-    @patch("shutil.rmtree")
-    @patch("os.makedirs")
-    def test_start_controller_bad_model_locator(self, mock_makedirs, mock_rmtree, mock_exists):
-        controller = CrossSiteModelEval(model_id="123e4567-e89b-12d3-a456-426614174000", model_locator_id="mloc")
-        fl_ctx = MagicMock()
-        fl_ctx.get_peer_context.return_value = None
-        engine = MagicMock()
-        fl_ctx.get_engine.return_value = engine
-        engine.get_clients.return_value = []
-        # provide a non ModelLocator
-        engine.get_workspace.return_value = MagicMock()
-        engine.get_component.return_value = "not_a_locator"
+        # METRICS dict (FOBS-serialisable without the numpy decomposer that only registers under
+        # full nvflare init); the real WEIGHTS path is covered by the tutorial integration sweep.
+        dxo = DXO(data_kind=DataKind.METRICS, data={"accuracy": 0.5})
+        result = dxo.to_shareable()  # carries ReturnCode.OK
+        fl_ctx = _fl_ctx()
 
-        controller.system_panic = MagicMock()
-        controller.fire_event = MagicMock()
-        controller.start_controller(fl_ctx)
+        controller._accept_local_model(client_name="c1", result=result, fl_ctx=fl_ctx)
 
-        controller.system_panic.assert_called_once()
-        mock_rmtree.assert_called()
-        mock_makedirs.assert_called()
+        # stock saved the single leaf DXO under the client name and triggered its validation
+        assert "c1" in controller._client_models
+        controller._send_validation_task.assert_called_once_with("c1", fl_ctx)
+        controller.flip.send_handled_exception.assert_not_called()
 
-    def test_control_flow_no_clients_timeout(self):
-        controller = CrossSiteModelEval(model_id="123e4567-e89b-12d3-a456-426614174000")
-        controller._participating_clients = []
-        controller._wait_for_clients_timeout = 0
-
-        fl_ctx = MagicMock()
-        fl_ctx.get_peer_context.return_value = None
-        engine = MagicMock()
-        engine.get_clients.return_value = []
-        fl_ctx.get_engine.return_value = engine
-
-        abort_signal = MagicMock()
-        abort_signal.triggered = False
-
-        # Should return quickly due to zero timeout
-        controller.control_flow(abort_signal, fl_ctx)
-
-    def test_control_flow_broadcast_submit_model_called(self):
-        controller = CrossSiteModelEval(model_id="123e4567-e89b-12d3-a456-426614174000")
-        controller._participating_clients = ["c1", "c2"]
-        controller._submit_model_task_name = "submit"
-
-        fl_ctx = MagicMock()
-        fl_ctx.get_peer_context.return_value = None
-        fl_ctx.get_engine.return_value = MagicMock()
-
+    def _wire_for_control_flow(self, controller, *, standing_tasks=0):
+        controller._submit_model_task_name = ""  # skip submit-model broadcast
+        controller._model_locator = None  # skip server-model validation
+        controller.get_num_standing_tasks = MagicMock(return_value=standing_tasks)
         controller.broadcast = MagicMock()
         controller.broadcast_and_wait = MagicMock()
 
+    def test_control_flow_normal_completion_broadcasts_post_validation_cleanup(self):
+        controller = _make()
+        controller._participating_clients = ["c1", "c2"]
+        self._wire_for_control_flow(controller)
         abort_signal = MagicMock()
         abort_signal.triggered = False
 
-        controller.control_flow(abort_signal, fl_ctx)
+        controller.control_flow(abort_signal, _fl_ctx())
 
-        controller.broadcast.assert_called_once()
+        controller.broadcast_and_wait.assert_called_once()
+        cleanup_task = controller.broadcast_and_wait.call_args.kwargs["task"]
+        assert cleanup_task.name == FlipTasks.POST_VALIDATION.value
 
-    def test_accept_local_model_handles_error_return_code(self):
-        controller = CrossSiteModelEval(model_id="123e4567-e89b-12d3-a456-426614174000")
-        controller.flip = MagicMock()
-        controller.log_error = MagicMock()
-        controller.fire_event = MagicMock()
+    def test_control_flow_abort_skips_post_validation_cleanup(self):
+        controller = _make()
+        controller._participating_clients = ["c1"]
+        self._wire_for_control_flow(controller)
+        abort_signal = MagicMock()
+        abort_signal.triggered = True  # stock returns early; cleanup must NOT run post-abort
 
-        share = Shareable()
-        share.set_header = MagicMock()
-        share.get_return_code = MagicMock(return_value=ReturnCode.EXECUTION_EXCEPTION)
-        share.get_header = MagicMock(return_value="boom")
+        controller.control_flow(abort_signal, _fl_ctx())
 
-        # should call send_handled_exception
-        fl_ctx = MagicMock()
-        fl_ctx.get_peer_context.return_value = None
-        controller._accept_local_model(client_name="c1", result=share, fl_ctx=fl_ctx)
+        controller.broadcast_and_wait.assert_not_called()
 
-        controller.flip.send_handled_exception.assert_called()
+    def test_control_flow_no_participating_clients_skips_cleanup(self):
+        controller = _make()
+        controller._participating_clients = []
+        controller._wait_for_clients_timeout = 0
+        controller._engine = MagicMock()
+        controller._engine.get_clients.return_value = []
+        self._wire_for_control_flow(controller)
+        abort_signal = MagicMock()
+        abort_signal.triggered = False
 
-    def test_accept_local_model_ok_calls_save_and_send(self):
-        controller = CrossSiteModelEval(model_id="123e4567-e89b-12d3-a456-426614174000")
-        controller._cross_val_models_dir = "/models"
-        controller._send_validation_task = MagicMock()
+        controller.control_flow(abort_signal, _fl_ctx())
 
-        # patch from_shareable to return a DXO-like object
-        with patch("flip.nvflare.controllers.cross_site_model_eval.from_shareable", return_value=MagicMock()):
-            with patch.object(controller, "_save_validation_content", return_value="/models/c1"):
-                share = Shareable()
-                share.get_return_code = MagicMock(return_value=ReturnCode.OK)
-                fl_ctx = MagicMock()
-                fl_ctx.get_peer_context.return_value = None
-                controller.fire_event = MagicMock()
-                controller._accept_local_model(client_name="c1", result=share, fl_ctx=fl_ctx)
-
-                assert controller._client_models.get("c1") == "/models/c1"
-                controller._send_validation_task.assert_called()
-
-    def test_before_send_validate_task_cb_model_not_found(self):
-        controller = CrossSiteModelEval(model_id="123e4567-e89b-12d3-a456-426614174000")
-        fl_ctx = MagicMock()
-        fl_ctx.get_peer_context.return_value = None
-        client_task = MagicMock()
-        client_task.task.props = {AppConstants.MODEL_OWNER: "m1"}
-
-        # make loader raise ValueError
-        with patch.object(controller, "_load_validation_content", side_effect=ValueError("nope")):
-            controller.system_panic = MagicMock()
-            controller.fire_event = MagicMock()
-            controller.log_error = MagicMock()
-            controller._before_send_validate_task_cb(client_task, fl_ctx)
-            controller.system_panic.assert_called()
-
-    def test_locate_server_models_invalid_dxo(self):
-        controller = CrossSiteModelEval(model_id="123e4567-e89b-12d3-a456-426614174000")
-        fl_ctx = MagicMock()
-        fl_ctx.get_peer_context.return_value = None
-        controller._model_locator = MagicMock()
-        controller._model_locator.get_model_names.return_value = ["m1"]
-        controller._model_locator.locate_model.return_value = "not_a_dxo"
-
-        controller.system_panic = MagicMock()
-        controller.log_info = MagicMock()
-        controller.fire_event = MagicMock()
-        res = controller._locate_server_models(fl_ctx)
-        assert res is False
-        controller.system_panic.assert_called()
-
-    def test_locate_server_models_success(self):
-        controller = CrossSiteModelEval(model_id="123e4567-e89b-12d3-a456-426614174000")
-        fl_ctx = MagicMock()
-        fl_ctx.get_peer_context.return_value = None
-        controller._model_locator = MagicMock()
-        controller._model_locator.get_model_names.return_value = ["m1"]
-        controller._model_locator.locate_model.return_value = MagicMock()
-
-        with patch("flip.nvflare.controllers.cross_site_model_eval.DXO", MagicMock):
-            with patch.object(controller, "_save_validation_content", return_value="/models/SRV_m1"):
-                controller.log_info = MagicMock()
-                controller.fire_event = MagicMock()
-                res = controller._locate_server_models(fl_ctx)
-
-        assert res is True
-        assert "SRV_m1" in controller._server_models
-
-
-@pytest.mark.parametrize(
-    ("name", "data_kind", "data", "meta"),
-    [
-        (
-            "metrics_sample",
-            DataKind.METRICS,
-            {"val_acc": 0.007118524517863989},
-            {},
-        )
-    ],
-)
-def test_save_and_load_validation_content(tmp_path, name, data_kind, data, meta, monkeypatch):
-    """Test saving and loading validation content with DXO."""
-    from pathlib import Path
-
-    # Arrange: controller instance with a valid UUID (required by __init__)
-    controller = CrossSiteModelEval(model_id="123e4567-e89b-12d3-a456-426614174000")
-
-    # ---- 🧩 Mock out logging to avoid FLContext internals ----
-    monkeypatch.setattr(controller, "log_debug", lambda *a, **kw: None)
-    monkeypatch.setattr(controller, "log_info", lambda *a, **kw: None)
-    monkeypatch.setattr(controller, "log_error", lambda *a, **kw: None)
-    monkeypatch.setattr(controller, "log_exception", lambda *a, **kw: None)
-    monkeypatch.setattr(controller, "system_panic", lambda *a, **kw: None)
-    # -----------------------------------------------------------
-
-    fl_ctx = MagicMock()
-
-    # Create a DXO to persist
-    dxo = DXO(data_kind=data_kind, data=data, meta=meta)
-
-    # Ensure directory exists
-    save_dir = tmp_path / "cross_val_models"
-    save_dir.mkdir(parents=True, exist_ok=True)
-
-    # Act: save the DXO, then load it back
-    saved_path = controller._save_validation_content(
-        name=name,
-        save_dir=str(save_dir),
-        dxo=dxo,
-        fl_ctx=fl_ctx,
-    )
-
-    # Assert: a file with this base path should exist (DXO manages its own extension(s))
-    assert Path(saved_path).exists() or any(
-        Path(str(saved_path) + ext).exists() for ext in (".npy", ".npz", ".json")
-    ), f"Expected saved DXO file(s) for base path {saved_path}"
-
-    loaded = controller._load_validation_content(
-        name=name,
-        load_dir=str(save_dir),
-        fl_ctx=fl_ctx,
-    )
-
-    # Validate round-trip content
-    assert isinstance(loaded, DXO)
-    assert loaded.data_kind == data_kind
-    assert loaded.data == data
-    assert loaded.meta == meta
+        controller.broadcast_and_wait.assert_not_called()

--- a/flip-utils/tests/unit/nvflare/controllers/test_cross_site_model_eval.py
+++ b/flip-utils/tests/unit/nvflare/controllers/test_cross_site_model_eval.py
@@ -162,3 +162,24 @@ class TestCrossSiteModelEval:
         controller.control_flow(abort_signal, _fl_ctx())
 
         controller.broadcast_and_wait.assert_not_called()
+
+    def test_init_invalid_cleanup_timeout_type_raises(self):
+        with pytest.raises(TypeError, match="cleanup_timeout must be int"):
+            CrossSiteModelEval(model_id=_MODEL_ID, cleanup_timeout="not-an-int")
+
+    def test_init_negative_cleanup_timeout_raises(self):
+        with pytest.raises(ValueError, match="cleanup_timeout must be greater"):
+            CrossSiteModelEval(model_id=_MODEL_ID, cleanup_timeout=-1)
+
+    def test_control_flow_cleanup_exception_triggers_system_panic(self):
+        controller = _make()
+        controller._participating_clients = ["c1"]
+        self._wire_for_control_flow(controller)
+        controller.broadcast_and_wait = MagicMock(side_effect=RuntimeError("cleanup boom"))
+        controller.system_panic = MagicMock()
+        abort_signal = MagicMock()
+        abort_signal.triggered = False
+
+        controller.control_flow(abort_signal, _fl_ctx())
+
+        controller.system_panic.assert_called_once()

--- a/flip-utils/tests/unit/nvflare/controllers/test_fed_evaluation.py
+++ b/flip-utils/tests/unit/nvflare/controllers/test_fed_evaluation.py
@@ -11,10 +11,12 @@
 #
 
 import os
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
+from nvflare.apis.dxo import DXO, DataKind
 from nvflare.apis.fl_constant import ReturnCode
+from nvflare.widgets.info_collector import GroupInfoCollector, InfoCollector
 
 from flip.constants import FlipTasks, PTConstants
 from flip.nvflare.controllers.cross_site_model_eval import CrossSiteModelEval as FlipCrossSiteModelEval
@@ -37,6 +39,20 @@ def _fl_ctx() -> MagicMock:
     fl_ctx.get_peer_context.return_value = None
     fl_ctx.get_prop.return_value = None
     return fl_ctx
+
+
+class _AbortAfter:
+    """abort_signal whose ``triggered`` returns False until the Nth read, then True — lets a test
+    drive control_flow to a specific abort checkpoint."""
+
+    def __init__(self, trigger_on: int):
+        self._reads = 0
+        self._trigger_on = trigger_on
+
+    @property
+    def triggered(self) -> bool:
+        self._reads += 1
+        return self._reads >= self._trigger_on
 
 
 class TestModelEval:
@@ -130,3 +146,328 @@ class TestModelEval:
         assert controller.broadcast.call_args.kwargs["task"].name == "validate"
         controller.broadcast_and_wait.assert_called_once()
         assert controller.broadcast_and_wait.call_args.kwargs["task"].name == FlipTasks.POST_TASK.value
+
+    # --- coverage for the overridden collection-evaluation methods ---
+
+    def test_start_controller_no_engine_panics(self):
+        controller = _make()
+        fl_ctx = _fl_ctx()
+        fl_ctx.get_engine.return_value = None
+        controller.system_panic = MagicMock()
+
+        controller.start_controller(fl_ctx)
+
+        controller.system_panic.assert_called_once()
+
+    @patch("os.makedirs")
+    @patch("shutil.rmtree")
+    @patch("os.path.exists", return_value=True)
+    def test_start_controller_sets_eval_dir_and_registers_clients(self, mock_exists, mock_rmtree, mock_makedirs):
+        controller = _make()
+        engine = MagicMock()
+        client = MagicMock()
+        client.name = "c1"
+        engine.get_clients.return_value = [client]
+        engine.get_workspace.return_value.get_run_dir.return_value = "/run"
+        fl_ctx = _fl_ctx()
+        fl_ctx.get_engine.return_value = engine
+
+        controller.start_controller(fl_ctx)
+
+        assert "c1" in controller._participating_clients
+        assert controller._eval_results["c1"] == {}
+        assert controller._eval_results_dir == os.path.join("/run", PTConstants.EvalDir)
+
+    def test_control_flow_locates_server_models_then_evaluates(self):
+        controller = _make(evaluation_task_name="validate")
+        controller._participating_clients = ["c1"]
+        controller._model_locator = MagicMock()
+        controller._locate_server_models = MagicMock(return_value=True)
+        controller.get_num_standing_tasks = MagicMock(return_value=0)
+        controller.broadcast = MagicMock()
+        controller.broadcast_and_wait = MagicMock()
+        abort_signal = MagicMock()
+        abort_signal.triggered = False
+
+        controller.control_flow(abort_signal, _fl_ctx())
+
+        controller._locate_server_models.assert_called_once()
+        controller.broadcast.assert_called_once()
+
+    def test_control_flow_locate_fails_returns_before_broadcast(self):
+        controller = _make()
+        controller._participating_clients = ["c1"]
+        controller._model_locator = MagicMock()
+        controller._locate_server_models = MagicMock(return_value=False)
+        controller.broadcast = MagicMock()
+        abort_signal = MagicMock()
+        abort_signal.triggered = False
+
+        controller.control_flow(abort_signal, _fl_ctx())
+
+        controller.broadcast.assert_not_called()
+
+    def test_control_flow_exception_triggers_system_panic(self):
+        controller = _make()
+        controller._participating_clients = ["c1"]
+        controller._model_locator = None
+        controller.broadcast = MagicMock(side_effect=RuntimeError("boom"))
+        controller.system_panic = MagicMock()
+        abort_signal = MagicMock()
+        abort_signal.triggered = False
+
+        controller.control_flow(abort_signal, _fl_ctx())
+
+        controller.system_panic.assert_called_once()
+
+    def test_locate_server_models_loads_collection(self):
+        controller = _make()
+        all_models = MagicMock()
+        all_models.data = {"m1": DXO(data_kind=DataKind.METRICS, data={"a": 1})}
+        controller._model_locator = MagicMock()
+        controller._model_locator.locate_model.return_value = all_models
+        controller._model_locator.model_names = ["m1"]
+
+        assert controller._locate_server_models(_fl_ctx()) is True
+        assert controller._all_models_dxo is all_models
+        assert controller._eval_results["m1"] == {}
+
+    def test_locate_server_models_non_dxo_panics(self):
+        controller = _make()
+        all_models = MagicMock()
+        all_models.data = {"m1": "not-a-dxo"}
+        controller._model_locator = MagicMock()
+        controller._model_locator.locate_model.return_value = all_models
+        controller._model_locator.model_names = ["m1"]
+        controller.system_panic = MagicMock()
+
+        assert controller._locate_server_models(_fl_ctx()) is False
+        controller.system_panic.assert_called_once()
+
+    def test_before_send_validate_task_cb_bundles_all_models(self):
+        controller = _make()
+        controller._all_models_dxo = DXO(data_kind=DataKind.METRICS, data={"a": 1})
+        controller._participating_clients = ["c1"]
+        client_task = MagicMock()
+
+        controller._before_send_validate_task_cb(client_task, _fl_ctx())
+
+        assert client_task.task.data is not None
+
+    def test_before_send_validate_task_cb_empty_models_panics(self):
+        controller = _make()
+        controller._all_models_dxo = None
+        controller.system_panic = MagicMock()
+
+        controller._before_send_validate_task_cb(MagicMock(), _fl_ctx())
+
+        controller.system_panic.assert_called_once()
+
+    def test_handle_event_get_stats_reports_eval_results(self):
+        controller = _make()
+        controller._formatter = MagicMock()
+        controller._formatter.format.return_value = {"acc": 0.9}
+        controller._eval_results = {"c1": "/eval/c1"}
+        collector = MagicMock(spec=GroupInfoCollector)
+        fl_ctx = _fl_ctx()
+        fl_ctx.get_prop.side_effect = lambda key, default=None: (
+            collector if key == InfoCollector.CTX_KEY_STATS_COLLECTOR else default
+        )
+
+        controller.handle_event(InfoCollector.EVENT_TYPE_GET_STATS, fl_ctx)
+
+        collector.add_info.assert_called_once()
+
+    def test_handle_event_get_stats_without_formatter_warns(self):
+        controller = _make()
+        controller._formatter = None
+        controller.log_warning = MagicMock()
+
+        controller.handle_event(InfoCollector.EVENT_TYPE_GET_STATS, _fl_ctx())
+
+        controller.log_warning.assert_called_once()
+
+    @patch("os.makedirs")
+    @patch("shutil.rmtree")
+    @patch("os.path.exists", return_value=False)
+    def test_start_controller_bad_model_locator_panics(self, mock_exists, mock_rmtree, mock_makedirs):
+        controller = _make(model_locator_id="mloc")
+        controller._participating_clients = ["c1"]
+        engine = MagicMock()
+        engine.get_workspace.return_value.get_run_dir.return_value = "/run"
+        engine.get_component.return_value = "not-a-locator"
+        fl_ctx = _fl_ctx()
+        fl_ctx.get_engine.return_value = engine
+        controller.system_panic = MagicMock()
+
+        controller.start_controller(fl_ctx)
+
+        controller.system_panic.assert_called_once()
+
+    @patch("os.makedirs")
+    @patch("shutil.rmtree")
+    @patch("os.path.exists", return_value=False)
+    def test_start_controller_bad_formatter_panics(self, mock_exists, mock_rmtree, mock_makedirs):
+        controller = _make(formatter_id="fmt")
+        controller._participating_clients = ["c1"]
+        engine = MagicMock()
+        engine.get_workspace.return_value.get_run_dir.return_value = "/run"
+        engine.get_component.return_value = "not-a-formatter"
+        fl_ctx = _fl_ctx()
+        fl_ctx.get_engine.return_value = engine
+        controller.system_panic = MagicMock()
+
+        controller.start_controller(fl_ctx)
+
+        controller.system_panic.assert_called_once()
+
+    @patch("os.makedirs")
+    @patch("shutil.rmtree")
+    @patch("os.path.exists", return_value=False)
+    def test_start_controller_valid_locator_and_formatter(self, mock_exists, mock_rmtree, mock_makedirs):
+        from nvflare.app_common.abstract.formatter import Formatter
+        from nvflare.app_common.abstract.model_locator import ModelLocator
+
+        controller = _make(model_locator_id="mloc", formatter_id="fmt")
+        controller._participating_clients = ["c1"]
+        mloc = MagicMock(spec=ModelLocator)
+        fmt = MagicMock(spec=Formatter)
+        engine = MagicMock()
+        engine.get_workspace.return_value.get_run_dir.return_value = "/run"
+        engine.get_component.side_effect = lambda cid: mloc if cid == "mloc" else fmt
+        fl_ctx = _fl_ctx()
+        fl_ctx.get_engine.return_value = engine
+
+        controller.start_controller(fl_ctx)
+
+        assert controller._model_locator is mloc
+        assert controller._formatter is fmt
+
+    @pytest.mark.parametrize(
+        "rc", [ReturnCode.MISSING_PEER_CONTEXT, ReturnCode.EXECUTION_RESULT_ERROR, "SOME_UNKNOWN_ERROR"]
+    )
+    def test_accept_val_result_error_rc_logs_empty_result(self, rc):
+        controller = _make()
+        result = MagicMock()
+        result.get_return_code.return_value = rc
+        result.get_header.return_value = None
+
+        controller._accept_val_result("c1", result, _fl_ctx())
+
+        assert controller._eval_results["c1"] == {}
+
+    def test_control_flow_no_clients_quits_before_eval(self):
+        controller = _make()
+        controller._participating_clients = []
+        controller._wait_for_clients_timeout = 0
+        controller._model_locator = None
+        engine = MagicMock()
+        engine.get_clients.return_value = []
+        fl_ctx = _fl_ctx()
+        fl_ctx.get_engine.return_value = engine
+        controller.broadcast = MagicMock()
+        abort_signal = MagicMock()
+        abort_signal.triggered = False
+
+        controller.control_flow(abort_signal, fl_ctx)
+
+        controller.broadcast.assert_not_called()
+
+    def test_control_flow_waits_for_standing_tasks(self):
+        controller = _make()
+        controller._participating_clients = ["c1"]
+        controller._model_locator = None
+        controller.get_num_standing_tasks = MagicMock(side_effect=[1, 0])
+        controller.broadcast = MagicMock()
+        controller.broadcast_and_wait = MagicMock()
+        abort_signal = MagicMock()
+        abort_signal.triggered = False
+
+        with patch("time.sleep"):
+            controller.control_flow(abort_signal, _fl_ctx())
+
+        controller.broadcast_and_wait.assert_called_once()
+
+    def test_locate_server_models_no_models(self):
+        controller = _make()
+        all_models = MagicMock()
+        all_models.data = {}
+        controller._model_locator = MagicMock()
+        controller._model_locator.locate_model.return_value = all_models
+        controller._model_locator.model_names = []
+
+        assert controller._locate_server_models(_fl_ctx()) is True
+        assert controller._all_models_dxo is all_models
+
+    def test_control_flow_abort_after_broadcast_skips_cleanup(self):
+        controller = _make()
+        controller._participating_clients = ["c1"]
+        controller._model_locator = None
+        controller.get_num_standing_tasks = MagicMock(return_value=0)
+        controller.broadcast = MagicMock()
+        controller.broadcast_and_wait = MagicMock()
+
+        controller.control_flow(_AbortAfter(trigger_on=1), _fl_ctx())  # aborts at the post-broadcast check
+
+        controller.broadcast_and_wait.assert_not_called()
+
+    def test_control_flow_abort_during_standing_tasks_skips_cleanup(self):
+        controller = _make()
+        controller._participating_clients = ["c1"]
+        controller._model_locator = None
+        controller.get_num_standing_tasks = MagicMock(return_value=1)
+        controller.broadcast = MagicMock()
+        controller.broadcast_and_wait = MagicMock()
+
+        with patch("time.sleep"):
+            controller.control_flow(_AbortAfter(trigger_on=2), _fl_ctx())  # aborts inside the wait loop
+
+        controller.broadcast_and_wait.assert_not_called()
+
+    def test_control_flow_waits_then_proceeds_when_clients_appear(self):
+        controller = _make(evaluation_task_name="validate")
+        controller._participating_clients = []
+        controller._wait_for_clients_timeout = 300
+        controller._model_locator = None
+        controller.get_num_standing_tasks = MagicMock(return_value=0)
+        controller.broadcast = MagicMock()
+        controller.broadcast_and_wait = MagicMock()
+        engine = MagicMock()
+        engine.get_clients.side_effect = [[], ["c1"]]  # empty first, then a client appears
+        fl_ctx = _fl_ctx()
+        fl_ctx.get_engine.return_value = engine
+        abort_signal = MagicMock()
+        abort_signal.triggered = False
+
+        with patch("time.sleep"):
+            controller.control_flow(abort_signal, fl_ctx)
+
+        controller.broadcast.assert_called_once()
+
+    def test_control_flow_abort_during_no_clients_wait(self):
+        controller = _make()
+        controller._participating_clients = []
+        controller._wait_for_clients_timeout = 300  # large, so the loop waits rather than timing out
+        controller._model_locator = None
+        engine = MagicMock()
+        engine.get_clients.return_value = []  # clients never appear
+        fl_ctx = _fl_ctx()
+        fl_ctx.get_engine.return_value = engine
+        controller.broadcast = MagicMock()
+
+        with patch("time.sleep"):
+            controller.control_flow(_AbortAfter(trigger_on=1), fl_ctx)  # aborts at the in-loop check
+
+        controller.broadcast.assert_not_called()
+
+    def test_handle_event_get_stats_non_group_collector_raises(self):
+        controller = _make()
+        controller._formatter = MagicMock()
+        collector = MagicMock()  # a truthy collector that is NOT a GroupInfoCollector
+        fl_ctx = _fl_ctx()
+        fl_ctx.get_prop.side_effect = lambda key, default=None: (
+            collector if key == InfoCollector.CTX_KEY_STATS_COLLECTOR else default
+        )
+
+        with pytest.raises(TypeError, match="collector must be GroupInfoCollector"):
+            controller.handle_event(InfoCollector.EVENT_TYPE_GET_STATS, fl_ctx)

--- a/flip-utils/tests/unit/nvflare/controllers/test_fed_evaluation.py
+++ b/flip-utils/tests/unit/nvflare/controllers/test_fed_evaluation.py
@@ -10,133 +10,123 @@
 # limitations under the License.
 #
 
+import os
 from unittest.mock import MagicMock
 
 import pytest
+from nvflare.apis.fl_constant import ReturnCode
 
+from flip.constants import FlipTasks, PTConstants
+from flip.nvflare.controllers.cross_site_model_eval import CrossSiteModelEval as FlipCrossSiteModelEval
 from flip.nvflare.controllers.fed_evaluation import ModelEval
+
+_MODEL_ID = "123e4567-e89b-12d3-a456-426614174000"
+
+
+def _make(**kwargs) -> ModelEval:
+    kwargs.setdefault("model_id", _MODEL_ID)
+    controller = ModelEval(**kwargs)
+    controller.flip = MagicMock()
+    for method in ("log_info", "log_debug", "log_error", "log_exception", "fire_event"):
+        setattr(controller, method, MagicMock())
+    return controller
+
+
+def _fl_ctx() -> MagicMock:
+    fl_ctx = MagicMock()
+    fl_ctx.get_peer_context.return_value = None
+    fl_ctx.get_prop.return_value = None
+    return fl_ctx
 
 
 class TestModelEval:
-    def test_init_with_valid_uuid(self):
-        """Test initialization with valid UUID stores it as fallback"""
-        model_id = "123e4567-e89b-12d3-a456-426614174000"
-        controller = ModelEval(model_id=model_id)
-        assert controller._model_id_fallback == model_id
+    """ModelEval evaluates a collection of server models against every client. It shares FLIP's
+    eval base (model-id resolution + hub exception reporting) with CrossSiteModelEval by
+    subclassing it, and overrides only the collection-evaluation orchestration.
+    """
+
+    def test_subclasses_flip_cross_site_model_eval(self):
+        """De-fork guard: shares one FLIP eval base; this also *defines* _validation_task_name
+        and the other attrs the fork referenced but never assigned."""
+        assert issubclass(ModelEval, FlipCrossSiteModelEval)
+        assert isinstance(_make(), FlipCrossSiteModelEval)
+
+    def test_init_stores_flip_model_id_and_eval_task_name(self):
+        controller = _make(evaluation_task_name="validate", cleanup_timeout=300)
+        assert controller._model_id_fallback == _MODEL_ID
         assert controller._model_id is None
-
-    def test_resolve_model_id_uses_fallback_when_fl_ctx_has_no_custom_props(self):
-        """Lazy resolution returns the constructor UUID when fl_ctx has no custom_props."""
-        model_id = "123e4567-e89b-12d3-a456-426614174000"
-        controller = ModelEval(model_id=model_id)
-        fl_ctx = MagicMock()
-        fl_ctx.get_prop.return_value = None
-        result = controller._resolve_model_id(fl_ctx)
-        assert result == model_id
-
-    def test_init_with_custom_task_check_period(self):
-        """Test initialization with custom task_check_period"""
-        model_id = "123e4567-e89b-12d3-a456-426614174000"
-        controller = ModelEval(model_id=model_id, task_check_period=1.0)
-        assert controller._task_check_period == 1.0
-
-    def test_init_with_custom_submit_model_timeout(self):
-        """Test initialization with custom submit_model_timeout"""
-        model_id = "123e4567-e89b-12d3-a456-426614174000"
-        controller = ModelEval(model_id=model_id, submit_model_timeout=1200)
-        assert controller._submit_model_timeout == 1200
-
-    def test_init_with_negative_submit_model_timeout_raises_error(self):
-        """Test initialization with negative submit_model_timeout raises ValueError"""
-        model_id = "123e4567-e89b-12d3-a456-426614174000"
-        with pytest.raises(ValueError, match="submit_model_timeout must be greater"):
-            ModelEval(model_id=model_id, submit_model_timeout=-1)
-
-    def test_init_with_custom_validation_timeout(self):
-        """Test initialization with custom validation_timeout"""
-        model_id = "123e4567-e89b-12d3-a456-426614174000"
-        controller = ModelEval(model_id=model_id, validation_timeout=7200)
-        assert controller._validation_timeout == 7200
-
-    def test_init_with_negative_validation_timeout_raises_error(self):
-        """Test initialization with negative validation_timeout raises ValueError"""
-        model_id = "123e4567-e89b-12d3-a456-426614174000"
-        with pytest.raises(ValueError, match="model_validate_timeout must be greater"):
-            ModelEval(model_id=model_id, validation_timeout=-1)
-
-    def test_init_with_custom_wait_for_clients_timeout(self):
-        """Test initialization with custom wait_for_clients_timeout"""
-        model_id = "123e4567-e89b-12d3-a456-426614174000"
-        controller = ModelEval(model_id=model_id, wait_for_clients_timeout=600)
-        assert controller._wait_for_clients_timeout == 600
-
-    def test_init_with_negative_wait_for_clients_timeout_raises_error(self):
-        """Test initialization with negative wait_for_clients_timeout raises ValueError"""
-        model_id = "123e4567-e89b-12d3-a456-426614174000"
-        with pytest.raises(ValueError, match="wait_for_clients_timeout must be greater"):
-            ModelEval(model_id=model_id, wait_for_clients_timeout=-1)
-
-    def test_init_with_custom_cleanup_timeout(self):
-        """Test initialization with custom cleanup_timeout"""
-        model_id = "123e4567-e89b-12d3-a456-426614174000"
-        controller = ModelEval(model_id=model_id, cleanup_timeout=300)
+        assert controller._evaluation_task_name == "validate"
         assert controller._cleanup_timeout == 300
+        # dead-residue fix: the attr the fork referenced but never defined now exists
+        assert controller._validation_task_name == "validate"
 
-    def test_init_with_negative_cleanup_timeout_raises_error(self):
-        """Test initialization with negative cleanup_timeout raises ValueError"""
-        model_id = "123e4567-e89b-12d3-a456-426614174000"
-        with pytest.raises(ValueError, match="cleanup_timeout must be greater"):
-            ModelEval(model_id=model_id, cleanup_timeout=-1)
+    def test_init_defaults_eval_task_name_and_results_dir(self):
+        controller = _make()
+        assert controller._evaluation_task_name == PTConstants.EvalTaskName
+        assert controller._eval_results_dir == PTConstants.EvalDir
+        assert controller._eval_results == {}
 
-    def test_init_with_custom_fatal_error_delay(self):
-        """Test initialization with custom fatal_error_delay"""
-        model_id = "123e4567-e89b-12d3-a456-426614174000"
-        controller = ModelEval(model_id=model_id, fatal_error_delay=10)
-        assert controller._fatal_error_delay == 10
+    def test_resolve_model_id_uses_fallback_when_fl_ctx_has_no_props(self):
+        controller = _make()
+        assert controller._resolve_model_id(_fl_ctx()) == _MODEL_ID
 
-    def test_init_with_negative_fatal_error_delay(self):
-        """Test initialization with negative fatal_error_delay is allowed (no validation)"""
-        model_id = "123e4567-e89b-12d3-a456-426614174000"
-        controller = ModelEval(model_id=model_id, fatal_error_delay=-1)
-        assert controller._fatal_error_delay == -1
+    @pytest.mark.parametrize(
+        ("kwargs", "match"),
+        [
+            ({"submit_model_timeout": -1}, "submit_model_timeout must be greater"),
+            ({"validation_timeout": -1}, "model_validate_timeout must be greater"),
+            ({"wait_for_clients_timeout": -1}, "wait_for_clients_timeout must be greater"),
+            ({"cleanup_timeout": -1}, "cleanup_timeout must be greater"),
+        ],
+    )
+    def test_init_negative_timeouts_raise(self, kwargs, match):
+        """Timeout validation is inherited from the stock/FLIP base."""
+        with pytest.raises(ValueError, match=match):
+            ModelEval(model_id=_MODEL_ID, **kwargs)
 
-    def test_init_with_cleanup_models_true(self):
-        """Test initialization with cleanup_models set to True"""
-        model_id = "123e4567-e89b-12d3-a456-426614174000"
-        controller = ModelEval(model_id=model_id, cleanup_models=True)
-        assert controller._cleanup_models is True
-
-    def test_init_with_cleanup_models_false(self):
-        """Test initialization with cleanup_models set to False"""
-        model_id = "123e4567-e89b-12d3-a456-426614174000"
-        controller = ModelEval(model_id=model_id, cleanup_models=False)
-        assert controller._cleanup_models is False
-
-    def test_init_with_custom_task_names(self):
-        """Test initialization with custom task names"""
-        model_id = "123e4567-e89b-12d3-a456-426614174000"
-        controller = ModelEval(
-            model_id=model_id, submit_model_task_name="custom_submit", evaluation_task_name="custom_eval"
-        )
+    def test_init_custom_task_names_and_clients(self):
+        controller = _make(submit_model_task_name="custom_submit", evaluation_task_name="custom_eval",
+                           participating_clients=["a", "b"])
         assert controller._submit_model_task_name == "custom_submit"
         assert controller._evaluation_task_name == "custom_eval"
+        assert controller._participating_clients == ["a", "b"]
 
-    def test_init_with_custom_component_ids(self):
-        """Test initialization with custom component IDs"""
-        model_id = "123e4567-e89b-12d3-a456-426614174000"
-        controller = ModelEval(model_id=model_id, model_locator_id="my_locator", formatter_id="my_formatter")
-        assert controller._model_locator_id == "my_locator"
-        assert controller._formatter_id == "my_formatter"
+    def test_accept_val_result_ok_records_result_path(self):
+        controller = _make()
+        controller._eval_results_dir = "/eval"
+        result = MagicMock()
+        result.get_return_code.return_value = ReturnCode.OK
 
-    def test_init_with_participating_clients_list(self):
-        """Test initialization with list of participating clients"""
-        model_id = "123e4567-e89b-12d3-a456-426614174000"
-        clients = ["client1", "client2", "client3"]
-        controller = ModelEval(model_id=model_id, participating_clients=clients)
-        assert controller._participating_clients == clients
+        controller._accept_val_result("c1", result, _fl_ctx())
 
-    def test_init_with_none_participating_clients(self):
-        """Test initialization with None participating_clients (default)"""
-        model_id = "123e4567-e89b-12d3-a456-426614174000"
-        controller = ModelEval(model_id=model_id, participating_clients=None)
-        assert controller._participating_clients is None
+        assert controller._eval_results["c1"] == os.path.join("/eval", "c1")
+        controller.flip.send_handled_exception.assert_not_called()
+
+    def test_accept_val_result_execution_exception_reports_and_empties(self):
+        controller = _make()
+        result = MagicMock()
+        result.get_return_code.return_value = ReturnCode.EXECUTION_EXCEPTION
+        result.get_header.return_value = "boom-traceback"
+
+        controller._accept_val_result("c1", result, _fl_ctx())
+
+        controller.flip.send_handled_exception.assert_called_once()
+        assert controller.flip.send_handled_exception.call_args.kwargs["formatted_exception"] == "boom-traceback"
+        assert controller._eval_results["c1"] == {}
+
+    def test_control_flow_broadcasts_eval_task_then_post_task_cleanup(self):
+        controller = _make(evaluation_task_name="validate")
+        controller._participating_clients = ["c1", "c2"]
+        controller._model_locator = None  # skip server-model loading
+        controller.get_num_standing_tasks = MagicMock(return_value=0)
+        controller.broadcast = MagicMock()
+        controller.broadcast_and_wait = MagicMock()
+        abort_signal = MagicMock()
+        abort_signal.triggered = False
+
+        controller.control_flow(abort_signal, _fl_ctx())
+
+        controller.broadcast.assert_called_once()
+        assert controller.broadcast.call_args.kwargs["task"].name == "validate"
+        controller.broadcast_and_wait.assert_called_once()
+        assert controller.broadcast_and_wait.call_args.kwargs["task"].name == FlipTasks.POST_TASK.value

--- a/flip-utils/tests/unit/nvflare/controllers/test_scatter_and_gather.py
+++ b/flip-utils/tests/unit/nvflare/controllers/test_scatter_and_gather.py
@@ -88,7 +88,9 @@ class TestAcceptTrainResult:
         controller = self._controller()
         controller._global_weights = {"weights": {"w1": 1.0, "w2": 2.0}}
 
-        result = DXO(data_kind=DataKind.WEIGHT_DIFF, data={"w1": 0.25, "w2": -0.5}, meta={"origin": "client"}).to_shareable()
+        result = DXO(
+            data_kind=DataKind.WEIGHT_DIFF, data={"w1": 0.25, "w2": -0.5}, meta={"origin": "client"}
+        ).to_shareable()
         result.add_cookie(AppConstants.CONTRIBUTION_ROUND, 2)
 
         accepted = controller._accept_train_result(client_name="site-1", result=result, fl_ctx=_ctx())
@@ -182,7 +184,9 @@ class TestHandleEvent:
 
         fl_ctx = MagicMock()
         fl_ctx.get_prop.side_effect = lambda key, default=None: (
-            "metrics-shareable" if key == FLContextKey.EVENT_DATA else (None if key == FLContextKey.JOB_META else default)
+            "metrics-shareable"
+            if key == FLContextKey.EVENT_DATA
+            else (None if key == FLContextKey.JOB_META else default)
         )
 
         with patch("flip.nvflare.controllers.scatter_and_gather.handle_metrics_event") as mock_metrics:
@@ -206,6 +210,46 @@ class TestHandleEvent:
 
         mock_metrics.assert_not_called()
         controller.log_error.assert_called_once()
+
+    def test_send_result_skips_relay_when_round_not_started(self):
+        # A multi-phase job (e.g. the diffusion AE/DM split) wires several ScatterAndGather
+        # controllers. SEND_RESULT is broadcast to every controller, but a controller whose
+        # control_flow has not run yet has _current_round is None (inherited from stock). It must
+        # not relay another controller's metric — previously it passed None into handle_metrics_event,
+        # raising "global_round must be type int but got NoneType".
+        controller = ScatterAndGather(model_id=_VALID_MODEL_ID)
+        controller.log_error = MagicMock()
+        controller._current_round = None  # this instance has not started its training loop
+
+        fl_ctx = MagicMock()
+        fl_ctx.get_prop.side_effect = lambda key, default=None: (
+            "metrics-shareable"
+            if key == FLContextKey.EVENT_DATA
+            else (None if key == FLContextKey.JOB_META else default)
+        )
+
+        with patch("flip.nvflare.controllers.scatter_and_gather.handle_metrics_event") as mock_metrics:
+            controller.handle_event(FlipEvents.SEND_RESULT, fl_ctx)  # must not raise
+
+        mock_metrics.assert_not_called()
+
+
+class TestFedJobSerialisation:
+    """FedJob/recipe serialisation must capture stock's __init__ args, not just model_id.
+
+    NVFLARE's ``get_component_init_parameters`` walks a component's base classes to inherit their
+    __init__ params ONLY when the subclass __init__ declares BOTH ``*args`` and ``**kwargs``. A
+    ``**kwargs``-only subclass silently drops the stock args (persistor_id, aggregator_id, …), so a
+    recipe's ScatterAndGather ends up with no persistor -> an empty round-0 global model -> the
+    Client-API trainer's ``load_state_dict({})`` crashes. This guards that regression.
+    """
+
+    def test_init_exposes_stock_args_for_recipe_serialisation(self):
+        from nvflare.fuel.utils.class_utils import get_component_init_parameters
+
+        params = set(get_component_init_parameters(ScatterAndGather(model_id=_VALID_MODEL_ID)))
+        for arg in ("persistor_id", "aggregator_id", "shareable_generator_id", "num_rounds", "min_clients"):
+            assert arg in params, f"'{arg}' dropped by FedJob serialisation (thin-subclass **kwargs trap)"
 
 
 class TestCheckAbortSignal:


### PR DESCRIPTION
## What

De-forks `flip-utils/flip/nvflare/` per #706 — converting six vendored copies of stock NVFLARE (or FLIP) classes into thin subclasses that override only the FLIP-specific hooks, so they track upstream instead of drifting. Builds on #701 (which did the same for `ScatterAndGather` / `ScatterAndGatherLDM`).

Base branch: `arkplus-platform-on-505` (this work stacks on #701, which is not yet in `develop`).

### The six de-forks (commit 1)

| Class | Change |
|---|---|
| `PercentilePrivacy` | subclass stock; keep only the `off` toggle |
| `CrossSiteModelEval` | subclass stock; **regain** T2 multi-DXO handling (`get_leaf_dxos`) + run-dir path-safety; abort/panic-guarded `POST_VALIDATION` cleanup |
| `ModelEval` | subclass FLIP's refactored `CrossSiteModelEval`; **fixes** the dead-fork residue (`self._validation_task_name` / `self._cross_val_dir` referenced but never defined) |
| `ValidationJsonGenerator` | subclass stock; **regain** the COLLECTION/T2 branch + numpy-float JSON encoder; preserve the manual-dispatch `handle_evaluation_events` rename |
| `EvaluationJsonGenerator` | dedupe as a subclass of FLIP's `ValidationJsonGenerator` (flat per-client shape) |
| `StagePercentilePrivacy` | subclass FLIP's `PercentilePrivacy`; keep the per-stage `process_dxo` |

**Net −756 lines** across the six modules. Unit tests rewritten to the FLIP contract (subclass guards + preserved behaviour + newly-inherited behaviour).

### Two fixes surfaced by full-tutorial verification (commit 2)

Both predate this PR (they reproduce on `arkplus-platform-on-505` without the de-fork) but block a clean tutorial run:

- **Recipe serialisation** (`standard_client_api` training was broken): NVFLARE's `FedJob`/recipe captures a component's inherited `__init__` args only when a thin subclass declares **both** `*args` and `**kwargs` (its `_retrieve_parameters` walks the base class only then). FLIP's `ScatterAndGather` declared `**kwargs` only, so recipes serialised just `model_id` and dropped `persistor_id`/`aggregator_id`/`num_rounds` — leaving the recipe's SAG with no persistor and an **empty round-0 global model** (Client-API trainer then crashed on `load_state_dict({})`). Fix: add `*args` (forwarded to `super()`) — keeps SAG a thin subclass. Guarded by a serialisation regression test. Regression from #701's SAG de-fork.
- **Metrics relay** (`latent_diffusion_model` logged non-fatal `TypeError`s): a multi-phase job wires several SAG controllers; `SEND_RESULT` broadcasts to all, but an inactive controller has `_current_round is None`, which was passed into `handle_metrics_event` → `"global_round must be type int"`. Fix: guard on `_current_round is None`.

## Verification

- Full flip-utils unit suite green (445 tests); `ruff` + `mypy` clean.
- **All six NVFLARE tutorials run clean** on a `flare-fl-base:dev` built from this branch — each reaches `RESULTS_UPLOADED` with zero errors:
  `xray_classification`, `xray_classification_client_api`, `3d_spleen_segmentation`, `3d_spleen_segmentation_evaluation`, `3d_spleen_segmentation_evaluation_client_api`, `latent_diffusion_model`.
- The de-fork itself introduces no behavioural change vs the forks (A/B'd against a pre-#706 baseline image); the two client_api/diffusion failures were pre-existing and are fixed in commit 2.

## Notes / follow-ups

- `InitialCheckpointPTModelPersistor` has the same `**kwargs`-only serialisation trap but is latent (recipes use stock `PTFileModelPersistor`); left as-is here, worth a preventative `*args` in a follow-up.

Closes #706.
