### PR TITLE
flip-api: lazy-initialize the SQLAlchemy engine in db/database.py

### DIFF
--- a/flip-api/README.md
+++ b/flip-api/README.md
@@ -97,7 +97,7 @@ applied a schema *diff* to an existing database.
 - Migration scripts live in `src/flip_api/db/migrations/` (so they ride the dev `src/`
   bind mount and the prod `COPY src/`); config is in `alembic.ini`.
 - `alembic.ini` holds **no** database URL or credentials. `env.py` reuses
-  `flip_api.db.database.engine`, so migrations inherit the exact same connection
+  `flip_api.db.database.get_engine()`, so migrations inherit the exact same connection
   string and the prod RDS-Proxy IAM authentication (a per-connection token minted
   by a `do_connect` hook). Tests inject their Testcontainers connection via
   `config.attributes["connection"]` instead.

--- a/flip-api/alembic.ini
+++ b/flip-api/alembic.ini
@@ -19,7 +19,7 @@ script_location = %(here)s/src/flip_api/db/migrations
 prepend_sys_path = .
 
 # NO sqlalchemy.url here on purpose. The database URL — including the prod AWS
-# Secrets Manager password lookup — is owned by flip_api.db.database.engine and
+# Secrets Manager password lookup — is owned by flip_api.db.database.get_engine() and
 # reused by env.py, or supplied as a live Connection injected by the integration
 # tests (config.attributes["connection"]). Secrets never live in this file.
 

--- a/flip-api/src/flip_api/db/database.py
+++ b/flip-api/src/flip_api/db/database.py
@@ -143,7 +143,30 @@ def _build_engine() -> Engine:
     return create_engine(db_url, echo=False)
 
 
-engine = _build_engine()
+# Lazily-created, reused engine. Built on first use rather than at import time
+# so importing this module never reads settings or constructs the engine as a
+# side effect (FLIP#583) — tests, scripts, and tooling can import it without a
+# configured environment. The lock guards the first-build race (the same
+# double-checked locking pattern as ``_get_rds_client`` above): ``get_engine``
+# is called from FastAPI's request threadpool and APScheduler job threads.
+_engine: Engine | None = None
+_engine_lock = threading.Lock()
+
+
+def get_engine() -> Engine:
+    """Return the shared SQLAlchemy engine, building it on first use.
+
+    Returns:
+        Engine: The lazily-built, module-cached engine for the active environment.
+    """
+    global _engine  # noqa: PLW0603
+    if _engine is None:
+        with _engine_lock:
+            # Re-check inside the lock: another thread may have built it while
+            # this one waited (double-checked locking).
+            if _engine is None:
+                _engine = _build_engine()
+    return _engine
 
 
 def get_session() -> Generator[Session, None, None]:
@@ -153,6 +176,6 @@ def get_session() -> Generator[Session, None, None]:
     Returns:
         Session: A new SQLModel session.
     """
-    session = Session(engine)
+    session = Session(get_engine())
     yield session
     session.close()

--- a/flip-api/src/flip_api/db/migrations/env.py
+++ b/flip-api/src/flip_api/db/migrations/env.py
@@ -20,9 +20,9 @@ database URL + secret handling as the application:
 * Online migrations prefer a live ``Connection`` injected programmatically via
   ``config.attributes["connection"]`` (the integration suite points this at its
   Testcontainers Postgres). When none is supplied — the CLI / entrypoint path —
-  we fall back to ``flip_api.db.database.engine``, which already encapsulates the
-  prod RDS-Proxy IAM auth (a per-connection token minted by a ``do_connect`` hook)
-  and the dev env-var URL.
+  we fall back to ``flip_api.db.database.get_engine()``, which already
+  encapsulates the prod RDS-Proxy IAM auth (a per-connection token minted by a
+  ``do_connect`` hook) and the dev env-var URL.
 """
 
 from logging.config import fileConfig
@@ -93,10 +93,10 @@ def run_migrations_offline() -> None:
     ``alembic upgrade --sql`` still works. The URL is taken from flip-api's engine
     so there is still a single source of truth for the connection string.
     """
-    from flip_api.db.database import engine
+    from flip_api.db.database import get_engine
 
     context.configure(
-        url=str(engine.url),
+        url=str(get_engine().url),
         target_metadata=target_metadata,
         literal_binds=True,
         dialect_opts={"paramstyle": "named"},
@@ -114,12 +114,13 @@ def run_migrations_online() -> None:
         _configure_and_run(injected)
         return
 
-    # Lazy import so the injected-connection path never imports flip-api's prod
-    # engine machinery (boto3 + the RDS-Proxy IAM do_connect hook registered at
-    # import time); a supplied Connection already carries its own credentials.
-    from flip_api.db.database import engine
+    # Only reached without an injected connection: get_engine() builds flip-api's
+    # prod engine machinery (boto3 + the RDS-Proxy IAM do_connect hook) on first
+    # call, so the injected-connection path never constructs it — a supplied
+    # Connection already carries its own credentials.
+    from flip_api.db.database import get_engine
 
-    with engine.connect() as connection:
+    with get_engine().connect() as connection:
         _configure_and_run(connection)
 
 

--- a/flip-api/src/flip_api/db/seed/fl_nets.py
+++ b/flip-api/src/flip_api/db/seed/fl_nets.py
@@ -14,7 +14,7 @@
 from sqlmodel import Session, select
 
 from flip_api.config import get_settings
-from flip_api.db.database import engine
+from flip_api.db.database import get_engine
 from flip_api.db.models.main_models import FLNets
 from flip_api.db.seed.seed_logger import logger
 
@@ -83,5 +83,5 @@ def seed_fl_nets(session: Session) -> list[FLNets]:
 
 
 if __name__ == "__main__":
-    with Session(engine) as session:
+    with Session(get_engine()) as session:
         nets = seed_fl_nets(session)

--- a/flip-api/src/flip_api/db/seed/fl_scheduler.py
+++ b/flip-api/src/flip_api/db/seed/fl_scheduler.py
@@ -13,7 +13,7 @@
 
 from sqlmodel import Session, col, select
 
-from flip_api.db.database import engine
+from flip_api.db.database import get_engine
 from flip_api.db.models.main_models import FLNets, FLScheduler
 from flip_api.db.seed.seed_logger import logger
 from flip_api.domain.schemas.status import NetStatus
@@ -48,5 +48,5 @@ def seed_fl_scheduler(session: Session, nets: list[FLNets]) -> list[FLScheduler]
 
 
 if __name__ == "__main__":
-    with Session(engine) as session:
+    with Session(get_engine()) as session:
         nets = session.exec(select(FLNets)).all()

--- a/flip-api/src/flip_api/db/seed/role_permissions.py
+++ b/flip-api/src/flip_api/db/seed/role_permissions.py
@@ -14,7 +14,7 @@ from uuid import UUID
 
 from sqlmodel import Session, select
 
-from flip_api.db.database import engine
+from flip_api.db.database import get_engine
 from flip_api.db.models.user_models import Permission, PermissionRef, Role, RolePermission
 from flip_api.db.seed.seed_logger import logger
 
@@ -82,7 +82,7 @@ def seed_role_permissions(session: Session) -> None:
 
 
 if __name__ == "__main__":
-    with Session(engine) as session:
+    with Session(get_engine()) as session:
         seed_role_permissions(session)
         logger.info("Role permissions seeding completed.")
         session.close()

--- a/flip-api/src/flip_api/db/seed/seed_essential_data.py
+++ b/flip-api/src/flip_api/db/seed/seed_essential_data.py
@@ -12,7 +12,7 @@
 
 from sqlmodel import Session
 
-from flip_api.db.database import engine
+from flip_api.db.database import get_engine
 from flip_api.db.seed.banner import seed_banner
 from flip_api.db.seed.fl_kit_slots import seed_fl_kit_slots
 from flip_api.db.seed.fl_nets import seed_fl_nets
@@ -37,7 +37,7 @@ def main() -> None:
     # the schema is already at head and only inserts idempotent essential data.
     logger.debug("About to seed the database...")
 
-    with Session(engine) as session:
+    with Session(get_engine()) as session:
         try:
             # Clear existing data
             logger.debug("Creating Roles")

--- a/flip-api/src/flip_api/fl_services/run_jobs.py
+++ b/flip-api/src/flip_api/fl_services/run_jobs.py
@@ -14,7 +14,7 @@ from fastapi import HTTPException, status
 from sqlalchemy import text
 from sqlmodel import Session
 
-from flip_api.db.database import engine
+from flip_api.db.database import get_engine
 from flip_api.domain.schemas.status import NetStatus
 from flip_api.fl_services.services.fl_scheduler_service import (
     check_for_available_net,
@@ -124,7 +124,7 @@ def run_jobs_scheduled_task() -> None:
     """
     logger.info("Running scheduled run_jobs execution... ⏰")
     try:
-        with Session(engine) as db:
+        with Session(get_engine()) as db:
             run_jobs_core(db)
     except Exception as e:
         error_message = f"Error in scheduled run_jobs execution: {str(e)}"

--- a/flip-api/src/flip_api/fl_services/services/fl_service.py
+++ b/flip-api/src/flip_api/fl_services/services/fl_service.py
@@ -18,7 +18,7 @@ from fastapi import Request
 from sqlmodel import Session, select
 
 from flip_api.config import get_settings
-from flip_api.db.database import engine
+from flip_api.db.database import get_engine
 from flip_api.db.models.main_models import FLJob, Trust
 from flip_api.domain.interfaces.fl import (
     DEFAULT_JOB_TYPE,
@@ -948,7 +948,7 @@ def keep_fl_api_session_alive() -> None:
     # NOTE In the old implementation, we had 3 'nets' in the database, each with its own FLAdminAPI. So each net had a
     # separate FLAdminAPI endpoint. Here, there should just be 1 net for now. If we add more nets in the future, they
     # might all have the same FLARE_API endpoint, if the FLARE_API controls all controllers/clients.
-    with Session(engine) as db:
+    with Session(get_engine()) as db:
         nets = fl_scheduler_service.get_nets(db)
 
         for net in nets:

--- a/flip-api/src/flip_api/private_services/stale_task_recovery.py
+++ b/flip-api/src/flip_api/private_services/stale_task_recovery.py
@@ -22,7 +22,7 @@ from datetime import datetime, timedelta, timezone
 from sqlmodel import Session, col, select
 
 from flip_api.config import get_settings
-from flip_api.db.database import engine
+from flip_api.db.database import get_engine
 from flip_api.db.models.main_models import TrustTask
 from flip_api.domain.schemas.status import TaskStatus, TaskType
 from flip_api.utils.logger import logger
@@ -130,7 +130,7 @@ def recover_stale_tasks_scheduled_task() -> None:
     """Scheduled task entry point for stale task recovery and post-processing retry."""
     logger.info("Running scheduled stale task recovery...")
     try:
-        with Session(engine) as db:
+        with Session(get_engine()) as db:
             recover_stale_tasks(db)
             retry_failed_post_processing(db)
     except Exception as e:

--- a/flip-api/src/flip_api/project_services/reimport_imaging_project_studies.py
+++ b/flip-api/src/flip_api/project_services/reimport_imaging_project_studies.py
@@ -14,7 +14,7 @@ from fastapi import HTTPException, status
 from sqlmodel import Session
 
 from flip_api.config import get_settings
-from flip_api.db.database import engine
+from flip_api.db.database import get_engine
 from flip_api.project_services.services.image_service import reimport_failed_studies
 from flip_api.project_services.services.project_services import get_reimport_queries_service
 from flip_api.utils.logger import logger
@@ -67,7 +67,7 @@ def reimport_imaging_project_studies_scheduled_task() -> None:
     """
     logger.info("🩻 Running scheduled reimport_imaging_project_studies execution...")
     try:
-        with Session(engine) as db:
+        with Session(get_engine()) as db:
             reimport_imaging_project_studies(db)
     except Exception as e:
         error_message = f"Error in scheduled reimport_imaging_project_studies execution: {str(e)}"

--- a/flip-api/src/flip_api/scripts/delete_trust.py
+++ b/flip-api/src/flip_api/scripts/delete_trust.py
@@ -66,7 +66,7 @@ from typing import Any
 from sqlmodel import Session, delete, select
 
 from flip_api.auth import trust_key_cache
-from flip_api.db.database import engine
+from flip_api.db.database import get_engine
 from flip_api.db.models.main_models import (
     FLJobTrust,
     FLKitSlot,
@@ -193,7 +193,7 @@ def main() -> None:
     parser.add_argument("--name", required=True, help="Trust name (exact match).")
     args = parser.parse_args()
 
-    with Session(engine) as session:
+    with Session(get_engine()) as session:
         result = delete_one_trust(args.name, session)
 
     # Single JSON line on stdout — the deploy script reads this to confirm

--- a/flip-api/src/flip_api/scripts/register_trust.py
+++ b/flip-api/src/flip_api/scripts/register_trust.py
@@ -61,7 +61,7 @@ import boto3
 from sqlmodel import Session, select
 
 from flip_api.config import get_settings
-from flip_api.db.database import engine
+from flip_api.db.database import get_engine
 from flip_api.db.models.main_models import FLKitSlot, Trust
 from flip_api.trusts_services.services.register_trust import (
     TrustRegistrationError,
@@ -255,7 +255,7 @@ def main() -> None:
     )
     args = parser.parse_args()
 
-    with Session(engine) as session:
+    with Session(get_engine()) as session:
         try:
             kits = register_one_trust(
                 args.name, args.code, args.region, session, require_existing=args.require_existing

--- a/flip-api/tests/debug_post_debug_task.py
+++ b/flip-api/tests/debug_post_debug_task.py
@@ -15,7 +15,7 @@ import os
 
 from sqlmodel import Session, col, delete, select
 
-from flip_api.db.database import engine
+from flip_api.db.database import get_engine
 from flip_api.db.models.main_models import (
     FLJob,
     FLLogs,
@@ -322,7 +322,7 @@ def cleanup_debug_projects() -> bool:
 
     # Perform database cleanup
     try:
-        with Session(engine) as session:
+        with Session(get_engine()) as session:
             success = delete_project_data_in_order(session, project_ids)
 
             if success:

--- a/flip-api/tests/fixtures/main_fixtures.py
+++ b/flip-api/tests/fixtures/main_fixtures.py
@@ -16,14 +16,14 @@ import pytest
 from fastapi.testclient import TestClient
 from sqlmodel import Session
 
-from flip_api.db.database import engine
+from flip_api.db.database import get_engine
 from flip_api.main import app
 
 
 @pytest.fixture(scope="module")
 def session():
     """Fixture for creating a synchronous database session."""
-    with Session(engine) as s:
+    with Session(get_engine()) as s:
         yield s
 
 

--- a/flip-api/tests/integration/conftest.py
+++ b/flip-api/tests/integration/conftest.py
@@ -12,8 +12,9 @@
 
 """Integration-test scaffolding.
 
-Boots a throwaway Postgres via Testcontainers once per session and rewires
-flip-api's module-level engine references at it so:
+Boots a throwaway Postgres via Testcontainers once per session and points
+flip-api's lazy engine cache (``database._engine``, read by ``get_engine()``)
+at it so:
 
 * the existing ``session`` fixture from ``tests.fixtures.main_fixtures`` (and
   every test depending on it) reads/writes the throwaway DB;
@@ -50,7 +51,6 @@ import flip_api.db.database as db_module
 # full schema. The imports look unused but are load-bearing — don't drop them.
 import flip_api.db.models.main_models  # noqa: F401
 import flip_api.db.models.user_models  # noqa: F401
-import tests.fixtures.main_fixtures as main_fixtures
 from flip_api.auth.dependencies import verify_token
 from flip_api.config import get_settings
 from flip_api.db.database import get_session
@@ -189,13 +189,15 @@ def integration_engine(pg_container: PostgresContainer):
         seed_roles(s)
         seed_role_permissions(s)
 
-    # Redirect every reference to the prod-bound engine at the throwaway DB.
-    # Both modules captured ``engine`` at import time, so we rebind both names.
-    main_fixtures.engine = engine
-    db_module.engine = engine
+    # Redirect every reference to the prod-bound engine at the throwaway DB by
+    # pre-populating the lazy cache: get_engine() callers (main_fixtures'
+    # ``session`` fixture, get_session, seed helpers) all read this at use time,
+    # so no prod-bound engine is ever built during the suite.
+    db_module._engine = engine
 
     yield engine
 
+    db_module._engine = None
     engine.dispose()
 
 

--- a/flip-api/tests/unit/db/test_database.py
+++ b/flip-api/tests/unit/db/test_database.py
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import importlib
 import logging
+import sys
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -43,6 +45,64 @@ def _reset_rds_client_cache():
     database._rds_client = None
     yield
     database._rds_client = None
+
+
+@pytest.fixture(autouse=True)
+def _reset_engine_cache():
+    """Clear the module-level lazy engine cache around every test."""
+    database._engine = None
+    yield
+    database._engine = None
+
+
+def test_import_performs_no_settings_read_or_engine_build():
+    """Importing the module must not read settings or build an engine (FLIP#583).
+
+    A fresh import is performed with ``get_settings`` booby-trapped so any
+    import-time configuration read fails loudly — importers (tests, scripts,
+    tooling) must not need env vars just to ``import flip_api.db.database``.
+    """
+    import flip_api.config as config
+    import flip_api.db as db_pkg
+
+    original_module = sys.modules["flip_api.db.database"]
+    original_get_settings = config.get_settings
+
+    def _boom() -> None:
+        raise AssertionError("get_settings() was called at import time")
+
+    try:
+        config.get_settings = _boom
+        del sys.modules["flip_api.db.database"]
+        fresh = importlib.import_module("flip_api.db.database")
+        assert fresh._engine is None
+    finally:
+        config.get_settings = original_get_settings
+        sys.modules["flip_api.db.database"] = original_module
+        db_pkg.database = original_module
+
+
+def test_get_engine_builds_once_and_caches():
+    """get_engine() builds the engine on first call and reuses it afterwards."""
+    sentinel = object()
+    with patch.object(database, "_build_engine", return_value=sentinel) as mock_build:
+        first = database.get_engine()
+        second = database.get_engine()
+
+    assert first is sentinel
+    assert second is sentinel
+    mock_build.assert_called_once()
+
+
+def test_get_session_uses_lazy_engine():
+    """get_session() sessions are bound to the lazily-built cached engine."""
+    with patch.object(database, "get_settings", return_value=_fake_settings(ENV="development")):
+        generator = database.get_session()
+        session = next(generator)
+
+    assert database._engine is not None
+    assert session.bind is database._engine
+    generator.close()
 
 
 def test_build_engine_dev_uses_env_password():


### PR DESCRIPTION
## Summary

Closes #583.

Importing `flip_api.db.database` no longer reads settings or builds the SQLAlchemy engine as an import side effect (raised by @garciadias in review of #558). The module-level `engine = _build_engine()` is replaced by a lazy `get_engine()` accessor — a module cache behind double-checked locking, mirroring the existing `_get_rds_client` pattern in the same file (`get_engine()` is called concurrently from FastAPI's request threadpool and APScheduler job threads).

`get_session()` and every direct `database.engine` importer (4 seed modules, `run_jobs`, `fl_service`, `reimport_imaging_project_studies`, `stale_task_recovery`, the two trust CLI scripts, Alembic's `env.py`, and the test helpers) now call `get_engine()` at use time.

The accessor is public (`get_engine()` rather than the issue's suggested `_get_engine()`) because those modules import it from outside `database.py`.

## Notable side change

`tests/integration/conftest.py` used to redirect flip-api at its Testcontainers Postgres by rebinding two import-time captures (`main_fixtures.engine` and `db_module.engine`). It now pre-populates the lazy cache (`db_module._engine`) once — every `get_engine()` caller picks it up at use time, and no prod-bound engine is ever built during the suite.

## Acceptance criteria

- [x] Importing `flip_api.db.database` performs no engine construction / settings read — enforced by a new unit test that re-imports the module with `get_settings` booby-trapped.
- [x] `get_session()` (and existing callers) behave unchanged at runtime — sessions are bound to the same shared engine, now built on first use.
- [x] Existing db unit tests still pass; added coverage for the lazy path (`test_import_performs_no_settings_read_or_engine_build`, `test_get_engine_builds_once_and_caches`, `test_get_session_uses_lazy_engine`).

## Verification

- `make unit_test` (ruff + mypy + unit suite): 1177 passed, 7 skipped.
- `make integration_test` (Testcontainers Postgres): 77 passed.
- Bare-environment import check: `import flip_api.db.database` succeeds with no env vars set; `_engine` stays `None` until first `get_engine()` call.

## Acceptance Criteria

*Imported from issue #583*

- Importing `flip_api.db.database` performs no engine construction / settings read.
- `get_session()` (and existing callers) behave unchanged at runtime.
- Existing db unit tests in `tests/unit/db/test_database.py` still pass; add coverage for the lazy path.

_Follow-up to PR #558._