### PR TITLE
fix(deploy): ship Ubuntu log paths from the Trust EC2 CloudWatch agent (#397)

### DIFF
--- a/deploy/providers/AWS/templates/cloudwatch-agent-trust.json.j2
+++ b/deploy/providers/AWS/templates/cloudwatch-agent-trust.json.j2
@@ -20,12 +20,12 @@ limitations under the License.
             "files": {
                 "collect_list": [
                     {
-                        "file_path": "/var/log/messages",
+                        "file_path": "/var/log/syslog",
                         "log_group_name": "/aws/ec2/flip-trust",
-                        "log_stream_name": "{{ ansible_ec2_instance_id }}/messages"
+                        "log_stream_name": "{{ ansible_ec2_instance_id }}/syslog"
                     },
                     {
-                        "file_path": "/var/log/docker",
+                        "file_path": "/var/lib/docker/containers/*/*.log",
                         "log_group_name": "/aws/ec2/flip-trust",
                         "log_stream_name": "{{ ansible_ec2_instance_id }}/docker"
                     }

--- a/deploy/providers/AWS/tests/test_cloudwatch_agent_template.py
+++ b/deploy/providers/AWS/tests/test_cloudwatch_agent_template.py
@@ -1,0 +1,83 @@
+# Copyright (c) 2026 Guy's and St Thomas' NHS Foundation Trust & King's College London
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Regression tests for the Trust EC2 CloudWatch agent config template.
+
+The Trust host runs Ubuntu, so the agent must tail Ubuntu log paths. A prior
+version shipped RHEL/CentOS paths (``/var/log/messages`` and a non-existent
+``/var/log/docker``), so the agent had nothing to read and never created a
+log stream (FLIP#397). These tests render the Jinja template and assert the
+paths are the Ubuntu ones, guarding against a regression to the RHEL paths.
+"""
+
+import json
+from pathlib import Path
+
+from jinja2 import Environment, FileSystemLoader
+
+TEMPLATES_DIR = Path(__file__).resolve().parent.parent / "templates"
+TEMPLATE_NAME = "cloudwatch-agent-trust.json.j2"
+INSTANCE_ID = "i-0123456789abcdef0"
+TRUST_LOG_GROUP = "/aws/ec2/flip-trust"
+
+
+def _render() -> dict:
+    """Render the Trust CloudWatch agent template and parse it as JSON.
+
+    Returns:
+        dict: The parsed agent configuration.
+    """
+    env = Environment(loader=FileSystemLoader(str(TEMPLATES_DIR)), autoescape=False)
+    rendered = env.get_template(TEMPLATE_NAME).render(ansible_ec2_instance_id=INSTANCE_ID)
+    return json.loads(rendered)
+
+
+def _file_paths(config: dict) -> list[str]:
+    """Extract the ``file_path`` of every collected log file.
+
+    Args:
+        config (dict): The parsed agent configuration.
+
+    Returns:
+        list[str]: The configured file paths, in declaration order.
+    """
+    return [entry["file_path"] for entry in config["logs"]["logs_collected"]["files"]["collect_list"]]
+
+
+def test_template_renders_to_valid_json() -> None:
+    """The template must render to a JSON object the agent can parse."""
+    assert isinstance(_render(), dict)
+
+
+def test_collects_ubuntu_log_paths() -> None:
+    """The agent tails the Ubuntu system log and the Docker json-file logs."""
+    paths = _file_paths(_render())
+    assert "/var/log/syslog" in paths
+    assert "/var/lib/docker/containers/*/*.log" in paths
+
+
+def test_does_not_ship_rhel_paths() -> None:
+    """Guard against regressing to the RHEL paths that never exist on Ubuntu."""
+    paths = _file_paths(_render())
+    assert "/var/log/messages" not in paths
+    assert "/var/log/docker" not in paths
+
+
+def test_all_streams_target_the_trust_log_group() -> None:
+    """Every collected file writes to the Trust EC2 log group, keyed by instance id."""
+    collect_list = _render()["logs"]["logs_collected"]["files"]["collect_list"]
+    assert collect_list, "expected at least one collected log file"
+    for entry in collect_list:
+        assert entry["log_group_name"] == TRUST_LOG_GROUP
+        assert entry["log_stream_name"].startswith(f"{INSTANCE_ID}/")


### PR DESCRIPTION
## What

Fix the Trust EC2 CloudWatch agent so it actually ships logs. The agent config
tailed RHEL/CentOS paths that never exist on the Ubuntu 24.04 trust host, so it
had nothing to read and never created a log stream — `/aws/ec2/flip-trust` stayed
empty (FLIP#397).

```
- /var/log/messages   ->  /var/log/syslog                       (rsyslog on Ubuntu)
- /var/log/docker     ->  /var/lib/docker/containers/*/*.log    (Docker's default
                                                                 json-file driver)
```

The agent runs as **root** by default (no `agent` block), so both the
`syslog:adm`-owned syslog and the root-owned Docker json logs are readable — the
paths were the only blocker.

### Why these paths (not the journald suggestion in the issue)

While implementing I verified two of the issue's premises against the AWS docs and
this deployment, and both were off:

- **The CloudWatch agent has no `journald` input.** Its `logs_collected` schema is
  `files` + `windows_events` only ([AWS config-file
  reference](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Agent-Configuration-File-Details.html)),
  so the issue's Option-A journald source isn't expressible in the agent config.
- **This deployment's Docker uses the default `json-file` driver** (no `daemon.json`
  / no compose `logging:` anywhere in `deploy/`), writing per-container logs to
  `/var/lib/docker/containers/<id>/<id>-json.log`. The `*/*.log` glob tails all of
  them into one instance-keyed stream.

## Scope: this is the remaining half of #397

The **Central Hub** half is already resolved on this base branch: that host is now
an ECS Fargate service (logs via the `awslogs` driver to `/ecs/*`) fronted by an
SSM bastion that deliberately runs no agent — `cloudwatch-agent.json.j2` and the
`/aws/ec2/flip` log group were removed. Only the **Trust EC2** template remained,
which this PR fixes.

## Verification

**Unit (render/regression test, new):** `tests/test_cloudwatch_agent_template.py`
renders the template and asserts the Ubuntu paths are present and the RHEL paths
are gone. `29 passed` (4 new + existing AWS-provider tests).

**End-to-end on a real stag Trust EC2:** provisioned a t3.xlarge Ubuntu 24.04 trust
host in the stag account (targeted `terraform apply -target=module.trust_ec2`),
installed the CloudWatch agent with the **rendered committed template**, ran a
throwaway Docker container, and started the agent with the exact `site.yml` ctl
command. Both streams appeared in the real `/aws/ec2/flip-trust` (previously 0
streams) with real content:

```
i-09c7bcf.../syslog : ip-10-0-101-7 systemd-networkd[552]: docker0: Gained IPv6LL   (real rsyslog)
i-09c7bcf.../docker : {"log":"flip397-docker-log-line-17 ...","stream":"stdout",...} (json-file glob)
```

The agent confirmed `run_as_user: root`, `configstatus: configured`. Test infra
(the EC2 + the two test streams) was torn down afterward; stag is back to
bastion-only.

## Note (out of scope)

The AWS-provider `pyproject.toml` has a pre-existing pytest-table conflict
(`[tool.pytest.ini_options]` + `ini_options_debug` rejected by pytest 8.4); tests
here were run with `-c /dev/null`. Untouched by this PR — flagging for a separate
cleanup.

Closes #397
