### PR TITLE
docs: sync READMEs, ReadTheDocs, CLAUDE.md and docstrings with code

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,15 +293,16 @@ This runs the following steps in order:
 | 2 | `make aws-login` | AWS SSO login |
 | 3 | `make init` | Terraform init with the S3 backend |
 | 4 | `make import-persistent` | Import pre-existing resources (Cognito, Secrets, S3 buckets) — idempotent, safe to re-run |
-| 5 | `make plan` | Review the Terraform execution plan |
-| 6 | `make apply` | Apply infrastructure changes |
-| 7 | `make update-env` | Refresh `.env.stag` with Terraform outputs |
-| 8 | `make ssh-config` | Write SSM-tunnelled `Host flip` / `Host flip-trust` into `~/.ssh/config` |
-| 9 | `make ansible-init` | Configure Trust EC2 with Docker, CloudWatch, and FL assets |
-| 10 | `make deploy-centralhub` | Force-redeploy ECS Fargate services + sync UI to S3 + invalidate CloudFront |
-| 11 | `make register-trusts` | Register trusts on the hub and write per-trust kit files |
-| 12 | `make deploy-trust` | Deploy trust stack to Trust EC2 via Docker Compose |
-| 13 | `make status` | Health checks |
+| 5 | `make generate-internal-service-key` | Mint the fl-server → hub `INTERNAL_SERVICE_KEY` (idempotent) |
+| 6 | `make plan` | Review the Terraform execution plan |
+| 7 | `make apply` | Apply infrastructure changes |
+| 8 | `make update-env` | Refresh `.env.stag` with Terraform outputs |
+| 9 | `make ssh-config` | Write SSM-tunnelled `Host flip` / `Host flip-trust` into `~/.ssh/config` |
+| 10 | `make ansible-init` | Configure Trust EC2 with Docker, CloudWatch, and FL assets |
+| 11 | `make deploy-centralhub` | Deploy the Central Hub containers to the `flip` SSH docker context (use `make deploy-ui` separately for the UI + CloudFront invalidation) |
+| 12 | `make register-trusts` | Register trusts on the hub and write per-trust kit files |
+| 13 | `make deploy-trust` | Deploy trust stack to Trust EC2 via Docker Compose |
+| 14 | `make status` | Health checks |
 
 > **Stag note:** staging has ~70 resources missing from Terraform state. `make import-persistent` (step 4) handles this — it probes state before each import and skips already-imported resources, so re-running after a failure is safe.
 

--- a/deploy/providers/AWS/CLAUDE.md
+++ b/deploy/providers/AWS/CLAUDE.md
@@ -7,7 +7,7 @@
 | `main.tf` | Provider config, VPC, subnets, IGW, NAT, route tables, RDS instance, Secrets Manager, SES |
 | `services.tf` | S3 buckets, Cognito |
 | `rds_proxy.tf` | RDS Proxy + IAM DB auth (proxy, IAM role/policy, SG, `rds-db:connect`) — see FLIP#556 |
-| `ecs.tf` | ECS cluster, ALB, target groups, listeners |
+| `ecs.tf` | ECS cluster, capacity providers, ECS CloudWatch log groups (ALB / NLB / target groups / listener rules live in `main.tf`) |
 | `ecs_services.tf` | ECS Fargate services (flip-api, FL services) |
 | `ecs_tasks.tf` | ECS task definitions for Central Hub services (flip-api + FL) |
 | `ecs_efs_provision.tf` | EFS access points + ECS provisioning task for FL workspace |

--- a/deploy/providers/AWS/README.md
+++ b/deploy/providers/AWS/README.md
@@ -98,15 +98,16 @@ This command executes the following steps in order:
 2. **`aws-login`**: Authenticate with AWS SSO
 3. **`init`**: Initialize Terraform with environment-specific S3 backend
 4. **`import-persistent`**: Import existing persistent AWS resources to prevent replacement
-5. **`plan`**: Generate and review the initial Terraform execution plan
-6. **`apply`**: Apply infrastructure changes
-7. **`update-env`**: Refresh the root environment file with Terraform outputs
-8. **`ssh-config`**: Update `~/.ssh/config` with EC2 instance IPs
-9. **`ansible-init`**: Configure EC2 instances with Docker, CloudWatch, and FL assets (Trust EC2 only — the Central Hub no longer runs application containers on its EC2 host)
-10. **`deploy-centralhub`**: Force-redeploy the Central Hub ECS Fargate services (`flip-api`, `fl-api-net-1`, `fl-server-net-1`) and sync the UI to S3 + invalidate CloudFront
-11. **`register-trusts`**: Register every locally-present trust kit file (`trust/.env.<CODE>.<env>`) on the running hub and fill each kit with hub-shared values
-12. **`deploy-trust`**: Deploy Trust services via Docker Compose to the Trust EC2
-13. **`status`**: Run comprehensive health checks
+5. **`generate-internal-service-key`**: Mint the fl-server → hub `INTERNAL_SERVICE_KEY` (idempotent — skipped if already set)
+6. **`plan`**: Generate and review the initial Terraform execution plan
+7. **`apply`**: Apply infrastructure changes
+8. **`update-env`**: Refresh the root environment file with Terraform outputs
+9. **`ssh-config`**: Update `~/.ssh/config` with EC2 instance IPs
+10. **`ansible-init`**: Configure EC2 instances with Docker, CloudWatch, and FL assets (Trust EC2 only — the Central Hub no longer runs application containers on its EC2 host)
+11. **`deploy-centralhub`**: Deploy the Central Hub containers to the `flip` SSH docker context (see the target definition in `deploy/providers/AWS/Makefile`). Use `make deploy-ui` separately for the UI + CloudFront invalidation
+12. **`register-trusts`**: Register every locally-present trust kit file (`trust/.env.<CODE>.<env>`) on the running hub and fill each kit with hub-shared values
+13. **`deploy-trust`**: Deploy Trust services via Docker Compose to the Trust EC2
+14. **`status`**: Run comprehensive health checks
 
 ### flip-ui on S3 + CloudFront
 

--- a/deploy/providers/local/README.md
+++ b/deploy/providers/local/README.md
@@ -191,11 +191,13 @@ The host/network firewall must allow outbound to **two separate Central Hub host
 
 ### Dynamic Public IP
 
-The NLB security group allowlists the trust's public IP for FL traffic. If the public IP changes (common with residential broadband), update it:
+The NLB security group allowlists the trust's public IP for FL traffic. If the public IP changes (common with residential broadband), update it. Set `LOCAL_TRUST_PUBLIC_IPS` (an HCL list of every allowlisted IP) in the env file and reconcile with `allow-local-trust-nlb`:
 
 ```bash
-TF_VAR_local_trust_public_ip=<new-ip> make -C deploy/providers/AWS plan apply
+LOCAL_TRUST_PUBLIC_IPS='["<new-ip>"]' make -C deploy/providers/AWS allow-local-trust-nlb LOCAL_TRUST_IP=<new-ip>
 ```
+
+Re-running with an already-listed IP is a no-op (idempotent).
 
 ## Troubleshooting
 

--- a/docs/source/components/component-fl-nodes.rst
+++ b/docs/source/components/component-fl-nodes.rst
@@ -43,7 +43,7 @@ A federated learning job is an ensemble of files (among which we can find `pytho
 we call an app. Some of these files are required to run the app (for instance, the `pyproject.toml` file in a Flower app),
 and some are optional. 
 
-The job type is passed as key `job_type` in the `config.json` (for NVFLARE) or `pyproject.toml` (for Flower).
+The job type is passed as key `job_type` in the `config.json` file (for both NVFLARE and Flower apps).
 
 Once uploaded, the UI will indicate which files are required for the specific job. 
 

--- a/docs/source/working-with-flip-apps/create-flip-app-from-flower.rst
+++ b/docs/source/working-with-flip-apps/create-flip-app-from-flower.rst
@@ -319,7 +319,7 @@ Abridged from ``fl-tutorials/flower/3d_spleen_segmentation/pyproject.toml``:
    name = "quickstart-monai"
    version = "1.0.0"
    dependencies = [
-       "flip-utils>=0.1.2",
+       "flip-utils>=0.1.8",
        "flwr[simulation]>=1.26.1",
        # ... your model-framework deps (monai, torch, nibabel, ...)
    ]

--- a/flip-api/src/flip_api/db/database.py
+++ b/flip-api/src/flip_api/db/database.py
@@ -150,7 +150,7 @@ def get_session() -> Generator[Session, None, None]:
     """
     Create a new SQLModel session.
 
-    Returns:
+    Yields:
         Session: A new SQLModel session.
     """
     session = Session(engine)

--- a/flip-api/src/flip_api/site_services/services/details_service.py
+++ b/flip-api/src/flip_api/site_services/services/details_service.py
@@ -27,7 +27,7 @@ def get_site_details(db: Session) -> ISiteDetails:
         db (Session): Database session.
 
     Returns:
-        SiteDetails: Current site details including banner and deployment mode.
+        ISiteDetails: Current site details including banner and deployment mode.
 
     Raises:
         HTTPException: If site details cannot be fetched due to an error.

--- a/flip-api/src/flip_api/user_services/get_user.py
+++ b/flip-api/src/flip_api/user_services/get_user.py
@@ -39,6 +39,7 @@ def get_user(
     Args:
         user_id (str): User ID or email.
         request (Request): FastAPI request object for headers.
+        db (Session): Database session.
         token_id (UUID): User ID from authentication token.
 
     Returns:

--- a/flip-utils/README.md
+++ b/flip-utils/README.md
@@ -300,7 +300,7 @@ Each tutorial's dataset is downloaded per-tutorial — see the tutorial's own RE
 
 ## Security
 
-Please report security vulnerabilities responsibly. For details on how to report a vulnerability, see [SECURITY.md](./SECURITY.md).
+Please report security vulnerabilities responsibly. For details on how to report a vulnerability, see [SECURITY.md](../SECURITY.md).
 
 **⚠️ Do not open a public GitHub issue for security bugs; instead, use the private GitHub Security Advisory feature.**
 
@@ -308,4 +308,4 @@ Please report security vulnerabilities responsibly. For details on how to report
 
 ## Contributing
 
-For information on how to contribute to this project, see [CONTRIBUTING.md](./CONTRIBUTING.md).
+For information on how to contribute to this project, see [CONTRIBUTING.md](../CONTRIBUTING.md).

--- a/trust/CLAUDE.md
+++ b/trust/CLAUDE.md
@@ -42,7 +42,7 @@ the commented dev form):
 
 The Hub-shared block is delimited by a sentinel comment
 (`# ── Hub-shared (managed by register-trust / sync-trust-kits — do not edit) ──`)
-that `scripts/distribute-trust-kits.sh` and `scripts/sync_trust_kit.py`
+that `scripts/distribute_trust_kits.py` and `scripts/sync_trust_kit.py`
 match byte-for-byte. The exact key set is the `HUB_SHARED_ENV_KEYS` tuple in
 `flip_api/scripts/register_trust.py` (`AES_KEY_BASE64`,
 `CENTRAL_HUB_API_URL`, `TRUST_API_KEY_HEADER`, `FL_BACKEND`,

--- a/trust/data-access-api/CLAUDE.md
+++ b/trust/data-access-api/CLAUDE.md
@@ -13,6 +13,6 @@ FastAPI service for querying the OMOP Common Data Model database. Receives cohor
 ## Commands
 
 ```bash
-make test        # ruff + mypy + pytest (unit + integration)
+make test        # ruff + mypy + pytest (unit only; integration runs via make integration_test)
 make unit_test   # Unit tests only
 ```

--- a/trust/trust-api/CLAUDE.md
+++ b/trust/trust-api/CLAUDE.md
@@ -14,7 +14,7 @@ FastAPI gateway running on each trust. Polls the Central Hub for tasks (FL train
 ## Commands
 
 ```bash
-make test        # ruff + mypy + pytest (unit + integration)
+make test        # ruff + mypy + pytest (unit only; integration runs via make integration_test)
 make unit_test   # Unit tests only (alias for local_test)
 make up/down     # Docker compose start/stop
 ```


### PR DESCRIPTION
> _This is an automated scheduled weekly task run by Alex's Claude Code — a documentation drift review that scans README files, ReadTheDocs source, CLAUDE.md files, and Python docstrings against the current tree and applies the high-confidence corrections._

# Description

Weekly documentation drift review. Every change is a concrete correction against the current tree — no scope creep, no cosmetic edits.

**READMEs**
- `README.md`, `deploy/providers/AWS/README.md`: the AWS `full-deploy` step list was missing `generate-internal-service-key` (step 5 in `deploy/providers/AWS/Makefile:698`); added and renumbered. The `deploy-centralhub` row also claimed "sync UI to S3 + invalidate CloudFront" — that's `make deploy-ui`, not `deploy-centralhub`, so the description is corrected.
- `deploy/providers/local/README.md`: the dynamic-public-IP snippet referenced `TF_VAR_local_trust_public_ip` (nonexistent singular). The real Terraform variable is `local_trust_public_ips` (plural, HCL list — see `deploy/providers/AWS/variables.tf:344`) and the canonical target is `allow-local-trust-nlb`.
- `flip-utils/README.md`: relative links `./SECURITY.md` and `./CONTRIBUTING.md` pointed at files that don't exist under `flip-utils/`; retargeted to the repo-root copies (`../SECURITY.md`, `../CONTRIBUTING.md`).

**ReadTheDocs source**
- `docs/source/components/component-fl-nodes.rst`: the doc said `job_type` lives in `pyproject.toml` for Flower, but every shipped Flower app / tutorial declares it in `app/config.json` (grep for `job_type` in Flower `pyproject.toml` files returns nothing). Corrected to "`config.json` for both NVFLARE and Flower apps".
- `docs/source/working-with-flip-apps/create-flip-app-from-flower.rst`: the sample `pyproject.toml` pinned `flip-utils>=0.1.2`; the actual Flower app / tutorial pyprojects (e.g. `fl-apps/flower/standard/pyproject.toml:30`, `fl-tutorials/flower/3d_spleen_segmentation/pyproject.toml:30`) use `>=0.1.8`. Bumped to match.

**CLAUDE.md**
- `trust/CLAUDE.md`: sentinel-matcher was named `scripts/distribute-trust-kits.sh` (shell, hyphenated). The actual script is `scripts/distribute_trust_kits.py` (Python, underscored — invoked by `Makefile:459`). No `.sh` variant exists.
- `trust/data-access-api/CLAUDE.md`, `trust/trust-api/CLAUDE.md`: both said `make test` runs "unit + integration", but each Makefile passes `--ignore=./tests/integration` to the `test:` target. Integration lives on the separate `make integration_test` target. Corrected.
- `deploy/providers/AWS/CLAUDE.md`: the Terraform file table claimed `ecs.tf` holds the "ALB, target groups, listeners". `ecs.tf` actually contains only the ECS cluster, capacity providers, and CloudWatch log groups; ALB / NLB / target groups / listener rules live in `main.tf`. Corrected.

**Docstrings**
- `flip-api/src/flip_api/db/database.py::get_session`: signature is `-> Generator[Session, None, None]` (used as a FastAPI dependency generator), but the docstring said `Returns: Session`. Changed to `Yields:` per Google-style convention for generators.
- `flip-api/src/flip_api/site_services/services/details_service.py::get_site_details`: docstring `Returns: SiteDetails` — there is no `SiteDetails` class; the return annotation is `ISiteDetails`. Fixed to match.
- `flip-api/src/flip_api/user_services/get_user.py::get_user`: signature has four parameters (`user_id`, `request`, `db`, `token_id`) but the `Args:` block omitted `db`. Added — mirroring `set_user_roles.py` / `update_user.py` in the same package.

## Linked Issues

_None — this is a routine documentation-drift sync, not a bug fix._

## Checklist

- [x] Follows the project's coding conventions and style guide
- [x] Updates documentation
- [ ] I have added tests that prove my fix is effective or that my feature works — _N/A, docs-only + non-behavioural docstring edits_
- [x] New and existing unit tests pass locally with my changes — _no runtime code paths changed_
- [x] Any dependent changes have been merged and published

## Type of Change

- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [x] In-line docstrings updated.
- [x] Documentation updated, tested `make -C docs/ docs`.

## Testing

Verification was per-finding (grepped the referenced Makefile targets / Terraform variables / source files against current `origin/develop`), not full-stack runtime testing — since every edit is either prose in a Markdown / RST file or a docstring-only change, there is no code path to exercise.

- [ ] Quick tests passed locally by running `make unit-test`. — _no runtime code changed; skipped_
- [ ] Integration tests pass (if applicable) by running `make integration-test`. — _N/A_

## Additional Notes

The scan surfaced a broader open question about `deploy-centralhub`: the Makefile deploys via SSH docker context to a `flip` host, while `deploy/providers/AWS/CLAUDE.md` describes the Central Hub as running on ECS Fargate. This PR only removes the demonstrably-wrong "syncs UI to S3 + invalidates CloudFront" claim from that step and defers the deeper ECS-vs-EC2 wording question to a follow-up — it's an architectural claim worth an SME's review, not a doc-drift edit.


---
_Generated by [Claude Code](https://claude.ai/code/session_019kXqe9cDdCpSopdHVetX5V)_