### PR TITLE
Fix flip-ui dark-mode contrast guard failures on develop

### DIFF
--- a/flip-ui/src/pages/admin/access-requests.vue
+++ b/flip-ui/src/pages/admin/access-requests.vue
@@ -52,22 +52,22 @@ name: Access Requests
                     <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
                         <thead class="bg-gray-50 dark:bg-gray-900">
                             <tr>
-                                <th scope="col" class="px-6 py-3 text-xs font-semibold tracking-wide text-left text-gray-500 uppercase dark:text-gray-400">
+                                <th scope="col" class="px-6 py-3 text-xs font-semibold tracking-wide text-left text-gray-500 uppercase dark:text-gray-300">
                                     Name
                                 </th>
-                                <th scope="col" class="px-6 py-3 text-xs font-semibold tracking-wide text-left text-gray-500 uppercase dark:text-gray-400">
+                                <th scope="col" class="px-6 py-3 text-xs font-semibold tracking-wide text-left text-gray-500 uppercase dark:text-gray-300">
                                     Email
                                 </th>
-                                <th scope="col" class="px-6 py-3 text-xs font-semibold tracking-wide text-left text-gray-500 uppercase dark:text-gray-400">
+                                <th scope="col" class="px-6 py-3 text-xs font-semibold tracking-wide text-left text-gray-500 uppercase dark:text-gray-300">
                                     Reason
                                 </th>
-                                <th scope="col" class="px-6 py-3 text-xs font-semibold tracking-wide text-left text-gray-500 uppercase dark:text-gray-400">
+                                <th scope="col" class="px-6 py-3 text-xs font-semibold tracking-wide text-left text-gray-500 uppercase dark:text-gray-300">
                                     Submitted
                                 </th>
-                                <th scope="col" class="px-6 py-3 text-xs font-semibold tracking-wide text-left text-gray-500 uppercase dark:text-gray-400">
+                                <th scope="col" class="px-6 py-3 text-xs font-semibold tracking-wide text-left text-gray-500 uppercase dark:text-gray-300">
                                     Status
                                 </th>
-                                <th scope="col" class="px-6 py-3 text-xs font-semibold tracking-wide text-right text-gray-500 uppercase dark:text-gray-400">
+                                <th scope="col" class="px-6 py-3 text-xs font-semibold tracking-wide text-right text-gray-500 uppercase dark:text-gray-300">
                                     Actions
                                 </th>
                             </tr>
@@ -77,13 +77,13 @@ name: Access Requests
                                 <td class="px-6 py-4 text-sm font-medium text-gray-900 whitespace-nowrap dark:text-gray-100">
                                     {{ row.fullName }}
                                 </td>
-                                <td class="px-6 py-4 text-sm text-gray-500 whitespace-nowrap dark:text-gray-400">
+                                <td class="px-6 py-4 text-sm text-gray-500 whitespace-nowrap dark:text-gray-300">
                                     {{ row.email }}
                                 </td>
-                                <td class="max-w-xs px-6 py-4 text-sm text-gray-500 truncate dark:text-gray-400" :title="row.reasonForAccess">
+                                <td class="max-w-xs px-6 py-4 text-sm text-gray-500 truncate dark:text-gray-300" :title="row.reasonForAccess">
                                     {{ row.reasonForAccess }}
                                 </td>
-                                <td class="px-6 py-4 text-sm text-gray-500 whitespace-nowrap dark:text-gray-400">
+                                <td class="px-6 py-4 text-sm text-gray-500 whitespace-nowrap dark:text-gray-300">
                                     {{ formatDate(row.createdAt) }}
                                 </td>
                                 <td class="px-6 py-4 whitespace-nowrap">
@@ -104,13 +104,13 @@ name: Access Requests
                                             Dismiss
                                         </AiButton>
                                     </div>
-                                    <span v-else class="text-xs text-gray-400 dark:text-gray-500">—</span>
+                                    <span v-else class="text-xs text-gray-400 dark:text-gray-300">—</span>
                                 </td>
                             </tr>
                         </tbody>
                     </table>
                 </div>
-                <div v-else class="p-8 text-sm text-center text-gray-500 dark:text-gray-400" data-test="access-requests-empty">
+                <div v-else class="p-8 text-sm text-center text-gray-500 dark:text-gray-300" data-test="access-requests-empty">
                     There are no access requests to show.
                 </div>
             </div>

--- a/flip-ui/src/partials/projects/EditProjectDrawer.vue
+++ b/flip-ui/src/partials/projects/EditProjectDrawer.vue
@@ -106,16 +106,16 @@
                                                 <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
                                                     Convert DICOMs to NIfTI
                                                 </label>
-                                                <p class="text-xs text-gray-500 dark:text-gray-400 mb-1">
+                                                <p class="text-xs text-gray-500 dark:text-gray-300 mb-1">
                                                     Automatically convert DICOM scans to NIfTI format when images are imported from PACS into XNAT.
                                                 </p>
-                                                <p class="text-xs text-gray-500 dark:text-gray-400 mb-1">
+                                                <p class="text-xs text-gray-500 dark:text-gray-300 mb-1">
                                                     When enabled, NIfTI files can be requested using the ResourceType parameter.
                                                 </p>
-                                                <p class="text-xs text-gray-500 dark:text-gray-400 mb-1">
+                                                <p class="text-xs text-gray-500 dark:text-gray-300 mb-1">
                                                     Disable this if you will be working with DICOM files directly.
                                                 </p>
-                                                <p class="text-xs italic text-gray-400 dark:text-gray-500 mb-2">
+                                                <p class="text-xs italic text-gray-400 dark:text-gray-300 mb-2">
                                                     This option is set when the project is created and cannot be changed.
                                                 </p>
                                                 <AiSwitch

--- a/flip-ui/src/partials/users/RegisterUserModal.vue
+++ b/flip-ui/src/partials/users/RegisterUserModal.vue
@@ -63,14 +63,14 @@
                                                 placeholder="Name"
                                             />
                                             <div v-else class="mt-2">
-                                                <label class="block mb-1 text-xs font-semibold text-gray-500 dark:text-gray-400">Name</label>
+                                                <label class="block mb-1 text-xs font-semibold text-gray-500 dark:text-gray-300">Name</label>
                                                 <input
                                                     data-test="name-field"
                                                     type="text"
                                                     :value="initialName"
                                                     readonly
                                                     disabled
-                                                    class="block w-full text-sm text-gray-500 bg-gray-100 border-gray-300 rounded-md shadow-sm cursor-not-allowed dark:bg-gray-900 dark:text-gray-400 dark:border-gray-700"
+                                                    class="block w-full text-sm text-gray-500 bg-gray-100 border-gray-300 rounded-md shadow-sm cursor-not-allowed dark:bg-gray-900 dark:text-gray-300 dark:border-gray-700"
                                                 >
                                             </div>
                                             <AiInput
@@ -89,14 +89,14 @@
                                                 placeholder="Email Address"
                                             />
                                             <div v-else class="mt-2">
-                                                <label class="block mb-1 text-xs font-semibold text-gray-500 dark:text-gray-400">Email</label>
+                                                <label class="block mb-1 text-xs font-semibold text-gray-500 dark:text-gray-300">Email</label>
                                                 <input
                                                     data-test="email-field"
                                                     type="email"
                                                     :value="initialEmail"
                                                     readonly
                                                     disabled
-                                                    class="block w-full text-sm text-gray-500 bg-gray-100 border-gray-300 rounded-md shadow-sm cursor-not-allowed dark:bg-gray-900 dark:text-gray-400 dark:border-gray-700"
+                                                    class="block w-full text-sm text-gray-500 bg-gray-100 border-gray-300 rounded-md shadow-sm cursor-not-allowed dark:bg-gray-900 dark:text-gray-300 dark:border-gray-700"
                                                 >
                                             </div>
                                             <Listbox v-model="selectedOption">


### PR DESCRIPTION
## What

develop's **FLIP UI CI is red at the tip** (since the #717 merge): the dark-mode contrast guard added by #716 (`src/__tests__/dark-mode-contrast.spec.ts`, "keeps dark-mode text at gray-300 or lighter") fails with three offenders:

- `src/pages/admin/access-requests.vue` (11 lines)
- `src/partials/projects/EditProjectDrawer.vue` (4 lines)
- `src/partials/users/RegisterUserModal.vue` (4 lines)

These files landed via PRs that ran in parallel with the #716 ink-floor sweep, so their `dark:text-gray-400/500` classes escaped it. Because the guard is a repo-scan spec, **every open PR's flip-ui check inherits the red** (e.g. #720).

## Fix

Mechanical bump of the offending `dark:text-gray-400` / `dark:text-gray-500` classes to the `dark:text-gray-300` floor the sweep established — 19 lines across the three files, no other changes.

## Verification

- `npx vitest run src/__tests__/dark-mode-contrast.spec.ts` — 2/2 passing
- `npm run test:unit` — 101/101 test files, 853 passed
- `npm run lint` — 0 errors (3 pre-existing max-len warnings in EditProjectDrawer.vue, untouched)