### PR TITLE
[Feature]: Models page — estate-wide, access-scoped model list

### DIFF
--- a/flip-api/src/flip_api/domain/interfaces/model.py
+++ b/flip-api/src/flip_api/domain/interfaces/model.py
@@ -65,6 +65,24 @@ class IAllModelsResponse(BaseModel):
     model_config = ConfigDict(populate_by_name=True, arbitrary_types_allowed=True)
 
 
+class IModelsListResponse(BaseModel):
+    """Paginated Models-list page plus per-status totals for the filter tiles (issue #726).
+
+    ``status_counts`` maps each ``ModelStatus`` value to its count across the caller's
+    access-scoped set, honouring search but **ignoring** the active status filter — so the
+    tiles keep their numbers while one is selected.
+    """
+
+    page: int
+    page_size: int = Field(alias="pageSize")
+    total_pages: int = Field(alias="totalPages")
+    total_records: int = Field(alias="totalRecords")
+    data: list[IAllModelsResponse]
+    status_counts: dict[str, int] = Field(default_factory=dict, alias="statusCounts")
+
+    model_config = ConfigDict(populate_by_name=True, arbitrary_types_allowed=True)
+
+
 class IModelLog(BaseModel):
     timestamp: datetime = Field(alias="@timestamp")
     model: str

--- a/flip-api/src/flip_api/domain/interfaces/model.py
+++ b/flip-api/src/flip_api/domain/interfaces/model.py
@@ -34,6 +34,37 @@ class ISaveModel(IModelDetails):
     project_id: UUID = Field(..., alias="projectId")
 
 
+class ITrustSummary(BaseModel):
+    """A trust participating in a model's federated run, for the Models-list chips."""
+
+    id: UUID
+    name: str
+    code: str | None = Field(default=None)
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class IAllModelsResponse(BaseModel):
+    """One row of the estate-wide Models list (issue #726).
+
+    Joins a model to its owning project (name), the owner's display name and the
+    model's run trusts. ``owner_name`` is null when the owner has no UserProfile
+    row; ``trusts`` is empty until training is initiated (no ModelTrustIntersect
+    rows exist before dispatch).
+    """
+
+    id: UUID
+    name: str
+    status: ModelStatus
+    project_id: UUID = Field(..., alias="projectId")
+    project_name: str = Field(..., alias="projectName")
+    owner_id: UUID = Field(..., alias="ownerId")
+    owner_name: str | None = Field(default=None, alias="ownerName")
+    trusts: list[ITrustSummary] = Field(default_factory=list)
+
+    model_config = ConfigDict(populate_by_name=True, arbitrary_types_allowed=True)
+
+
 class IModelLog(BaseModel):
     timestamp: datetime = Field(alias="@timestamp")
     model: str

--- a/flip-api/src/flip_api/main.py
+++ b/flip-api/src/flip_api/main.py
@@ -44,6 +44,7 @@ from flip_api.fl_services import (
 from flip_api.model_services import (
     delete_model,
     edit_model,
+    get_all_models,
     get_job_types,
     get_metrics,
     retrieve_logs_for_model,
@@ -194,6 +195,7 @@ ROUTERS: tuple[APIRouter, ...] = (
     # Model services
     delete_model.router,
     edit_model.router,
+    get_all_models.router,
     get_metrics.router,
     retrieve_logs_for_model.router,
     retrieve_model_status_from_logs.router,

--- a/flip-api/src/flip_api/model_services/get_all_models.py
+++ b/flip-api/src/flip_api/model_services/get_all_models.py
@@ -19,54 +19,63 @@ from flip_api.auth.auth_utils import has_permissions
 from flip_api.auth.dependencies import verify_token
 from flip_api.db.database import get_session
 from flip_api.db.models.user_models import PermissionRef
-from flip_api.domain.interfaces.model import IAllModelsResponse
+from flip_api.domain.interfaces.model import IModelsListResponse
 from flip_api.domain.schemas.status import ModelStatus
 from flip_api.model_services.services.model_service import get_all_models_service
 from flip_api.utils.logger import logger
-from flip_api.utils.paging_utils import IPagedData, get_total_pages
+from flip_api.utils.paging_utils import get_total_pages
 
 router = APIRouter(prefix="/models", tags=["model_services"])
 
 
-def _parse_status(raw_status: str | None) -> ModelStatus | None:
-    """Validate the optional ``status`` query param against ``ModelStatus``.
+def _parse_statuses(raw_status: str | None) -> list[ModelStatus] | None:
+    """Validate the optional ``status`` query param (comma-separated) against ``ModelStatus``.
+
+    A comma-separated list lets the group filter tiles narrow to several statuses at once
+    (e.g. ``INITIATED,PENDING`` for "Queued").
 
     Args:
         raw_status (str | None): The raw ``status`` query param, if supplied.
 
     Returns:
-        ModelStatus | None: The parsed status, or None when no filter was requested.
+        list[ModelStatus] | None: The parsed statuses, or None when no filter was requested.
 
     Raises:
-        HTTPException: 400 if a non-empty value does not match a known status.
+        HTTPException: 400 if any value does not match a known status.
     """
     if not raw_status:
         return None
-    try:
-        return ModelStatus(raw_status)
-    except ValueError:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"Invalid model status filter: {raw_status}",
-        )
+    parsed: list[ModelStatus] = []
+    for part in raw_status.split(","):
+        value = part.strip()
+        if not value:
+            continue
+        try:
+            parsed.append(ModelStatus(value))
+        except ValueError:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Invalid model status filter: {value}",
+            )
+    return parsed or None
 
 
 @router.get(
     "",
     summary="Get a paginated, access-scoped list of models across every project.",
-    response_model=IPagedData[IAllModelsResponse],
+    response_model=IModelsListResponse,
     status_code=status.HTTP_200_OK,
 )
 def get_all_models_endpoint(
     request: Request,
     session: Session = Depends(get_session),
     user_id: UUID = Depends(verify_token),
-) -> IPagedData[IAllModelsResponse]:
+) -> IModelsListResponse:
     """Estate-wide model list, scoped to the projects the caller can access (issue #726).
 
     A caller sees models for projects they own or have been granted access to; a user with
-    ``CAN_MANAGE_PROJECTS`` sees every model. Supports search (model or project name), an
-    optional ``status`` filter and pagination.
+    ``CAN_MANAGE_PROJECTS`` sees every model. Supports search (model or project name), a
+    comma-separated ``status`` filter and pagination, and returns per-status tile counts.
 
     Args:
         request (Request): The HTTP request, used to read query params.
@@ -74,12 +83,12 @@ def get_all_models_endpoint(
         user_id (UUID): The authenticated caller's id.
 
     Returns:
-        IPagedData[IAllModelsResponse]: A paginated page of models joined with project, owner and trusts.
+        IModelsListResponse: A page of models (project, owner, trusts) plus per-status counts.
     """
     logger.info("Requesting estate-wide models list")
 
     query_params = dict(request.query_params)
-    status_filter = _parse_status(query_params.get("status"))
+    status_filter = _parse_statuses(query_params.get("status"))
 
     # Managers see every model — drop the per-user access filter (equivalent to user_id = None),
     # mirroring get_projects_endpoint.
@@ -88,13 +97,16 @@ def get_all_models_endpoint(
     else:
         requesting_user_id = user_id
 
-    response, paging = get_all_models_service(session, requesting_user_id, query_params, status_filter)
+    response, status_counts, paging = get_all_models_service(
+        session, requesting_user_id, query_params, status_filter
+    )
     total_pages = get_total_pages(response.total_rows, paging.page_size)
 
-    return IPagedData(
+    return IModelsListResponse(
         page=paging.page_number,
         page_size=paging.page_size,
         total_pages=total_pages,
         total_records=response.total_rows,
         data=response.data,
+        status_counts=status_counts,
     )  # type: ignore[call-arg]

--- a/flip-api/src/flip_api/model_services/get_all_models.py
+++ b/flip-api/src/flip_api/model_services/get_all_models.py
@@ -1,0 +1,100 @@
+# Copyright (c) Guy's and St Thomas' NHS Foundation Trust & King's College London
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from sqlmodel import Session
+
+from flip_api.auth.auth_utils import has_permissions
+from flip_api.auth.dependencies import verify_token
+from flip_api.db.database import get_session
+from flip_api.db.models.user_models import PermissionRef
+from flip_api.domain.interfaces.model import IAllModelsResponse
+from flip_api.domain.schemas.status import ModelStatus
+from flip_api.model_services.services.model_service import get_all_models_service
+from flip_api.utils.logger import logger
+from flip_api.utils.paging_utils import IPagedData, get_total_pages
+
+router = APIRouter(prefix="/models", tags=["model_services"])
+
+
+def _parse_status(raw_status: str | None) -> ModelStatus | None:
+    """Validate the optional ``status`` query param against ``ModelStatus``.
+
+    Args:
+        raw_status (str | None): The raw ``status`` query param, if supplied.
+
+    Returns:
+        ModelStatus | None: The parsed status, or None when no filter was requested.
+
+    Raises:
+        HTTPException: 400 if a non-empty value does not match a known status.
+    """
+    if not raw_status:
+        return None
+    try:
+        return ModelStatus(raw_status)
+    except ValueError:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Invalid model status filter: {raw_status}",
+        )
+
+
+@router.get(
+    "",
+    summary="Get a paginated, access-scoped list of models across every project.",
+    response_model=IPagedData[IAllModelsResponse],
+    status_code=status.HTTP_200_OK,
+)
+def get_all_models_endpoint(
+    request: Request,
+    session: Session = Depends(get_session),
+    user_id: UUID = Depends(verify_token),
+) -> IPagedData[IAllModelsResponse]:
+    """Estate-wide model list, scoped to the projects the caller can access (issue #726).
+
+    A caller sees models for projects they own or have been granted access to; a user with
+    ``CAN_MANAGE_PROJECTS`` sees every model. Supports search (model or project name), an
+    optional ``status`` filter and pagination.
+
+    Args:
+        request (Request): The HTTP request, used to read query params.
+        session (Session): The database session.
+        user_id (UUID): The authenticated caller's id.
+
+    Returns:
+        IPagedData[IAllModelsResponse]: A paginated page of models joined with project, owner and trusts.
+    """
+    logger.info("Requesting estate-wide models list")
+
+    query_params = dict(request.query_params)
+    status_filter = _parse_status(query_params.get("status"))
+
+    # Managers see every model — drop the per-user access filter (equivalent to user_id = None),
+    # mirroring get_projects_endpoint.
+    if has_permissions(user_id, [PermissionRef.CAN_MANAGE_PROJECTS], session):
+        requesting_user_id = None
+    else:
+        requesting_user_id = user_id
+
+    response, paging = get_all_models_service(session, requesting_user_id, query_params, status_filter)
+    total_pages = get_total_pages(response.total_rows, paging.page_size)
+
+    return IPagedData(
+        page=paging.page_number,
+        page_size=paging.page_size,
+        total_pages=total_pages,
+        total_records=response.total_rows,
+        data=response.data,
+    )  # type: ignore[call-arg]

--- a/flip-api/src/flip_api/model_services/services/model_service.py
+++ b/flip-api/src/flip_api/model_services/services/model_service.py
@@ -429,8 +429,8 @@ def get_all_models_service(
     session: Session,
     user_id: UUID | None,
     query_params: dict,
-    status_filter: ModelStatus | None = None,
-) -> tuple[IPagedResponse[IAllModelsResponse], PagingInfo]:
+    status_filter: list[ModelStatus] | None = None,
+) -> tuple[IPagedResponse[IAllModelsResponse], dict[str, int], PagingInfo]:
     """Estate-wide, access-scoped model list joined with project name, owner and run trusts (#726).
 
     Mirrors the projects-list access rule: when ``user_id`` is provided the query is restricted to
@@ -439,27 +439,34 @@ def get_all_models_service(
     models and projects are always excluded. Search matches the model name or the owning project
     name; results are newest-first and paginated.
 
+    Alongside the page it returns per-status counts over the same access-scoped, search-filtered set
+    but **without** the status filter — so the filter tiles keep their numbers while one is selected.
+
     Args:
         session (Session): The database session.
         user_id (UUID | None): The requesting user, or ``None`` to see every model (manager bypass).
         query_params (dict): Raw query params (``pageNumber`` / ``pageSize`` / ``search``).
-        status_filter (ModelStatus | None): Optional model-status filter.
+        status_filter (list[ModelStatus] | None): Optional set of statuses to filter the list to.
 
     Returns:
-        tuple[IPagedResponse[IAllModelsResponse], PagingInfo]: The page of rows plus paging details.
+        tuple[IPagedResponse[IAllModelsResponse], dict[str, int], PagingInfo]: the page of rows, the
+        ``status value -> count`` map for the tiles, and the paging details.
     """
     paging = get_paging_details(query_string_parameters=query_params)
 
-    conditions: list[Any] = [col(Model.deleted).is_(False), col(Projects.deleted).is_(False)]
+    # Base conditions exclude the status filter so the tile counts see every status.
+    base_conditions: list[Any] = [col(Model.deleted).is_(False), col(Projects.deleted).is_(False)]
     if user_id is not None:
-        conditions.append(or_(Projects.owner_id == user_id, ProjectUserAccess.user_id == user_id))
-    if status_filter is not None:
-        conditions.append(Model.status == status_filter)
+        base_conditions.append(or_(Projects.owner_id == user_id, ProjectUserAccess.user_id == user_id))
     if paging.search_str:
         pattern = f"%{paging.search_str.lower()}%"
-        conditions.append(
+        base_conditions.append(
             or_(func.lower(Model.name).like(pattern), func.lower(Projects.name).like(pattern))
         )
+
+    list_conditions = list(base_conditions)
+    if status_filter:
+        list_conditions.append(col(Model.status).in_(status_filter))
 
     # LEFT JOIN ProjectUserAccess pinned to this user (mirrors get_projects_paginated_orm) so the
     # access OR-clause can match a granted project without fanning the row out per access record.
@@ -472,7 +479,7 @@ def get_all_models_service(
         .join(Projects, col(Model.project_id) == Projects.id)
         .outerjoin(ProjectUserAccess, access_join)
         .outerjoin(UserProfile, col(UserProfile.user_id) == Model.owner_id)
-        .where(and_(*conditions))
+        .where(and_(*list_conditions))
         .order_by(desc(col(Model.creation_timestamp)))
         .limit(paging.page_size)
         .offset(paging.offset)
@@ -481,11 +488,22 @@ def get_all_models_service(
         select(func.count(func.distinct(col(Model.id))))
         .join(Projects, col(Model.project_id) == Projects.id)
         .outerjoin(ProjectUserAccess, access_join)
-        .where(and_(*conditions))
+        .where(and_(*list_conditions))
+    )
+    status_counts_query = (
+        select(Model.status, func.count(func.distinct(col(Model.id))))  # type: ignore[call-overload]
+        .join(Projects, col(Model.project_id) == Projects.id)
+        .outerjoin(ProjectUserAccess, access_join)
+        .where(and_(*base_conditions))
+        .group_by(Model.status)
     )
 
     total_rows = session.exec(count_query).one_or_none() or 0
     rows = session.exec(rows_query).all()
+    status_counts = {
+        (status.value if isinstance(status, ModelStatus) else str(status)): count
+        for status, count in session.exec(status_counts_query).all()
+    }
 
     trusts_by_model = _run_trusts_by_model([model.id for model, _, _ in rows], session)
 
@@ -503,4 +521,4 @@ def get_all_models_service(
         for model, project_name, owner_name in rows
     ]
 
-    return IPagedResponse[IAllModelsResponse](data=data, total_rows=total_rows), paging
+    return IPagedResponse[IAllModelsResponse](data=data, total_rows=total_rows), status_counts, paging

--- a/flip-api/src/flip_api/model_services/services/model_service.py
+++ b/flip-api/src/flip_api/model_services/services/model_service.py
@@ -10,25 +10,39 @@
 # limitations under the License.
 #
 
+from collections import defaultdict
 from typing import Any
 from uuid import UUID
 
-from sqlmodel import Session, select
+from sqlmodel import Session, and_, col, desc, func, or_, select
 
-from flip_api.db.models.main_models import FLKitSlot, FLLogs, FLMetrics, Model, ModelTrustIntersect, Trust
+from flip_api.db.models.main_models import (
+    FLKitSlot,
+    FLLogs,
+    FLMetrics,
+    Model,
+    ModelTrustIntersect,
+    Projects,
+    ProjectUserAccess,
+    Trust,
+)
+from flip_api.db.models.user_models import UserProfile
 from flip_api.domain.interfaces.model import (
+    IAllModelsResponse,
     IDetailedModelStatus,
     IModelAuditAction,
     IModelDetails,
     IModelMetrics,
     IModelMetricsData,
     IModelMetricsValue,
+    ITrustSummary,
 )
 from flip_api.domain.schemas.actions import ModelAuditAction
 from flip_api.domain.schemas.status import ModelStatus
 from flip_api.fl_services.services import fl_scheduler_service
 from flip_api.model_services.utils.audit_helper import audit_model_action, audit_model_actions
 from flip_api.utils.logger import logger
+from flip_api.utils.paging_utils import IPagedResponse, PagingInfo, get_paging_details
 
 
 def edit_model(model_id: UUID, model_details: IModelDetails, user_id: UUID, session: Session) -> None:
@@ -378,3 +392,115 @@ def get_metrics(model_id: UUID, session: Session) -> list[IModelMetrics]:
         series.data.append(IModelMetricsValue(xValue=row.global_round, yValue=row.result))
 
     return list(metrics_map.values())
+
+
+def _run_trusts_by_model(model_ids: list[UUID], session: Session) -> dict[UUID, list[ITrustSummary]]:
+    """Group each model's participating (run) trusts, keyed by model id.
+
+    Reads ``ModelTrustIntersect`` -> ``Trust`` (the same source as
+    ``retrieve_trusts_in_model``). Only populated once training is initiated, so
+    models awaiting dispatch simply map to an empty list.
+
+    Args:
+        model_ids (list[UUID]): Model ids to fetch trusts for. Empty input short-circuits.
+        session (Session): The database session.
+
+    Returns:
+        dict[UUID, list[ITrustSummary]]: ``model_id -> [trust, ...]``. Missing keys mean no trusts.
+    """
+    trusts_by_model: dict[UUID, list[ITrustSummary]] = defaultdict(list)
+    if not model_ids:
+        return trusts_by_model
+
+    rows = session.exec(
+        select(ModelTrustIntersect.model_id, Trust.id, Trust.name, Trust.code)
+        .join(Trust, col(Trust.id) == ModelTrustIntersect.trust_id)
+        .where(col(ModelTrustIntersect.model_id).in_(model_ids))
+    ).all()
+    for model_id, trust_id, trust_name, trust_code in rows:
+        if model_id is None:
+            continue
+        trusts_by_model[model_id].append(ITrustSummary(id=trust_id, name=trust_name, code=trust_code))
+
+    return trusts_by_model
+
+
+def get_all_models_service(
+    session: Session,
+    user_id: UUID | None,
+    query_params: dict,
+    status_filter: ModelStatus | None = None,
+) -> tuple[IPagedResponse[IAllModelsResponse], PagingInfo]:
+    """Estate-wide, access-scoped model list joined with project name, owner and run trusts (#726).
+
+    Mirrors the projects-list access rule: when ``user_id`` is provided the query is restricted to
+    models whose project the user owns or has a ``ProjectUserAccess`` row for; when ``user_id`` is
+    ``None`` (a manager with ``CAN_MANAGE_PROJECTS``) no access filter is applied. Soft-deleted
+    models and projects are always excluded. Search matches the model name or the owning project
+    name; results are newest-first and paginated.
+
+    Args:
+        session (Session): The database session.
+        user_id (UUID | None): The requesting user, or ``None`` to see every model (manager bypass).
+        query_params (dict): Raw query params (``pageNumber`` / ``pageSize`` / ``search``).
+        status_filter (ModelStatus | None): Optional model-status filter.
+
+    Returns:
+        tuple[IPagedResponse[IAllModelsResponse], PagingInfo]: The page of rows plus paging details.
+    """
+    paging = get_paging_details(query_string_parameters=query_params)
+
+    conditions: list[Any] = [col(Model.deleted).is_(False), col(Projects.deleted).is_(False)]
+    if user_id is not None:
+        conditions.append(or_(Projects.owner_id == user_id, ProjectUserAccess.user_id == user_id))
+    if status_filter is not None:
+        conditions.append(Model.status == status_filter)
+    if paging.search_str:
+        pattern = f"%{paging.search_str.lower()}%"
+        conditions.append(
+            or_(func.lower(Model.name).like(pattern), func.lower(Projects.name).like(pattern))
+        )
+
+    # LEFT JOIN ProjectUserAccess pinned to this user (mirrors get_projects_paginated_orm) so the
+    # access OR-clause can match a granted project without fanning the row out per access record.
+    access_join = and_(
+        col(ProjectUserAccess.project_id) == Projects.id, ProjectUserAccess.user_id == user_id
+    )
+
+    rows_query = (
+        select(Model, Projects.name, UserProfile.name)  # type: ignore[call-overload]
+        .join(Projects, col(Model.project_id) == Projects.id)
+        .outerjoin(ProjectUserAccess, access_join)
+        .outerjoin(UserProfile, col(UserProfile.user_id) == Model.owner_id)
+        .where(and_(*conditions))
+        .order_by(desc(col(Model.creation_timestamp)))
+        .limit(paging.page_size)
+        .offset(paging.offset)
+    )
+    count_query = (
+        select(func.count(func.distinct(col(Model.id))))
+        .join(Projects, col(Model.project_id) == Projects.id)
+        .outerjoin(ProjectUserAccess, access_join)
+        .where(and_(*conditions))
+    )
+
+    total_rows = session.exec(count_query).one_or_none() or 0
+    rows = session.exec(rows_query).all()
+
+    trusts_by_model = _run_trusts_by_model([model.id for model, _, _ in rows], session)
+
+    data = [
+        IAllModelsResponse(
+            id=model.id,
+            name=model.name,
+            status=model.status,
+            project_id=model.project_id,
+            project_name=project_name,
+            owner_id=model.owner_id,
+            owner_name=owner_name,
+            trusts=trusts_by_model.get(model.id, []),
+        )  # type: ignore[call-arg]
+        for model, project_name, owner_name in rows
+    ]
+
+    return IPagedResponse[IAllModelsResponse](data=data, total_rows=total_rows), paging

--- a/flip-api/tests/integration/test_all_models_endpoint.py
+++ b/flip-api/tests/integration/test_all_models_endpoint.py
@@ -253,6 +253,22 @@ def test_invalid_status_param_is_rejected(client: TestClient, session, project_f
     assert response.status_code == 400
 
 
+def test_empty_result_returns_no_rows_and_zero_counts(
+    client: TestClient, session, project_factory, model_factory
+):
+    """A search that matches nothing yields an empty page (exercises the no-model-ids trust path)."""
+    user_id = uuid4()
+    project = _add_project(session, project_factory, owner_id=user_id, name="Sparse")
+    _add_model(session, model_factory, project_id=project.id, owner_id=user_id, name="only-model")
+
+    override_verify_token_as(user_id)
+    body = client.get(MODELS_URL, params={"search": "no-such-model-anywhere"}).json()
+
+    assert body["data"] == []
+    assert body["totalRecords"] == 0
+    assert body["statusCounts"] == {}
+
+
 def test_multiple_statuses_filter_the_list_at_once(
     client: TestClient, session, project_factory, model_factory
 ):

--- a/flip-api/tests/integration/test_all_models_endpoint.py
+++ b/flip-api/tests/integration/test_all_models_endpoint.py
@@ -251,3 +251,79 @@ def test_invalid_status_param_is_rejected(client: TestClient, session, project_f
     response = client.get(MODELS_URL, params={"status": "NOT_A_STATUS"})
 
     assert response.status_code == 400
+
+
+def test_multiple_statuses_filter_the_list_at_once(
+    client: TestClient, session, project_factory, model_factory
+):
+    """A comma-separated ``status`` filters to any of the given statuses (drives the group tiles)."""
+    user_id = uuid4()
+    project = _add_project(session, project_factory, owner_id=user_id, name="Multi")
+    pending = _add_model(
+        session, model_factory, project_id=project.id, owner_id=user_id, name="p", status=ModelStatus.PENDING
+    )
+    initiated = _add_model(
+        session, model_factory, project_id=project.id, owner_id=user_id, name="i", status=ModelStatus.INITIATED
+    )
+    _add_model(
+        session, model_factory, project_id=project.id, owner_id=user_id, name="prep", status=ModelStatus.PREPARED
+    )
+
+    override_verify_token_as(user_id)
+    response = client.get(MODELS_URL, params={"status": "PENDING,INITIATED"})
+
+    assert response.status_code == 200
+    assert _ids(response.json()) == {str(pending.id), str(initiated.id)}
+
+
+def test_response_carries_per_status_counts(client: TestClient, session, project_factory, model_factory):
+    """The response includes per-status totals over the access-scoped set (the tile numbers)."""
+    user_id = uuid4()
+    project = _add_project(session, project_factory, owner_id=user_id, name="Counts")
+    for _ in range(2):
+        _add_model(session, model_factory, project_id=project.id, owner_id=user_id, status=ModelStatus.PENDING)
+    _add_model(session, model_factory, project_id=project.id, owner_id=user_id, status=ModelStatus.TRAINING_STARTED)
+
+    override_verify_token_as(user_id)
+    counts = client.get(MODELS_URL).json()["statusCounts"]
+
+    assert counts.get("PENDING") == 2
+    assert counts.get("TRAINING_STARTED") == 1
+
+
+def test_status_counts_ignore_the_active_status_filter(
+    client: TestClient, session, project_factory, model_factory
+):
+    """Tile counts show every status even while the list is filtered to one, so tiles stay usable."""
+    user_id = uuid4()
+    project = _add_project(session, project_factory, owner_id=user_id, name="Facets")
+    pending = _add_model(
+        session, model_factory, project_id=project.id, owner_id=user_id, status=ModelStatus.PENDING
+    )
+    _add_model(session, model_factory, project_id=project.id, owner_id=user_id, status=ModelStatus.TRAINING_STARTED)
+
+    override_verify_token_as(user_id)
+    body = client.get(MODELS_URL, params={"status": "PENDING"}).json()
+
+    # The list is narrowed to the filtered status...
+    assert _ids(body) == {str(pending.id)}
+    # ...but the tiles still see the full breakdown.
+    assert body["statusCounts"].get("PENDING") == 1
+    assert body["statusCounts"].get("TRAINING_STARTED") == 1
+
+
+def test_status_counts_exclude_inaccessible_projects(
+    client: TestClient, session, project_factory, model_factory
+):
+    """Counts obey the same access scoping as the list — foreign models never inflate a tile."""
+    user_id = uuid4()
+    other_id = uuid4()
+    mine = _add_project(session, project_factory, owner_id=user_id, name="Mine")
+    foreign = _add_project(session, project_factory, owner_id=other_id, name="Foreign")
+    _add_model(session, model_factory, project_id=mine.id, owner_id=user_id, status=ModelStatus.PENDING)
+    _add_model(session, model_factory, project_id=foreign.id, owner_id=other_id, status=ModelStatus.PENDING)
+
+    override_verify_token_as(user_id)
+    counts = client.get(MODELS_URL).json()["statusCounts"]
+
+    assert counts.get("PENDING") == 1

--- a/flip-api/tests/integration/test_all_models_endpoint.py
+++ b/flip-api/tests/integration/test_all_models_endpoint.py
@@ -1,0 +1,253 @@
+# Copyright (c) Guy's and St Thomas' NHS Foundation Trust & King's College London
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Integration coverage of the estate-wide ``GET /api/models`` endpoint (issue #726).
+
+The cross-project models list joins each model to its owning project (name), the
+model's run trusts (``ModelTrustIntersect`` -> ``Trust``) and the owner's display
+name, then applies the same access scoping as the projects list: a caller sees
+only models whose project they own or have ``ProjectUserAccess`` to, while a
+manager (``CAN_MANAGE_PROJECTS``) sees every model. These are SQL-shaped joins +
+access filters that pass silently under a mocked session, so they are exercised
+against the throwaway Postgres.
+"""
+
+from uuid import UUID, uuid4
+
+from fastapi.testclient import TestClient
+
+from flip_api.db.models.main_models import (
+    Model,
+    ModelTrustIntersect,
+    Projects,
+    ProjectUserAccess,
+    Trust,
+)
+from flip_api.db.models.user_models import UserProfile
+from flip_api.domain.schemas.status import ModelStatus, ProjectStatus, TrustIntersectStatus
+from tests.integration.conftest import admin_user, override_verify_token_as
+
+MODELS_URL = "/api/models"
+
+
+def _add_project(session, project_factory, *, owner_id: UUID, name: str = "Project") -> Projects:
+    project = project_factory.build(owner_id=owner_id, name=name, deleted=False, status=ProjectStatus.APPROVED)
+    session.add(project)
+    session.commit()
+    return project
+
+
+def _add_model(
+    session,
+    model_factory,
+    *,
+    project_id: UUID,
+    owner_id: UUID,
+    name: str = "Model",
+    status: ModelStatus = ModelStatus.PREPARED,
+) -> Model:
+    model = model_factory.build(
+        project_id=project_id, owner_id=owner_id, name=name, deleted=False, status=status
+    )
+    session.add(model)
+    session.commit()
+    return model
+
+
+def _grant_access(session, *, project_id: UUID, user_id: UUID) -> None:
+    session.add(ProjectUserAccess(project_id=project_id, user_id=user_id))
+    session.commit()
+
+
+def _add_run_trust(session, trust_factory, *, model_id: UUID, name: str, code: str) -> Trust:
+    trust = trust_factory.build(name=name, code=code)
+    session.add(trust)
+    session.commit()
+    session.add(
+        ModelTrustIntersect(model_id=model_id, trust_id=trust.id, status=TrustIntersectStatus.INITIALISED)
+    )
+    session.commit()
+    return trust
+
+
+def _ids(payload) -> set[str]:
+    return {row["id"] for row in payload["data"]}
+
+
+def test_lists_only_models_from_projects_the_user_can_access(
+    client: TestClient, session, project_factory, model_factory
+):
+    """A researcher sees models for projects they own or are granted, never others'."""
+    user_id = uuid4()
+    other_id = uuid4()
+
+    owned = _add_project(session, project_factory, owner_id=user_id, name="Owned")
+    granted = _add_project(session, project_factory, owner_id=other_id, name="Granted")
+    foreign = _add_project(session, project_factory, owner_id=other_id, name="Foreign")
+    _grant_access(session, project_id=granted.id, user_id=user_id)
+
+    m_owned = _add_model(session, model_factory, project_id=owned.id, owner_id=user_id, name="owned-model")
+    m_granted = _add_model(session, model_factory, project_id=granted.id, owner_id=other_id, name="granted-model")
+    _add_model(session, model_factory, project_id=foreign.id, owner_id=other_id, name="foreign-model")
+
+    override_verify_token_as(user_id)
+    response = client.get(MODELS_URL)
+
+    assert response.status_code == 200
+    assert _ids(response.json()) == {str(m_owned.id), str(m_granted.id)}
+
+
+def test_admin_sees_all_models(client: TestClient, session, project_factory, model_factory):
+    """A manager (CAN_MANAGE_PROJECTS) sees models across every project."""
+    admin_id = admin_user(session)
+    other_id = uuid4()
+
+    p1 = _add_project(session, project_factory, owner_id=other_id, name="P1")
+    p2 = _add_project(session, project_factory, owner_id=other_id, name="P2")
+    m1 = _add_model(session, model_factory, project_id=p1.id, owner_id=other_id, name="m1")
+    m2 = _add_model(session, model_factory, project_id=p2.id, owner_id=other_id, name="m2")
+
+    override_verify_token_as(admin_id)
+    response = client.get(MODELS_URL)
+
+    assert response.status_code == 200
+    assert {str(m1.id), str(m2.id)} <= _ids(response.json())
+
+
+def test_row_carries_project_name_owner_name_and_run_trusts(
+    client: TestClient, session, project_factory, model_factory, trust_factory
+):
+    """Each row joins project name, owner display name and the model's run trusts."""
+    user_id = uuid4()
+    session.add(UserProfile(user_id=user_id, name="Dr Ada"))
+    session.commit()
+
+    project = _add_project(session, project_factory, owner_id=user_id, name="Stroke triage")
+    model = _add_model(session, model_factory, project_id=project.id, owner_id=user_id, name="stroke-v1")
+    _add_run_trust(session, trust_factory, model_id=model.id, name="Guy's & St Thomas'", code="GSTT")
+    _add_run_trust(session, trust_factory, model_id=model.id, name="King's College Hospital", code="KCH")
+
+    override_verify_token_as(user_id)
+    row = next(r for r in client.get(MODELS_URL).json()["data"] if r["id"] == str(model.id))
+
+    assert row["projectId"] == str(project.id)
+    assert row["projectName"] == "Stroke triage"
+    assert row["ownerName"] == "Dr Ada"
+    assert {t["code"] for t in row["trusts"]} == {"GSTT", "KCH"}
+
+
+def test_model_without_run_trusts_returns_empty_trusts(
+    client: TestClient, session, project_factory, model_factory
+):
+    """A model that has not been dispatched (no ModelTrustIntersect rows) has an empty trust list."""
+    user_id = uuid4()
+    project = _add_project(session, project_factory, owner_id=user_id, name="Fresh")
+    model = _add_model(
+        session, model_factory, project_id=project.id, owner_id=user_id, status=ModelStatus.PENDING
+    )
+
+    override_verify_token_as(user_id)
+    row = next(r for r in client.get(MODELS_URL).json()["data"] if r["id"] == str(model.id))
+
+    assert row["trusts"] == []
+
+
+def test_status_filter_narrows_results(client: TestClient, session, project_factory, model_factory):
+    """``?status=`` returns only models in that lifecycle state."""
+    user_id = uuid4()
+    project = _add_project(session, project_factory, owner_id=user_id, name="Mixed")
+    training = _add_model(
+        session, model_factory, project_id=project.id, owner_id=user_id,
+        name="live", status=ModelStatus.TRAINING_STARTED,
+    )
+    _add_model(
+        session, model_factory, project_id=project.id, owner_id=user_id,
+        name="done", status=ModelStatus.RESULTS_UPLOADED,
+    )
+
+    override_verify_token_as(user_id)
+    response = client.get(MODELS_URL, params={"status": "TRAINING_STARTED"})
+
+    assert response.status_code == 200
+    assert _ids(response.json()) == {str(training.id)}
+
+
+def test_search_matches_project_name(client: TestClient, session, project_factory, model_factory):
+    """Search matches on the owning project's name, not just the model name."""
+    user_id = uuid4()
+    retino = _add_project(session, project_factory, owner_id=user_id, name="Diabetic retinopathy")
+    sepsis = _add_project(session, project_factory, owner_id=user_id, name="Sepsis early warning")
+    m_retino = _add_model(session, model_factory, project_id=retino.id, owner_id=user_id, name="grade-v1")
+    _add_model(session, model_factory, project_id=sepsis.id, owner_id=user_id, name="tsm-v1")
+
+    override_verify_token_as(user_id)
+    response = client.get(MODELS_URL, params={"search": "retinopathy"})
+
+    assert response.status_code == 200
+    assert _ids(response.json()) == {str(m_retino.id)}
+
+
+def test_excludes_soft_deleted_models_and_projects(
+    client: TestClient, session, project_factory, model_factory
+):
+    """Soft-deleted models, and models under a soft-deleted project, are not listed."""
+    user_id = uuid4()
+    live_project = _add_project(session, project_factory, owner_id=user_id, name="Live")
+    kept = _add_model(session, model_factory, project_id=live_project.id, owner_id=user_id, name="kept")
+
+    deleted_model = model_factory.build(
+        project_id=live_project.id, owner_id=user_id, name="gone", deleted=True, status=ModelStatus.PREPARED
+    )
+    session.add(deleted_model)
+    deleted_project = project_factory.build(
+        owner_id=user_id, name="DeadProject", deleted=True, status=ProjectStatus.APPROVED
+    )
+    session.add(deleted_project)
+    session.commit()
+    orphan = _add_model(session, model_factory, project_id=deleted_project.id, owner_id=user_id, name="orphan")
+
+    override_verify_token_as(user_id)
+    ids = _ids(client.get(MODELS_URL).json())
+
+    assert str(kept.id) in ids
+    assert str(deleted_model.id) not in ids
+    assert str(orphan.id) not in ids
+
+
+def test_results_are_paginated(client: TestClient, session, project_factory, model_factory):
+    """The list is paginated: pageSize bounds the page and the wrapper reports the true totals."""
+    user_id = uuid4()
+    project = _add_project(session, project_factory, owner_id=user_id, name="Many")
+    for i in range(3):
+        _add_model(session, model_factory, project_id=project.id, owner_id=user_id, name=f"m{i}")
+
+    override_verify_token_as(user_id)
+    page_one = client.get(MODELS_URL, params={"pageNumber": 1, "pageSize": 2}).json()
+
+    assert page_one["totalRecords"] == 3
+    assert page_one["totalPages"] == 2
+    assert len(page_one["data"]) == 2
+
+    page_two = client.get(MODELS_URL, params={"pageNumber": 2, "pageSize": 2}).json()
+    assert len(page_two["data"]) == 1
+    # No overlap between pages.
+    assert _ids(page_one).isdisjoint(_ids(page_two))
+
+
+def test_invalid_status_param_is_rejected(client: TestClient, session, project_factory, model_factory):
+    """An unrecognised status value is a 400, not a silent all-models response."""
+    user_id = uuid4()
+    override_verify_token_as(user_id)
+
+    response = client.get(MODELS_URL, params={"status": "NOT_A_STATUS"})
+
+    assert response.status_code == 400

--- a/flip-ui/src/components/AiHeader/__tests__/AiHeader.spec.ts
+++ b/flip-ui/src/components/AiHeader/__tests__/AiHeader.spec.ts
@@ -125,6 +125,7 @@ describe("AiHeader", () => {
 
         expect(navLinks.map(l => l.text())).toEqual([
             "Projects",
+            "Models",
             "Connection Status",
             "Admin"
         ]);

--- a/flip-ui/src/composables/navigation.ts
+++ b/flip-ui/src/composables/navigation.ts
@@ -19,6 +19,7 @@ import { computed, ComputedRef } from "vue";
 import { IAIHeaderProps } from "@/components/AiHeader/AiHeader.vue";
 import { IMainNavigationProps } from "@/components/AiMainNavigation/AiMainNavigation.vue";
 import { useAuthStore } from "@/store/auth";
+import ModelsIcon from "~icons/carbon/machine-learning-model";
 import AdminIcon from "~icons/heroicons-outline/finger-print";
 import projectsIcon from "~icons/ic/twotone-library-books";
 import ConnectionIcon from "~icons/ph/plug-duotone";
@@ -33,6 +34,13 @@ export default function useNavigation(props: IMainNavigationProps | IAIHeaderPro
             href: "/projects",
             current: props.currentPage.startsWith("/project"),
             icon: projectsIcon,
+            canAccess: true
+        },
+        {
+            name: "Models",
+            href: "/models",
+            current: props.currentPage === "/models",
+            icon: ModelsIcon,
             canAccess: true
         },
         {

--- a/flip-ui/src/pages/__tests__/models.spec.ts
+++ b/flip-ui/src/pages/__tests__/models.spec.ts
@@ -1,0 +1,215 @@
+/*
+ * Copyright (c) 2026 Guy's and St Thomas' NHS Foundation Trust & King's College London
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+
+import { createTestingPinia } from "@pinia/testing";
+import { mount } from "@vue/test-utils";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { ref } from "vue";
+
+import { IModelSummary, IModelSummaryTrust } from "@/services/model-service";
+
+import Page from "../models.vue";
+
+interface ModelsResponse {
+    data: IModelSummary[];
+    totalPages: number;
+    page: number;
+}
+
+const mockSwrvData = ref<ModelsResponse | undefined>(undefined);
+
+vi.mock("swrv", () => ({
+    default: () => ({
+        data: mockSwrvData,
+        mutate: vi.fn(),
+        error: ref(null)
+    })
+}));
+
+const stubs = {
+    AiLoader: { template: "<div />" },
+    AiSearch: {
+        props: ["modelValue"],
+        emits: ["update:modelValue"],
+        template: "<input data-test='model-search' :value='modelValue' @input='$emit(\"update:modelValue\", $event.target.value)' />"
+    },
+    AiPagination: { template: "<div />" },
+    // Expose `to` as an attribute so tests can assert the link target.
+    "router-link": {
+        template: "<a :data-to='to'><slot /></a>",
+        props: ["to"]
+    }
+};
+
+const trust = (code: string): IModelSummaryTrust => ({
+    id: `t-${code}`,
+    name: `${code} NHS Foundation Trust`,
+    code
+});
+
+const makeModel = (over: Partial<IModelSummary> = {}): IModelSummary => ({
+    id: "m1",
+    name: "stroke-v1",
+    status: "PREPARED",
+    projectId: "p1",
+    projectName: "Stroke triage",
+    ownerId: "u1",
+    ownerName: "Dr Ada",
+    trusts: [trust("GSTT")],
+    ...over
+});
+
+const setModels = (models: IModelSummary[]): void => {
+    mockSwrvData.value = {
+        data: models,
+        totalPages: 1,
+        page: 1
+    };
+};
+
+function mountPage(options: { permissions?: string[] } = {}) {
+    const { permissions = [] } = options;
+
+    return mount(Page, {
+        global: {
+            plugins: [createTestingPinia({
+                createSpy: vi.fn,
+                stubActions: false,
+                initialState: {
+                    auth: {
+                        user: {
+                            userId: "u1",
+                            permissions
+                        }
+                    }
+                }
+            })],
+            stubs
+        }
+    });
+}
+
+beforeEach(() => {
+    mockSwrvData.value = undefined;
+});
+
+describe("Models Page", () => {
+    test("renders the component", () => {
+        expect(mountPage().exists()).toBe(true);
+    });
+
+    test("renders one row per model returned by the API", async () => {
+        setModels([
+            makeModel(),
+            makeModel({
+                id: "m2",
+                name: "sepsis-v1",
+                projectId: "p2",
+                projectName: "Sepsis"
+            })
+        ]);
+        const wrapper = mountPage();
+        await wrapper.vm.$nextTick();
+
+        expect(wrapper.find("[data-test='models-list-item-0']").exists()).toBe(true);
+        expect(wrapper.find("[data-test='models-list-item-1']").exists()).toBe(true);
+    });
+
+    test("the model name links to the model page and the project name to the project page", async () => {
+        setModels([makeModel()]);
+        const wrapper = mountPage();
+        await wrapper.vm.$nextTick();
+
+        expect(wrapper.find("[data-test='model-name']").attributes("data-to")).toBe("/project/p1/model/m1");
+        expect(wrapper.find("[data-test='model-project']").attributes("data-to")).toBe("/project/p1");
+    });
+
+    test("renders trust chips using the trust code", async () => {
+        setModels([makeModel({ trusts: [trust("GSTT"), trust("KCH")] })]);
+        const wrapper = mountPage();
+        await wrapper.vm.$nextTick();
+
+        const chips = wrapper.findAll("[data-test='model-trust-chip']");
+        expect(chips).toHaveLength(2);
+        expect(chips.map(c => c.text())).toEqual(expect.arrayContaining(["GSTT", "KCH"]));
+    });
+
+    test("shows an explanatory note instead of chips when a model has no run trusts yet", async () => {
+        setModels([makeModel({
+            trusts: [],
+            status: "PENDING"
+        })]);
+        const wrapper = mountPage();
+        await wrapper.vm.$nextTick();
+
+        expect(wrapper.findAll("[data-test='model-trust-chip']")).toHaveLength(0);
+        expect(wrapper.find("[data-test='model-trusts-empty']").exists()).toBe(true);
+        expect(wrapper.find("[data-test='model-trusts-empty']").text().toLowerCase()).toContain("training");
+    });
+
+    test("renders a human-readable status label", async () => {
+        setModels([makeModel({ status: "TRAINING_STARTED" })]);
+        const wrapper = mountPage();
+        await wrapper.vm.$nextTick();
+
+        expect(wrapper.find("[data-test='model-status-indicator']").text()).toBe("Training Started");
+    });
+
+    test("renders the empty-state copy when the API returns zero models", async () => {
+        setModels([]);
+        const wrapper = mountPage();
+        await wrapper.vm.$nextTick();
+
+        expect(wrapper.text()).toContain("There are no models to show");
+        expect(wrapper.findAll("[data-test='models-list-item-0']")).toHaveLength(0);
+    });
+
+    test("the status filter offers a value per model status and can be changed without error", async () => {
+        setModels([makeModel({ status: "TRAINING_STARTED" })]);
+        const wrapper = mountPage();
+        await wrapper.vm.$nextTick();
+
+        const filter = wrapper.find("[data-test='model-status-filter']");
+        expect(filter.exists()).toBe(true);
+        await filter.setValue("TRAINING_STARTED");
+        await wrapper.vm.$nextTick();
+
+        expect(wrapper.exists()).toBe(true);
+    });
+
+    test("typing in the search input triggers a paginated reload (debouncedWatch)", async () => {
+        setModels([makeModel()]);
+        const wrapper = mountPage();
+        await wrapper.vm.$nextTick();
+
+        await wrapper.find("[data-test='model-search']").setValue("stroke");
+        await new Promise((resolve) => setTimeout(resolve, 600));
+        await wrapper.vm.$nextTick();
+
+        expect(wrapper.exists()).toBe(true);
+    });
+
+    test("falls back to the owner email local-part when ownerName is unset", async () => {
+        setModels([makeModel({
+            ownerName: null,
+            ownerId: "u1"
+        })]);
+        const wrapper = mountPage();
+        await wrapper.vm.$nextTick();
+
+        // With no ownerName the row should still render without throwing.
+        expect(wrapper.find("[data-test='models-list-item-0']").exists()).toBe(true);
+    });
+});

--- a/flip-ui/src/pages/__tests__/models.spec.ts
+++ b/flip-ui/src/pages/__tests__/models.spec.ts
@@ -215,8 +215,14 @@ describe("Models Page", () => {
 
     test("clicking the Model header sorts rows by name and toggles direction", async () => {
         setModels([
-            makeModel({ id: "m1", name: "zebra" }),
-            makeModel({ id: "m2", name: "apple" })
+            makeModel({
+                id: "m1",
+                name: "zebra"
+            }),
+            makeModel({
+                id: "m2",
+                name: "apple"
+            })
         ]);
         const wrapper = mountPage();
         await wrapper.vm.$nextTick();
@@ -230,8 +236,16 @@ describe("Models Page", () => {
 
     test("clicking the Status header groups rows by lifecycle stage (ascending)", async () => {
         setModels([
-            makeModel({ id: "m1", name: "done", status: "RESULTS_UPLOADED" }),
-            makeModel({ id: "m2", name: "created", status: "PENDING" })
+            makeModel({
+                id: "m1",
+                name: "done",
+                status: "RESULTS_UPLOADED"
+            }),
+            makeModel({
+                id: "m2",
+                name: "created",
+                status: "PENDING"
+            })
         ]);
         const wrapper = mountPage();
         await wrapper.vm.$nextTick();

--- a/flip-ui/src/pages/__tests__/models.spec.ts
+++ b/flip-ui/src/pages/__tests__/models.spec.ts
@@ -26,6 +26,7 @@ interface ModelsResponse {
     data: IModelSummary[];
     totalPages: number;
     page: number;
+    statusCounts: Record<string, number>;
 }
 
 const mockSwrvData = ref<ModelsResponse | undefined>(undefined);
@@ -71,11 +72,12 @@ const makeModel = (over: Partial<IModelSummary> = {}): IModelSummary => ({
     ...over
 });
 
-const setModels = (models: IModelSummary[]): void => {
+const setModels = (models: IModelSummary[], statusCounts: Record<string, number> = {}): void => {
     mockSwrvData.value = {
         data: models,
         totalPages: 1,
-        page: 1
+        page: 1,
+        statusCounts
     };
 };
 
@@ -176,17 +178,38 @@ describe("Models Page", () => {
         expect(wrapper.findAll("[data-test='models-list-item-0']")).toHaveLength(0);
     });
 
-    test("the status filter offers a value per model status and can be changed without error", async () => {
-        setModels([makeModel({ status: "TRAINING_STARTED" })]);
+    test("renders a filter tile per group with counts summed from statusCounts", async () => {
+        setModels([makeModel({ status: "TRAINING_STARTED" })], {
+            TRAINING_STARTED: 3,
+            PENDING: 1,
+            INITIATED: 2,
+            ERROR: 1,
+            RESULTS_UPLOAD_FAILED: 1
+        });
         const wrapper = mountPage();
         await wrapper.vm.$nextTick();
 
-        const filter = wrapper.find("[data-test='model-status-filter']");
-        expect(filter.exists()).toBe(true);
-        await filter.setValue("TRAINING_STARTED");
+        expect(wrapper.find("[data-test='filter-tile-training']").exists()).toBe(true);
+        expect(wrapper.find("[data-test='filter-tile-count-training']").text()).toBe("3");
+        // Queued groups PENDING + INITIATED = 3.
+        expect(wrapper.find("[data-test='filter-tile-count-queued']").text()).toBe("3");
+        // Needs attention groups ERROR + RESULTS_UPLOAD_FAILED + STOPPED = 2.
+        expect(wrapper.find("[data-test='filter-tile-count-attention']").text()).toBe("2");
+    });
+
+    test("clicking a filter tile activates it, and clicking it again clears the filter", async () => {
+        setModels([makeModel({ status: "RESULTS_UPLOADED" })], { RESULTS_UPLOADED: 1 });
+        const wrapper = mountPage();
         await wrapper.vm.$nextTick();
 
-        expect(wrapper.exists()).toBe(true);
+        const tile = wrapper.find("[data-test='filter-tile-completed']");
+        expect(tile.attributes("aria-pressed")).toBe("false");
+
+        await tile.trigger("click");
+        expect(tile.attributes("aria-pressed")).toBe("true");
+
+        await tile.trigger("click");
+        expect(tile.attributes("aria-pressed")).toBe("false");
     });
 
     test("typing in the search input triggers a paginated reload (debouncedWatch)", async () => {

--- a/flip-ui/src/pages/__tests__/models.spec.ts
+++ b/flip-ui/src/pages/__tests__/models.spec.ts
@@ -212,4 +212,43 @@ describe("Models Page", () => {
         // With no ownerName the row should still render without throwing.
         expect(wrapper.find("[data-test='models-list-item-0']").exists()).toBe(true);
     });
+
+    test("clicking the Model header sorts rows by name and toggles direction", async () => {
+        setModels([
+            makeModel({ id: "m1", name: "zebra" }),
+            makeModel({ id: "m2", name: "apple" })
+        ]);
+        const wrapper = mountPage();
+        await wrapper.vm.$nextTick();
+
+        await wrapper.find("[data-test='sort-header-name']").trigger("click");
+        expect(wrapper.findAll("[data-test='model-name']").map(n => n.text())).toEqual(["apple", "zebra"]);
+
+        await wrapper.find("[data-test='sort-header-name']").trigger("click");
+        expect(wrapper.findAll("[data-test='model-name']").map(n => n.text())).toEqual(["zebra", "apple"]);
+    });
+
+    test("clicking the Status header groups rows by lifecycle stage (ascending)", async () => {
+        setModels([
+            makeModel({ id: "m1", name: "done", status: "RESULTS_UPLOADED" }),
+            makeModel({ id: "m2", name: "created", status: "PENDING" })
+        ]);
+        const wrapper = mountPage();
+        await wrapper.vm.$nextTick();
+
+        await wrapper.find("[data-test='sort-header-status']").trigger("click");
+        // PENDING (earliest lifecycle) sorts before RESULTS_UPLOADED.
+        expect(wrapper.findAll("[data-test='model-name']").map(n => n.text())).toEqual(["created", "done"]);
+    });
+
+    test("each row carries a status-coloured left rail", async () => {
+        setModels([makeModel({ status: "TRAINING_STARTED" })]);
+        const wrapper = mountPage();
+        await wrapper.vm.$nextTick();
+
+        const rail = wrapper.find("[data-test='model-status-rail']");
+        expect(rail.exists()).toBe(true);
+        // Training runs get the live magenta rail.
+        expect(rail.classes().some(c => c.includes("fuchsia"))).toBe(true);
+    });
 });

--- a/flip-ui/src/pages/__tests__/models.spec.ts
+++ b/flip-ui/src/pages/__tests__/models.spec.ts
@@ -288,4 +288,81 @@ describe("Models Page", () => {
         // Training runs get the live magenta rail.
         expect(rail.classes().some(c => c.includes("fuchsia"))).toBe(true);
     });
+
+    test("clicking the Project header sorts rows by project name", async () => {
+        setModels([
+            makeModel({
+                id: "m1",
+                name: "a",
+                projectName: "Zebra project"
+            }),
+            makeModel({
+                id: "m2",
+                name: "b",
+                projectName: "Apple project"
+            })
+        ]);
+        const wrapper = mountPage();
+        await wrapper.vm.$nextTick();
+
+        await wrapper.find("[data-test='sort-header-project']").trigger("click");
+        expect(wrapper.findAll("[data-test='model-project']").map(p => p.text()))
+            .toEqual(["Apple project", "Zebra project"]);
+    });
+
+    test("clicking the Trusts header sorts rows by trust count (fewest first)", async () => {
+        setModels([
+            makeModel({
+                id: "m1",
+                name: "three",
+                trusts: [trust("A"), trust("B"), trust("C")]
+            }),
+            makeModel({
+                id: "m2",
+                name: "one",
+                trusts: [trust("A")]
+            })
+        ]);
+        const wrapper = mountPage();
+        await wrapper.vm.$nextTick();
+
+        await wrapper.find("[data-test='sort-header-trusts']").trigger("click");
+        expect(wrapper.findAll("[data-test='model-name']").map(n => n.text())).toEqual(["one", "three"]);
+    });
+
+    test("a trust chip with no code falls back to a cleaned, truncated name", async () => {
+        setModels([makeModel({
+            trusts: [{
+                id: "t-long",
+                name: "Very Long Hospital Name Here NHS Foundation Trust",
+                code: undefined as unknown as string
+            }]
+        })]);
+        const wrapper = mountPage();
+        await wrapper.vm.$nextTick();
+
+        const chip = wrapper.find("[data-test='model-trust-chip']");
+        // "NHS Foundation Trust" stripped, then truncated to 14 chars + ellipsis.
+        expect(chip.text().endsWith("…")).toBe(true);
+        expect(chip.text().slice(0, -1)).toHaveLength(14);
+    });
+
+    test("the owner sub-line shows an em-dash when ownerName is unset", async () => {
+        setModels([makeModel({ ownerName: null })]);
+        const wrapper = mountPage();
+        await wrapper.vm.$nextTick();
+
+        expect(wrapper.find("[data-test='models-list-item-0']").text()).toContain("—");
+    });
+
+    test("an error/terminal status renders a red pill and a red rail", async () => {
+        setModels([makeModel({ status: "STOPPED" })]);
+        const wrapper = mountPage();
+        await wrapper.vm.$nextTick();
+
+        const pill = wrapper.find("[data-test='model-status-indicator']");
+        expect(pill.text()).toBe("Stopped");
+        expect(pill.classes().some(c => c.includes("red"))).toBe(true);
+        expect(wrapper.find("[data-test='model-status-rail']").classes()).toContain("bg-red-500");
+    });
 });

--- a/flip-ui/src/pages/__tests__/models.spec.ts
+++ b/flip-ui/src/pages/__tests__/models.spec.ts
@@ -224,17 +224,6 @@ describe("Models Page", () => {
         expect(wrapper.exists()).toBe(true);
     });
 
-    test("falls back to the owner email local-part when ownerName is unset", async () => {
-        setModels([makeModel({
-            ownerName: null,
-            ownerId: "u1"
-        })]);
-        const wrapper = mountPage();
-        await wrapper.vm.$nextTick();
-
-        // With no ownerName the row should still render without throwing.
-        expect(wrapper.find("[data-test='models-list-item-0']").exists()).toBe(true);
-    });
 
     test("clicking the Model header sorts rows by name and toggles direction", async () => {
         setModels([

--- a/flip-ui/src/pages/models.vue
+++ b/flip-ui/src/pages/models.vue
@@ -399,7 +399,8 @@ debouncedWatch(
 );
 
 const getSearchQuery = (): void => {
-    searchQueryParam.value = search.value ? `&search=${search.value}` : "";
+    // Encode the term so characters like & ? # % don't corrupt the query string.
+    searchQueryParam.value = search.value ? `&search=${encodeURIComponent(search.value)}` : "";
 };
 
 const updateModelList = (pageNumberInt: number): void => {

--- a/flip-ui/src/pages/models.vue
+++ b/flip-ui/src/pages/models.vue
@@ -61,99 +61,116 @@
                     </select>
                 </div>
 
-                <!-- Models table -->
+                <!-- Models table (div/grid layout: transparent rows + status rail, escapes the
+                     global `<table>` styling in main.css) -->
                 <div class="px-8 pb-8">
-                    <div class="overflow-hidden border border-gray-200 rounded-xl dark:border-dark-raised">
-                        <table class="w-full text-left">
-                            <thead class="bg-gray-50 dark:bg-dark-raised">
-                                <tr class="text-xs font-mono uppercase tracking-wider text-gray-500 dark:text-gray-300">
-                                    <th class="px-6 py-3 font-medium">
-                                        Model
-                                    </th>
-                                    <th class="px-6 py-3 font-medium">
-                                        Project
-                                    </th>
-                                    <th class="px-6 py-3 font-medium">
-                                        Trusts
-                                    </th>
-                                    <th class="px-6 py-3 font-medium text-right">
-                                        Status
-                                    </th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                <tr
-                                    v-for="(model, index) in models"
-                                    :key="model.id"
-                                    :data-test="`models-list-item-${index}`"
-                                    class="border-t border-gray-100 transition hover:bg-gray-50 dark:border-dark-raised dark:hover:bg-dark-canvas"
+                    <div class="overflow-hidden border border-gray-200 rounded-xl dark:border-dark-border">
+                        <!-- Header row: sortable columns -->
+                        <div class="flex items-stretch bg-gray-50 border-b border-gray-200 dark:bg-dark-surface dark:border-dark-border">
+                            <div class="w-[3px] shrink-0" />
+                            <div :class="GRID_CLASS" class="flex-1 gap-4 px-6 py-3">
+                                <button
+                                    v-for="col in columns"
+                                    :key="col.label"
+                                    type="button"
+                                    :data-test="col.key ? `sort-header-${col.key}` : undefined"
+                                    class="flex items-center gap-1 text-xs font-mono font-medium uppercase tracking-wider text-gray-500 dark:text-gray-300 select-none"
+                                    :class="[
+                                        col.align === 'right' ? 'justify-end' : 'justify-start',
+                                        col.key ? 'cursor-pointer hover:text-gray-700 dark:hover:text-gray-200' : 'cursor-default'
+                                    ]"
+                                    @click="col.key && toggleSort(col.key)"
                                 >
-                                    <!-- Model -->
-                                    <td class="px-6 py-4 align-top">
-                                        <router-link
-                                            :to="`/project/${model.projectId}/model/${model.id}`"
-                                            data-test="model-name"
-                                            class="font-mono text-sm font-semibold text-gray-900 hover:text-primary-600 dark:text-gray-100 dark:hover:text-primary-300"
-                                            @click.stop
-                                        >
-                                            {{ model.name }}
-                                        </router-link>
-                                        <p class="mt-1 text-xs text-gray-500 dark:text-gray-300">
-                                            {{ ownerLabel(model) }}
-                                        </p>
-                                    </td>
-                                    <!-- Project -->
-                                    <td class="px-6 py-4 align-top">
-                                        <router-link
-                                            :to="`/project/${model.projectId}`"
-                                            data-test="model-project"
-                                            class="text-sm font-semibold text-gray-900 hover:text-primary-600 dark:text-gray-100 dark:hover:text-primary-300"
-                                            @click.stop
-                                        >
-                                            {{ model.projectName }}
-                                        </router-link>
-                                    </td>
-                                    <!-- Trusts -->
-                                    <td class="px-6 py-4 align-top">
-                                        <div v-if="model.trusts.length" class="flex flex-wrap items-center gap-1.5">
-                                            <span
-                                                v-for="t in model.trusts"
-                                                :key="t.id"
-                                                data-test="model-trust-chip"
-                                                :title="t.name"
-                                                class="inline-flex items-center gap-1 rounded-full border border-gray-200 bg-white px-2.5 py-0.5 text-xs text-gray-700 dark:border-dark-raised dark:bg-dark-canvas dark:text-gray-200"
-                                            >
-                                                <span class="inline-block w-1.5 h-1.5 rounded-full bg-emerald-500" />
-                                                {{ trustChipLabel(t) }}
-                                            </span>
-                                        </div>
-                                        <p
-                                            v-else
-                                            data-test="model-trusts-empty"
-                                            class="text-xs italic text-gray-400 dark:text-gray-300"
-                                        >
-                                            Trusts assigned when training starts
-                                        </p>
-                                    </td>
-                                    <!-- Status -->
-                                    <td class="px-6 py-4 align-top text-right">
+                                    {{ col.label }}
+                                    <span
+                                        v-if="col.key && sortKey === col.key"
+                                        class="text-primary-600 dark:text-primary-300"
+                                    >{{ sortDir === "asc" ? "↑" : "↓" }}</span>
+                                </button>
+                            </div>
+                        </div>
+
+                        <!-- Data rows -->
+                        <div
+                            v-for="(model, index) in sortedModels"
+                            :key="model.id"
+                            :data-test="`models-list-item-${index}`"
+                            class="flex items-stretch border-t border-gray-100 transition first:border-t-0 hover:bg-gray-50 dark:border-dark-border dark:hover:bg-dark-raised"
+                        >
+                            <!-- Status rail -->
+                            <div
+                                data-test="model-status-rail"
+                                class="w-[3px] shrink-0"
+                                :class="railClass(model.status)"
+                            />
+                            <div :class="GRID_CLASS" class="flex-1 items-center gap-4 px-6 py-4">
+                                <!-- Model -->
+                                <div class="min-w-0">
+                                    <router-link
+                                        :to="`/project/${model.projectId}/model/${model.id}`"
+                                        data-test="model-name"
+                                        class="font-mono text-sm font-semibold text-gray-900 hover:text-primary-600 dark:text-gray-100 dark:hover:text-primary-300"
+                                        @click.stop
+                                    >
+                                        {{ model.name }}
+                                    </router-link>
+                                    <p class="mt-1 text-xs text-gray-500 dark:text-gray-300">
+                                        {{ ownerLabel(model) }}
+                                    </p>
+                                </div>
+                                <!-- Project -->
+                                <div class="min-w-0">
+                                    <router-link
+                                        :to="`/project/${model.projectId}`"
+                                        data-test="model-project"
+                                        class="text-sm font-semibold text-gray-900 hover:text-primary-600 dark:text-gray-100 dark:hover:text-primary-300"
+                                        @click.stop
+                                    >
+                                        {{ model.projectName }}
+                                    </router-link>
+                                </div>
+                                <!-- Trusts -->
+                                <div class="min-w-0">
+                                    <div v-if="model.trusts.length" class="flex flex-wrap items-center gap-1.5">
                                         <span
-                                            data-test="model-status-indicator"
-                                            class="inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-medium"
-                                            :class="statusPillClass(model.status)"
+                                            v-for="t in model.trusts"
+                                            :key="t.id"
+                                            data-test="model-trust-chip"
+                                            :title="t.name"
+                                            class="inline-flex items-center gap-1 rounded-full border border-gray-200 bg-white px-2.5 py-0.5 text-xs text-gray-700 dark:border-dark-border dark:bg-dark-surface dark:text-gray-200"
                                         >
-                                            <span class="inline-block w-1.5 h-1.5 rounded-full" :class="statusDotClass(model.status)" />
-                                            {{ modelStatusLabel(model.status) }}
+                                            <span class="inline-block w-1.5 h-1.5 rounded-full bg-emerald-500" />
+                                            {{ trustChipLabel(t) }}
                                         </span>
-                                    </td>
-                                </tr>
-                                <tr v-if="!models.length">
-                                    <td colspan="4" class="px-6 py-12 text-center text-sm text-gray-500 dark:text-gray-300">
-                                        There are no models to show
-                                    </td>
-                                </tr>
-                            </tbody>
-                        </table>
+                                    </div>
+                                    <p
+                                        v-else
+                                        data-test="model-trusts-empty"
+                                        class="text-xs italic text-gray-400 dark:text-gray-300"
+                                    >
+                                        Trusts assigned when training starts
+                                    </p>
+                                </div>
+                                <!-- Status -->
+                                <div class="flex justify-end">
+                                    <span
+                                        data-test="model-status-indicator"
+                                        class="inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-medium"
+                                        :class="statusPillClass(model.status)"
+                                    >
+                                        <span class="inline-block w-1.5 h-1.5 rounded-full" :class="statusDotClass(model.status)" />
+                                        {{ modelStatusLabel(model.status) }}
+                                    </span>
+                                </div>
+                            </div>
+                        </div>
+
+                        <div
+                            v-if="!sortedModels.length"
+                            class="px-6 py-12 text-center text-sm text-gray-500 dark:text-gray-300"
+                        >
+                            There are no models to show
+                        </div>
                     </div>
 
                     <AiPagination
@@ -218,6 +235,92 @@ const { data, error } = useSWRV(
 useErrorHandler(error);
 
 const models = computed<IModelSummary[]>(() => data.value?.data ?? []);
+
+type SortKey = "name" | "project" | "trusts" | "status";
+type SortDir = "asc" | "desc";
+
+interface IColumn {
+    key?: SortKey;
+    label: string;
+    align?: "left" | "right";
+}
+
+// Shared grid template so the header and data rows stay column-aligned.
+const GRID_CLASS = "grid grid-cols-[minmax(0,1.6fr)_minmax(0,1.4fr)_minmax(0,1.6fr)_auto]";
+
+const columns: IColumn[] = [
+    {
+        key: "name",
+        label: "Model"
+    },
+    {
+        key: "project",
+        label: "Project"
+    },
+    {
+        key: "trusts",
+        label: "Trusts"
+    },
+    {
+        key: "status",
+        label: "Status",
+        align: "right"
+    }
+];
+
+// Null sortKey keeps the backend order (newest-first) until a header is clicked.
+const sortKey = ref<SortKey | null>(null);
+const sortDir = ref<SortDir>("asc");
+
+// First click on a column sorts ascending; subsequent clicks toggle direction.
+const toggleSort = (key: SortKey): void => {
+    if (sortKey.value === key) {
+        sortDir.value = sortDir.value === "asc" ? "desc" : "asc";
+    }
+    else {
+        sortKey.value = key;
+        sortDir.value = "asc";
+    }
+};
+
+// Lifecycle rank so a Status sort groups models by stage in a sensible order.
+const STATUS_RANK: Record<ModelStatus, number> = {
+    PENDING: 0,
+    INITIATED: 1,
+    PREPARED: 2,
+    TRAINING_STARTED: 3,
+    RESULTS_UPLOADED: 4,
+    RESULTS_UPLOAD_FAILED: 5,
+    ERROR: 6,
+    STOPPED: 7
+};
+const statusRank = (s: ModelStatus | undefined): number => (s ? STATUS_RANK[s] ?? 99 : 99);
+
+const SORT_COMPARATORS: Record<SortKey, (a: IModelSummary, b: IModelSummary) => number> = {
+    name: (a, b) => a.name.localeCompare(b.name),
+    project: (a, b) => a.projectName.localeCompare(b.projectName) || a.name.localeCompare(b.name),
+    trusts: (a, b) => a.trusts.length - b.trusts.length || a.name.localeCompare(b.name),
+    status: (a, b) => statusRank(a.status) - statusRank(b.status) || a.name.localeCompare(b.name)
+};
+
+// Client-side sort of the current page (mirrors the Connection Status trusts table).
+const sortedModels = computed<IModelSummary[]>(() => {
+    if (!sortKey.value) return models.value;
+    const cmp = SORT_COMPARATORS[sortKey.value];
+
+    return [...models.value].sort(sortDir.value === "asc" ? cmp : (a, b) => cmp(b, a));
+});
+
+// Status-toned left rail: magenta = live training, amber = preparing, emerald =
+// completed, red = needs attention, neutral = created/queued.
+const railClass = (status: ModelStatus | undefined): string => {
+    if (isModelStatusError(status)) return "bg-red-500";
+    if (status === "RESULTS_UPLOADED") return "bg-emerald-500";
+    if (status === "TRAINING_STARTED") return "bg-fuchsia-500";
+    if (status === "PREPARED") return "bg-amber-500";
+
+    return "bg-gray-300 dark:bg-gray-600";
+};
 
 debouncedWatch(
     search,

--- a/flip-ui/src/pages/models.vue
+++ b/flip-ui/src/pages/models.vue
@@ -1,0 +1,286 @@
+<!--
+    Copyright (c) 2026 Guy's and St Thomas' NHS Foundation Trust & King's College London
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+        http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+
+<!-- eslint-disable vue/multi-word-component-names -->
+<route lang="yaml">
+    name: Models
+</route>
+
+<template>
+    <div class="flex flex-col w-full h-full">
+        <transition name="fade" mode="out-in">
+            <AiLoader v-if="!data?.data" />
+            <div v-else class="flex flex-col flex-1 min-w-0 overflow-y-auto">
+                <!-- Page header (mirrors the Projects page spine) -->
+                <header class="flex flex-col gap-4 px-8 pt-8 pb-4 sm:flex-row sm:items-end sm:justify-between">
+                    <div>
+                        <p class="text-xs font-mono uppercase tracking-widest text-gray-500 dark:text-gray-300">
+                            Estate-wide · every project
+                        </p>
+                        <h1 class="text-3xl font-semibold font-heading mt-1 text-gray-900 dark:text-gray-100">
+                            <span class="text-primary-600 underline decoration-4 decoration-primary-500/60 underline-offset-8 dark:text-white">Models</span>
+                            <span class="ml-3 text-gray-400 dark:text-gray-300 font-medium">{{ data.totalRecords ?? data.data.length }}</span>
+                        </h1>
+                        <p class="mt-2 text-sm text-gray-500 dark:text-gray-300">
+                            The federated training queue across every project you can access.
+                        </p>
+                    </div>
+                </header>
+
+                <!-- Toolbar: search + status filter -->
+                <div class="flex flex-wrap items-center gap-3 px-8 pb-4">
+                    <div class="flex-1 min-w-[240px]">
+                        <AiSearch
+                            v-model="search"
+                            placeholder="Search models or projects…"
+                            data-test="model-search"
+                        />
+                    </div>
+                    <select
+                        v-model="statusFilter"
+                        data-test="model-status-filter"
+                        aria-label="Filter by status"
+                        class="h-10 rounded-lg border border-gray-200 bg-white px-3 text-sm text-gray-700 dark:border-dark-raised dark:bg-dark-canvas dark:text-gray-200"
+                    >
+                        <option value="">
+                            All statuses
+                        </option>
+                        <option v-for="s in STATUS_OPTIONS" :key="s" :value="s">
+                            {{ modelStatusLabel(s) }}
+                        </option>
+                    </select>
+                </div>
+
+                <!-- Models table -->
+                <div class="px-8 pb-8">
+                    <div class="overflow-hidden border border-gray-200 rounded-xl dark:border-dark-raised">
+                        <table class="w-full text-left">
+                            <thead class="bg-gray-50 dark:bg-dark-raised">
+                                <tr class="text-xs font-mono uppercase tracking-wider text-gray-500 dark:text-gray-300">
+                                    <th class="px-6 py-3 font-medium">
+                                        Model
+                                    </th>
+                                    <th class="px-6 py-3 font-medium">
+                                        Project
+                                    </th>
+                                    <th class="px-6 py-3 font-medium">
+                                        Trusts
+                                    </th>
+                                    <th class="px-6 py-3 font-medium text-right">
+                                        Status
+                                    </th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr
+                                    v-for="(model, index) in models"
+                                    :key="model.id"
+                                    :data-test="`models-list-item-${index}`"
+                                    class="border-t border-gray-100 transition hover:bg-gray-50 dark:border-dark-raised dark:hover:bg-dark-canvas"
+                                >
+                                    <!-- Model -->
+                                    <td class="px-6 py-4 align-top">
+                                        <router-link
+                                            :to="`/project/${model.projectId}/model/${model.id}`"
+                                            data-test="model-name"
+                                            class="font-mono text-sm font-semibold text-gray-900 hover:text-primary-600 dark:text-gray-100 dark:hover:text-primary-300"
+                                            @click.stop
+                                        >
+                                            {{ model.name }}
+                                        </router-link>
+                                        <p class="mt-1 text-xs text-gray-500 dark:text-gray-300">
+                                            {{ ownerLabel(model) }}
+                                        </p>
+                                    </td>
+                                    <!-- Project -->
+                                    <td class="px-6 py-4 align-top">
+                                        <router-link
+                                            :to="`/project/${model.projectId}`"
+                                            data-test="model-project"
+                                            class="text-sm font-semibold text-gray-900 hover:text-primary-600 dark:text-gray-100 dark:hover:text-primary-300"
+                                            @click.stop
+                                        >
+                                            {{ model.projectName }}
+                                        </router-link>
+                                    </td>
+                                    <!-- Trusts -->
+                                    <td class="px-6 py-4 align-top">
+                                        <div v-if="model.trusts.length" class="flex flex-wrap items-center gap-1.5">
+                                            <span
+                                                v-for="t in model.trusts"
+                                                :key="t.id"
+                                                data-test="model-trust-chip"
+                                                :title="t.name"
+                                                class="inline-flex items-center gap-1 rounded-full border border-gray-200 bg-white px-2.5 py-0.5 text-xs text-gray-700 dark:border-dark-raised dark:bg-dark-canvas dark:text-gray-200"
+                                            >
+                                                <span class="inline-block w-1.5 h-1.5 rounded-full bg-emerald-500" />
+                                                {{ trustChipLabel(t) }}
+                                            </span>
+                                        </div>
+                                        <p
+                                            v-else
+                                            data-test="model-trusts-empty"
+                                            class="text-xs italic text-gray-400 dark:text-gray-300"
+                                        >
+                                            Trusts assigned when training starts
+                                        </p>
+                                    </td>
+                                    <!-- Status -->
+                                    <td class="px-6 py-4 align-top text-right">
+                                        <span
+                                            data-test="model-status-indicator"
+                                            class="inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-medium"
+                                            :class="statusPillClass(model.status)"
+                                        >
+                                            <span class="inline-block w-1.5 h-1.5 rounded-full" :class="statusDotClass(model.status)" />
+                                            {{ modelStatusLabel(model.status) }}
+                                        </span>
+                                    </td>
+                                </tr>
+                                <tr v-if="!models.length">
+                                    <td colspan="4" class="px-6 py-12 text-center text-sm text-gray-500 dark:text-gray-300">
+                                        There are no models to show
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+
+                    <AiPagination
+                        class="mt-4"
+                        :total-pages="data?.totalPages ?? 1"
+                        :current-page="data?.page ?? 1"
+                        @page-update="updateModelList"
+                    />
+                </div>
+            </div>
+        </transition>
+    </div>
+</template>
+
+<script setup lang="ts">
+import { debouncedWatch } from "@vueuse/core";
+import useSWRV from "swrv";
+import { computed, ref } from "vue";
+
+import AiLoader from "@/components/AiLoader/AiLoader.vue";
+import AiPagination from "@/components/AiPagination/AiPagination.vue";
+import AiSearch from "@/components/AiSearch/AiSearch.vue";
+import useErrorHandler from "@/composables/useErrorHandler";
+import { getAllModels,
+    IModelSummary,
+    IModelSummaryTrust,
+    isModelStatusError,
+    ModelStatus,
+    modelStatusLabel } from "@/services/model-service";
+
+const pageSize = 20;
+
+const search = ref("");
+const pageNumber = ref(1);
+const searchQueryParam = ref("");
+const statusFilter = ref<ModelStatus | "">("");
+const statusQueryParam = ref("");
+
+// Lifecycle order, matching the model status enum. Drives the status-filter dropdown.
+const STATUS_OPTIONS: ModelStatus[] = [
+    "PENDING",
+    "INITIATED",
+    "PREPARED",
+    "TRAINING_STARTED",
+    "RESULTS_UPLOADED",
+    "RESULTS_UPLOAD_FAILED",
+    "ERROR",
+    "STOPPED"
+];
+
+const { data, error } = useSWRV(
+    () =>
+        `/models?pageNumber=${pageNumber.value}&pageSize=${pageSize}${searchQueryParam.value}${statusQueryParam.value}`,
+    getAllModels,
+    {
+        dedupingInterval: 5_000,
+        shouldRetryOnError: false,
+        refreshInterval: 5_000
+    }
+);
+
+useErrorHandler(error);
+
+const models = computed<IModelSummary[]>(() => data.value?.data ?? []);
+
+debouncedWatch(
+    search,
+    () => updateModelList(1),
+    { debounce: 500 }
+);
+
+debouncedWatch(
+    statusFilter,
+    () => {
+        statusQueryParam.value = statusFilter.value ? `&status=${statusFilter.value}` : "";
+        pageNumber.value = 1;
+    },
+    { debounce: 300 }
+);
+
+const getSearchQuery = (): void => {
+    searchQueryParam.value = search.value ? `&search=${search.value}` : "";
+};
+
+const updateModelList = (pageNumberInt: number): void => {
+    pageNumber.value = pageNumberInt;
+    getSearchQuery();
+};
+
+// Prefer the trust's short code (e.g. "GSTT"); otherwise strip common name bloat
+// and truncate so chips stay compact — mirrors the Projects page behaviour.
+const trustChipLabel = (trust: IModelSummaryTrust): string => {
+    if (trust.code) return trust.code;
+    if (!trust.name) return "";
+    const stripped = trust.name
+        .replace(/\bNHS Foundation Trust\b/gi, "")
+        .replace(/\bNHS Trust\b/gi, "")
+        .replace(/\bTrust\b/gi, "")
+        .trim();
+    if (stripped.length <= 16) return stripped;
+
+    return stripped.slice(0, 14) + "…";
+};
+
+// Owner display name (UserProfile.name from the backend). Falls back to an
+// em-dash when the owner has no profile row — the endpoint carries no email.
+const ownerLabel = (model: IModelSummary): string => model.ownerName || "—";
+
+const statusPillClass = (status: ModelStatus | undefined): string => {
+    if (isModelStatusError(status)) {
+        return "bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-200";
+    }
+    if (status === "RESULTS_UPLOADED") {
+        return "bg-emerald-100 text-emerald-900 dark:bg-emerald-900/40 dark:text-emerald-100";
+    }
+    if (status === "TRAINING_STARTED" || status === "PREPARED") {
+        return "bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-200";
+    }
+
+    return "bg-gray-200 text-gray-700 dark:bg-dark-raised dark:text-gray-300";
+};
+
+const statusDotClass = (status: ModelStatus | undefined): string => {
+    if (isModelStatusError(status)) return "bg-red-500";
+    if (status === "RESULTS_UPLOADED") return "bg-emerald-500";
+    if (status === "TRAINING_STARTED" || status === "PREPARED") return "bg-amber-500";
+
+    return "bg-gray-400";
+};
+</script>

--- a/flip-ui/src/pages/models.vue
+++ b/flip-ui/src/pages/models.vue
@@ -37,7 +37,36 @@
                     </div>
                 </header>
 
-                <!-- Toolbar: search + status filter -->
+                <!-- Filter tiles: one per lifecycle group, each a toggle. Click the active tile to reset. -->
+                <div class="flex flex-wrap gap-3 px-8 pb-4">
+                    <button
+                        v-for="tile in TILES"
+                        :key="tile.key"
+                        type="button"
+                        :data-test="`filter-tile-${tile.key}`"
+                        :aria-pressed="activeTile === tile.key"
+                        class="flex-1 min-w-[150px] rounded-xl border bg-white px-4 py-3 text-left transition dark:bg-dark-surface"
+                        :class="activeTile === tile.key
+                            ? [tile.ring, 'ring-[3px]']
+                            : 'border-gray-200 hover:border-gray-300 dark:border-dark-border dark:hover:border-dark-border-strong'"
+                        @click="toggleTile(tile.key)"
+                    >
+                        <div class="flex items-center gap-2">
+                            <span class="inline-block w-2 h-2 rounded-full" :class="tile.dot" />
+                            <span class="text-[11px] font-mono uppercase tracking-widest text-gray-500 dark:text-gray-300">
+                                {{ tile.label }}
+                            </span>
+                        </div>
+                        <div
+                            :data-test="`filter-tile-count-${tile.key}`"
+                            class="mt-1 text-2xl font-heading font-bold text-gray-900 dark:text-gray-100"
+                        >
+                            {{ tileCount(tile) }}
+                        </div>
+                    </button>
+                </div>
+
+                <!-- Toolbar: search -->
                 <div class="flex flex-wrap items-center gap-3 px-8 pb-4">
                     <div class="flex-1 min-w-[240px]">
                         <AiSearch
@@ -46,19 +75,6 @@
                             data-test="model-search"
                         />
                     </div>
-                    <select
-                        v-model="statusFilter"
-                        data-test="model-status-filter"
-                        aria-label="Filter by status"
-                        class="h-10 rounded-lg border border-gray-200 bg-white px-3 text-sm text-gray-700 dark:border-dark-raised dark:bg-dark-canvas dark:text-gray-200"
-                    >
-                        <option value="">
-                            All statuses
-                        </option>
-                        <option v-for="s in STATUS_OPTIONS" :key="s" :value="s">
-                            {{ modelStatusLabel(s) }}
-                        </option>
-                    </select>
                 </div>
 
                 <!-- Models table (div/grid layout: transparent rows + status rail, escapes the
@@ -206,20 +222,59 @@ const pageSize = 20;
 const search = ref("");
 const pageNumber = ref(1);
 const searchQueryParam = ref("");
-const statusFilter = ref<ModelStatus | "">("");
 const statusQueryParam = ref("");
 
-// Lifecycle order, matching the model status enum. Drives the status-filter dropdown.
-const STATUS_OPTIONS: ModelStatus[] = [
-    "PENDING",
-    "INITIATED",
-    "PREPARED",
-    "TRAINING_STARTED",
-    "RESULTS_UPLOADED",
-    "RESULTS_UPLOAD_FAILED",
-    "ERROR",
-    "STOPPED"
+type GroupKey = "training" | "preparing" | "queued" | "completed" | "attention";
+
+interface ITile {
+    key: GroupKey;
+    label: string;
+    statuses: ModelStatus[];
+    dot: string;
+    ring: string;
+}
+
+// Summary filter tiles — one per lifecycle group. `statuses` is the set a tile filters to;
+// `dot`/`ring` are whole literal Tailwind classes so the JIT compiler emits them.
+const TILES: ITile[] = [
+    {
+        key: "training",
+        label: "In training",
+        statuses: ["TRAINING_STARTED"],
+        dot: "bg-fuchsia-500",
+        ring: "border-fuchsia-500 ring-fuchsia-500/40"
+    },
+    {
+        key: "preparing",
+        label: "Preparing",
+        statuses: ["PREPARED"],
+        dot: "bg-amber-500",
+        ring: "border-amber-500 ring-amber-500/40"
+    },
+    {
+        key: "queued",
+        label: "Queued",
+        statuses: ["INITIATED", "PENDING"],
+        dot: "bg-gray-400",
+        ring: "border-gray-400 ring-gray-400/40"
+    },
+    {
+        key: "completed",
+        label: "Completed",
+        statuses: ["RESULTS_UPLOADED"],
+        dot: "bg-emerald-500",
+        ring: "border-emerald-500 ring-emerald-500/40"
+    },
+    {
+        key: "attention",
+        label: "Needs attention",
+        statuses: ["ERROR", "RESULTS_UPLOAD_FAILED", "STOPPED"],
+        dot: "bg-red-500",
+        ring: "border-red-500 ring-red-500/40"
+    }
 ];
+
+const activeTile = ref<GroupKey | null>(null);
 
 const { data, error } = useSWRV(
     () =>
@@ -235,6 +290,18 @@ const { data, error } = useSWRV(
 useErrorHandler(error);
 
 const models = computed<IModelSummary[]>(() => data.value?.data ?? []);
+
+// A tile's number sums the per-status counts the backend returns for its group.
+const tileCount = (tile: ITile): number =>
+    tile.statuses.reduce((sum, s) => sum + (data.value?.statusCounts?.[s] ?? 0), 0);
+
+// Toggle a tile: clicking the active tile clears the filter, otherwise filters to its statuses.
+const toggleTile = (key: GroupKey): void => {
+    activeTile.value = activeTile.value === key ? null : key;
+    const tile = TILES.find(t => t.key === activeTile.value);
+    statusQueryParam.value = tile ? `&status=${tile.statuses.join(",")}` : "";
+    pageNumber.value = 1;
+};
 
 type SortKey = "name" | "project" | "trusts" | "status";
 type SortDir = "asc" | "desc";
@@ -329,15 +396,6 @@ debouncedWatch(
     search,
     () => updateModelList(1),
     { debounce: 500 }
-);
-
-debouncedWatch(
-    statusFilter,
-    () => {
-        statusQueryParam.value = statusFilter.value ? `&status=${statusFilter.value}` : "";
-        pageNumber.value = 1;
-    },
-    { debounce: 300 }
 );
 
 const getSearchQuery = (): void => {

--- a/flip-ui/src/pages/models.vue
+++ b/flip-ui/src/pages/models.vue
@@ -245,8 +245,11 @@ interface IColumn {
     align?: "left" | "right";
 }
 
-// Shared grid template so the header and data rows stay column-aligned.
-const GRID_CLASS = "grid grid-cols-[minmax(0,1.6fr)_minmax(0,1.4fr)_minmax(0,1.6fr)_auto]";
+// Shared grid template so the header and data rows stay column-aligned. Every track is a
+// fractional unit (no `auto`): each row is its own grid, so a content-sized column — e.g. a
+// variable-width Status pill — would resolve to a different width per row and knock the columns
+// out of alignment. Fixed fractions keep every row's tracks identical.
+const GRID_CLASS = "grid grid-cols-[minmax(0,1.7fr)_minmax(0,1.4fr)_minmax(0,1.5fr)_minmax(0,0.9fr)]";
 
 const columns: IColumn[] = [
     {

--- a/flip-ui/src/services/__tests__/model-service.spec.ts
+++ b/flip-ui/src/services/__tests__/model-service.spec.ts
@@ -14,7 +14,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { _http } from "@/services/api";
-import { buildModelSteps, clearJobTypesCache, createModel, DEFAULT_JOB_TYPE, deleteModel, editModel, fetchJobTypes, getDownloadUrlForResults, getLogsForModel, getModel, getModelFileStatus, getModelMetrics, getModels, getPreSignedUrl, getRequiredFilesForJobType, getStatusEnumValue, initialiseTraining, isValidJobType, type ModelStatus, ModelStatusEnum, stopTraining, uploadModelFile } from "@/services/model-service";
+import { buildModelSteps, clearJobTypesCache, createModel, DEFAULT_JOB_TYPE, deleteModel, editModel, fetchJobTypes, getAllModels, getDownloadUrlForResults, getLogsForModel, getModel, getModelFileStatus, getModelMetrics, getModels, getPreSignedUrl, getRequiredFilesForJobType, getStatusEnumValue, initialiseTraining, isValidJobType, type ModelStatus, ModelStatusEnum, stopTraining, uploadModelFile } from "@/services/model-service";
 
 vi.mock("@/services/api", () => ({
     _http: {
@@ -35,6 +35,32 @@ describe("model-service", () => {
         // a single failing test would poison every subsequent test in the
         // suite via the module-level `_jobTypesCache`.
         clearJobTypesCache();
+    });
+
+    describe("getAllModels", () => {
+        it("GETs the given URL and returns the paged models response with statusCounts", async () => {
+            const page = {
+                data: [{
+                    id: "m1",
+                    name: "stroke-v1",
+                    projectId: "p1",
+                    projectName: "Stroke triage",
+                    ownerId: "u1",
+                    trusts: []
+                }],
+                page: 1,
+                pageSize: 20,
+                totalPages: 1,
+                totalRecords: 1,
+                statusCounts: { PENDING: 1 }
+            };
+            vi.mocked(_http.get).mockResolvedValue({ data: page } as never);
+
+            const result = await getAllModels("/models?pageNumber=1&pageSize=20&status=INITIATED,PENDING");
+
+            expect(_http.get).toHaveBeenCalledWith("/models?pageNumber=1&pageSize=20&status=INITIATED,PENDING");
+            expect(result).toEqual(page);
+        });
     });
 
     describe("fetchJobTypes", () => {

--- a/flip-ui/src/services/model-service.ts
+++ b/flip-ui/src/services/model-service.ts
@@ -333,9 +333,18 @@ export interface IModelSummary {
     trusts: IModelSummaryTrust[];
 }
 
+/**
+ * A page of the estate-wide Models list plus per-status totals for the filter tiles.
+ * ``statusCounts`` maps each ``ModelStatus`` value to its count across the caller's
+ * access-scoped set (honouring search, ignoring the active status filter).
+ */
+export interface IModelsPage extends IPaginatedResponse<IModelSummary> {
+    statusCounts: Record<string, number>;
+}
+
 /** Fetch the paginated, access-scoped list of models across every project the user can see. */
-export async function getAllModels(url: string): Promise<IPaginatedResponse<IModelSummary>> {
-    const response = await _http.get<IPaginatedResponse<IModelSummary>>(url);
+export async function getAllModels(url: string): Promise<IModelsPage> {
+    const response = await _http.get<IModelsPage>(url);
 
     return response.data;
 }

--- a/flip-ui/src/services/model-service.ts
+++ b/flip-ui/src/services/model-service.ts
@@ -310,6 +310,36 @@ export async function getModels(url: string): Promise<IPaginatedResponse<IModel>
     return response.data;
 }
 
+/** A trust participating in a model's federated run, for the Models-list chips. */
+export interface IModelSummaryTrust {
+    id: string;
+    name: string;
+    code?: string | null;
+}
+
+/**
+ * One row of the estate-wide Models list (issue #726): a model joined with its
+ * owning project, the owner's display name and the model's run trusts. `trusts`
+ * is empty until training is initiated (no trusts are assigned before dispatch).
+ */
+export interface IModelSummary {
+    id: string;
+    name: string;
+    status?: ModelStatus;
+    projectId: string;
+    projectName: string;
+    ownerId: string;
+    ownerName?: string | null;
+    trusts: IModelSummaryTrust[];
+}
+
+/** Fetch the paginated, access-scoped list of models across every project the user can see. */
+export async function getAllModels(url: string): Promise<IPaginatedResponse<IModelSummary>> {
+    const response = await _http.get<IPaginatedResponse<IModelSummary>>(url);
+
+    return response.data;
+}
+
 export async function getModel(url: string): Promise<IModelDashboard> {
     const response = await _http.post<IModelDashboard>(url);
 

--- a/flip-ui/src/services/model-service.ts
+++ b/flip-ui/src/services/model-service.ts
@@ -325,7 +325,9 @@ export interface IModelSummaryTrust {
 export interface IModelSummary {
     id: string;
     name: string;
-    status?: ModelStatus;
+    // Required: the /models endpoint returns a status for every row (unlike the
+    // per-project IModel list, whose cached payloads predate the status column).
+    status: ModelStatus;
     projectId: string;
     projectName: string;
     ownerId: string;
@@ -335,11 +337,12 @@ export interface IModelSummary {
 
 /**
  * A page of the estate-wide Models list plus per-status totals for the filter tiles.
- * ``statusCounts`` maps each ``ModelStatus`` value to its count across the caller's
- * access-scoped set (honouring search, ignoring the active status filter).
+ * ``statusCounts`` maps each ``ModelStatus`` to its count across the caller's
+ * access-scoped set (honouring search, ignoring the active status filter). Statuses
+ * with no models are omitted, so the map is partial.
  */
 export interface IModelsPage extends IPaginatedResponse<IModelSummary> {
-    statusCounts: Record<string, number>;
+    statusCounts: Partial<Record<ModelStatus, number>>;
 }
 
 /** Fetch the paginated, access-scoped list of models across every project the user can see. */


### PR DESCRIPTION
## Summary

Adds the estate-wide **Models** page (issue #726): a new top-level page where a user sees every model across the projects they can access (admins see all), in a **Model · Project · Trusts · Status** table. The model name links to the model page and the project name to the project page.

## Backend — `GET /models` (flip-api)

- New access-scoped, paginated endpoint joining each model to its owning **project name**, the **owner** display name and its **run trusts** (`ModelTrustIntersect`).
- Reuses the projects-list access rule exactly: `owner ∨ ProjectUserAccess`, with `CAN_MANAGE_PROJECTS` dropping the filter (managers see all). Never returns a model whose project the caller can't see. Soft-deleted models/projects excluded.
- **Search** over model **or** project name; **newest-first**; **pagination**.
- **Comma-separated `status` filter** (e.g. `INITIATED,PENDING`) so a group filter tile can narrow to several statuses at once; unknown values → 400.
- **`statusCounts`** in the response — per-status totals over the access-scoped, search-filtered set, **ignoring the active status filter** so the filter tiles keep their numbers while one is selected.
- Integration tests over the throwaway Postgres: access scoping, admin bypass, trust join, empty-trust case, single- and multi-status filter, search, soft-delete exclusion, pagination, per-status counts (scoping + facet behaviour), invalid status.

## Frontend — Models page (flip-ui)

- New `/models` route + `pages/models.vue`, and a **Models** nav item between Projects and Connection Status.
- Rows link out (model → `/project/{projectId}/model/{modelId}`, project → `/project/{projectId}`); trusts render as chips (with a "Trusts assigned when training starts" note before dispatch); status as a pill.
- **Summary filter tiles** — five toggleable cards (In training / Preparing / Queued / Completed / Needs attention) with live counts from `statusCounts` and a tone-coloured dot + selected ring, per the design handoff. Clicking a tile filters the list to its status group; clicking the active tile clears it. (Replaces the interim status dropdown.)
- **Sortable column headers** — click Model / Project / Trusts / Status to sort, with an ↑/↓ indicator and direction toggle (mirrors the Connection Status trusts table). Client-side over the current page; default preserves the backend newest-first order until a header is clicked.
- **Status-coloured left rail** on each row (magenta live / amber preparing / emerald done / red attention / neutral queued).
- **Transparent dark-mode rows** — the table is a div/grid layout rather than a raw `<table>`, so it escapes the global `main.css` table styling (which fills rows `dark:bg-gray-800` and adds rings/cell borders); rows are transparent with a subtle hover. Columns use fixed `fr` tracks so they stay aligned row-to-row.
- Search (debounced) + pagination, refreshed on the shared 5s SWRV poll.
- Vitest coverage for rendering, link targets, trust chips / empty-trust note, status label, empty state, sorting, filter tiles + counts, search. `AiHeader` nav test updated for the new item.

## Verification

- flip-api: new integration suite green, adjacent model/project flows green, `ruff` + `mypy` clean.
- flip-ui: full unit suite green, `eslint` clean, dark-mode contrast guard green.
- Deployed to **stag** and exercised end-to-end (all lifecycle stages seeded; tiles, sorting, links and multi-status filtering confirmed against real data). See the deployment comment below.

## Notes / follow-ups

- The endpoint is picked up by the auto-generated API reference (`autoapi`); a short user-guide note for the page is a small follow-up.
- Sorting is client-side over the current page (matching the Connection Status table); server-side sort across all pages is a possible later enhancement.
- Deferred to follow-ups (per #726): the **Progress** column (round strips / metrics / ETA) and the per-project model count on the Projects list.

Closes #726


## Acceptance Criteria

*Imported from issue #726*

- [x] A new **Models** nav item appears in the top nav (`composables/navigation.ts`), positioned **between Projects and Connection Status**, `canAccess: true`, routing to `/models`.
- [x] A new route `/models` renders a `pages/models.vue` under `MainLayout` (mirroring the Projects page), registered in `router/index.ts`.
- [x] The page lists models across **all projects the user can access**; a researcher/viewer sees only their owned/granted projects' models, and an admin/project-manager sees every model. Access scoping matches the existing project-list rule exactly (owner **or** `ProjectUserAccess`, with `CAN_MANAGE_PROJECTS` removing the filter).
- [x] The table shows the four columns: **Model name · Project · Trusts · Status**.
- [x] Clicking a **model name** navigates to that model's page (`/project/{projectId}/model/{modelId}`); clicking a **project name** navigates to that project's page (`/project/{projectId}`). Inner links use `router-link` with `@click.stop` (as in `ModelList.vue`).
- [x] **Trusts** render as reused `TrustChip` pills from the model's run trusts; when a model has no run trusts yet (not dispatched), the cell shows a short explanatory note instead of being blank.
- [x] **Status** renders using the existing `ModelStatus` → `MODEL_STATUS_LABELS` mapping and status-pill styling (no new statuses invented).
- [x] A **status filter** (single-select over `ModelStatus`) narrows the list, backed by the endpoint's `?status=` param.
- [x] The list supports **search** (by model name / project name, debounced ~500ms, as `ModelList.vue`) and **pagination** (`AiPagination`).
- [x] Live-ish updates: the list re-fetches on the existing SWRV poll interval used by the other model views (`refreshInterval` / `dedupingInterval` 5000).
- [x] *(nice-to-have)* an **owner** sub-line under the model name — only if it doesn't bloat the endpoint/component.
- [x] Empty state ("No models in this view.") and loading skeletons handled.
- [x] Unit tests for the new page/component (list rendering, access-scoped fetch, link targets, status filter, search/pagination) — TDD per project convention.
