### PR TITLE
Head-only broadcast for frozen-backbone cross-site validation (GlobalModelEval)

### DIFF
--- a/fl-services/nvflare/fl-api-base/fl_api/utils/prepare_config.py
+++ b/fl-services/nvflare/fl-api-base/fl_api/utils/prepare_config.py
@@ -180,14 +180,53 @@ def _inject_reconstruct_full_model_filter(config: dict) -> None:
     before any other incoming task_data_filter. Injected alongside the KeepOnlyVars result filter —
     together the matched client-side ends of the frozen-backbone round-trip. Mutates ``config`` in
     place.
+
+    NVFLARE rejects a job in which the same task appears in more than one task_data_filters chain
+    (``FedJsonConfigurator._build_filter_table`` raises "multiple data filter chains defined for
+    task ..."), so any pre-existing chain covering ``train`` or ``validate`` is FOLDED INTO the
+    injected chain rather than left alongside it: its filters keep their relative order after the
+    reconstruct filter (which must see the broadcast first), and any ``ReconstructFullModel*`` filter
+    already wired (e.g. by a ``FlipFedAvgRecipe(aggregate_only_regex=...)`` export) is dropped as
+    superseded — the deploy-time instance must be the ONE holding the round-0 cache across both
+    tasks. A pre-existing chain that also covers OTHER tasks cannot be folded without silently
+    changing which tasks its filters run on, so that raises instead.
+
+    Raises:
+        ValueError: if an existing task_data_filters chain covers ``train`` or ``validate`` together
+            with other tasks — unmergeable, and NVFLARE would reject the overlap at job parse time.
     """
     reconstruct_filter = {
         "id": "reconstruct_full_model",
         "path": "flip.nvflare.components.ReconstructFullModelForEval",
         "args": {},
     }
+    covered_tasks = {"train", "validate"}
     filters_blocks = config.setdefault("task_data_filters", [])
-    filters_blocks.insert(0, {"tasks": ["train", "validate"], "filters": [reconstruct_filter]})
+    to_merge = [block for block in filters_blocks if covered_tasks & set(block.get("tasks", []))]
+    unmergeable = [block for block in to_merge if set(block.get("tasks", [])) - covered_tasks]
+    if unmergeable:
+        raise ValueError(
+            "AGGREGATE_ONLY_REGEX requires a single client task_data_filters chain over ['train', 'validate'], "
+            f"but the app config has a chain over {unmergeable[0].get('tasks')} — folding it in would apply its "
+            "filters to train/validate only, and NVFLARE rejects a task covered by two chains. Restrict the "
+            "chain to train/validate tasks or unset AGGREGATE_ONLY_REGEX."
+        )
+    merged_filters = [reconstruct_filter]
+    for block in to_merge:
+        for existing in block.get("filters", []):
+            if str(existing.get("path", "")).startswith("flip.nvflare.components.ReconstructFullModel"):
+                # Already wired (e.g. recipe-baked); superseded by the instance injected above — keeping
+                # both would double-reconstruct and NVFLARE would build a second, cache-less instance.
+                logger.info(f"Dropping pre-existing {existing.get('path')} filter superseded by injected chain")
+                continue
+            merged_filters.append(existing)
+        if set(block["tasks"]) != covered_tasks and len(block.get("filters", [])) > 0:
+            logger.warning(
+                f"Folding task_data_filters chain over {block['tasks']} into the injected "
+                "['train', 'validate'] chain; its filters now run on both tasks"
+            )
+    remaining_blocks = [block for block in filters_blocks if not any(block is merged for merged in to_merge)]
+    config["task_data_filters"] = [{"tasks": ["train", "validate"], "filters": merged_filters}, *remaining_blocks]
 
 
 def _inject_trim_broadcast_filter(config: dict, include_regex: str) -> None:
@@ -221,6 +260,17 @@ def _inject_trim_eval_broadcast_filter(config: dict, include_regex: str) -> None
     from the backbone it cached at training round 0. Kept as its own ``["validate"]`` chain (distinct
     from the ``["train"]`` TrimBroadcastVars chain); both filters are stateless, so a separate
     server-side instance per task is fine. Mutates ``config`` in place.
+
+    Detection is by membership (any chain covering ``validate``), not exact match — NVFLARE rejects a
+    task covered by two chains, so appending a second validate-covering chain would fail the job at
+    parse time. But unlike the round-gated TrimBroadcastVars (which no-ops on tasks without a round
+    header), this filter trims UNCONDITIONALLY, so it must not be appended into a chain that also
+    covers other tasks (it would e.g. trim the round-0 ``train`` broadcast and destroy the client's
+    backbone cache) — that raises instead.
+
+    Raises:
+        ValueError: if an existing task_data_filters chain covers ``validate`` together with other
+            tasks — the unconditional trim cannot be scoped to ``validate`` within a shared chain.
     """
     trim_filter = {
         "id": "trim_eval_broadcast_to_trainable",
@@ -229,9 +279,18 @@ def _inject_trim_eval_broadcast_filter(config: dict, include_regex: str) -> None
     }
     filters_blocks = config.setdefault("task_data_filters", [])
     for block in filters_blocks:
-        if block.get("tasks", []) == ["validate"]:
-            block.setdefault("filters", []).append(trim_filter)
-            return
+        tasks = block.get("tasks", [])
+        if "validate" not in tasks:
+            continue
+        if tasks != ["validate"]:
+            raise ValueError(
+                "AGGREGATE_ONLY_REGEX requires a dedicated ['validate'] server task_data_filters chain, but the "
+                f"app config has a chain over {tasks} — TrimEvalBroadcastVars trims unconditionally, so it cannot "
+                "share a chain with other tasks, and NVFLARE rejects a task covered by two chains. Split validate "
+                "into its own chain or unset AGGREGATE_ONLY_REGEX."
+            )
+        block.setdefault("filters", []).append(trim_filter)
+        return
     filters_blocks.append({"tasks": ["validate"], "filters": [trim_filter]})
 
 

--- a/fl-services/nvflare/fl-api-base/fl_api/utils/prepare_config.py
+++ b/fl-services/nvflare/fl-api-base/fl_api/utils/prepare_config.py
@@ -165,26 +165,29 @@ def _inject_keep_only_vars_filter(config: dict, include_regex: str) -> None:
 
 
 def _inject_reconstruct_full_model_filter(config: dict) -> None:
-    """Prepend a ReconstructFullModel filter to the ``train`` task_data_filters (client-side).
+    """Prepend a ReconstructFullModelForEval filter covering BOTH ``train`` and ``validate`` (client).
 
     The client-side half of the head-only broadcast: it rebuilds the full global model from the
-    trimmed (head-only) broadcast the server sends after round 0 (see ``_inject_trim_broadcast_filter``
-    / TrimBroadcastVars), so the client trainer keeps receiving a full state dict and needs no change.
-    Prepended so it runs before any other incoming task_data_filter. Injected alongside the
-    KeepOnlyVars result filter — the two are the matched client-side ends of the frozen-backbone
-    round-trip. Mutates ``config`` in place.
+    trimmed (head-only) broadcast the server sends after round 0 (training, see
+    ``_inject_trim_broadcast_filter`` / TrimBroadcastVars) and for cross-site validation (see
+    ``_inject_trim_eval_broadcast_filter`` / TrimEvalBroadcastVars), so the client trainer and
+    validator keep receiving a full state dict and need no change.
+
+    Wired as a SINGLE filter chain over ``["train", "validate"]`` so ONE component instance handles
+    both tasks: the frozen backbone the client reconstructs against is the round-0 broadcast cached
+    during training, and NVFLARE builds a fresh filter instance per chain occurrence — so that cache
+    is only visible during validation when the same instance serves both tasks. Prepended so it runs
+    before any other incoming task_data_filter. Injected alongside the KeepOnlyVars result filter —
+    together the matched client-side ends of the frozen-backbone round-trip. Mutates ``config`` in
+    place.
     """
     reconstruct_filter = {
         "id": "reconstruct_full_model",
-        "path": "flip.nvflare.components.ReconstructFullModel",
+        "path": "flip.nvflare.components.ReconstructFullModelForEval",
         "args": {},
     }
     filters_blocks = config.setdefault("task_data_filters", [])
-    for block in filters_blocks:
-        if "train" in block.get("tasks", []):
-            block.setdefault("filters", []).insert(0, reconstruct_filter)
-            return
-    filters_blocks.append({"tasks": ["train"], "filters": [reconstruct_filter]})
+    filters_blocks.insert(0, {"tasks": ["train", "validate"], "filters": [reconstruct_filter]})
 
 
 def _inject_trim_broadcast_filter(config: dict, include_regex: str) -> None:
@@ -208,6 +211,30 @@ def _inject_trim_broadcast_filter(config: dict, include_regex: str) -> None:
     filters_blocks.append({"tasks": ["train"], "filters": [trim_filter]})
 
 
+def _inject_trim_eval_broadcast_filter(config: dict, include_regex: str) -> None:
+    """Append a TrimEvalBroadcastVars filter to the ``validate`` task_data_filters (server-side).
+
+    The server-side half of head-only cross-site validation: it trims the ``validate`` broadcast
+    (the full aggregated global model that ``GlobalModelEval`` sends to each client for scoring) down
+    to only the trainable params matching ``include_regex``, so the frozen ~759 MiB backbone is not
+    re-shipped for evaluation — the client rebuilds the full model via ReconstructFullModelForEval
+    from the backbone it cached at training round 0. Kept as its own ``["validate"]`` chain (distinct
+    from the ``["train"]`` TrimBroadcastVars chain); both filters are stateless, so a separate
+    server-side instance per task is fine. Mutates ``config`` in place.
+    """
+    trim_filter = {
+        "id": "trim_eval_broadcast_to_trainable",
+        "path": "flip.nvflare.components.TrimEvalBroadcastVars",
+        "args": {"include_vars": include_regex},
+    }
+    filters_blocks = config.setdefault("task_data_filters", [])
+    for block in filters_blocks:
+        if block.get("tasks", []) == ["validate"]:
+            block.setdefault("filters", []).append(trim_filter)
+            return
+    filters_blocks.append({"tasks": ["validate"], "filters": [trim_filter]})
+
+
 def configure_client(
     job_dir: Path,
     app_name: str,
@@ -225,7 +252,9 @@ def configure_client(
         project_id (str): unique project_id identifier
         cohort_query (str): cohort query identifying the project (SQL query used to obtain the data)
         aggregate_only_regex (str | None): when set, inject a KeepOnlyVars ``train`` result filter so
-            only matching (trainable) params are sent per round (frozen-backbone head-only, FLIP#684).
+            only matching (trainable) params are sent per round, plus a ReconstructFullModelForEval
+            data filter over ``train``+``validate`` that rebuilds the full model client-side for both
+            training and cross-site validation (frozen-backbone head-only, FLIP#684 / #730).
 
     Returns:
         Path: path to the client config file that was updated.
@@ -283,8 +312,10 @@ def configure_server(
         aggregator (str): name of the aggregator to be used
         aggregation_weights (dict): aggregation weights to be used in the job (per trust)
         aggregate_only_regex (str | None): when set, inject a TrimBroadcastVars ``train`` data filter so
-            only the trainable params (matching the regex) are broadcast per round after round 0
-            (frozen-backbone head-only downstream — the server-side mirror of the client KeepOnlyVars).
+            only the trainable params (matching the regex) are broadcast per round after round 0, plus a
+            TrimEvalBroadcastVars ``validate`` data filter so post-training cross-site validation also
+            broadcasts only the head (frozen-backbone head-only downstream — the server-side mirror of
+            the client KeepOnlyVars / ReconstructFullModelForEval; FLIP#684 / #730).
 
     Returns:
         Path: path to the server config file that was updated.
@@ -347,8 +378,10 @@ def configure_server(
 
     if aggregate_only_regex:
         _inject_trim_broadcast_filter(config, aggregate_only_regex)
+        _inject_trim_eval_broadcast_filter(config, aggregate_only_regex)
         logger.info(
-            f"Injected TrimBroadcastVars data filter (include_vars={aggregate_only_regex!r}) for app '{app_name}'"
+            f"Injected TrimBroadcastVars (train) + TrimEvalBroadcastVars (validate) data filters "
+            f"(include_vars={aggregate_only_regex!r}) for app '{app_name}'"
         )
 
     write_config(config, config_file)

--- a/fl-services/nvflare/fl-api-base/tests/utils/test_prepare_config.py
+++ b/fl-services/nvflare/fl-api-base/tests/utils/test_prepare_config.py
@@ -264,9 +264,10 @@ class TestConfigureClient:
     def test_configure_client_injects_reconstruct_full_model_filter(
         self, mock_isfile, mock_write_config, mock_read_config
     ):
-        """With aggregate_only_regex set, a ReconstructFullModel filter is prepended to the train
-        task_data_filters — the client half of the head-only broadcast (it rebuilds the full model
-        from the trimmed broadcast the server sends after round 0)."""
+        """With aggregate_only_regex set, a ReconstructFullModelForEval filter is prepended as its own
+        chain over BOTH ``train`` and ``validate`` — the client half of the head-only broadcast for
+        training AND cross-site validation (one instance shares the round-0 backbone cache across both
+        tasks; #730)."""
         mock_read_config.return_value = {"task_result_filters": [{"tasks": ["train"], "filters": []}]}
 
         configure_client(
@@ -278,14 +279,16 @@ class TestConfigureClient:
         )
 
         modified_config = mock_write_config.call_args[0][0]
-        train_block = next(b for b in modified_config["task_data_filters"] if "train" in b["tasks"])
-        assert train_block["filters"][0]["path"] == "flip.nvflare.components.ReconstructFullModel"
+        reconstruct_block = modified_config["task_data_filters"][0]
+        assert reconstruct_block["tasks"] == ["train", "validate"]
+        assert reconstruct_block["filters"][0]["path"] == "flip.nvflare.components.ReconstructFullModelForEval"
 
     def test_configure_client_reconstruct_filter_prepended_before_existing_data_filter(
         self, mock_isfile, mock_write_config, mock_read_config
     ):
-        """An existing train task_data_filters block keeps its filters; ReconstructFullModel is
-        prepended so the full model is rebuilt before any other incoming data filter runs."""
+        """An existing train task_data_filters block keeps its filters untouched; the
+        ReconstructFullModelForEval chain is prepended as a separate block so it is built/applied
+        first (and, being a single ``["train", "validate"]`` chain, shares one instance across tasks)."""
         mock_read_config.return_value = {
             "task_data_filters": [
                 {"tasks": ["train"], "filters": [{"id": "existing", "path": "some.Filter"}]}
@@ -301,14 +304,18 @@ class TestConfigureClient:
         )
 
         modified_config = mock_write_config.call_args[0][0]
-        train_block = next(b for b in modified_config["task_data_filters"] if "train" in b["tasks"])
-        assert train_block["filters"][0]["path"] == "flip.nvflare.components.ReconstructFullModel"
-        assert train_block["filters"][1]["id"] == "existing"
+        reconstruct_block = modified_config["task_data_filters"][0]
+        assert reconstruct_block["tasks"] == ["train", "validate"]
+        assert reconstruct_block["filters"][0]["path"] == "flip.nvflare.components.ReconstructFullModelForEval"
+        # The pre-existing train block is preserved unchanged, after the injected chain.
+        existing_block = modified_config["task_data_filters"][1]
+        assert existing_block["filters"][0]["id"] == "existing"
 
     def test_configure_client_no_regex_leaves_data_filters_untouched(
         self, mock_isfile, mock_write_config, mock_read_config
     ):
-        """No aggregate_only_regex → no ReconstructFullModel injected (normal full-model broadcast)."""
+        """No aggregate_only_regex → no reconstruct filter injected (normal full-model broadcast) —
+        this is the ``evaluation``/multimodel path, which must never head-only-trim."""
         mock_read_config.return_value = {"task_result_filters": [{"tasks": ["train"], "filters": []}]}
 
         configure_client(
@@ -320,7 +327,7 @@ class TestConfigureClient:
 
         modified_config = mock_write_config.call_args[0][0]
         assert all(
-            f.get("path") != "flip.nvflare.components.ReconstructFullModel"
+            f.get("path") != "flip.nvflare.components.ReconstructFullModelForEval"
             for b in modified_config.get("task_data_filters", [])
             for f in b.get("filters", [])
         )
@@ -440,10 +447,40 @@ class TestConfigureServer:
         assert train_block["filters"][-1]["path"] == "flip.nvflare.components.TrimBroadcastVars"
         assert train_block["filters"][-1]["args"]["include_vars"] == "omni_heads"
 
+    def test_configure_server_injects_trim_eval_broadcast_filter(
+        self, mock_isfile, mock_read_config, mock_write_config
+    ):
+        """With aggregate_only_regex set, a TrimEvalBroadcastVars filter is added to a ``validate``
+        task_data_filters chain — the server half of head-only cross-site validation (#730). It is a
+        separate chain from the ``train`` TrimBroadcastVars one."""
+        mock_read_config.return_value = self._minimal_server_config()
+
+        configure_server(
+            job_dir=MOCK_JOB_APP_DIR,
+            app_name=MOCK_APP_NAME,
+            global_rounds=3,
+            trusts=MOCK_APP_CLIENTS,
+            ignore_result_error=True,
+            aggregator="agg",
+            aggregation_weights=MOCK_AGGREGATION_WEIGHTS,
+            aggregate_only_regex="omni_heads",
+        )
+
+        modified_config = mock_write_config.call_args[0][0]
+        validate_block = next(b for b in modified_config["task_data_filters"] if b["tasks"] == ["validate"])
+        eval_filter = validate_block["filters"][-1]
+        assert eval_filter["path"] == "flip.nvflare.components.TrimEvalBroadcastVars"
+        assert eval_filter["args"]["include_vars"] == "omni_heads"
+        # The train chain is still present and distinct.
+        train_block = next(b for b in modified_config["task_data_filters"] if "train" in b["tasks"])
+        assert train_block["filters"][-1]["path"] == "flip.nvflare.components.TrimBroadcastVars"
+
     def test_configure_server_no_regex_leaves_data_filters_untouched(
         self, mock_isfile, mock_read_config, mock_write_config
     ):
-        """No aggregate_only_regex → no TrimBroadcastVars injected (normal full-model broadcast)."""
+        """No aggregate_only_regex → neither TrimBroadcastVars nor TrimEvalBroadcastVars injected
+        (normal full-model broadcast) — this is the ``evaluation``/multimodel path, which must never
+        head-only-trim the validate broadcast (clients don't hold the arbitrary server checkpoints)."""
         mock_read_config.return_value = self._minimal_server_config()
 
         configure_server(
@@ -457,11 +494,13 @@ class TestConfigureServer:
         )
 
         modified_config = mock_write_config.call_args[0][0]
-        assert all(
-            f.get("path") != "flip.nvflare.components.TrimBroadcastVars"
+        injected_paths = {
+            f.get("path")
             for b in modified_config.get("task_data_filters", [])
             for f in b.get("filters", [])
-        )
+        }
+        assert "flip.nvflare.components.TrimBroadcastVars" not in injected_paths
+        assert "flip.nvflare.components.TrimEvalBroadcastVars" not in injected_paths
 
     def test_configure_server_file_not_found(self, mock_isfile):
         # Setup

--- a/fl-services/nvflare/fl-api-base/tests/utils/test_prepare_config.py
+++ b/fl-services/nvflare/fl-api-base/tests/utils/test_prepare_config.py
@@ -39,6 +39,14 @@ MOCK_APP_CLIENTS = ["app-trust1", "app-trust2"]
 MOCK_AGGREGATION_WEIGHTS = {"trust1": 0.5, "trust2": 0.5}
 
 
+def _assert_no_duplicate_task_chains(config: dict) -> None:
+    """Each task may appear in at most ONE task_data_filters chain — NVFLARE's FedJsonConfigurator
+    raises ConfigError ("multiple data filter chains defined for task ...") at job parse time
+    otherwise, failing the job on every client/server before any filter runs."""
+    tasks = [task for block in config.get("task_data_filters", []) for task in block.get("tasks", [])]
+    assert len(tasks) == len(set(tasks)), f"task covered by more than one task_data_filters chain: {tasks}"
+
+
 @pytest.fixture
 def mock_get_settings():
     with patch("fl_api.utils.prepare_config.get_settings") as mock_settings:
@@ -282,16 +290,19 @@ class TestConfigureClient:
         reconstruct_block = modified_config["task_data_filters"][0]
         assert reconstruct_block["tasks"] == ["train", "validate"]
         assert reconstruct_block["filters"][0]["path"] == "flip.nvflare.components.ReconstructFullModelForEval"
+        _assert_no_duplicate_task_chains(modified_config)
 
-    def test_configure_client_reconstruct_filter_prepended_before_existing_data_filter(
+    def test_configure_client_reconstruct_filter_folds_existing_train_chain(
         self, mock_isfile, mock_write_config, mock_read_config
     ):
-        """An existing train task_data_filters block keeps its filters untouched; the
-        ReconstructFullModelForEval chain is prepended as a separate block so it is built/applied
-        first (and, being a single ``["train", "validate"]`` chain, shares one instance across tasks)."""
+        """An existing train task_data_filters chain is FOLDED into the injected ``["train",
+        "validate"]`` chain — NVFLARE rejects a task covered by two chains, so it cannot be left
+        alongside. ReconstructFullModelForEval stays first so the full model is rebuilt before any
+        other incoming data filter runs; unrelated chains are preserved untouched."""
         mock_read_config.return_value = {
             "task_data_filters": [
-                {"tasks": ["train"], "filters": [{"id": "existing", "path": "some.Filter"}]}
+                {"tasks": ["train"], "filters": [{"id": "existing", "path": "some.Filter"}]},
+                {"tasks": ["other_task"], "filters": [{"id": "unrelated", "path": "some.OtherFilter"}]},
             ]
         }
 
@@ -304,12 +315,74 @@ class TestConfigureClient:
         )
 
         modified_config = mock_write_config.call_args[0][0]
-        reconstruct_block = modified_config["task_data_filters"][0]
-        assert reconstruct_block["tasks"] == ["train", "validate"]
-        assert reconstruct_block["filters"][0]["path"] == "flip.nvflare.components.ReconstructFullModelForEval"
-        # The pre-existing train block is preserved unchanged, after the injected chain.
-        existing_block = modified_config["task_data_filters"][1]
-        assert existing_block["filters"][0]["id"] == "existing"
+        merged_block = modified_config["task_data_filters"][0]
+        assert merged_block["tasks"] == ["train", "validate"]
+        assert merged_block["filters"][0]["path"] == "flip.nvflare.components.ReconstructFullModelForEval"
+        assert merged_block["filters"][1]["id"] == "existing"
+        # The unrelated chain is preserved unchanged, after the injected chain.
+        assert modified_config["task_data_filters"][1]["filters"][0]["id"] == "unrelated"
+        _assert_no_duplicate_task_chains(modified_config)
+
+    def test_configure_client_reconstruct_filter_supersedes_recipe_baked_one(
+        self, mock_isfile, mock_write_config, mock_read_config
+    ):
+        """A ReconstructFullModel data filter already baked into the app config (e.g. by a
+        ``FlipFedAvgRecipe(aggregate_only_regex=...)`` export) is dropped as superseded: the
+        deploy-time chain must hold the ONE instance whose round-0 cache is shared across train and
+        validate — keeping both would reconstruct twice via a second, cache-less instance."""
+        mock_read_config.return_value = {
+            "task_data_filters": [
+                {
+                    "tasks": ["train"],
+                    "filters": [
+                        {"id": "reconstruct_full_model", "path": "flip.nvflare.components.ReconstructFullModel"}
+                    ],
+                }
+            ]
+        }
+
+        configure_client(
+            job_dir=MOCK_JOB_APP_DIR,
+            app_name=MOCK_APP_NAME,
+            project_id=MOCK_PROJECT_ID,
+            cohort_query=MOCK_COHORT_QUERY,
+            aggregate_only_regex="omni_heads",
+        )
+
+        modified_config = mock_write_config.call_args[0][0]
+        assert modified_config["task_data_filters"] == [
+            {
+                "tasks": ["train", "validate"],
+                "filters": [
+                    {
+                        "id": "reconstruct_full_model",
+                        "path": "flip.nvflare.components.ReconstructFullModelForEval",
+                        "args": {},
+                    }
+                ],
+            }
+        ]
+
+    def test_configure_client_reconstruct_filter_rejects_unmergeable_chain(
+        self, mock_isfile, mock_write_config, mock_read_config
+    ):
+        """A chain covering train/validate together with OTHER tasks cannot be folded without changing
+        which tasks its filters run on → clear configure-time error, instead of NVFLARE's parse-time
+        duplicate-chain ConfigError on every client."""
+        mock_read_config.return_value = {
+            "task_data_filters": [
+                {"tasks": ["train", "custom_task"], "filters": [{"id": "existing", "path": "some.Filter"}]}
+            ]
+        }
+
+        with pytest.raises(ValueError, match=r"chain over \['train', 'custom_task'\]"):
+            configure_client(
+                job_dir=MOCK_JOB_APP_DIR,
+                app_name=MOCK_APP_NAME,
+                project_id=MOCK_PROJECT_ID,
+                cohort_query=MOCK_COHORT_QUERY,
+                aggregate_only_regex="omni_heads",
+            )
 
     def test_configure_client_no_regex_leaves_data_filters_untouched(
         self, mock_isfile, mock_write_config, mock_read_config
@@ -474,6 +547,56 @@ class TestConfigureServer:
         # The train chain is still present and distinct.
         train_block = next(b for b in modified_config["task_data_filters"] if "train" in b["tasks"])
         assert train_block["filters"][-1]["path"] == "flip.nvflare.components.TrimBroadcastVars"
+        _assert_no_duplicate_task_chains(modified_config)
+
+    def test_configure_server_trim_eval_appended_to_existing_validate_block(
+        self, mock_isfile, mock_read_config, mock_write_config
+    ):
+        """An existing dedicated ``["validate"]`` chain gains TrimEvalBroadcastVars (appended, so it
+        runs after any other outgoing data filter) instead of a second validate-covering chain, which
+        NVFLARE would reject at parse time."""
+        config = self._minimal_server_config()
+        config["task_data_filters"] = [{"tasks": ["validate"], "filters": [{"id": "existing", "path": "some.Filter"}]}]
+        mock_read_config.return_value = config
+
+        configure_server(
+            job_dir=MOCK_JOB_APP_DIR,
+            app_name=MOCK_APP_NAME,
+            global_rounds=3,
+            trusts=MOCK_APP_CLIENTS,
+            ignore_result_error=True,
+            aggregator="agg",
+            aggregation_weights=MOCK_AGGREGATION_WEIGHTS,
+            aggregate_only_regex="omni_heads",
+        )
+
+        modified_config = mock_write_config.call_args[0][0]
+        validate_block = next(b for b in modified_config["task_data_filters"] if b["tasks"] == ["validate"])
+        assert validate_block["filters"][0]["id"] == "existing"
+        assert validate_block["filters"][-1]["path"] == "flip.nvflare.components.TrimEvalBroadcastVars"
+        _assert_no_duplicate_task_chains(modified_config)
+
+    def test_configure_server_trim_eval_rejects_multi_task_validate_chain(
+        self, mock_isfile, mock_read_config, mock_write_config
+    ):
+        """TrimEvalBroadcastVars trims unconditionally (no round gate), so it must not be appended
+        into a chain that also covers other tasks — it would e.g. trim the round-0 train broadcast
+        and destroy the client's backbone cache → clear configure-time error."""
+        config = self._minimal_server_config()
+        config["task_data_filters"] = [{"tasks": ["validate", "other_task"], "filters": []}]
+        mock_read_config.return_value = config
+
+        with pytest.raises(ValueError, match=r"chain over \['validate', 'other_task'\]"):
+            configure_server(
+                job_dir=MOCK_JOB_APP_DIR,
+                app_name=MOCK_APP_NAME,
+                global_rounds=3,
+                trusts=MOCK_APP_CLIENTS,
+                ignore_result_error=True,
+                aggregator="agg",
+                aggregation_weights=MOCK_AGGREGATION_WEIGHTS,
+                aggregate_only_regex="omni_heads",
+            )
 
     def test_configure_server_no_regex_leaves_data_filters_untouched(
         self, mock_isfile, mock_read_config, mock_write_config

--- a/flip-utils/flip/nvflare/components/__init__.py
+++ b/flip-utils/flip/nvflare/components/__init__.py
@@ -25,7 +25,9 @@ Exports:
     - InitialCheckpointPTModelPersistor: Seeds the initial global model from a server-side backbone checkpoint
     - KeepOnlyVars: Include-only DXO filter (keep matching weights) — head-only per-round updates
     - TrimBroadcastVars: Server-side filter — broadcast only the trainable vars after round 0
+    - TrimEvalBroadcastVars: Server-side filter — broadcast only the trainable vars for cross-site eval
     - ReconstructFullModel: Client-side filter — rebuild the full model from a trimmed broadcast
+    - ReconstructFullModelForEval: Client-side filter — rebuild the full model for train AND eval
     - ValidationJsonGenerator: Validation results JSON generator
     - EvaluationJsonGenerator: Evaluation results JSON generator
     - PersistToS3AndCleanup: S3 persistence and cleanup component
@@ -36,7 +38,7 @@ Exports:
     - ClientExceptionReporter: Reports client task failures to the FLIP hub
 """
 
-from flip.nvflare.components.broadcast_trim_filter import TrimBroadcastVars
+from flip.nvflare.components.broadcast_trim_filter import TrimBroadcastVars, TrimEvalBroadcastVars
 from flip.nvflare.components.cleanup import CleanupImages
 from flip.nvflare.components.client_exception_reporter import ClientExceptionReporter
 from flip.nvflare.components.custom_percentile_privacy import PercentilePrivacy
@@ -53,7 +55,7 @@ from flip.nvflare.components.pt_model_locator import (
     PTModelLocator,
 )
 from flip.nvflare.components.pt_model_persistor import InitialCheckpointPTModelPersistor
-from flip.nvflare.components.reconstruct_model_filter import ReconstructFullModel
+from flip.nvflare.components.reconstruct_model_filter import ReconstructFullModel, ReconstructFullModelForEval
 from flip.nvflare.components.stage_percentile_privacy import StagePercentilePrivacy
 from flip.nvflare.components.validation_json_generator import ValidationJsonGenerator
 
@@ -67,7 +69,9 @@ __all__ = [
     "InitialCheckpointPTModelPersistor",
     "KeepOnlyVars",
     "TrimBroadcastVars",
+    "TrimEvalBroadcastVars",
     "ReconstructFullModel",
+    "ReconstructFullModelForEval",
     "ValidationJsonGenerator",
     "EvaluationJsonGenerator",
     "PersistToS3AndCleanup",

--- a/flip-utils/flip/nvflare/components/broadcast_trim_filter.py
+++ b/flip-utils/flip/nvflare/components/broadcast_trim_filter.py
@@ -63,21 +63,62 @@ class TrimBroadcastVars(DXOFilter):
             # the frozen backbone once. Returning None leaves the DXO untouched.
             return None
 
+        return self._trim_to_pattern(dxo, fl_ctx)
+
+    def _trim_to_pattern(self, dxo: DXO, fl_ctx: FLContext) -> DXO | None:
+        """Trim ``dxo.data`` to only the weight keys matching ``self.pattern``.
+
+        Shared by the round-gated training filter and the always-trim evaluation variant
+        (:class:`TrimEvalBroadcastVars`). Non-mutating on the caller's dict — it builds a new dict —
+        because on the server ``dxo.data`` aliases the retained global model, so popping keys would
+        corrupt the server's own weights.
+
+        Args:
+            dxo (DXO): the outgoing broadcast DXO whose ``data`` (a weights dict) is trimmed.
+            fl_ctx (FLContext): the FL context, used only for logging.
+
+        Returns:
+            DXO | None: the DXO with its data trimmed to the matching (head) keys, or ``None`` (leave
+            the DXO untouched, i.e. broadcast the full model) when the regex matches no keys.
+        """
+        assert self.pattern is not None  # callers guard the no-pattern (no-op) case before dispatching here
         weights = dxo.data
         trimmed = {name: value for name, value in weights.items() if self.pattern.search(name)}
         if not trimmed:
             # Matching nothing almost certainly means a wrong regex — broadcast the full model rather
-            # than an empty one (clients would have nothing to train from).
+            # than an empty one (clients would have nothing to train from / validate).
             self.log_warning(
                 fl_ctx,
-                f"TrimBroadcastVars: regex {self.pattern.pattern!r} matched no keys; broadcasting full model.",
+                f"{type(self).__name__}: regex {self.pattern.pattern!r} matched no keys; broadcasting full model.",
             )
             return None
 
         self.log_info(
             fl_ctx,
-            f"TrimBroadcastVars: broadcasting {len(trimmed)} of {len(weights)} var(s) "
-            f"matching {self.pattern.pattern!r} at round {current_round}.",
+            f"{type(self).__name__}: broadcasting {len(trimmed)} of {len(weights)} var(s) "
+            f"matching {self.pattern.pattern!r}.",
         )
         dxo.data = trimmed
         return dxo
+
+
+class TrimEvalBroadcastVars(TrimBroadcastVars):
+    """Server-side ``task_data_filter`` for the ``validate`` task: broadcast ONLY the trainable head.
+
+    The evaluation counterpart of :class:`TrimBroadcastVars`. Post-training cross-site validation
+    (``GlobalModelEval``) re-broadcasts the full ~759 MiB global model to every client purely so it
+    can be scored — but for a frozen-backbone fine-tune the backbone is byte-identical to the
+    pretrained checkpoint each client already received at training round 0, so re-shipping it is pure
+    waste. This trims the ``validate`` broadcast down to just the head; the client's
+    :class:`ReconstructFullModelForEval` merges it back onto the backbone it cached during training,
+    so the validator still receives a full state dict — no change to user validation code is required.
+
+    Unlike :class:`TrimBroadcastVars`, the trim is **unconditional**: the cross-site-validation task
+    carries no ``CURRENT_ROUND`` header (the round-gated parent would therefore never trim it), and
+    the client always already holds the backbone by the time validation runs.
+    """
+
+    def process_dxo(self, dxo: DXO, shareable: Shareable, fl_ctx: FLContext) -> DXO | None:
+        if self.pattern is None:
+            return None
+        return self._trim_to_pattern(dxo, fl_ctx)

--- a/flip-utils/flip/nvflare/components/reconstruct_model_filter.py
+++ b/flip-utils/flip/nvflare/components/reconstruct_model_filter.py
@@ -12,6 +12,7 @@
 
 from nvflare.apis.dxo import DataKind
 from nvflare.apis.dxo_filter import DXO, DXOFilter
+from nvflare.apis.fl_constant import FLContextKey
 from nvflare.apis.fl_context import FLContext
 from nvflare.apis.shareable import Shareable
 from nvflare.app_common.app_constant import AppConstants
@@ -77,4 +78,77 @@ class ReconstructFullModel(DXOFilter):
             f"({len(self._full_weights)} vars) at round {current_round}.",
         )
         dxo.data = dict(self._full_weights)
+        return dxo
+
+
+class ReconstructFullModelForEval(ReconstructFullModel):
+    """Client-side ``task_data_filter`` for BOTH ``train`` and ``validate``: rebuild the full model.
+
+    Extends :class:`ReconstructFullModel` to also reconstruct the full model for post-training
+    cross-site validation (``GlobalModelEval``), whose head-only broadcast is produced by the
+    server-side :class:`~flip.nvflare.components.broadcast_trim_filter.TrimEvalBroadcastVars`.
+
+    Why one component on two tasks. The frozen backbone the client needs to reconstruct against is
+    the one it received at training round 0 — in production the pretrained checkpoint is de-bundled
+    server-side and never shipped to clients (see ``InitialCheckpointPTModelPersistor``), so the
+    client's ONLY copy of the backbone is the round-0 broadcast cached during training. NVFLARE builds
+    a fresh filter instance per filter-chain occurrence, so the training cache is shared with the
+    evaluation phase ONLY when the same component instance handles both tasks — i.e. one filter chain
+    whose ``tasks`` are ``["train", "validate"]``. This class is therefore wired onto both.
+
+    Behaviour is dispatched by the current task name (set in ``fl_ctx`` before client task-data
+    filters run):
+
+    * **train** (or any non-evaluation task): delegate to :class:`ReconstructFullModel` — the proven
+      round-gated cache-at-round-0 / merge-thereafter logic is unchanged.
+    * **validate**: merge the broadcast (head-only, or a full model if the server fell back) onto the
+      retained full model from training and hand the validator a full state dict. Fails loudly if the
+      client never cached a full model (it never trained → no backbone) or if the broadcast carries
+      keys absent from the retained model (a mismatch that would otherwise validate wrong weights).
+    """
+
+    def __init__(self, data_kinds: list[str] | None = None, evaluate_task_name: str = AppConstants.TASK_VALIDATION):
+        """
+        Args:
+            data_kinds: DXO kinds to filter; defaults to WEIGHTS and WEIGHT_DIFF.
+            evaluate_task_name: the task name under which cross-site validation broadcasts the model.
+                Defaults to NVFLARE's ``AppConstants.TASK_VALIDATION`` ("validate").
+        """
+        super().__init__(data_kinds=data_kinds)
+        self._evaluate_task_name = evaluate_task_name
+
+    def process_dxo(self, dxo: DXO, shareable: Shareable, fl_ctx: FLContext) -> DXO | None:
+        task_name = fl_ctx.get_prop(FLContextKey.TASK_NAME)
+        if task_name != self._evaluate_task_name:
+            # Training (or any non-eval task): unchanged round-gated reconstruction.
+            return super().process_dxo(dxo, shareable, fl_ctx)
+
+        if self._full_weights is None:
+            # Validation broadcast arrived but no full model was ever cached → this client never
+            # trained (so never received the round-0 backbone). Fail loudly rather than validate an
+            # incomplete model.
+            raise RuntimeError(
+                "ReconstructFullModelForEval: received a validation broadcast but no full model was "
+                "cached during training (client likely did not participate in training); cannot "
+                "reconstruct the frozen backbone for evaluation."
+            )
+
+        broadcast = dxo.data
+        unexpected = set(broadcast) - set(self._full_weights)
+        if unexpected:
+            # The broadcast carries keys the retained model doesn't have — a structural mismatch.
+            # Refuse rather than silently validate against a wrong/partial model.
+            raise RuntimeError(
+                f"ReconstructFullModelForEval: validation broadcast has {len(unexpected)} key(s) absent "
+                f"from the retained full model (e.g. {sorted(unexpected)[:3]}); refusing to reconstruct."
+            )
+
+        merged = dict(self._full_weights)
+        merged.update(broadcast)
+        self.log_info(
+            fl_ctx,
+            f"ReconstructFullModelForEval: merged {len(broadcast)} validation broadcast var(s) into the "
+            f"retained full model ({len(merged)} vars) for task {task_name!r}.",
+        )
+        dxo.data = merged
         return dxo

--- a/flip-utils/tests/unit/nvflare/components/test_broadcast_trim_filter.py
+++ b/flip-utils/tests/unit/nvflare/components/test_broadcast_trim_filter.py
@@ -14,7 +14,7 @@ from unittest.mock import MagicMock
 from nvflare.apis.dxo import DXO, DataKind
 from nvflare.app_common.app_constant import AppConstants
 
-from flip.nvflare.components.broadcast_trim_filter import TrimBroadcastVars
+from flip.nvflare.components.broadcast_trim_filter import TrimBroadcastVars, TrimEvalBroadcastVars
 
 
 def _ctx():
@@ -87,3 +87,39 @@ class TestTrimBroadcastVars:
         f = TrimBroadcastVars(include_vars="omni_heads")
         out = f.process_dxo(_dxo(DataKind.WEIGHT_DIFF), _shareable(2), _ctx())
         assert set(out.data.keys()) == {"omni_heads.0.weight", "omni_heads.0.bias"}
+
+
+class TestTrimEvalBroadcastVars:
+    """The evaluation counterpart trims the ``validate`` broadcast unconditionally (there is no
+    round header on cross-site validation, so the round-gated parent would never trim it)."""
+
+    def test_trims_when_no_round_header(self):
+        f = TrimEvalBroadcastVars(include_vars="omni_heads")
+        out = f.process_dxo(_dxo(), _shareable(None), _ctx())
+        assert set(out.data.keys()) == {"omni_heads.0.weight", "omni_heads.0.bias"}
+
+    def test_trims_even_at_round_zero(self):
+        """Round 0 would pass through untouched in the round-gated parent; the eval variant still
+        trims (the client already holds the backbone by validation time)."""
+        f = TrimEvalBroadcastVars(include_vars="omni_heads")
+        out = f.process_dxo(_dxo(), _shareable(0), _ctx())
+        assert set(out.data.keys()) == {"omni_heads.0.weight", "omni_heads.0.bias"}
+
+    def test_does_not_mutate_the_input_dict(self):
+        f = TrimEvalBroadcastVars(include_vars="omni_heads")
+        dxo = _dxo()
+        original_dict = dxo.data
+        original_keys = set(original_dict.keys())
+        out = f.process_dxo(dxo, _shareable(None), _ctx())
+        assert set(original_dict.keys()) == original_keys
+        assert out.data is not original_dict
+
+    def test_warns_and_broadcasts_full_when_regex_matches_nothing(self):
+        f = TrimEvalBroadcastVars(include_vars="does_not_exist")
+        f.log_warning = MagicMock()
+        assert f.process_dxo(_dxo(), _shareable(None), _ctx()) is None
+        f.log_warning.assert_called_once()
+
+    def test_noop_when_include_vars_empty(self):
+        assert TrimEvalBroadcastVars(include_vars="").process_dxo(_dxo(), _shareable(None), _ctx()) is None
+        assert TrimEvalBroadcastVars(include_vars=None).process_dxo(_dxo(), _shareable(None), _ctx()) is None

--- a/flip-utils/tests/unit/nvflare/components/test_reconstruct_model_filter.py
+++ b/flip-utils/tests/unit/nvflare/components/test_reconstruct_model_filter.py
@@ -12,15 +12,25 @@
 from unittest.mock import MagicMock
 
 import pytest
+import torch
 from nvflare.apis.dxo import DXO, DataKind
+from nvflare.apis.fl_constant import FLContextKey
 from nvflare.app_common.app_constant import AppConstants
 
-from flip.nvflare.components.reconstruct_model_filter import ReconstructFullModel
+from flip.nvflare.components.reconstruct_model_filter import ReconstructFullModel, ReconstructFullModelForEval
 
 
 def _ctx():
     ctx = MagicMock()
     ctx.get_peer_context.return_value = None
+    return ctx
+
+
+def _task_ctx(task_name):
+    """An FL context that reports the given current task name to task-aware filters."""
+    ctx = MagicMock()
+    ctx.get_peer_context.return_value = None
+    ctx.get_prop.side_effect = lambda key, default=None: (task_name if key == FLContextKey.TASK_NAME else default)
     return ctx
 
 
@@ -71,3 +81,77 @@ class TestReconstructFullModel:
         f.process_dxo(_dxo({"backbone.0": 5, "omni_heads.0.weight": 1}), _shareable(0), _ctx())
         out = f.process_dxo(_dxo({"omni_heads.0.weight": 9}), _shareable(1), _ctx())
         assert out.data is not f._full_weights
+
+
+class TestReconstructFullModelForEval:
+    """The eval-aware variant handles the same instance across ``train`` and ``validate`` — training
+    populates the backbone cache; validation merges the head-only broadcast back onto it."""
+
+    def test_train_task_delegates_to_round_gated_parent(self):
+        """On the train task it is byte-for-byte the parent: round 0 caches + passes through, later
+        rounds merge the head."""
+        f = ReconstructFullModelForEval()
+        cached = f.process_dxo(
+            _dxo({"backbone.0": 5, "omni_heads.0.weight": 1}), _shareable(0), _task_ctx("train")
+        )
+        assert cached is None  # round 0: cached and passed through unchanged
+        out = f.process_dxo(_dxo({"omni_heads.0.weight": 9}), _shareable(1), _task_ctx("train"))
+        assert out.data == {"backbone.0": 5, "omni_heads.0.weight": 9}
+
+    def test_validate_merges_head_onto_cached_backbone(self):
+        f = ReconstructFullModelForEval()
+        # Training cached the round-0 full model (frozen backbone + an initial head).
+        f.process_dxo(
+            _dxo({"backbone.0": 5, "backbone.1": 6, "omni_heads.0.weight": 1}), _shareable(0), _task_ctx("train")
+        )
+        # Cross-site validation broadcast, trimmed by the server to the head only.
+        out = f.process_dxo(_dxo({"omni_heads.0.weight": 42}), _shareable(None), _task_ctx("validate"))
+        assert out.data == {"backbone.0": 5, "backbone.1": 6, "omni_heads.0.weight": 42}
+
+    def test_validate_without_cache_raises(self):
+        """A client that never trained has no cached backbone → fail loudly rather than validate a
+        headless/partial model."""
+        f = ReconstructFullModelForEval()
+        with pytest.raises(RuntimeError, match="no full model was cached during training"):
+            f.process_dxo(_dxo({"omni_heads.0.weight": 42}), _shareable(None), _task_ctx("validate"))
+
+    def test_validate_with_unexpected_keys_raises(self):
+        """A broadcast key absent from the retained model is a structural mismatch → refuse."""
+        f = ReconstructFullModelForEval()
+        f.process_dxo(_dxo({"backbone.0": 5, "omni_heads.0.weight": 1}), _shareable(0), _task_ctx("train"))
+        with pytest.raises(RuntimeError, match="absent from the retained full model"):
+            f.process_dxo(_dxo({"phantom.key": 7}), _shareable(None), _task_ctx("validate"))
+
+    def test_validate_full_broadcast_fallback_reconstructs(self):
+        """If the server fell back to a full broadcast (regex matched nothing), merging a full model
+        onto the cache still yields exactly that full model."""
+        f = ReconstructFullModelForEval()
+        f.process_dxo(_dxo({"backbone.0": 5, "omni_heads.0.weight": 1}), _shareable(0), _task_ctx("train"))
+        out = f.process_dxo(
+            _dxo({"backbone.0": 5, "omni_heads.0.weight": 9}), _shareable(None), _task_ctx("validate")
+        )
+        assert out.data == {"backbone.0": 5, "omni_heads.0.weight": 9}
+
+    def test_reconstructed_dict_is_a_copy_not_the_retained_state(self):
+        f = ReconstructFullModelForEval()
+        f.process_dxo(_dxo({"backbone.0": 5, "omni_heads.0.weight": 1}), _shareable(0), _task_ctx("train"))
+        out = f.process_dxo(_dxo({"omni_heads.0.weight": 9}), _shareable(None), _task_ctx("validate"))
+        assert out.data is not f._full_weights
+
+    def test_numeric_parity_with_full_broadcast(self):
+        """The reconstructed (cached backbone + broadcast head) state dict is tensor-equal to the full
+        global model the server WOULD have broadcast — the head-only eval path is lossless."""
+        backbone = {"backbone.0": torch.randn(4, 4), "backbone.1": torch.randn(8)}
+        global_head = {"omni_heads.0.weight": torch.randn(5, 4), "omni_heads.0.bias": torch.randn(5)}
+        full_global = {**backbone, **global_head}  # what a full validate broadcast would carry
+
+        f = ReconstructFullModelForEval()
+        # Client cached the round-0 full model: the SAME frozen backbone, an older (pre-aggregation) head.
+        cached = {**backbone, "omni_heads.0.weight": torch.randn(5, 4), "omni_heads.0.bias": torch.randn(5)}
+        f.process_dxo(_dxo(dict(cached)), _shareable(0), _task_ctx("train"))
+        # Validate: server trimmed the global model to just the head.
+        out = f.process_dxo(_dxo(dict(global_head)), _shareable(None), _task_ctx("validate"))
+
+        assert set(out.data.keys()) == set(full_global.keys())
+        for key, value in full_global.items():
+            assert torch.equal(out.data[key], value), f"tensor mismatch at {key}"


### PR DESCRIPTION
Closes #730.

> Recovers the work from the (now-closed) #732 and re-targets it at `develop`. The prerequisite frozen-backbone **head-only-training** code has since landed in `develop`, so this now applies cleanly on top of it (the single commit cherry-picks onto `develop` with zero conflicts).

Extends the frozen-backbone **head-only** optimisation from training to the post-training **cross-site validation** (`GlobalModelEval`) so the `validate` broadcast ships only the trainable head instead of the full ~759 MiB model. Gated on `AGGREGATE_ONLY_REGEX`, so it applies only to the frozen-backbone finetune path (`standard`/`fed_opt`) and **never** to the `evaluation`/multimodel job type (whose server-staged checkpoints the clients don't hold).

## What changed
- **Server** — `TrimEvalBroadcastVars` (new): trims the `validate` broadcast to the head **unconditionally** (cross-site validation carries no `CURRENT_ROUND` header, so the round-gated `TrimBroadcastVars` would never trim it).
- **Client** — `ReconstructFullModelForEval` (new): merges the head-only `validate` broadcast back onto the full model, so `RUN_VALIDATOR`/the app `validator.py` still receive a full state dict — **no change to user validation code**.
- **Wiring** — `prepare_config.py`: server injects `TrimEvalBroadcastVars` on a dedicated `["validate"]` chain (detected by membership; a multi-task validate chain raises, since the unconditional trim must not gain tasks); client injects `ReconstructFullModelForEval` on a single `["train", "validate"]` chain (see design note). NVFLARE rejects a task covered by two data-filter chains, so any pre-existing chain over train/validate is **folded into** the injected chain (reconstruct first; a recipe-baked `ReconstructFullModel` is dropped as superseded; a chain also covering other tasks raises a clear configure-time error). Both gated on `AGGREGATE_ONLY_REGEX`.

## Design note — corrects the issue's stated client-side approach
The issue proposed reconstructing from the on-disk pretrained checkpoint. That is **infeasible in production**: `InitialCheckpointPTModelPersistor` de-bundles the backbone **server-side** and it *"never reaches the clients"* — a client's only copy of the frozen backbone is the round-0 broadcast it cached during training. So the client reuses that **training cache** instead of disk.

Because NVFLARE builds a **fresh filter instance per filter-chain occurrence** (`fed_json_config.py`), the cache is shared with the eval phase only when **one instance serves both tasks**. Hence `ReconstructFullModelForEval` is wired as a single `task_data_filter` chain over `["train", "validate"]` and dispatches on the current task name (`FLContextKey.TASK_NAME`, set in `fl_ctx` before client data filters run). It **fails loudly** if the client never trained (no cached backbone) or the broadcast carries keys absent from the retained model — never silently validates wrong weights.

## Why it's lossless
The frozen backbone is byte-identical on the server and every client, so validating `(cached backbone + global head)` equals validating the full global model. A unit test asserts **tensor-level numeric parity** with a full broadcast.

## Tests (re-verified on top of `develop`)
- `flip-utils`: `TrimEvalBroadcastVars` + `ReconstructFullModelForEval` unit tests (always-trim, trims-even-at-round-zero, regex-no-match fallback, train-delegation, head-merge, no-cache guard, unexpected-key guard, full-broadcast fallback, **numeric parity**). Full suite (499) passes; ruff clean.
- `fl-api-base`: `prepare_config` injection tests — validate chain present for finetune; **neither** trim/reconstruct injected for the no-regex evaluation path; emitted configs keep **at most one data-filter chain per task** (the NVFLARE parse invariant); fold/dedupe/unmergeable-error branches. **29 prepare_config tests pass** (129 suite-wide); ruff + mypy clean.

## Verified on the NVFLARE simulator (2 clients)
A two-key (backbone + head) job with the exact filter layout `prepare_config` emits — `ScatterAndGather` (2 rounds) then `GlobalModelEval`, with an executor that fails the job if any task ever receives a partial state dict:
- **Round 0**: full broadcast; client caches it (`cached full global model (2 vars)`).
- **Round 1**: `TrimBroadcastVars: broadcasting 1 of 2 var(s)`; executor still sees the full dict (reconstructed).
- **Validate** (no round header): `TrimEvalBroadcastVars: broadcasting 1 of 2 var(s)`; the **same filter instance** merges it onto the retained model (`merged 1 validation broadcast var(s) into the retained full model (2 vars)`); executor sees the full dict on both sites; `cross_val_results.json` written.
- **Negative control**: the pre-review two-chain client layout fails to parse on every client with `ConfigError: multiple data filter chains defined for task train/in` — the exact failure the review flagged.

## Acceptance Criteria

*Imported from issue #730*

- [x] Head-only broadcast on the `validate` task for frozen-backbone finetunes; client reconstructs full model from the cached round-0 backbone + broadcast head (cache, not disk — see design note).
- [x] `evaluation` / `ModelEval` (multimodel) path is untouched — still ships full models.
- [x] Strict-load guard fails loudly on an incomplete reconstruction.
- [x] Unit tests for both filters (incl. regex-matches-nothing fallback, missing-key guard).
- [x] **Numeric parity test**: validation metrics with head-only broadcast match the full-broadcast baseline to floating-point tolerance.
- [x] No change required to `RUN_VALIDATOR` or app `validator.py`.
