### PR TITLE
FL classification metrics logged under a shared class-less label collapse all classes into one chart series

### DIFF
--- a/fl-tutorials/nvflare/image_classification/xray_classification/app_files/trainer.py
+++ b/fl-tutorials/nvflare/image_classification/xray_classification/app_files/trainer.py
@@ -481,14 +481,14 @@ class FLIP_TRAINER(Executor):
                         val_value = 0.0
 
                     send_metrics_value(
-                        label=f"{'train'.upper()}-{metric.upper()}",
+                        label=f"{'train'.upper()}-{metric.upper()}-{lesion_name}",
                         round=round,
                         value=train_value,
                         fl_ctx=fl_ctx,
                         flip=self.flip,
                     )
                     send_metrics_value(
-                        label=f"{'val'.upper()}-{metric.upper()}",
+                        label=f"{'val'.upper()}-{metric.upper()}-{lesion_name}",
                         round=round,
                         value=val_value,
                         fl_ctx=fl_ctx,

--- a/fl-tutorials/nvflare/image_classification/xray_classification/app_files/validator.py
+++ b/fl-tutorials/nvflare/image_classification/xray_classification/app_files/validator.py
@@ -206,7 +206,7 @@ class FLIP_VALIDATOR(Executor):
         for metric in ["f1-score", "precision", "recall"]:
             for lesion_name in self._lesions.get_lesion_list():
                 send_metrics_value(
-                    label=f"{'test'.upper()}-{metric.upper()}",
+                    label=f"{'test'.upper()}-{metric.upper()}-{lesion_name}",
                     value=metrics[metric][lesion_name][-1],
                     fl_ctx=fl_ctx,
                     round=0,


### PR DESCRIPTION
## What

Append the class name to per-class classification metric labels in the NVFLARE xray classification template, so each class is charted as its own series.

- `xray_classification/app_files/trainer.py` — `TRAIN-{metric}` / `VAL-{metric}` → `TRAIN-{metric}-{lesion_name}` / `VAL-{metric}-{lesion_name}`
- `xray_classification/app_files/validator.py` — `TEST-{metric}` → `TEST-{metric}-{lesion_name}`

## Why

`get_metrics` groups stored metrics strictly by `(label, trust)` with no class dimension (`flip-api …/model_services/services/model_service.py`), and the chart plots one point per row. Sending every lesion's precision/recall/f1 under a single class-less label (`TRAIN-F1-SCORE`, …) collapsed all N classes onto one series per trust — N points piled on the same x, indistinguishable, with the *visible* per-round count shifting whenever two classes held equal values and overlapped. Encoding the class in the label gives one clean line per class with one unambiguous point per round.

This mirrors the pattern the **Flower** templates already use (`flip-utils/flip/flower/metrics.py` + per-class keys like `train_f1-{name}`) and the fix already applied in the Ark+ fine-tuning app.

## Scope / audit

- The **client-API** xray trainer already labels per-class (`TRAIN-{metric}-{name}`), so it's untouched.
- Grep across `fl-tutorials/nvflare` + `fl-apps/nvflare` confirms no other class-less `-{metric}` sends remain.
- No backend/schema change needed — per-class labels is the established cross-backend convention.

## Verification

- `ruff check` passes on both files; `py_compile` clean.
- Diff is 3 lines; no tests reference the old label strings.
- Behavioural verification (one line per `*-<CLASS>` series, one point/round/trust) needs a live FL run — see the checklist in #737.

Closes #737
