### PR TITLE
fix(flip-ui): stub ~icons and drain dynamic imports to kill the vitest EnvironmentTeardownError flake

### DIFF
--- a/flip-ui/src/components/AiAlert/__tests__/__snapshots__/AiAlert.spec.ts.snap
+++ b/flip-ui/src/components/AiAlert/__tests__/__snapshots__/AiAlert.spec.ts.snap
@@ -14,20 +14,8 @@ exports[`Ai Alert > Renders Component 1`] = `
       <!--v-if-->
       <svg
         class="w-5 h-5 text-lightgreen-900 dark:text-green-200"
-        height="1.2em"
-        viewBox="0 0 24 24"
-        width="1.2em"
-      >
-        <path
-          d="M12 4c-4.41 0-8 3.59-8 8s3.59 8 8 8s8-3.59 8-8s-3.59-8-8-8zm-2 13l-4-4l1.41-1.41L10 14.17l6.59-6.59L18 9l-8 8z"
-          fill="currentColor"
-          opacity=".3"
-        />
-        <path
-          d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10s10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8s8 3.59 8 8s-3.59 8-8 8zm4.59-12.42L10 14.17l-2.59-2.58L6 13l4 4l8-8z"
-          fill="currentColor"
-        />
-      </svg>
+        data-icon="ic:twotone-check-circle"
+      />
       <!--v-if-->
     </div>
     <div

--- a/flip-ui/src/components/AiAlert/__tests__/__snapshots__/AiErrorAlert.spec.ts.snap
+++ b/flip-ui/src/components/AiAlert/__tests__/__snapshots__/AiErrorAlert.spec.ts.snap
@@ -12,20 +12,8 @@ exports[`AiErrorAlert > Renders Component 1`] = `
     >
       <svg
         class="w-5 h-5 text-red-500 dark:text-red-200"
-        height="1.2em"
-        viewBox="0 0 24 24"
-        width="1.2em"
-      >
-        <path
-          d="M12 4c-4.41 0-8 3.59-8 8s3.59 8 8 8s8-3.59 8-8s-3.59-8-8-8zm5 11.59L15.59 17L12 13.41L8.41 17L7 15.59L10.59 12L7 8.41L8.41 7L12 10.59L15.59 7L17 8.41L13.41 12L17 15.59z"
-          fill="currentColor"
-          opacity=".3"
-        />
-        <path
-          d="M12 2C6.47 2 2 6.47 2 12s4.47 10 10 10s10-4.47 10-10S17.53 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8s8 3.59 8 8s-3.59 8-8 8zm3.59-13L12 10.59L8.41 7L7 8.41L10.59 12L7 15.59L8.41 17L12 13.41L15.59 17L17 15.59L13.41 12L17 8.41z"
-          fill="currentColor"
-        />
-      </svg>
+        data-icon="ic:twotone-cancel"
+      />
     </div>
     <div
       class="flex-1 ml-3 md:flex md:justify-between"
@@ -54,15 +42,8 @@ exports[`AiErrorAlert > Renders Component 1`] = `
           
           <svg
             class="w-5 h-5 text-red-500 dark:text-red-200 dark:group-hover:text-red-100 transition group-hover:text-red-800"
-            height="1.2em"
-            viewBox="0 0 24 24"
-            width="1.2em"
-          >
-            <path
-              d="M19 6.41L17.59 5L12 10.59L6.41 5L5 6.41L10.59 12L5 17.59L6.41 19L12 13.41L17.59 19L19 17.59L13.41 12L19 6.41z"
-              fill="currentColor"
-            />
-          </svg>
+            data-icon="mdi:close"
+          />
           
         </button>
       </div>

--- a/flip-ui/src/components/AiBanner/__tests__/__snapshots__/AiBanner.spec.ts.snap
+++ b/flip-ui/src/components/AiBanner/__tests__/__snapshots__/AiBanner.spec.ts.snap
@@ -20,20 +20,8 @@ exports[`AiBanner > Renders Component 1`] = `
           <svg
             aria-hidden="true"
             class="w-6 h-6 text-white"
-            height="1.2em"
-            viewBox="0 0 256 256"
-            width="1.2em"
-          >
-            <path
-              d="M152 160h40a40 40 0 0 0 0-80h-40z"
-              fill="currentColor"
-              opacity=".2"
-            />
-            <path
-              d="M240 120a48 48 0 0 0-48-48h-40c-.5 0-52.4-.7-101.7-42.1a15.9 15.9 0 0 0-17.1-2.2A15.7 15.7 0 0 0 24 42.2v155.6a15.7 15.7 0 0 0 9.2 14.5a16.4 16.4 0 0 0 6.8 1.5a15.9 15.9 0 0 0 10.3-3.7c37.9-31.8 77.2-39.6 93.7-41.5v35.1a15.9 15.9 0 0 0 7.1 13.3l11 7.4a16.8 16.8 0 0 0 14.7 1.6a15.9 15.9 0 0 0 9.7-11.1l11.9-47.3A48.2 48.2 0 0 0 240 120zM40 197.8V42.2C82.7 78 126.4 85.8 144 87.5v65c-17.6 1.7-61.3 9.5-104 45.3zM171 211l-11-7.3V168h21.8zm21-59h-32V88h32a32 32 0 0 1 0 64z"
-              fill="currentColor"
-            />
-          </svg>
+            data-icon="ph:megaphone-duotone"
+          />
         </span>
         <div
           class="flex items-center flex-1"
@@ -55,15 +43,8 @@ exports[`AiBanner > Renders Component 1`] = `
           >
             <svg
               class="w-5 h-5 text-white transition rounded hover:text-primary-200"
-              height="1.2em"
-              viewBox="0 0 24 24"
-              width="1.2em"
-            >
-              <path
-                d="M19 6.41L17.59 5L12 10.59L6.41 5L5 6.41L10.59 12L5 17.59L6.41 19L12 13.41L17.59 19L19 17.59L13.41 12L19 6.41z"
-                fill="currentColor"
-              />
-            </svg>
+              data-icon="mdi:close"
+            />
           </div>
         </div>
       </div>

--- a/flip-ui/src/components/AiPagination/__tests__/__snapshots__/AiPagination.spec.ts.snap
+++ b/flip-ui/src/components/AiPagination/__tests__/__snapshots__/AiPagination.spec.ts.snap
@@ -33,16 +33,9 @@ exports[`Ai Pagination > Renders Component 1`] = `
             
             <svg
               class="mr-2"
+              data-icon="ic:arrow-back"
               data-v-bf58aa44=""
-              height="1.2em"
-              viewBox="0 0 24 24"
-              width="1.2em"
-            >
-              <path
-                d="M20 11H7.83l5.59-5.59L12 4l-8 8l8 8l1.41-1.41L7.83 13H20v-2z"
-                fill="currentColor"
-              />
-            </svg>
+            />
             
              Previous 
             
@@ -110,16 +103,9 @@ exports[`Ai Pagination > Renders Component 1`] = `
             
             <svg
               class="ml-2"
+              data-icon="ic:arrow-forward"
               data-v-bf58aa44=""
-              height="1.2em"
-              viewBox="0 0 24 24"
-              width="1.2em"
-            >
-              <path
-                d="M12 4l-1.41 1.41L16.17 11H4v2h12.17l-5.58 5.59L12 20l8-8z"
-                fill="currentColor"
-              />
-            </svg>
+            />
             
           </button>
         </div>

--- a/flip-ui/src/components/AiSearch/__tests__/__snapshots__/AiSearch.spec.ts.snap
+++ b/flip-ui/src/components/AiSearch/__tests__/__snapshots__/AiSearch.spec.ts.snap
@@ -10,15 +10,8 @@ exports[`Ai Search > Renders Component 1`] = `
     >
       <svg
         class="w-5 h-5 text-gray-400 dark:text-gray-600"
-        height="1.2em"
-        viewBox="0 0 24 24"
-        width="1.2em"
-      >
-        <path
-          d="M9.5 3A6.5 6.5 0 0 1 16 9.5c0 1.61-.59 3.09-1.56 4.23l.27.27h.79l5 5l-1.5 1.5l-5-5v-.79l-.27-.27A6.516 6.516 0 0 1 9.5 16A6.5 6.5 0 0 1 3 9.5A6.5 6.5 0 0 1 9.5 3m0 2C7 5 5 7 5 9.5S7 14 9.5 14S14 12 14 9.5S12 5 9.5 5z"
-          fill="currentColor"
-        />
-      </svg>
+        data-icon="mdi:magnify"
+      />
     </div>
     <input
       class="block w-full pl-10 text-sm transition duration-300 border-gray-300 dark:border-dark-border dark:bg-dark-surface rounded-md shadow-sm focus:border-primary-500 dark:focus:ring-primary-400 dark:focus:border-primary-400 focus:ring-primary-500 focus:ring-1 dark:text-gray-300"

--- a/flip-ui/src/components/AiSelect/__tests__/__snapshots__/AiChipSelect.spec.ts.snap
+++ b/flip-ui/src/components/AiSelect/__tests__/__snapshots__/AiChipSelect.spec.ts.snap
@@ -26,15 +26,8 @@ exports[`AI Chip Select > renders the component successfully 1`] = `
     >
       <svg
         class="w-5 h-5 text-gray-400 dark:text-gray-300"
-        height="1.2em"
-        viewBox="0 0 24 24"
-        width="1.2em"
-      >
-        <path
-          d="M7.41 8.58L12 13.17l4.59-4.59L18 10l-6 6l-6-6l1.41-1.42z"
-          fill="currentColor"
-        />
-      </svg>
+        data-icon="mdi:chevron-down"
+      />
     </span>
   </button>
   <transition-stub

--- a/flip-ui/src/components/AiSelect/__tests__/__snapshots__/AiSelect.spec.ts.snap
+++ b/flip-ui/src/components/AiSelect/__tests__/__snapshots__/AiSelect.spec.ts.snap
@@ -39,16 +39,9 @@ exports[`Ai Select > renders the correct markups 1`] = `
         >
           <svg
             class="w-5 h-5 text-gray-400 dark:text-gray-300"
+            data-icon="mdi:chevron-down"
             data-v-969afcb6=""
-            height="1.2em"
-            viewBox="0 0 24 24"
-            width="1.2em"
-          >
-            <path
-              d="M7.41 8.58L12 13.17l4.59-4.59L18 10l-6 6l-6-6l1.41-1.42z"
-              fill="currentColor"
-            />
-          </svg>
+          />
         </span>
       </button>
       <!--teleport start-->

--- a/flip-ui/src/unit-tests/pages/__snapshots__/page-not-found.spec.ts.snap
+++ b/flip-ui/src/unit-tests/pages/__snapshots__/page-not-found.spec.ts.snap
@@ -6,21 +6,9 @@ exports[`Page Not Found > renders the component successfully 1`] = `
 >
   <svg
     class="font-black w-36 h-36 text-primary-600 dark:text-primary-400"
+    data-icon="ph:signpost-duotone"
     data-test="title"
-    height="1.2em"
-    viewBox="0 0 256 256"
-    width="1.2em"
-  >
-    <path
-      d="M240 112l-36 40H40a8 8 0 0 1-8-8V80a8 8 0 0 1 8-8h164z"
-      fill="currentColor"
-      opacity=".2"
-    />
-    <path
-      d="M245.9 106.6l-36-40A8.1 8.1 0 0 0 204 64h-68V32a8 8 0 0 0-16 0v32H40a16 16 0 0 0-16 16v64a16 16 0 0 0 16 16h80v64a8 8 0 0 0 16 0v-64h68a8.1 8.1 0 0 0 5.9-2.6l36-40a8 8 0 0 0 0-10.8zM200.4 144H40V80h160.4l28.8 32z"
-      fill="currentColor"
-    />
-  </svg>
+  />
   <div
     class="items-center mt-8 text-center text-gray-600 dark:text-gray-300"
   >

--- a/flip-ui/test/iconStubPlugin.ts
+++ b/flip-ui/test/iconStubPlugin.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2026 Guy's and St Thomas' NHS Foundation Trust & King's College London
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Plugin } from "vite";
+
+const ICONS_PREFIX = "~icons/";
+const RESOLVED_PREFIX = `\0${ICONS_PREFIX}`;
+
+/**
+ * Vitest-only replacement for unplugin-icons (FLIP#748).
+ *
+ * unplugin-icons serves every `~icons/<collection>/<name>` import (whether written by hand or generated
+ * by unplugin-vue-components' IconsResolver) as a module the test runner fetches asynchronously. A
+ * component render during a spec kicks off that fetch, the spec file can finish before it settles, and
+ * the still-pending import then rejects against the torn-down environment — vitest records it under
+ * "Unhandled Errors" (EnvironmentTeardownError) and exits 1 even though every test passed. Resolving
+ * the whole `~icons/*` namespace to a synchronous inline stub removes that race for the entire icon
+ * catalogue instead of patching individual specs.
+ *
+ * The stub renders `<svg data-icon="<collection>:<name>">`, so icon-presence assertions and snapshots
+ * stay meaningful (the icon's identity is visible in the markup) and usage-site attributes such as
+ * classes still fall through to the root element, exactly as with the real icon components.
+ */
+export default function iconStubPlugin(): Plugin {
+    return {
+        name: "flip-ui:vitest-icon-stub",
+        enforce: "pre",
+        resolveId(id) {
+            if (id.startsWith(ICONS_PREFIX)) return `\0${id}`;
+        },
+        load(id) {
+            if (!id.startsWith(RESOLVED_PREFIX)) return;
+            const iconName = id.slice(RESOLVED_PREFIX.length).split("?")[0].replace(/\//g, ":");
+            return [
+                "import { h } from \"vue\";",
+                "export default {",
+                `    name: ${JSON.stringify(iconName)},`,
+                `    render: () => h("svg", { "data-icon": ${JSON.stringify(iconName)} })`,
+                "};"
+            ].join("\n");
+        }
+    };
+}

--- a/flip-ui/test/iconStubPlugin.ts
+++ b/flip-ui/test/iconStubPlugin.ts
@@ -16,6 +16,29 @@ import type { Plugin } from "vite";
 const ICONS_PREFIX = "~icons/";
 const RESOLVED_PREFIX = `\0${ICONS_PREFIX}`;
 
+// CodeQL js/bad-code-sanitization: JSON.stringify alone does not escape every character that can
+// misbehave when its output is embedded in generated code (`<`, `>`, `/`, U+2028, U+2029, ...).
+// Icon names come from the repo's own ~icons/... import ids rather than attacker input, but
+// escaping them anyway keeps the generated module literal inert whatever the id contains.
+const UNSAFE_CHARS = /[<>/\b\f\n\r\t\0\u2028\u2029]/g;
+const UNSAFE_CHAR_MAP: Record<string, string> = {
+    "<": "\\u003C",
+    ">": "\\u003E",
+    "/": "\\u002F",
+    "\b": "\\b",
+    "\f": "\\f",
+    "\n": "\\n",
+    "\r": "\\r",
+    "\t": "\\t",
+    "\0": "\\u0000",
+    "\u2028": "\\u2028",
+    "\u2029": "\\u2029"
+};
+
+function escapeUnsafeChars(code: string): string {
+    return code.replace(UNSAFE_CHARS, (char) => UNSAFE_CHAR_MAP[char]);
+}
+
 /**
  * Vitest-only replacement for unplugin-icons (FLIP#748).
  *
@@ -41,11 +64,12 @@ export default function iconStubPlugin(): Plugin {
         load(id) {
             if (!id.startsWith(RESOLVED_PREFIX)) return;
             const iconName = id.slice(RESOLVED_PREFIX.length).split("?")[0].replace(/\//g, ":");
+            const iconNameLiteral = escapeUnsafeChars(JSON.stringify(iconName));
             return [
                 "import { h } from \"vue\";",
                 "export default {",
-                `    name: ${JSON.stringify(iconName)},`,
-                `    render: () => h("svg", { "data-icon": ${JSON.stringify(iconName)} })`,
+                `    name: ${iconNameLiteral},`,
+                `    render: () => h("svg", { "data-icon": ${iconNameLiteral} })`,
                 "};"
             ].join("\n");
         }

--- a/flip-ui/test/setup.ts
+++ b/flip-ui/test/setup.ts
@@ -72,11 +72,21 @@ beforeAll(async () => {
 
 // Cleanup after all tests
 afterAll(async () => {
+  // Belt-and-braces companion to the afterEach drain below, for imports kicked
+  // off outside a test body (e.g. in a spec's own afterAll hook) — FLIP#748.
+  await vi.dynamicImportSettled()
   console.log('Cleaning up test environment...')
 })
 
 // Cleanup after each test
 afterEach(async () => {
+  // FLIP#748: drain dynamic imports started during the test before the file's
+  // environment can be torn down. A fire-and-forget router.push() resolves its
+  // lazy route component via an unawaited dynamic import (e.g. signOut →
+  // routeChange.gotoLogin() → import of Login.vue and its ~icons modules); if
+  // that fetch is still in flight when vitest tears the environment down, it
+  // rejects as an EnvironmentTeardownError and fails an all-green run.
+  await vi.dynamicImportSettled()
   // Clear all mocks to ensure test isolation
   vi.clearAllMocks()
 })

--- a/flip-ui/vite.config.mts
+++ b/flip-ui/vite.config.mts
@@ -12,6 +12,8 @@ import Inspector from "vite-plugin-vue-inspector";
 import Layouts from "vite-plugin-vue-layouts-next";
 import svgLoader from "vite-svg-loader";
 
+import iconStubPlugin from "./test/iconStubPlugin";
+
 // https://vitejs.dev/config/
 export default defineConfig(({ mode, command }) => {
 
@@ -55,10 +57,15 @@ export default defineConfig(({ mode, command }) => {
                     }
                 }),
             Inspector(),
-            Icons({
-                compiler: "vue3",
-                autoInstall: true
-            }),
+            // FLIP#748: under vitest, swap unplugin-icons for a synchronous stub of the
+            // whole ~icons/* namespace — the real plugin's async icon modules race spec
+            // teardown and fail all-green runs (see test/iconStubPlugin.ts).
+            mode === "test"
+                ? iconStubPlugin()
+                : Icons({
+                    compiler: "vue3",
+                    autoInstall: true
+                }),
             Components({
                 dts: false,
                 resolvers: IconsResolver({ prefix: "icon" })


### PR DESCRIPTION
# Description

FLIP UI CI intermittently failed runs in which **every test passed**: vitest exited 1 with

```
EnvironmentTeardownError: Cannot load '/@id/~icons/mdi/lock-outline' imported from
flip-ui/src/pages/auth/Login.vue after the environment was torn down.
This error originated in "src/layouts/__tests__/MainLayout.spec.ts" test file.
```

**Root cause.** A fire-and-forget `router.push()` during a spec starts an unawaited dynamic import chain that can still be in flight when vitest tears down the spec file's environment. The concrete chain behind the CI failures: `MainLayout.spec.ts`'s sign-out test runs the real `authStore.signOut` (`stubActions: false`) → `routeChange.gotoLogin()` → `router.push("/auth/login")` on the real app router (unawaited, `vite-plugin-pages` `importMode: "async"`) → lazy import of `Login.vue` → its `~icons/mdi/lock-outline` import — served asynchronously by `unplugin-icons` — is the slow last link that loses the race against teardown. The pending import then rejects, vitest records it under "Unhandled Errors", and the run exits 1 despite `Tests N passed`.

**Fix** (two complementary changes; no `dangerouslyIgnoreUnhandledErrors`, no error suppression):

1. **`~icons/*` is stubbed synchronously under vitest.** `vite.config.mts` swaps `unplugin-icons` for `test/iconStubPlugin.ts` when `mode === "test"`. Every `~icons/<collection>/<name>` id (hand-written imports and the ones `IconsResolver` generates for `<icon-*>` template tags alike) resolves to a trivial inline component rendering `<svg data-icon="<collection>:<name>">` — no iconify collection parsing or `autoInstall` network access in the test env, and icon assertions/snapshots stay meaningful because the icon's identity is in the markup and usage-site classes still fall through to the root element.
2. **Pending dynamic imports are drained before teardown.** The global `afterEach`/`afterAll` in `test/setup.ts` now `await vi.dynamicImportSettled()`, so any import kicked off by a test (lazy route components included) settles while the environment is still alive. This is load-bearing: with the stub alone, a 6th consecutive local run still reproduced the identical failure signature on the *stubbed* module id, proving the race actually starts one level up (the unawaited route import) and that no plugin-level stub can close it by itself — under vitest even a virtual module is fetched through an async RPC.

The 8 icon-bearing snapshots are refreshed accordingly (inline `<svg><path .../></svg>` blocks become the stub's `data-icon` element; nothing else in them changed). `svg`-presence assertions (`AiChipSelect`, `project-status`) keep passing since the stub's root is still an `<svg>`.

Fixes #748

## Note for #742

The head of #742 (`fix-live-activity-card-responsive` — the branch behind one of the two failing runs cited in the issue) still carries this bug: it keeps `unplugin-icons` with the async `~icons/*` resolution (`mdi`/`ph`), `Login.vue`'s `~icons/mdi/lock-outline` import, and no import drain. Its icon-collection consolidation and `@iconify/json` bump also touch the same 8 snapshot files refreshed here, so whichever PR merges second should rerun `npm run test:unit:update` — after this fix the refresh is trivial (only `data-icon` names change, not svg path data).

## Verification

- `npm run lint` — exit 0 (3 pre-existing `max-len` warnings in `EditProjectDrawer.vue`, untouched by this PR).
- `npm run test:unit` — **8 consecutive green runs** (102 files, 873 passed | 1 skipped each time).
- `src/layouts/__tests__/MainLayout.spec.ts` (the spec named in every CI failure) — **20 consecutive green runs** in isolation.
- Negative control: before the drain was added, run 6 of 6 reproduced the exact CI failure signature locally, confirming both the diagnosis and that the drain (not luck) closes the race.

- CodeQL alert #136 (`js/bad-code-sanitization`) on the stub plugin's generated code is fixed in `78d1c5c0` (escape map applied after `JSON.stringify`); 0 open code-scanning alerts on the PR head.

## Checklist

- [x] Follows the project's coding conventions and style guide
- [ ] Updates documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Type of Change

- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make -C docs/ docs`.


## Acceptance Criteria

*Imported from issue #748*

- [x] The `~icons` async-import teardown race can no longer occur in `npm run test:unit` (icons stubbed/synchronous under vitest).
- [x] Full `npm run lint` + `npm run test:unit` green.
- [x] No `dangerouslyIgnoreUnhandledErrors` or blanket error suppression.
- [x] Icon-dependent snapshots/specs still meaningful (stub renders an identifiable element).
