### PR TITLE
Prod/stag hub deploys: immutable SHA image tags + task-definition-revision deploys

### DIFF
--- a/.github/workflows/docker_build_flip_api.yml
+++ b/.github/workflows/docker_build_flip_api.yml
@@ -85,6 +85,9 @@ jobs:
 
           TAGS="${REGISTRY}/${IMAGE_NAME}:${SHA}"
 
+          # An empty sha would silently publish a mutable literal `sha-` tag — refuse.
+          [[ -n "$SHA" ]] || { echo "::error::empty commit SHA — cannot compute the sha-<short7> tag"; exit 1; }
+
           # Immutable short-SHA tag consumed by `make deploy-centralhub` (FLIP#751).
           # Length 7 must match the tag resolution in deploy/providers/AWS/Makefile.
           TAGS="${TAGS},${REGISTRY}/${IMAGE_NAME}:sha-${SHA:0:7}"

--- a/.github/workflows/docker_build_flip_api.yml
+++ b/.github/workflows/docker_build_flip_api.yml
@@ -85,6 +85,10 @@ jobs:
 
           TAGS="${REGISTRY}/${IMAGE_NAME}:${SHA}"
 
+          # Immutable short-SHA tag consumed by `make deploy-centralhub` (FLIP#751).
+          # Length 7 must match the tag resolution in deploy/providers/AWS/Makefile.
+          TAGS="${TAGS},${REGISTRY}/${IMAGE_NAME}:sha-${SHA:0:7}"
+
           # Branch name sanitization
           SAFE_REF_NAME=$(echo "$REF_NAME" | sed 's/[^a-zA-Z0-9]/-/g')
           TAGS="${TAGS},${REGISTRY}/${IMAGE_NAME}:${SAFE_REF_NAME}"

--- a/.github/workflows/docker_build_orthanc.yml
+++ b/.github/workflows/docker_build_orthanc.yml
@@ -59,8 +59,12 @@ jobs:
         run: |
           TAGS="${REGISTRY}/${IMAGE_NAME}:${{ github.sha }}"
 
-          # Immutable short-SHA tag consumed by `make deploy-centralhub` (FLIP#751).
-          # Length 7 must match the tag resolution in deploy/providers/AWS/Makefile.
+          # An empty sha would silently publish a mutable literal `sha-` tag — refuse.
+          [[ -n "$GH_SHA" ]] || { echo "::error::empty commit SHA — cannot compute the sha-<short7> tag"; exit 1; }
+
+          # Immutable short-SHA tag (FLIP#751), pushed uniformly on every publish; today
+          # only the hub ECS images are consumed (by `make deploy-centralhub`). Length 7
+          # must match the tag resolution in deploy/providers/AWS/Makefile.
           TAGS="${TAGS},${REGISTRY}/${IMAGE_NAME}:sha-${GH_SHA:0:7}"
 
           # Branch name sanitization

--- a/.github/workflows/docker_build_orthanc.yml
+++ b/.github/workflows/docker_build_orthanc.yml
@@ -53,10 +53,15 @@ jobs:
           GH_REF_NAME: ${{ github.ref_name }}
           GH_EVENT_NAME: ${{ github.event_name }}
           GH_REF: ${{ github.ref }}
+          GH_SHA: ${{ github.sha }}
           GH_WR_BRANCH: ${{ github.event.workflow_run.head_branch }}
           GH_WR_EVENT: ${{ github.event.workflow_run.event }}
         run: |
           TAGS="${REGISTRY}/${IMAGE_NAME}:${{ github.sha }}"
+
+          # Immutable short-SHA tag consumed by `make deploy-centralhub` (FLIP#751).
+          # Length 7 must match the tag resolution in deploy/providers/AWS/Makefile.
+          TAGS="${TAGS},${REGISTRY}/${IMAGE_NAME}:sha-${GH_SHA:0:7}"
 
           # Branch name sanitization
           SAFE_REF_NAME=$(echo "$GH_REF_NAME" | sed 's/[^a-zA-Z0-9]/-/g')

--- a/.github/workflows/docker_build_trust_data_access_api.yml
+++ b/.github/workflows/docker_build_trust_data_access_api.yml
@@ -86,6 +86,10 @@ jobs:
 
           TAGS="${REGISTRY}/${IMAGE_NAME}:${SHA}"
 
+          # Immutable short-SHA tag consumed by `make deploy-centralhub` (FLIP#751).
+          # Length 7 must match the tag resolution in deploy/providers/AWS/Makefile.
+          TAGS="${TAGS},${REGISTRY}/${IMAGE_NAME}:sha-${SHA:0:7}"
+
           # Branch name sanitization
           SAFE_REF_NAME=$(echo "$REF_NAME" | sed 's/[^a-zA-Z0-9]/-/g')
           TAGS="${TAGS},${REGISTRY}/${IMAGE_NAME}:${SAFE_REF_NAME}"

--- a/.github/workflows/docker_build_trust_data_access_api.yml
+++ b/.github/workflows/docker_build_trust_data_access_api.yml
@@ -86,8 +86,12 @@ jobs:
 
           TAGS="${REGISTRY}/${IMAGE_NAME}:${SHA}"
 
-          # Immutable short-SHA tag consumed by `make deploy-centralhub` (FLIP#751).
-          # Length 7 must match the tag resolution in deploy/providers/AWS/Makefile.
+          # An empty sha would silently publish a mutable literal `sha-` tag — refuse.
+          [[ -n "$SHA" ]] || { echo "::error::empty commit SHA — cannot compute the sha-<short7> tag"; exit 1; }
+
+          # Immutable short-SHA tag (FLIP#751), pushed uniformly on every publish; today
+          # only the hub ECS images are consumed (by `make deploy-centralhub`). Length 7
+          # must match the tag resolution in deploy/providers/AWS/Makefile.
           TAGS="${TAGS},${REGISTRY}/${IMAGE_NAME}:sha-${SHA:0:7}"
 
           # Branch name sanitization

--- a/.github/workflows/docker_build_trust_imaging_api.yml
+++ b/.github/workflows/docker_build_trust_imaging_api.yml
@@ -84,6 +84,10 @@ jobs:
 
           TAGS="${REGISTRY}/${IMAGE_NAME}:${SHA}"
 
+          # Immutable short-SHA tag consumed by `make deploy-centralhub` (FLIP#751).
+          # Length 7 must match the tag resolution in deploy/providers/AWS/Makefile.
+          TAGS="${TAGS},${REGISTRY}/${IMAGE_NAME}:sha-${SHA:0:7}"
+
           # Branch name sanitization
           SAFE_REF_NAME=$(echo "$REF_NAME" | sed 's/[^a-zA-Z0-9]/-/g')
           TAGS="${TAGS},${REGISTRY}/${IMAGE_NAME}:${SAFE_REF_NAME}"

--- a/.github/workflows/docker_build_trust_imaging_api.yml
+++ b/.github/workflows/docker_build_trust_imaging_api.yml
@@ -84,8 +84,12 @@ jobs:
 
           TAGS="${REGISTRY}/${IMAGE_NAME}:${SHA}"
 
-          # Immutable short-SHA tag consumed by `make deploy-centralhub` (FLIP#751).
-          # Length 7 must match the tag resolution in deploy/providers/AWS/Makefile.
+          # An empty sha would silently publish a mutable literal `sha-` tag — refuse.
+          [[ -n "$SHA" ]] || { echo "::error::empty commit SHA — cannot compute the sha-<short7> tag"; exit 1; }
+
+          # Immutable short-SHA tag (FLIP#751), pushed uniformly on every publish; today
+          # only the hub ECS images are consumed (by `make deploy-centralhub`). Length 7
+          # must match the tag resolution in deploy/providers/AWS/Makefile.
           TAGS="${TAGS},${REGISTRY}/${IMAGE_NAME}:sha-${SHA:0:7}"
 
           # Branch name sanitization

--- a/.github/workflows/docker_build_trust_trust_api.yml
+++ b/.github/workflows/docker_build_trust_trust_api.yml
@@ -85,6 +85,10 @@ jobs:
 
           TAGS="${REGISTRY}/${IMAGE_NAME}:${SHA}"
 
+          # Immutable short-SHA tag consumed by `make deploy-centralhub` (FLIP#751).
+          # Length 7 must match the tag resolution in deploy/providers/AWS/Makefile.
+          TAGS="${TAGS},${REGISTRY}/${IMAGE_NAME}:sha-${SHA:0:7}"
+
           # Branch name sanitization
           SAFE_REF_NAME=$(echo "$REF_NAME" | sed 's/[^a-zA-Z0-9]/-/g')
           TAGS="${TAGS},${REGISTRY}/${IMAGE_NAME}:${SAFE_REF_NAME}"

--- a/.github/workflows/docker_build_trust_trust_api.yml
+++ b/.github/workflows/docker_build_trust_trust_api.yml
@@ -85,8 +85,12 @@ jobs:
 
           TAGS="${REGISTRY}/${IMAGE_NAME}:${SHA}"
 
-          # Immutable short-SHA tag consumed by `make deploy-centralhub` (FLIP#751).
-          # Length 7 must match the tag resolution in deploy/providers/AWS/Makefile.
+          # An empty sha would silently publish a mutable literal `sha-` tag — refuse.
+          [[ -n "$SHA" ]] || { echo "::error::empty commit SHA — cannot compute the sha-<short7> tag"; exit 1; }
+
+          # Immutable short-SHA tag (FLIP#751), pushed uniformly on every publish; today
+          # only the hub ECS images are consumed (by `make deploy-centralhub`). Length 7
+          # must match the tag resolution in deploy/providers/AWS/Makefile.
           TAGS="${TAGS},${REGISTRY}/${IMAGE_NAME}:sha-${SHA:0:7}"
 
           # Branch name sanitization

--- a/.github/workflows/docker_build_xnat_db.yml
+++ b/.github/workflows/docker_build_xnat_db.yml
@@ -60,8 +60,12 @@ jobs:
         run: |
           TAGS="${REGISTRY}/${IMAGE_NAME}:${{ github.sha }}"
 
-          # Immutable short-SHA tag consumed by `make deploy-centralhub` (FLIP#751).
-          # Length 7 must match the tag resolution in deploy/providers/AWS/Makefile.
+          # An empty sha would silently publish a mutable literal `sha-` tag — refuse.
+          [[ -n "$GH_SHA" ]] || { echo "::error::empty commit SHA — cannot compute the sha-<short7> tag"; exit 1; }
+
+          # Immutable short-SHA tag (FLIP#751), pushed uniformly on every publish; today
+          # only the hub ECS images are consumed (by `make deploy-centralhub`). Length 7
+          # must match the tag resolution in deploy/providers/AWS/Makefile.
           TAGS="${TAGS},${REGISTRY}/${IMAGE_NAME}:sha-${GH_SHA:0:7}"
 
           # Branch name sanitization

--- a/.github/workflows/docker_build_xnat_db.yml
+++ b/.github/workflows/docker_build_xnat_db.yml
@@ -54,10 +54,15 @@ jobs:
           GH_REF_NAME: ${{ github.ref_name }}
           GH_EVENT_NAME: ${{ github.event_name }}
           GH_REF: ${{ github.ref }}
+          GH_SHA: ${{ github.sha }}
           GH_WR_BRANCH: ${{ github.event.workflow_run.head_branch }}
           GH_WR_EVENT: ${{ github.event.workflow_run.event }}
         run: |
           TAGS="${REGISTRY}/${IMAGE_NAME}:${{ github.sha }}"
+
+          # Immutable short-SHA tag consumed by `make deploy-centralhub` (FLIP#751).
+          # Length 7 must match the tag resolution in deploy/providers/AWS/Makefile.
+          TAGS="${TAGS},${REGISTRY}/${IMAGE_NAME}:sha-${GH_SHA:0:7}"
 
           # Branch name sanitization
           SAFE_REF_NAME=$(echo "$GH_REF_NAME" | sed 's/[^a-zA-Z0-9]/-/g')

--- a/.github/workflows/docker_build_xnat_nginx.yml
+++ b/.github/workflows/docker_build_xnat_nginx.yml
@@ -60,8 +60,12 @@ jobs:
         run: |
           TAGS="${REGISTRY}/${IMAGE_NAME}:${{ github.sha }}"
 
-          # Immutable short-SHA tag consumed by `make deploy-centralhub` (FLIP#751).
-          # Length 7 must match the tag resolution in deploy/providers/AWS/Makefile.
+          # An empty sha would silently publish a mutable literal `sha-` tag — refuse.
+          [[ -n "$GH_SHA" ]] || { echo "::error::empty commit SHA — cannot compute the sha-<short7> tag"; exit 1; }
+
+          # Immutable short-SHA tag (FLIP#751), pushed uniformly on every publish; today
+          # only the hub ECS images are consumed (by `make deploy-centralhub`). Length 7
+          # must match the tag resolution in deploy/providers/AWS/Makefile.
           TAGS="${TAGS},${REGISTRY}/${IMAGE_NAME}:sha-${GH_SHA:0:7}"
 
           # Branch name sanitization

--- a/.github/workflows/docker_build_xnat_nginx.yml
+++ b/.github/workflows/docker_build_xnat_nginx.yml
@@ -54,10 +54,15 @@ jobs:
           GH_REF_NAME: ${{ github.ref_name }}
           GH_EVENT_NAME: ${{ github.event_name }}
           GH_REF: ${{ github.ref }}
+          GH_SHA: ${{ github.sha }}
           GH_WR_BRANCH: ${{ github.event.workflow_run.head_branch }}
           GH_WR_EVENT: ${{ github.event.workflow_run.event }}
         run: |
           TAGS="${REGISTRY}/${IMAGE_NAME}:${{ github.sha }}"
+
+          # Immutable short-SHA tag consumed by `make deploy-centralhub` (FLIP#751).
+          # Length 7 must match the tag resolution in deploy/providers/AWS/Makefile.
+          TAGS="${TAGS},${REGISTRY}/${IMAGE_NAME}:sha-${GH_SHA:0:7}"
 
           # Branch name sanitization
           SAFE_REF_NAME=$(echo "$GH_REF_NAME" | sed 's/[^a-zA-Z0-9]/-/g')

--- a/.github/workflows/docker_build_xnat_web.yml
+++ b/.github/workflows/docker_build_xnat_web.yml
@@ -79,8 +79,12 @@ jobs:
         run: |
           TAGS="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}"
 
-          # Immutable short-SHA tag consumed by `make deploy-centralhub` (FLIP#751).
-          # Length 7 must match the tag resolution in deploy/providers/AWS/Makefile.
+          # An empty sha would silently publish a mutable literal `sha-` tag — refuse.
+          [[ -n "$GH_SHA" ]] || { echo "::error::empty commit SHA — cannot compute the sha-<short7> tag"; exit 1; }
+
+          # Immutable short-SHA tag (FLIP#751), pushed uniformly on every publish; today
+          # only the hub ECS images are consumed (by `make deploy-centralhub`). Length 7
+          # must match the tag resolution in deploy/providers/AWS/Makefile.
           TAGS="${TAGS},${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:sha-${GH_SHA:0:7}"
 
           # Branch name sanitization

--- a/.github/workflows/docker_build_xnat_web.yml
+++ b/.github/workflows/docker_build_xnat_web.yml
@@ -73,10 +73,15 @@ jobs:
           GH_REF_NAME: ${{ github.ref_name }}
           GH_EVENT_NAME: ${{ github.event_name }}
           GH_REF: ${{ github.ref }}
+          GH_SHA: ${{ github.sha }}
           GH_WR_BRANCH: ${{ github.event.workflow_run.head_branch }}
           GH_WR_EVENT: ${{ github.event.workflow_run.event }}
         run: |
           TAGS="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}"
+
+          # Immutable short-SHA tag consumed by `make deploy-centralhub` (FLIP#751).
+          # Length 7 must match the tag resolution in deploy/providers/AWS/Makefile.
+          TAGS="${TAGS},${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:sha-${GH_SHA:0:7}"
 
           # Branch name sanitization
           SAFE_REF_NAME=$(echo "$GH_REF_NAME" | sed 's/[^a-zA-Z0-9]/-/g')

--- a/.github/workflows/fl-docker-build-flower.yml
+++ b/.github/workflows/fl-docker-build-flower.yml
@@ -54,10 +54,12 @@ jobs:
       - name: Determine image tags
         id: tags
         run: |
-          # Immutable short-SHA tag consumed by `make deploy-centralhub` (FLIP#751).
-          # Length 7 must match the tag resolution in deploy/providers/AWS/Makefile.
+          # Immutable short-SHA tag (FLIP#751): the server/api images are consumed by
+          # `make deploy-centralhub`; the base/client tags are pushed uniformly. Length 7
+          # must match the tag resolution in deploy/providers/AWS/Makefile.
           # Persisted to GITHUB_ENV so the per-image build/push/cleanup steps see it.
           SHORT_SHA="$(echo "${{ github.sha }}" | cut -c1-7)"
+          [[ -n "$SHORT_SHA" ]] || { echo "::error::empty commit SHA — cannot compute the sha-<short7> tag"; exit 1; }
           echo "SHORT_SHA=${SHORT_SHA}" >> $GITHUB_ENV
 
           BASE_TAGS="${REGISTRY}/${ORG}/${BASE_IMAGE}:${{ github.sha }},${REGISTRY}/${ORG}/${BASE_IMAGE}:sha-${SHORT_SHA}"

--- a/.github/workflows/fl-docker-build-flower.yml
+++ b/.github/workflows/fl-docker-build-flower.yml
@@ -54,10 +54,16 @@ jobs:
       - name: Determine image tags
         id: tags
         run: |
-          BASE_TAGS="${REGISTRY}/${ORG}/${BASE_IMAGE}:${{ github.sha }}"
-          SERVER_TAGS="${REGISTRY}/${ORG}/${SERVER_IMAGE}:${{ github.sha }}"
-          CLIENT_TAGS="${REGISTRY}/${ORG}/${CLIENT_IMAGE}:${{ github.sha }}"
-          API_TAGS="${REGISTRY}/${ORG}/${API_IMAGE}:${{ github.sha }}"
+          # Immutable short-SHA tag consumed by `make deploy-centralhub` (FLIP#751).
+          # Length 7 must match the tag resolution in deploy/providers/AWS/Makefile.
+          # Persisted to GITHUB_ENV so the per-image build/push/cleanup steps see it.
+          SHORT_SHA="$(echo "${{ github.sha }}" | cut -c1-7)"
+          echo "SHORT_SHA=${SHORT_SHA}" >> $GITHUB_ENV
+
+          BASE_TAGS="${REGISTRY}/${ORG}/${BASE_IMAGE}:${{ github.sha }},${REGISTRY}/${ORG}/${BASE_IMAGE}:sha-${SHORT_SHA}"
+          SERVER_TAGS="${REGISTRY}/${ORG}/${SERVER_IMAGE}:${{ github.sha }},${REGISTRY}/${ORG}/${SERVER_IMAGE}:sha-${SHORT_SHA}"
+          CLIENT_TAGS="${REGISTRY}/${ORG}/${CLIENT_IMAGE}:${{ github.sha }},${REGISTRY}/${ORG}/${CLIENT_IMAGE}:sha-${SHORT_SHA}"
+          API_TAGS="${REGISTRY}/${ORG}/${API_IMAGE}:${{ github.sha }},${REGISTRY}/${ORG}/${API_IMAGE}:sha-${SHORT_SHA}"
 
           if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
             BASE_TAGS="${BASE_TAGS},${REGISTRY}/${ORG}/${BASE_IMAGE}:prod"
@@ -105,7 +111,8 @@ jobs:
         run: |
           docker build ${BUILD_ARGS} \
             -f fl-services/flower/fl-base/Dockerfile \
-            -t $REGISTRY/$ORG/$BASE_IMAGE:${{ github.sha }} .
+            -t $REGISTRY/$ORG/$BASE_IMAGE:${{ github.sha }} \
+            -t $REGISTRY/$ORG/$BASE_IMAGE:sha-$SHORT_SHA .
 
           # Tag environment-specific
           if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
@@ -119,6 +126,7 @@ jobs:
       - name: Push Base Image
         run: |
           docker push $REGISTRY/$ORG/$BASE_IMAGE:${{ github.sha }}
+          docker push $REGISTRY/$ORG/$BASE_IMAGE:sha-$SHORT_SHA
           if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
             docker push $REGISTRY/$ORG/$BASE_IMAGE:prod
           elif [[ "${{ github.ref }}" == "refs/heads/develop" ]]; then
@@ -129,6 +137,7 @@ jobs:
       - name: Cleanup after base image
         run: |
           # Remove untagged local copies but keep the SHA-tagged image for dependent builds
+          docker rmi $REGISTRY/$ORG/$BASE_IMAGE:sha-$SHORT_SHA || true
           if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
             docker rmi $REGISTRY/$ORG/$BASE_IMAGE:prod || true
           elif [[ "${{ github.ref }}" == "refs/heads/develop" ]]; then
@@ -146,7 +155,8 @@ jobs:
           docker build ${BUILD_ARGS} \
             -f fl-services/flower/superlink/Dockerfile \
             --build-arg BASE_REF=$REGISTRY/$ORG/$BASE_IMAGE:${{ github.sha }} \
-            -t $REGISTRY/$ORG/$SERVER_IMAGE:${{ github.sha }} fl-services/flower/superlink
+            -t $REGISTRY/$ORG/$SERVER_IMAGE:${{ github.sha }} \
+            -t $REGISTRY/$ORG/$SERVER_IMAGE:sha-$SHORT_SHA fl-services/flower/superlink
 
           if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
             docker tag $REGISTRY/$ORG/$SERVER_IMAGE:${{ github.sha }} $REGISTRY/$ORG/$SERVER_IMAGE:prod
@@ -159,6 +169,7 @@ jobs:
       - name: Push SuperLink Image
         run: |
           docker push $REGISTRY/$ORG/$SERVER_IMAGE:${{ github.sha }}
+          docker push $REGISTRY/$ORG/$SERVER_IMAGE:sha-$SHORT_SHA
           if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
             docker push $REGISTRY/$ORG/$SERVER_IMAGE:prod
           elif [[ "${{ github.ref }}" == "refs/heads/develop" ]]; then
@@ -169,6 +180,7 @@ jobs:
       - name: Cleanup after SuperLink
         run: |
           docker rmi $REGISTRY/$ORG/$SERVER_IMAGE:${{ github.sha }} || true
+          docker rmi $REGISTRY/$ORG/$SERVER_IMAGE:sha-$SHORT_SHA || true
           if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
             docker rmi $REGISTRY/$ORG/$SERVER_IMAGE:prod || true
           elif [[ "${{ github.ref }}" == "refs/heads/develop" ]]; then
@@ -186,7 +198,8 @@ jobs:
           docker build ${BUILD_ARGS} \
             -f fl-services/flower/supernode/Dockerfile \
             --build-arg BASE_REF=$REGISTRY/$ORG/$BASE_IMAGE:${{ github.sha }} \
-            -t $REGISTRY/$ORG/$CLIENT_IMAGE:${{ github.sha }} fl-services/flower/supernode
+            -t $REGISTRY/$ORG/$CLIENT_IMAGE:${{ github.sha }} \
+            -t $REGISTRY/$ORG/$CLIENT_IMAGE:sha-$SHORT_SHA fl-services/flower/supernode
 
           if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
             docker tag $REGISTRY/$ORG/$CLIENT_IMAGE:${{ github.sha }} $REGISTRY/$ORG/$CLIENT_IMAGE:prod
@@ -199,6 +212,7 @@ jobs:
       - name: Push SuperNode Image
         run: |
           docker push $REGISTRY/$ORG/$CLIENT_IMAGE:${{ github.sha }}
+          docker push $REGISTRY/$ORG/$CLIENT_IMAGE:sha-$SHORT_SHA
           if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
             docker push $REGISTRY/$ORG/$CLIENT_IMAGE:prod
           elif [[ "${{ github.ref }}" == "refs/heads/develop" ]]; then
@@ -209,6 +223,7 @@ jobs:
       - name: Cleanup after SuperNode
         run: |
           docker rmi $REGISTRY/$ORG/$CLIENT_IMAGE:${{ github.sha }} || true
+          docker rmi $REGISTRY/$ORG/$CLIENT_IMAGE:sha-$SHORT_SHA || true
           if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
             docker rmi $REGISTRY/$ORG/$CLIENT_IMAGE:prod || true
           elif [[ "${{ github.ref }}" == "refs/heads/develop" ]]; then
@@ -225,7 +240,8 @@ jobs:
         run: |
           docker build ${BUILD_ARGS} \
             -f fl-services/flower/fl-api-flower/Dockerfile \
-            -t $REGISTRY/$ORG/$API_IMAGE:${{ github.sha }} fl-services/flower/fl-api-flower
+            -t $REGISTRY/$ORG/$API_IMAGE:${{ github.sha }} \
+            -t $REGISTRY/$ORG/$API_IMAGE:sha-$SHORT_SHA fl-services/flower/fl-api-flower
 
           if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
             docker tag $REGISTRY/$ORG/$API_IMAGE:${{ github.sha }} $REGISTRY/$ORG/$API_IMAGE:prod
@@ -238,6 +254,7 @@ jobs:
       - name: Push FL API Image
         run: |
           docker push $REGISTRY/$ORG/$API_IMAGE:${{ github.sha }}
+          docker push $REGISTRY/$ORG/$API_IMAGE:sha-$SHORT_SHA
           if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
             docker push $REGISTRY/$ORG/$API_IMAGE:prod
           elif [[ "${{ github.ref }}" == "refs/heads/develop" ]]; then
@@ -248,6 +265,7 @@ jobs:
       - name: Final cleanup
         run: |
           docker rmi $REGISTRY/$ORG/$API_IMAGE:${{ github.sha }} || true
+          docker rmi $REGISTRY/$ORG/$API_IMAGE:sha-$SHORT_SHA || true
           if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
             docker rmi $REGISTRY/$ORG/$API_IMAGE:prod || true
           elif [[ "${{ github.ref }}" == "refs/heads/develop" ]]; then

--- a/.github/workflows/fl-docker-build-nvflare.yml
+++ b/.github/workflows/fl-docker-build-nvflare.yml
@@ -52,10 +52,12 @@ jobs:
       - name: Determine image tags
         id: tags
         run: |
-          # Immutable short-SHA tag consumed by `make deploy-centralhub` (FLIP#751).
-          # Length 7 must match the tag resolution in deploy/providers/AWS/Makefile.
+          # Immutable short-SHA tag (FLIP#751): the server/api images are consumed by
+          # `make deploy-centralhub`; the base/client tags are pushed uniformly. Length 7
+          # must match the tag resolution in deploy/providers/AWS/Makefile.
           # Persisted to GITHUB_ENV so the per-image build/push/cleanup steps see it.
           SHORT_SHA="$(echo "${{ github.sha }}" | cut -c1-7)"
+          [[ -n "$SHORT_SHA" ]] || { echo "::error::empty commit SHA — cannot compute the sha-<short7> tag"; exit 1; }
           echo "SHORT_SHA=${SHORT_SHA}" >> $GITHUB_ENV
 
           BASE_TAGS="${REGISTRY}/${ORG}/${BASE_IMAGE}:${{ github.sha }},${REGISTRY}/${ORG}/${BASE_IMAGE}:sha-${SHORT_SHA}"

--- a/.github/workflows/fl-docker-build-nvflare.yml
+++ b/.github/workflows/fl-docker-build-nvflare.yml
@@ -52,10 +52,16 @@ jobs:
       - name: Determine image tags
         id: tags
         run: |
-          BASE_TAGS="${REGISTRY}/${ORG}/${BASE_IMAGE}:${{ github.sha }}"
-          SERVER_TAGS="${REGISTRY}/${ORG}/${SERVER_IMAGE}:${{ github.sha }}"
-          CLIENT_TAGS="${REGISTRY}/${ORG}/${CLIENT_IMAGE}:${{ github.sha }}"
-          API_TAGS="${REGISTRY}/${ORG}/${API_IMAGE}:${{ github.sha }}"
+          # Immutable short-SHA tag consumed by `make deploy-centralhub` (FLIP#751).
+          # Length 7 must match the tag resolution in deploy/providers/AWS/Makefile.
+          # Persisted to GITHUB_ENV so the per-image build/push/cleanup steps see it.
+          SHORT_SHA="$(echo "${{ github.sha }}" | cut -c1-7)"
+          echo "SHORT_SHA=${SHORT_SHA}" >> $GITHUB_ENV
+
+          BASE_TAGS="${REGISTRY}/${ORG}/${BASE_IMAGE}:${{ github.sha }},${REGISTRY}/${ORG}/${BASE_IMAGE}:sha-${SHORT_SHA}"
+          SERVER_TAGS="${REGISTRY}/${ORG}/${SERVER_IMAGE}:${{ github.sha }},${REGISTRY}/${ORG}/${SERVER_IMAGE}:sha-${SHORT_SHA}"
+          CLIENT_TAGS="${REGISTRY}/${ORG}/${CLIENT_IMAGE}:${{ github.sha }},${REGISTRY}/${ORG}/${CLIENT_IMAGE}:sha-${SHORT_SHA}"
+          API_TAGS="${REGISTRY}/${ORG}/${API_IMAGE}:${{ github.sha }},${REGISTRY}/${ORG}/${API_IMAGE}:sha-${SHORT_SHA}"
 
           if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
             BASE_TAGS="${BASE_TAGS},${REGISTRY}/${ORG}/${BASE_IMAGE}:prod"
@@ -100,7 +106,8 @@ jobs:
         run: |
           docker build ${BUILD_ARGS} \
             -f fl-services/nvflare/fl-base/Dockerfile \
-            -t $REGISTRY/$ORG/$BASE_IMAGE:${{ github.sha }} .
+            -t $REGISTRY/$ORG/$BASE_IMAGE:${{ github.sha }} \
+            -t $REGISTRY/$ORG/$BASE_IMAGE:sha-$SHORT_SHA .
 
           # Tag environment-specific
           if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
@@ -114,6 +121,7 @@ jobs:
       - name: Push Base Image
         run: |
           docker push $REGISTRY/$ORG/$BASE_IMAGE:${{ github.sha }}
+          docker push $REGISTRY/$ORG/$BASE_IMAGE:sha-$SHORT_SHA
           if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
             docker push $REGISTRY/$ORG/$BASE_IMAGE:prod
           elif [[ "${{ github.ref }}" == "refs/heads/develop" ]]; then
@@ -124,6 +132,7 @@ jobs:
       - name: Cleanup after base image
         run: |
           # Remove untagged local copies but keep the SHA-tagged image for dependent builds
+          docker rmi $REGISTRY/$ORG/$BASE_IMAGE:sha-$SHORT_SHA || true
           if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
             docker rmi $REGISTRY/$ORG/$BASE_IMAGE:prod || true
           elif [[ "${{ github.ref }}" == "refs/heads/develop" ]]; then
@@ -141,7 +150,8 @@ jobs:
           docker build ${BUILD_ARGS} \
             -f fl-services/nvflare/fl-server/Dockerfile \
             --build-arg BASE_REF=$REGISTRY/$ORG/$BASE_IMAGE:${{ github.sha }} \
-            -t $REGISTRY/$ORG/$SERVER_IMAGE:${{ github.sha }} fl-services/nvflare/fl-server
+            -t $REGISTRY/$ORG/$SERVER_IMAGE:${{ github.sha }} \
+            -t $REGISTRY/$ORG/$SERVER_IMAGE:sha-$SHORT_SHA fl-services/nvflare/fl-server
 
           if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
             docker tag $REGISTRY/$ORG/$SERVER_IMAGE:${{ github.sha }} $REGISTRY/$ORG/$SERVER_IMAGE:prod
@@ -154,6 +164,7 @@ jobs:
       - name: Push FL Server Image
         run: |
           docker push $REGISTRY/$ORG/$SERVER_IMAGE:${{ github.sha }}
+          docker push $REGISTRY/$ORG/$SERVER_IMAGE:sha-$SHORT_SHA
           if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
             docker push $REGISTRY/$ORG/$SERVER_IMAGE:prod
           elif [[ "${{ github.ref }}" == "refs/heads/develop" ]]; then
@@ -164,6 +175,7 @@ jobs:
       - name: Cleanup after FL Server
         run: |
           docker rmi $REGISTRY/$ORG/$SERVER_IMAGE:${{ github.sha }} || true
+          docker rmi $REGISTRY/$ORG/$SERVER_IMAGE:sha-$SHORT_SHA || true
           if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
             docker rmi $REGISTRY/$ORG/$SERVER_IMAGE:prod || true
           elif [[ "${{ github.ref }}" == "refs/heads/develop" ]]; then
@@ -181,7 +193,8 @@ jobs:
           docker build ${BUILD_ARGS} \
             -f fl-services/nvflare/fl-client/Dockerfile \
             --build-arg BASE_REF=$REGISTRY/$ORG/$BASE_IMAGE:${{ github.sha }} \
-            -t $REGISTRY/$ORG/$CLIENT_IMAGE:${{ github.sha }} fl-services/nvflare/fl-client
+            -t $REGISTRY/$ORG/$CLIENT_IMAGE:${{ github.sha }} \
+            -t $REGISTRY/$ORG/$CLIENT_IMAGE:sha-$SHORT_SHA fl-services/nvflare/fl-client
 
           if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
             docker tag $REGISTRY/$ORG/$CLIENT_IMAGE:${{ github.sha }} $REGISTRY/$ORG/$CLIENT_IMAGE:prod
@@ -194,6 +207,7 @@ jobs:
       - name: Push FL Client Image
         run: |
           docker push $REGISTRY/$ORG/$CLIENT_IMAGE:${{ github.sha }}
+          docker push $REGISTRY/$ORG/$CLIENT_IMAGE:sha-$SHORT_SHA
           if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
             docker push $REGISTRY/$ORG/$CLIENT_IMAGE:prod
           elif [[ "${{ github.ref }}" == "refs/heads/develop" ]]; then
@@ -204,6 +218,7 @@ jobs:
       - name: Cleanup after FL Client
         run: |
           docker rmi $REGISTRY/$ORG/$CLIENT_IMAGE:${{ github.sha }} || true
+          docker rmi $REGISTRY/$ORG/$CLIENT_IMAGE:sha-$SHORT_SHA || true
           if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
             docker rmi $REGISTRY/$ORG/$CLIENT_IMAGE:prod || true
           elif [[ "${{ github.ref }}" == "refs/heads/develop" ]]; then
@@ -220,7 +235,8 @@ jobs:
         run: |
           docker build ${BUILD_ARGS} \
             -f fl-services/nvflare/fl-api-base/Dockerfile \
-            -t $REGISTRY/$ORG/$API_IMAGE:${{ github.sha }} fl-services/nvflare/fl-api-base
+            -t $REGISTRY/$ORG/$API_IMAGE:${{ github.sha }} \
+            -t $REGISTRY/$ORG/$API_IMAGE:sha-$SHORT_SHA fl-services/nvflare/fl-api-base
 
           if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
             docker tag $REGISTRY/$ORG/$API_IMAGE:${{ github.sha }} $REGISTRY/$ORG/$API_IMAGE:prod
@@ -233,6 +249,7 @@ jobs:
       - name: Push FL API Image
         run: |
           docker push $REGISTRY/$ORG/$API_IMAGE:${{ github.sha }}
+          docker push $REGISTRY/$ORG/$API_IMAGE:sha-$SHORT_SHA
           if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
             docker push $REGISTRY/$ORG/$API_IMAGE:prod
           elif [[ "${{ github.ref }}" == "refs/heads/develop" ]]; then
@@ -243,6 +260,7 @@ jobs:
       - name: Final cleanup
         run: |
           docker rmi $REGISTRY/$ORG/$API_IMAGE:${{ github.sha }} || true
+          docker rmi $REGISTRY/$ORG/$API_IMAGE:sha-$SHORT_SHA || true
           if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
             docker rmi $REGISTRY/$ORG/$API_IMAGE:prod || true
           elif [[ "${{ github.ref }}" == "refs/heads/develop" ]]; then

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -335,6 +335,8 @@ GitHub Actions: `test_flip_api.yml`, `test_flip_ui.yml`, `test_trust_*.yml`, `do
 
 **The application `docker_build_*.yml` workflows (`flip_api`, `trust_trust_api`, `trust_imaging_api`, `trust_data_access_api`) auto-publish to GHCR only after their service's test workflow passes on `develop` or `main`.** They trigger via `workflow_run` on the matching test workflow (`FLIP API CI`, `Trust - Trust API CI`, etc.) and a job-level `if` gates on `workflow_run.conclusion == 'success'` — a red test suite never publishes. Path filtering is inherited from the test workflow, so a build still only fires when that service changed. (`orthanc`, `xnat_*` keep their direct push trigger — they have no test suite to gate on; `flip-ui` is a CI smoke test that never publishes.)
 
+Every publish also pushes an immutable **`sha-<short7>`** tag (first 7 chars of the built commit) alongside the mutable `:stag`/`:prod` tags. Hub ECS deploys pin these sha tags via task-definition revisions — `make deploy-centralhub` resolves the env branch tip's tag, `make rollback-centralhub` repoints at the previous revision (FLIP#751; see `deploy/providers/AWS/README.md` "Central Hub deploys and rollback").
+
 > **Note:** `workflow_run` triggers only take effect once these workflow files are on the repo's **default branch**. The first merge that introduces them won't retroactively publish; subsequent qualifying pushes will.
 
 Branch pushes do NOT build images. If you pin a branch-named tag in a compose file (e.g. `ghcr.io/londonaicentre/flip-api:my-feature-branch`) for prod testing, manually trigger the relevant build workflow via `workflow_dispatch` (which bypasses the test gate):

--- a/README.md
+++ b/README.md
@@ -304,7 +304,7 @@ This runs the following steps in order:
 | 8 | `make update-env` | Refresh `.env.stag` with Terraform outputs |
 | 9 | `make ssh-config` | Write SSM-tunnelled `Host flip` / `Host flip-trust` into `~/.ssh/config` |
 | 10 | `make ansible-init` | Configure Trust EC2 with Docker, CloudWatch, and FL assets |
-| 11 | `make deploy-centralhub` | Force-redeploy ECS Fargate services + sync UI to S3 + invalidate CloudFront |
+| 11 | `make deploy-centralhub` | Deploy ECS Fargate services at the env branch tip (immutable `sha-<short7>` task-def revisions) + sync UI to S3 + invalidate CloudFront |
 | 12 | `make register-trusts` | Register trusts on the hub and write per-trust kit files |
 | 13 | `make deploy-trust` | Deploy trust stack to Trust EC2 via Docker Compose |
 | 14 | `make status` | Health checks |

--- a/deploy/providers/AWS/AGENTS.md
+++ b/deploy/providers/AWS/AGENTS.md
@@ -35,7 +35,7 @@ make full-deploy PROD=true                    # Full prod deploy
 make full-deploy-hybrid PROD=<stag|true> [LOCAL_TRUST_IP=<ip>]  # Hybrid with on-prem trust
 make init/plan/apply                          # Terraform workflow
 make deploy-centralhub                        # ECS deploy at env branch tip via sha-<short7> task-def revisions + CloudFront UI (FLIP#751; TAG= to pin)
-make rollback-centralhub                      # Repoint ECS services at the previous ACTIVE task-def revision
+make rollback-centralhub                      # Repoint ECS services at the previous ACTIVE task-def revision + deregister the rolled-away one
 make deploy-trust                             # Deploy trust stack to EC2
 make deploy-ui                                # Build + sync UI to S3 + invalidate CloudFront
 make status                                   # Health checks
@@ -64,7 +64,7 @@ make aws-login                                # AWS SSO login
 
 ## Verifying a Central-Hub FL redeploy
 
-An FL redeploy is `make deploy-centralhub` (branch-tip resolution, or `TAG=sha-<short7>` for a pinned build) — it registers new task-definition revisions for `fl-server-net-1` / `fl-api-net-1` pinning the immutable sha tag and repoints the services at them (FLIP#751; the old flow re-pulled the mutable `:stag`/`:prod` tag via `update-service --force-new-deployment`). To confirm the new image is actually running, compare the task's image digest to the GHCR tag — **but select the container by name, not by array index**:
+An FL redeploy is `make deploy-centralhub` (branch-tip resolution, or `TAG=sha-<short7>` for a pinned build) — it registers new task-definition revisions for `fl-server-net-1` / `fl-api-net-1` pinning the immutable sha tag and repoints the services at them (FLIP#751; the old flow re-pulled the mutable `:stag`/`:prod` tag via `update-service --force-new-deployment`). Note it also rolls `flip-api` to the same tag and finishes with `make deploy-ui`, which builds `flip-ui` **from your local working tree** — run it from a clean checkout of the deployed branch. To confirm the new image is actually running, compare the task's image digest to the GHCR tag — **but select the container by name, not by array index**:
 
 - `aws ecs describe-tasks` returns `containers` as an array, and the **GuardDuty Runtime Monitoring sidecar** (`aws-guardduty-agent-*`) usually sorts first. Querying `containers[0].imageDigest` reads the *agent's* digest, not the FL container's.
 - The GuardDuty agent image lives in an AWS-internal ECR, **never GHCR**, so its digest returns **HTTP 404** when looked up in `ghcr.io`. A 404 digest is the sidecar — not a stale FL image. (This burned a full investigation on 2026-06-24: `66446df3…` was the GuardDuty agent; the real `fl-server-net-1` digest `29b10362…` matched `:stag` exactly. Both `flare-fl-server:stag` and `flare-fl-api:stag` were rebuilt by the #624 FL-deps merge, configs created `15:54–15:55Z`.)

--- a/deploy/providers/AWS/AGENTS.md
+++ b/deploy/providers/AWS/AGENTS.md
@@ -34,7 +34,8 @@ make full-deploy PROD=stag                   # Full staging deploy
 make full-deploy PROD=true                    # Full prod deploy
 make full-deploy-hybrid PROD=<stag|true> [LOCAL_TRUST_IP=<ip>]  # Hybrid with on-prem trust
 make init/plan/apply                          # Terraform workflow
-make deploy-centralhub                        # ECS force-redeploy + CloudFront UI
+make deploy-centralhub                        # ECS deploy at env branch tip via sha-<short7> task-def revisions + CloudFront UI (FLIP#751; TAG= to pin)
+make rollback-centralhub                      # Repoint ECS services at the previous ACTIVE task-def revision
 make deploy-trust                             # Deploy trust stack to EC2
 make deploy-ui                                # Build + sync UI to S3 + invalidate CloudFront
 make status                                   # Health checks
@@ -59,11 +60,11 @@ make aws-login                                # AWS SSO login
 - **CloudFront + S3**: flip-ui static hosting
 - **Secrets Manager**: `FLIP_API` secret (AES key, DB password, key hashes)
 - **Cognito**: `flip-user-pool` with email auth
-- **Container registry**: **GHCR** (`ghcr.io/londonaicentre/`) for every FLIP image (flip-api, flare-fl-api, flare-fl-server, flower-superlink, trust-api, imaging-api, data-access-api, orthanc, omop-db, XNAT). ECS Fargate task definitions pull directly from GHCR — `var.docker_registry` in `variables.tf` defaults to it; trust EC2 / on-prem hosts do too. **There is no ECR mirror.** A surgical centralhub redeploy (per `project_prod_ecs_deploy.md` — don't `make apply` for prod) is: GH workflow `workflow_dispatch` to build the branch image to GHCR → `aws ecs register-task-definition` with the branch tag → `aws ecs update-service --force-new-deployment`. The flip-ui bundle ships separately via `make deploy-ui` (it's static assets in S3, not a container image).
+- **Container registry**: **GHCR** (`ghcr.io/londonaicentre/`) for every FLIP image (flip-api, flare-fl-api, flare-fl-server, flower-superlink, trust-api, imaging-api, data-access-api, orthanc, omop-db, XNAT). ECS Fargate task definitions pull directly from GHCR — `var.docker_registry` in `variables.tf` defaults to it; trust EC2 / on-prem hosts do too. **There is no ECR mirror.** A surgical centralhub redeploy (per `project_prod_ecs_deploy.md` — don't `make apply` for prod) is now one command: GH workflow `workflow_dispatch` to build the branch image to GHCR (publishes `sha-<short7>`) → `make deploy-centralhub TAG=sha-<short7>`, which registers new task-definition revisions and repoints the services (FLIP#751 — the previously manual register-task-definition + update-service runbook). The flip-ui bundle ships separately via `make deploy-ui` (it's static assets in S3, not a container image).
 
 ## Verifying a Central-Hub FL redeploy
 
-A surgical FL redeploy is `aws ecs update-service --force-new-deployment` on `fl-server-net-1` / `fl-api-net-1` (Fargate re-pulls the `:stag`/`:prod` tag on every task start — no task-def revision needed). To confirm the new image is actually running, compare the task's image digest to the GHCR tag — **but select the container by name, not by array index**:
+An FL redeploy is `make deploy-centralhub` (branch-tip resolution, or `TAG=sha-<short7>` for a pinned build) — it registers new task-definition revisions for `fl-server-net-1` / `fl-api-net-1` pinning the immutable sha tag and repoints the services at them (FLIP#751; the old flow re-pulled the mutable `:stag`/`:prod` tag via `update-service --force-new-deployment`). To confirm the new image is actually running, compare the task's image digest to the GHCR tag — **but select the container by name, not by array index**:
 
 - `aws ecs describe-tasks` returns `containers` as an array, and the **GuardDuty Runtime Monitoring sidecar** (`aws-guardduty-agent-*`) usually sorts first. Querying `containers[0].imageDigest` reads the *agent's* digest, not the FL container's.
 - The GuardDuty agent image lives in an AWS-internal ECR, **never GHCR**, so its digest returns **HTTP 404** when looked up in `ghcr.io`. A 404 digest is the sidecar — not a stale FL image. (This burned a full investigation on 2026-06-24: `66446df3…` was the GuardDuty agent; the real `fl-server-net-1` digest `29b10362…` matched `:stag` exactly. Both `flare-fl-server:stag` and `flare-fl-api:stag` were rebuilt by the #624 FL-deps merge, configs created `15:54–15:55Z`.)

--- a/deploy/providers/AWS/CLAUDE.md
+++ b/deploy/providers/AWS/CLAUDE.md
@@ -36,7 +36,7 @@ make full-deploy-hybrid PROD=<stag|true> [LOCAL_TRUST_IP=<ip>]  # Hybrid with on
 make full-deploy-hub-only PROD=<stag|true>    # Hub only, NO cloud Trust EC2 (all trusts on-prem, e.g. GPU hosts) — see README "Hub-only Deployment"
 make init/plan/apply                          # Terraform workflow
 make deploy-centralhub                        # ECS deploy at env branch tip via sha-<short7> task-def revisions + CloudFront UI (FLIP#751; TAG= to pin)
-make rollback-centralhub                      # Repoint ECS services at the previous ACTIVE task-def revision
+make rollback-centralhub                      # Repoint ECS services at the previous ACTIVE task-def revision + deregister the rolled-away one
 make deploy-trust                             # Deploy trust stack to EC2
 make deploy-ui                                # Build + sync UI to S3 + invalidate CloudFront
 make status                                   # Health checks
@@ -65,7 +65,7 @@ make aws-login                                # AWS SSO login
 
 ## Verifying a Central-Hub FL redeploy
 
-An FL redeploy is `make deploy-centralhub` (branch-tip resolution, or `TAG=sha-<short7>` for a pinned build) — it registers new task-definition revisions for `fl-server-net-1` / `fl-api-net-1` pinning the immutable sha tag and repoints the services at them (FLIP#751; the old flow re-pulled the mutable `:stag`/`:prod` tag via `update-service --force-new-deployment`). To confirm the new image is actually running, compare the task's image digest to the GHCR tag — **but select the container by name, not by array index**:
+An FL redeploy is `make deploy-centralhub` (branch-tip resolution, or `TAG=sha-<short7>` for a pinned build) — it registers new task-definition revisions for `fl-server-net-1` / `fl-api-net-1` pinning the immutable sha tag and repoints the services at them (FLIP#751; the old flow re-pulled the mutable `:stag`/`:prod` tag via `update-service --force-new-deployment`). Note it also rolls `flip-api` to the same tag and finishes with `make deploy-ui`, which builds `flip-ui` **from your local working tree** — run it from a clean checkout of the deployed branch. To confirm the new image is actually running, compare the task's image digest to the GHCR tag — **but select the container by name, not by array index**:
 
 - `aws ecs describe-tasks` returns `containers` as an array, and the **GuardDuty Runtime Monitoring sidecar** (`aws-guardduty-agent-*`) usually sorts first. Querying `containers[0].imageDigest` reads the *agent's* digest, not the FL container's.
 - The GuardDuty agent image lives in an AWS-internal ECR, **never GHCR**, so its digest returns **HTTP 404** when looked up in `ghcr.io`. A 404 digest is the sidecar — not a stale FL image. (This burned a full investigation on 2026-06-24: `66446df3…` was the GuardDuty agent; the real `fl-server-net-1` digest `29b10362…` matched `:stag` exactly. Both `flare-fl-server:stag` and `flare-fl-api:stag` were rebuilt by the #624 FL-deps merge, configs created `15:54–15:55Z`.)

--- a/deploy/providers/AWS/CLAUDE.md
+++ b/deploy/providers/AWS/CLAUDE.md
@@ -35,7 +35,8 @@ make full-deploy PROD=true                    # Full prod deploy
 make full-deploy-hybrid PROD=<stag|true> [LOCAL_TRUST_IP=<ip>]  # Hybrid with on-prem trust
 make full-deploy-hub-only PROD=<stag|true>    # Hub only, NO cloud Trust EC2 (all trusts on-prem, e.g. GPU hosts) — see README "Hub-only Deployment"
 make init/plan/apply                          # Terraform workflow
-make deploy-centralhub                        # ECS force-redeploy + CloudFront UI
+make deploy-centralhub                        # ECS deploy at env branch tip via sha-<short7> task-def revisions + CloudFront UI (FLIP#751; TAG= to pin)
+make rollback-centralhub                      # Repoint ECS services at the previous ACTIVE task-def revision
 make deploy-trust                             # Deploy trust stack to EC2
 make deploy-ui                                # Build + sync UI to S3 + invalidate CloudFront
 make status                                   # Health checks
@@ -60,11 +61,11 @@ make aws-login                                # AWS SSO login
 - **CloudFront + S3**: flip-ui static hosting
 - **Secrets Manager**: `FLIP_API` secret (AES key, DB password, key hashes)
 - **Cognito**: `flip-user-pool` with email auth
-- **Container registry**: **GHCR** (`ghcr.io/londonaicentre/`) for every FLIP image (flip-api, flare-fl-api, flare-fl-server, flower-superlink, trust-api, imaging-api, data-access-api, orthanc, omop-db, XNAT). ECS Fargate task definitions pull directly from GHCR — `var.docker_registry` in `variables.tf` defaults to it; trust EC2 / on-prem hosts do too. **There is no ECR mirror.** A surgical centralhub redeploy (per `project_prod_ecs_deploy.md` — don't `make apply` for prod) is: GH workflow `workflow_dispatch` to build the branch image to GHCR → `aws ecs register-task-definition` with the branch tag → `aws ecs update-service --force-new-deployment`. The flip-ui bundle ships separately via `make deploy-ui` (it's static assets in S3, not a container image).
+- **Container registry**: **GHCR** (`ghcr.io/londonaicentre/`) for every FLIP image (flip-api, flare-fl-api, flare-fl-server, flower-superlink, trust-api, imaging-api, data-access-api, orthanc, omop-db, XNAT). ECS Fargate task definitions pull directly from GHCR — `var.docker_registry` in `variables.tf` defaults to it; trust EC2 / on-prem hosts do too. **There is no ECR mirror.** A surgical centralhub redeploy (per `project_prod_ecs_deploy.md` — don't `make apply` for prod) is now one command: GH workflow `workflow_dispatch` to build the branch image to GHCR (publishes `sha-<short7>`) → `make deploy-centralhub TAG=sha-<short7>`, which registers new task-definition revisions and repoints the services (FLIP#751 — the previously manual register-task-definition + update-service runbook). The flip-ui bundle ships separately via `make deploy-ui` (it's static assets in S3, not a container image).
 
 ## Verifying a Central-Hub FL redeploy
 
-A surgical FL redeploy is `aws ecs update-service --force-new-deployment` on `fl-server-net-1` / `fl-api-net-1` (Fargate re-pulls the `:stag`/`:prod` tag on every task start — no task-def revision needed). To confirm the new image is actually running, compare the task's image digest to the GHCR tag — **but select the container by name, not by array index**:
+An FL redeploy is `make deploy-centralhub` (branch-tip resolution, or `TAG=sha-<short7>` for a pinned build) — it registers new task-definition revisions for `fl-server-net-1` / `fl-api-net-1` pinning the immutable sha tag and repoints the services at them (FLIP#751; the old flow re-pulled the mutable `:stag`/`:prod` tag via `update-service --force-new-deployment`). To confirm the new image is actually running, compare the task's image digest to the GHCR tag — **but select the container by name, not by array index**:
 
 - `aws ecs describe-tasks` returns `containers` as an array, and the **GuardDuty Runtime Monitoring sidecar** (`aws-guardduty-agent-*`) usually sorts first. Querying `containers[0].imageDigest` reads the *agent's* digest, not the FL container's.
 - The GuardDuty agent image lives in an AWS-internal ECR, **never GHCR**, so its digest returns **HTTP 404** when looked up in `ghcr.io`. A 404 digest is the sidecar — not a stale FL image. (This burned a full investigation on 2026-06-24: `66446df3…` was the GuardDuty agent; the real `fl-server-net-1` digest `29b10362…` matched `:stag` exactly. Both `flare-fl-server:stag` and `flare-fl-api:stag` were rebuilt by the #624 FL-deps merge, configs created `15:54–15:55Z`.)

--- a/deploy/providers/AWS/Makefile
+++ b/deploy/providers/AWS/Makefile
@@ -479,13 +479,18 @@ deploy-centralhub: ## Deploy Central Hub ECS services at the env branch tip (new
 	    200) echo "   ✓ $$service: $$new_image verified in GHCR";; \
 	    404) \
 	      case "$$service" in \
-	        flip-api) wf=docker_build_flip_api.yml;; \
-	        *) wf=fl-docker-build-$(FL_BACKEND).yml;; \
+	        flip-api) wf=docker_build_flip_api.yml; is_fl=false;; \
+	        *) wf=fl-docker-build-$(FL_BACKEND).yml; is_fl=true;; \
 	      esac; \
 	      echo "❌ $$new_image not found in GHCR."; \
 	      echo "   Builds are path-filtered (a merge that didn't touch this service publishes no new"; \
 	      echo "   tag for it), and flip-api's is additionally test-gated so it may still be running:"; \
 	      echo "     gh run list --workflow=$$wf"; \
+	      if [ "$$is_fl" = true ]; then \
+	        echo "   $$wf builds fl-server, fl-api, fl-client and fl-base together, so their sha-<short7>"; \
+	        echo "   tags publish as one set — a 404 here means that whole backend build did not run for"; \
+	        echo "   this commit, not that a single image within the multi-image build is missing."; \
+	      fi; \
 	      echo "   To build a missing / branch / hotfix image: gh workflow run $$wf --ref <branch>"; \
 	      echo "   Nothing has been deployed."; \
 	      exit 1;; \
@@ -500,6 +505,19 @@ deploy-centralhub: ## Deploy Central Hub ECS services at the env branch tip (new
 	done; \
 	deployed=""; tmp_td=""; \
 	trap 'rm -f $$tmp_td' EXIT; \
+	warn_mixed() { \
+	  [ -n "$$deployed" ] || return 0; \
+	  echo ""; \
+	  echo "   ============================== MIXED STATE =============================="; \
+	  echo "   ⚠️  PARTIAL DEPLOY — some services were already repointed this run before"; \
+	  echo "       this failure; the Central Hub now runs a mix of old and new revisions."; \
+	  echo "       Already repointed:$$deployed"; \
+	  echo "       → Fix the error above and re-run 'make deploy-centralhub' to converge."; \
+	  echo "       → Do NOT 'make rollback-centralhub' blindly: it would also downgrade the"; \
+	  echo "         services that deployed cleanly this run."; \
+	  echo "   ========================================================================="; \
+	  echo ""; \
+	}; \
 	for service in $(CENTRALHUB_ECS_SERVICES); do \
 	  current_td=$$(aws ecs describe-services --cluster $(ECS_CLUSTER) --services $$service \
 	    --query 'services[0].taskDefinition' --output text); \
@@ -517,8 +535,7 @@ deploy-centralhub: ## Deploy Central Hub ECS services at the env branch tip (new
 	  if ! new_td_arn=$$(aws ecs register-task-definition --cli-input-json file://$$tmp_td \
 	      --query 'taskDefinition.taskDefinitionArn' --output text); then \
 	    echo "❌ $$service: register-task-definition failed."; \
-	    [ -z "$$deployed" ] || echo "   ⚠️  Already repointed this run:$$deployed — the hub is mixed. Fix and re-run"; \
-	    [ -z "$$deployed" ] || echo "   to converge; do NOT rollback-centralhub blindly (it would also downgrade the untouched services)."; \
+	    warn_mixed; \
 	    exit 1; \
 	  fi; \
 	  rm -f $$tmp_td; tmp_td=""; \
@@ -530,8 +547,7 @@ deploy-centralhub: ## Deploy Central Hub ECS services at the env branch tip (new
 	    echo "   so the latest-ACTIVE lookups in ecs_services.tf keep tracking the running revision."; \
 	    aws ecs deregister-task-definition --task-definition "$$new_td_arn" >/dev/null \
 	      || echo "   ⚠️  deregister failed too — deregister $${new_td_arn##*/} manually, or the next terraform apply will adopt it."; \
-	    [ -z "$$deployed" ] || echo "   ⚠️  Already repointed this run:$$deployed — the hub is mixed. Fix and re-run"; \
-	    [ -z "$$deployed" ] || echo "   to converge; do NOT rollback-centralhub blindly (it would also downgrade the untouched services)."; \
+	    warn_mixed; \
 	    exit 1; \
 	  fi; \
 	  deployed="$$deployed $$service"; \
@@ -601,6 +617,9 @@ rollback-centralhub: ## Repoint each Central Hub ECS service at its previous ACT
 	  echo "     aws ecs describe-services --cluster $(ECS_CLUSTER) --services $(CENTRALHUB_ECS_SERVICES) --query 'services[].events[:5]'"; \
 	  exit 1; }
 	@echo "✅ Central Hub ECS services rolled back."
+	@echo "⚠️  The flip-ui bundle was NOT rolled back — if the reverted release also changed the"
+	@echo "   UI, re-run 'make deploy-ui PROD=$(PROD)' from the matching commit to avoid a"
+	@echo "   frontend/backend mismatch."
 
 .PHONY: deploy-ui
 deploy-ui: ## Build flip-ui from the working tree and deploy it to S3 + invalidate CloudFront

--- a/deploy/providers/AWS/Makefile
+++ b/deploy/providers/AWS/Makefile
@@ -422,10 +422,16 @@ deploy-centralhub: ## Deploy Central Hub ECS services at the env branch tip (new
 	## shell function) so the git fetch only runs when this target does; `cut -c1-7` pins the
 	## abbreviation to exactly 7 chars to match CI's sha-tag truncation — `git rev-parse --short=7`
 	## can grow beyond 7 when abbreviations become ambiguous, and the GHCR guard below
-	## catches any residual mismatch loudly. Per service: the app container is selected BY
-	## NAME (prod task defs carry a GuardDuty sidecar as containers[0]) and only its image
-	## tag is swapped before registering the new revision. Pass TAG=sha-<short7> to deploy
-	## a hotfix / feature-branch image (build it first via workflow_dispatch — see
+	## catches any residual mismatch loudly. Two phases: EVERY service's target image is
+	## resolved and its GHCR manifest verified before ANY service is mutated, so a missing
+	## tag (builds are path-filtered — a merge that didn't touch a service publishes no new
+	## tag for it) aborts with nothing deployed. Non-ghcr.io registries skip the manifest
+	## check (LZA ECR pull-through cache, FLIP#749). The app container is selected BY NAME —
+	## never by index — matching the describe-tasks convention in TROUBLESHOOTING.md §1.9
+	## and staying robust to sidecar/ordering changes; only its image tag is swapped before
+	## registering the new revision. Task-def tags are carried over only when non-empty
+	## (register-task-definition rejects an empty tags array). Pass TAG=sha-<short7> to
+	## deploy a hotfix / feature-branch image (build it first via workflow_dispatch — see
 	## CLAUDE.md); revert with `make rollback-centralhub`.
 	@set -e; \
 	export AWS_PROFILE=$(AWS_PROFILE) AWS_REGION=$(AWS_REGION); \
@@ -433,9 +439,67 @@ deploy-centralhub: ## Deploy Central Hub ECS services at the env branch tip (new
 	if [ -z "$$TAG" ]; then \
 	  echo "🔎 Resolving deploy tag from the tip of $(DEPLOY_GIT_REF)..."; \
 	  git fetch -q origin; \
-	  TAG="sha-$$(git rev-parse $(DEPLOY_GIT_REF) | cut -c1-7)"; \
+	  sha=$$(git rev-parse $(DEPLOY_GIT_REF)) || { echo "❌ Cannot resolve $(DEPLOY_GIT_REF)"; exit 1; }; \
+	  TAG="sha-$$(printf '%s' "$$sha" | cut -c1-7)"; \
 	fi; \
+	printf '%s' "$$TAG" | grep -Eq '^sha-[0-9a-f]{7}$$' || { \
+	  echo "❌ TAG '$$TAG' is not an immutable sha-<short7> tag (sha- followed by 7 hex chars)."; \
+	  echo "   deploy-centralhub only deploys CI-published sha tags — a mutable tag here would"; \
+	  echo "   defeat the revision audit trail. Omit TAG= to deploy the tip of $(DEPLOY_GIT_REF)."; \
+	  exit 1; }; \
 	echo "🚀 Deploying Central Hub ECS services in $(ECS_CLUSTER) at $$TAG..."; \
+	for service in $(CENTRALHUB_ECS_SERVICES); do \
+	  current_td=$$(aws ecs describe-services --cluster $(ECS_CLUSTER) --services $$service \
+	    --query 'services[0].taskDefinition' --output text); \
+	  if [ -z "$$current_td" ] || [ "$$current_td" = "None" ]; then \
+	    echo "❌ $$service not found in cluster $(ECS_CLUSTER)"; exit 1; \
+	  fi; \
+	  td_json=$$(aws ecs describe-task-definition --task-definition "$$current_td"); \
+	  image=$$(printf '%s' "$$td_json" | jq -r --arg name "$$service" \
+	    '.taskDefinition.containerDefinitions[] | select(.name == $$name).image'); \
+	  [ -n "$$image" ] || { echo "❌ $$service: no container named '$$service' in $$current_td"; exit 1; }; \
+	  case "$$image" in \
+	  *@*) echo "❌ $$service: digest-pinned image '$$image' — cannot swap a tag onto it"; exit 1;; \
+	  esac; \
+	  new_image="$${image%:*}:$$TAG"; \
+	  case "$$new_image" in \
+	  ghcr.io/*) \
+	    repo=$${new_image#ghcr.io/}; repo=$${repo%:*}; \
+	    token=$$(curl -fsSL "https://ghcr.io/token?scope=repository:$$repo:pull" | jq -r '.token // empty'); \
+	    [ -n "$$token" ] || { \
+	      echo "❌ GHCR token fetch failed (network/registry problem) — cannot verify $$new_image."; \
+	      echo "   This is NOT a missing build; retry once GHCR is reachable. Nothing has been deployed."; \
+	      exit 1; }; \
+	    accept='application/vnd.oci.image.index.v1+json, application/vnd.oci.image.manifest.v1+json'; \
+	    accept="$$accept, application/vnd.docker.distribution.manifest.list.v2+json"; \
+	    accept="$$accept, application/vnd.docker.distribution.manifest.v2+json"; \
+	    status=$$(curl -sSI -o /dev/null -w '%{http_code}' -H "Authorization: Bearer $$token" \
+	      -H "Accept: $$accept" "https://ghcr.io/v2/$$repo/manifests/$$TAG") || status=000; \
+	    case "$$status" in \
+	    200) echo "   ✓ $$service: $$new_image verified in GHCR";; \
+	    404) \
+	      case "$$service" in \
+	        flip-api) wf=docker_build_flip_api.yml;; \
+	        *) wf=fl-docker-build-$(FL_BACKEND).yml;; \
+	      esac; \
+	      echo "❌ $$new_image not found in GHCR."; \
+	      echo "   Builds are path-filtered (a merge that didn't touch this service publishes no new"; \
+	      echo "   tag for it), and flip-api's is additionally test-gated so it may still be running:"; \
+	      echo "     gh run list --workflow=$$wf"; \
+	      echo "   To build a missing / branch / hotfix image: gh workflow run $$wf --ref <branch>"; \
+	      echo "   Nothing has been deployed."; \
+	      exit 1;; \
+	    *) \
+	      echo "❌ GHCR manifest check for $$new_image returned HTTP $$status — a registry/auth/"; \
+	      echo "   network problem, not a missing build. Do not dispatch rebuilds; retry the deploy."; \
+	      echo "   Nothing has been deployed."; \
+	      exit 1;; \
+	    esac;; \
+	  *) echo "   ⚠️  $$new_image is not on ghcr.io — skipping the registry existence check (FLIP#749)";; \
+	  esac; \
+	done; \
+	deployed=""; tmp_td=""; \
+	trap 'rm -f $$tmp_td' EXIT; \
 	for service in $(CENTRALHUB_ECS_SERVICES); do \
 	  current_td=$$(aws ecs describe-services --cluster $(ECS_CLUSTER) --services $$service \
 	    --query 'services[0].taskDefinition' --output text); \
@@ -444,45 +508,43 @@ deploy-centralhub: ## Deploy Central Hub ECS services at the env branch tip (new
 	    '.taskDefinition.containerDefinitions[] | select(.name == $$name).image'); \
 	  [ -n "$$image" ] || { echo "❌ $$service: no container named '$$service' in $$current_td"; exit 1; }; \
 	  new_image="$${image%:*}:$$TAG"; \
-	  case "$$new_image" in \
-	  ghcr.io/*) \
-	    repo=$${new_image#ghcr.io/}; repo=$${repo%:*}; \
-	    token=$$(curl -fsSL "https://ghcr.io/token?scope=repository:$$repo:pull" | jq -r '.token'); \
-	    accept='application/vnd.oci.image.index.v1+json, application/vnd.oci.image.manifest.v1+json'; \
-	    accept="$$accept, application/vnd.docker.distribution.manifest.list.v2+json"; \
-	    accept="$$accept, application/vnd.docker.distribution.manifest.v2+json"; \
-	    if ! curl -fsI -o /dev/null -H "Authorization: Bearer $$token" -H "Accept: $$accept" \
-	        "https://ghcr.io/v2/$$repo/manifests/$$TAG"; then \
-	      case "$$service" in \
-	        flip-api) wf=docker_build_flip_api.yml;; \
-	        *) wf=fl-docker-build-$(FL_BACKEND).yml;; \
-	      esac; \
-	      echo "❌ $$new_image not found in GHCR."; \
-	      echo "   Builds are test-gated and may still be running (or red) — check:"; \
-	      echo "     gh run list --workflow=$$wf"; \
-	      echo "   For a branch/hotfix image, build it first: gh workflow run $$wf --ref <branch>"; \
-	      exit 1; \
-	    fi;; \
-	  *) echo "   ⚠️  $$new_image is not on ghcr.io — skipping the registry existence check";; \
-	  esac; \
 	  jq_prog='.taskDefinition.containerDefinitions |= map(if .name == $$name then .image = $$image else . end)'; \
 	  jq_prog="$$jq_prog | (.taskDefinition | del(.taskDefinitionArn, .revision, .status, .requiresAttributes,"; \
 	  jq_prog="$$jq_prog .compatibilities, .registeredAt, .registeredBy, .deregisteredAt))"; \
 	  jq_prog="$$jq_prog + (if ((.tags // []) | length) > 0 then {tags: .tags} else {} end)"; \
 	  tmp_td=$$(mktemp); \
 	  printf '%s' "$$td_json" | jq --arg name "$$service" --arg image "$$new_image" "$$jq_prog" > $$tmp_td; \
-	  new_td_arn=$$(aws ecs register-task-definition --cli-input-json file://$$tmp_td \
-	    --query 'taskDefinition.taskDefinitionArn' --output text); \
-	  rm -f $$tmp_td; \
+	  if ! new_td_arn=$$(aws ecs register-task-definition --cli-input-json file://$$tmp_td \
+	      --query 'taskDefinition.taskDefinitionArn' --output text); then \
+	    echo "❌ $$service: register-task-definition failed."; \
+	    [ -z "$$deployed" ] || echo "   ⚠️  Already repointed this run:$$deployed — the hub is mixed. Fix and re-run"; \
+	    [ -z "$$deployed" ] || echo "   to converge; do NOT rollback-centralhub blindly (it would also downgrade the untouched services)."; \
+	    exit 1; \
+	  fi; \
+	  rm -f $$tmp_td; tmp_td=""; \
 	  echo "   ↻ $$service: $${current_td##*/} → $${new_td_arn##*/} ($$new_image)"; \
-	  aws ecs update-service --cluster $(ECS_CLUSTER) --service $$service \
-	    --task-definition "$$new_td_arn" \
-	    --query 'service.serviceName' --output text >/dev/null; \
+	  if ! aws ecs update-service --cluster $(ECS_CLUSTER) --service $$service \
+	      --task-definition "$$new_td_arn" \
+	      --query 'service.serviceName' --output text >/dev/null; then \
+	    echo "❌ $$service: update-service failed — deregistering the just-registered $${new_td_arn##*/}"; \
+	    echo "   so the latest-ACTIVE lookups in ecs_services.tf keep tracking the running revision."; \
+	    aws ecs deregister-task-definition --task-definition "$$new_td_arn" >/dev/null \
+	      || echo "   ⚠️  deregister failed too — deregister $${new_td_arn##*/} manually, or the next terraform apply will adopt it."; \
+	    [ -z "$$deployed" ] || echo "   ⚠️  Already repointed this run:$$deployed — the hub is mixed. Fix and re-run"; \
+	    [ -z "$$deployed" ] || echo "   to converge; do NOT rollback-centralhub blindly (it would also downgrade the untouched services)."; \
+	    exit 1; \
+	  fi; \
+	  deployed="$$deployed $$service"; \
 	done
 	@echo "⏳ Waiting for Central Hub ECS services to stabilise..."
 	@AWS_PROFILE=$(AWS_PROFILE) AWS_REGION=$(AWS_REGION) aws ecs wait services-stable \
 	  --cluster $(ECS_CLUSTER) \
-	  --services $(CENTRALHUB_ECS_SERVICES)
+	  --services $(CENTRALHUB_ECS_SERVICES) || { \
+	  echo "❌ Services did not stabilise — ECS keeps retrying the new deployment in the background"; \
+	  echo "   (no circuit breaker). Inspect:"; \
+	  echo "     aws ecs describe-services --cluster $(ECS_CLUSTER) --services $(CENTRALHUB_ECS_SERVICES) --query 'services[].events[:5]'"; \
+	  echo "   Revert with: make rollback-centralhub PROD=$(PROD)"; \
+	  exit 1; }
 	@$(MAKE) deploy-ui PROD=$(PROD)
 	@echo "✅ Central Hub ECS services and UI deployed."
 
@@ -490,20 +552,30 @@ deploy-centralhub: ## Deploy Central Hub ECS services at the env branch tip (new
 rollback-centralhub: ## Repoint each Central Hub ECS service at its previous ACTIVE task-definition revision
 	## Reverts the last deploy-centralhub in seconds — no rebuild, no env-file edit. Each
 	## service moves to the highest ACTIVE revision below its current one (CLI- and
-	## Terraform-registered revisions both count). The UI is NOT rolled back — re-run
-	## `make deploy-ui` from the matching commit if the UI must move too.
+	## Terraform-registered revisions both count), then the rolled-away revision is
+	## DEREGISTERED so the latest-ACTIVE lookups in ecs_services.tf converge back to the
+	## running revision — without this, the next `terraform apply` would re-adopt the very
+	## revision just rolled back from (its max() tracks latest ACTIVE, not what runs).
+	## Deregistered revisions stay describable for forensics. If the rolled-away revision
+	## is Terraform's own (a rollback straight after an apply), the next apply re-registers
+	## the family — that is the documented bootstrap-tag path; re-run deploy-centralhub
+	## after it. The UI is NOT rolled back — re-run `make deploy-ui` from the matching
+	## commit if the UI must move too.
 	@set -e; \
 	export AWS_PROFILE=$(AWS_PROFILE) AWS_REGION=$(AWS_REGION); \
 	echo "⏪ Rolling back Central Hub ECS services in $(ECS_CLUSTER)..."; \
 	for service in $(CENTRALHUB_ECS_SERVICES); do \
 	  current_td=$$(aws ecs describe-services --cluster $(ECS_CLUSTER) --services $$service \
 	    --query 'services[0].taskDefinition' --output text); \
+	  if [ -z "$$current_td" ] || [ "$$current_td" = "None" ]; then \
+	    echo "❌ $$service not found in cluster $(ECS_CLUSTER)"; exit 1; \
+	  fi; \
 	  family=$${current_td##*/}; family=$${family%%:*}; rev=$${current_td##*:}; \
+	  arns=$$(aws ecs list-task-definitions --family-prefix $$family --status ACTIVE --sort DESC \
+	    --query 'taskDefinitionArns' --output json); \
 	  jq_prev='map(select(contains("/" + $$family + ":")))'; \
 	  jq_prev="$$jq_prev"' | map(select((split(":") | last | tonumber) < $$rev)) | first // empty'; \
-	  previous=$$(aws ecs list-task-definitions --family-prefix $$family --status ACTIVE --sort DESC \
-	    --query 'taskDefinitionArns' --output json | \
-	    jq -r --arg family "$$family" --argjson rev "$$rev" "$$jq_prev"); \
+	  previous=$$(printf '%s' "$$arns" | jq -r --arg family "$$family" --argjson rev "$$rev" "$$jq_prev"); \
 	  if [ -z "$$previous" ]; then \
 	    echo "❌ $$service: no ACTIVE revision below $${current_td##*/} to roll back to"; exit 1; \
 	  fi; \
@@ -511,11 +583,23 @@ rollback-centralhub: ## Repoint each Central Hub ECS service at its previous ACT
 	  aws ecs update-service --cluster $(ECS_CLUSTER) --service $$service \
 	    --task-definition "$$previous" \
 	    --query 'service.serviceName' --output text >/dev/null; \
+	  if ! aws ecs deregister-task-definition --task-definition "$$current_td" \
+	      --query 'taskDefinition.status' --output text >/dev/null; then \
+	    echo "❌ $$service rolled back to $${previous##*/}, but deregistering $${current_td##*/} failed —"; \
+	    echo "   it is still the latest ACTIVE revision, so the next terraform apply would re-adopt"; \
+	    echo "   it. Deregister manually:"; \
+	    echo "     aws ecs deregister-task-definition --task-definition $$current_td"; \
+	    exit 1; \
+	  fi; \
+	  echo "   🗑  $$service: deregistered $${current_td##*/} (stays describable, no longer ACTIVE)"; \
 	done
 	@echo "⏳ Waiting for Central Hub ECS services to stabilise..."
 	@AWS_PROFILE=$(AWS_PROFILE) AWS_REGION=$(AWS_REGION) aws ecs wait services-stable \
 	  --cluster $(ECS_CLUSTER) \
-	  --services $(CENTRALHUB_ECS_SERVICES)
+	  --services $(CENTRALHUB_ECS_SERVICES) || { \
+	  echo "❌ Services did not stabilise after the rollback — inspect:"; \
+	  echo "     aws ecs describe-services --cluster $(ECS_CLUSTER) --services $(CENTRALHUB_ECS_SERVICES) --query 'services[].events[:5]'"; \
+	  exit 1; }
 	@echo "✅ Central Hub ECS services rolled back."
 
 .PHONY: deploy-ui

--- a/deploy/providers/AWS/Makefile
+++ b/deploy/providers/AWS/Makefile
@@ -166,6 +166,14 @@ export TF_VAR_FL_KIT_SLOT_NAMES=${FL_KIT_SLOT_NAMES}
 ECS_CLUSTER ?= flip-cluster
 CENTRALHUB_ECS_SERVICES = flip-api fl-api-net-1 fl-server-net-1
 
+# Immutable Central Hub deploys (FLIP#751): CI publishes a `sha-<short7>` tag for every
+# image; deploy-centralhub resolves that tag from the tip of the env's branch and
+# registers new task-definition revisions pointing at it, so what is live is always a
+# recorded commit and rollback-centralhub can repoint at the previous revision. The
+# env-file tags (DOCKER_TAG / DOCKER_FL_TAG) remain the bootstrap-only defaults Terraform
+# bakes into a (re)created task-definition family — day-to-day deploys never touch them.
+DEPLOY_GIT_REF := $(if $(filter true,$(PROD)),origin/main,origin/develop)
+
 TRUST_IMAGES = \
 	$(DOCKER_REGISTRY)trust-api:$(DOCKER_TAG) \
 	$(DOCKER_REGISTRY)imaging-api:$(DOCKER_TAG) \
@@ -409,17 +417,67 @@ seed-trust-data: check-trust-ec2-enabled ssh-config ## Load trust-specific OMOP 
 	@echo "✅ Trust data seeding complete."
 
 .PHONY: deploy-centralhub
-deploy-centralhub: ## Force-redeploy Central Hub ECS services and publish the UI
-	@echo "🚀 Force-redeploying Central Hub ECS services in $(ECS_CLUSTER)..."
+deploy-centralhub: ## Deploy Central Hub ECS services at the env branch tip (new task-def revisions) and publish the UI
+	## Immutable deploy (FLIP#751). The tag is resolved INSIDE the recipe (not a Make-level
+	## shell function) so the git fetch only runs when this target does; `cut -c1-7` pins the
+	## abbreviation to exactly 7 chars to match CI's sha-tag truncation — `git rev-parse --short=7`
+	## can grow beyond 7 when abbreviations become ambiguous, and the GHCR guard below
+	## catches any residual mismatch loudly. Per service: the app container is selected BY
+	## NAME (prod task defs carry a GuardDuty sidecar as containers[0]) and only its image
+	## tag is swapped before registering the new revision. Pass TAG=sha-<short7> to deploy
+	## a hotfix / feature-branch image (build it first via workflow_dispatch — see
+	## CLAUDE.md); revert with `make rollback-centralhub`.
 	@set -e; \
+	export AWS_PROFILE=$(AWS_PROFILE) AWS_REGION=$(AWS_REGION); \
+	TAG="$(TAG)"; \
+	if [ -z "$$TAG" ]; then \
+	  echo "🔎 Resolving deploy tag from the tip of $(DEPLOY_GIT_REF)..."; \
+	  git fetch -q origin; \
+	  TAG="sha-$$(git rev-parse $(DEPLOY_GIT_REF) | cut -c1-7)"; \
+	fi; \
+	echo "🚀 Deploying Central Hub ECS services in $(ECS_CLUSTER) at $$TAG..."; \
 	for service in $(CENTRALHUB_ECS_SERVICES); do \
-	  echo "   ↻ $$service"; \
-	  AWS_PROFILE=$(AWS_PROFILE) AWS_REGION=$(AWS_REGION) aws ecs update-service \
-	    --cluster $(ECS_CLUSTER) \
-	    --service $$service \
-	    --force-new-deployment \
-	    --query 'service.serviceName' \
-	    --output text >/dev/null; \
+	  current_td=$$(aws ecs describe-services --cluster $(ECS_CLUSTER) --services $$service \
+	    --query 'services[0].taskDefinition' --output text); \
+	  td_json=$$(aws ecs describe-task-definition --task-definition "$$current_td" --include TAGS); \
+	  image=$$(printf '%s' "$$td_json" | jq -r --arg name "$$service" \
+	    '.taskDefinition.containerDefinitions[] | select(.name == $$name).image'); \
+	  [ -n "$$image" ] || { echo "❌ $$service: no container named '$$service' in $$current_td"; exit 1; }; \
+	  new_image="$${image%:*}:$$TAG"; \
+	  case "$$new_image" in \
+	  ghcr.io/*) \
+	    repo=$${new_image#ghcr.io/}; repo=$${repo%:*}; \
+	    token=$$(curl -fsSL "https://ghcr.io/token?scope=repository:$$repo:pull" | jq -r '.token'); \
+	    accept='application/vnd.oci.image.index.v1+json, application/vnd.oci.image.manifest.v1+json'; \
+	    accept="$$accept, application/vnd.docker.distribution.manifest.list.v2+json"; \
+	    accept="$$accept, application/vnd.docker.distribution.manifest.v2+json"; \
+	    if ! curl -fsI -o /dev/null -H "Authorization: Bearer $$token" -H "Accept: $$accept" \
+	        "https://ghcr.io/v2/$$repo/manifests/$$TAG"; then \
+	      case "$$service" in \
+	        flip-api) wf=docker_build_flip_api.yml;; \
+	        *) wf=fl-docker-build-$(FL_BACKEND).yml;; \
+	      esac; \
+	      echo "❌ $$new_image not found in GHCR."; \
+	      echo "   Builds are test-gated and may still be running (or red) — check:"; \
+	      echo "     gh run list --workflow=$$wf"; \
+	      echo "   For a branch/hotfix image, build it first: gh workflow run $$wf --ref <branch>"; \
+	      exit 1; \
+	    fi;; \
+	  *) echo "   ⚠️  $$new_image is not on ghcr.io — skipping the registry existence check";; \
+	  esac; \
+	  jq_prog='.taskDefinition.containerDefinitions |= map(if .name == $$name then .image = $$image else . end)'; \
+	  jq_prog="$$jq_prog | (.taskDefinition | del(.taskDefinitionArn, .revision, .status, .requiresAttributes,"; \
+	  jq_prog="$$jq_prog .compatibilities, .registeredAt, .registeredBy, .deregisteredAt))"; \
+	  jq_prog="$$jq_prog + (if ((.tags // []) | length) > 0 then {tags: .tags} else {} end)"; \
+	  tmp_td=$$(mktemp); \
+	  printf '%s' "$$td_json" | jq --arg name "$$service" --arg image "$$new_image" "$$jq_prog" > $$tmp_td; \
+	  new_td_arn=$$(aws ecs register-task-definition --cli-input-json file://$$tmp_td \
+	    --query 'taskDefinition.taskDefinitionArn' --output text); \
+	  rm -f $$tmp_td; \
+	  echo "   ↻ $$service: $${current_td##*/} → $${new_td_arn##*/} ($$new_image)"; \
+	  aws ecs update-service --cluster $(ECS_CLUSTER) --service $$service \
+	    --task-definition "$$new_td_arn" \
+	    --query 'service.serviceName' --output text >/dev/null; \
 	done
 	@echo "⏳ Waiting for Central Hub ECS services to stabilise..."
 	@AWS_PROFILE=$(AWS_PROFILE) AWS_REGION=$(AWS_REGION) aws ecs wait services-stable \
@@ -427,6 +485,38 @@ deploy-centralhub: ## Force-redeploy Central Hub ECS services and publish the UI
 	  --services $(CENTRALHUB_ECS_SERVICES)
 	@$(MAKE) deploy-ui PROD=$(PROD)
 	@echo "✅ Central Hub ECS services and UI deployed."
+
+.PHONY: rollback-centralhub
+rollback-centralhub: ## Repoint each Central Hub ECS service at its previous ACTIVE task-definition revision
+	## Reverts the last deploy-centralhub in seconds — no rebuild, no env-file edit. Each
+	## service moves to the highest ACTIVE revision below its current one (CLI- and
+	## Terraform-registered revisions both count). The UI is NOT rolled back — re-run
+	## `make deploy-ui` from the matching commit if the UI must move too.
+	@set -e; \
+	export AWS_PROFILE=$(AWS_PROFILE) AWS_REGION=$(AWS_REGION); \
+	echo "⏪ Rolling back Central Hub ECS services in $(ECS_CLUSTER)..."; \
+	for service in $(CENTRALHUB_ECS_SERVICES); do \
+	  current_td=$$(aws ecs describe-services --cluster $(ECS_CLUSTER) --services $$service \
+	    --query 'services[0].taskDefinition' --output text); \
+	  family=$${current_td##*/}; family=$${family%%:*}; rev=$${current_td##*:}; \
+	  jq_prev='map(select(contains("/" + $$family + ":")))'; \
+	  jq_prev="$$jq_prev"' | map(select((split(":") | last | tonumber) < $$rev)) | first // empty'; \
+	  previous=$$(aws ecs list-task-definitions --family-prefix $$family --status ACTIVE --sort DESC \
+	    --query 'taskDefinitionArns' --output json | \
+	    jq -r --arg family "$$family" --argjson rev "$$rev" "$$jq_prev"); \
+	  if [ -z "$$previous" ]; then \
+	    echo "❌ $$service: no ACTIVE revision below $${current_td##*/} to roll back to"; exit 1; \
+	  fi; \
+	  echo "   ⏪ $$service: $${current_td##*/} → $${previous##*/}"; \
+	  aws ecs update-service --cluster $(ECS_CLUSTER) --service $$service \
+	    --task-definition "$$previous" \
+	    --query 'service.serviceName' --output text >/dev/null; \
+	done
+	@echo "⏳ Waiting for Central Hub ECS services to stabilise..."
+	@AWS_PROFILE=$(AWS_PROFILE) AWS_REGION=$(AWS_REGION) aws ecs wait services-stable \
+	  --cluster $(ECS_CLUSTER) \
+	  --services $(CENTRALHUB_ECS_SERVICES)
+	@echo "✅ Central Hub ECS services rolled back."
 
 .PHONY: deploy-ui
 deploy-ui: ## Build flip-ui from the working tree and deploy it to S3 + invalidate CloudFront
@@ -723,7 +813,7 @@ full-deploy: ## Full AWS deployment: provision infrastructure, deploy cloud Trus
 	## 4. update-env: refresh .env with Terraform outputs (EC2 IPs, DB endpoint, Cognito IDs)
 	## 5. ssh-config + ansible-init: configure the SSM bastion and provision the Trust EC2
 	##    (ansible-init uses trust_num=1 by default; re-run with KIT=<CODE> after register-trusts for slot-specific data)
-	## 6. deploy-centralhub: force-redeploy Central Hub ECS services and publish the UI
+	## 6. deploy-centralhub: deploy Central Hub ECS services at the env branch tip (new task-def revisions) + publish the UI
 	## 7. register-trusts: register every live trust/.env.*.<env> kit on the hub and write kit files
 	## 8. deploy-trust + status: bring up cloud Trust container stack and verify
 	## Prerequisite: create stub kit files first: make new-trust TRUST_CODE=<CODE> TRUST_NAME="..." TRUST_REGION=London PROD=$(PROD)
@@ -759,7 +849,7 @@ full-deploy-with-local-trust: ## Full AWS deployment (honours PROD) plus on-prem
 	## 4. update-env: refresh .env.{PROD} with Terraform outputs (EC2 IPs, DB endpoint, Cognito IDs)
 	## 5. ssh-config + ansible-init: configure the SSM bastion and provision the Trust EC2
 	##    (ansible-init uses trust_num=1 by default; re-run with KIT=<CODE> after register-trusts for slot-specific data)
-	## 6. deploy-centralhub: force-redeploy Central Hub ECS services and publish the UI
+	## 6. deploy-centralhub: deploy Central Hub ECS services at the env branch tip (new task-def revisions) + publish the UI
 	## 7. register-trusts: register every live trust/.env.*.<env> kit on the hub and write kit files
 	## 8. deploy-trust + provision-local-trust + status: bring up cloud + on-prem trust hosts and verify
 	## NOTE: After this completes you must manually:

--- a/deploy/providers/AWS/README.md
+++ b/deploy/providers/AWS/README.md
@@ -231,7 +231,7 @@ aws s3 rb s3://flipstag
 Two stag-specific watch-outs:
 
 - **`make import-persistent` failing partway through** is fine on a re-run — every import in `scripts/import-resources.sh` is idempotent (probes `terraform state list` before importing). The script will skip already-imported resources and only attempt the missing ones.
-- **The task definitions applied before `deploy-centralhub` need image tags from `.env.stag`** (`DOCKER_TAG`, `DOCKER_FL_TAG`) that exist in GHCR. Branch tags do **not** auto-build on push — trigger the relevant `docker_build_*` workflows via `workflow_dispatch` before applying a branch image tag (see [the build trigger note in CLAUDE.md](../../../CLAUDE.md#docker-image-builds-manual-trigger-required-for-branches)). These env-file tags are only Terraform's bootstrap defaults — day-to-day image deploys pin immutable `sha-<short7>` tags instead (see [Central Hub deploys and rollback](#central-hub-deploys-and-rollback-immutable-sha-tags)).
+- **The task definitions applied before `deploy-centralhub` need image tags from `.env.stag`** (`DOCKER_TAG`, `DOCKER_FL_TAG`) that exist in GHCR. Branch tags do **not** auto-build on push — trigger the relevant `docker_build_*` workflows via `workflow_dispatch` before applying a branch image tag (see [the build trigger note in CLAUDE.md](../../../CLAUDE.md#docker-image-builds-gated-on-tests-manual-trigger-for-branches)). These env-file tags are only Terraform's bootstrap defaults — day-to-day image deploys pin immutable `sha-<short7>` tags instead (see [Central Hub deploys and rollback](#central-hub-deploys-and-rollback-immutable-sha-tags)).
 
 For a **future fresh prod or dev** account that needs the same migration, the flow is the stag runbook above minus step 1 (`make import-persistent` is only needed on environments with the stag-style state gap) and with `PROD=true` on every `make` call for prod (dev uses the separate `deploy/providers/AWS/dev/` Terraform root, no `PROD=` flag).
 
@@ -293,16 +293,25 @@ make status
 the UI (same as `make deploy-ui`):
 
 1. Resolves `TAG=sha-<short7>` from the tip of the env's branch — `PROD=true` → `origin/main`,
-   `PROD=stag` → `origin/develop` (`git fetch` runs inside the target).
-2. Verifies each service's image exists in GHCR at that tag. Builds are test-gated (`workflow_run`
-   on the service's test suite), so right after a merge the tag may not exist yet — the guard fails
-   fast and names the workflow to check. The build workflows are also path-filtered, so a merge that
-   didn't touch a service leaves that service without an image at the new tip; trigger the missing
-   build manually (`gh workflow run <workflow>.yml --ref <branch>` builds the branch tip and
-   publishes its sha tag), then re-run the deploy.
+   `PROD=stag` → `origin/develop` (`git fetch` runs inside the target). The tag must match
+   `sha-<7 hex chars>` — a mutable tag (e.g. a stray `TAG=stag`) is rejected before any AWS call.
+2. Verifies **every** service's image exists in GHCR at that tag **before mutating anything** — a
+   missing tag aborts with nothing deployed. The build workflows are path-filtered, so a merge that
+   didn't touch a service (most commonly a flip-api-only merge, which does not rebuild the FL
+   images) leaves that service without an image at the new tip; flip-api's build is additionally
+   test-gated (`workflow_run` on its test suite), so right after a merge its tag may still be
+   building. The guard names the workflow to check; trigger the missing build manually
+   (`gh workflow run <workflow>.yml --ref <branch>` builds the branch tip and publishes its sha
+   tag), then re-run the deploy. A non-404 registry error (outage, auth) is reported as such —
+   don't dispatch rebuilds for it. Non-`ghcr.io` registries skip the manifest check entirely
+   (LZA ECR pull-through cache, FLIP#749).
 3. Per service: registers a new task-definition revision with only the app container's image tag
-   swapped (containers are selected **by name** — prod task defs carry a GuardDuty sidecar) and
-   repoints the service at the new revision.
+   swapped (containers are selected **by name**, never by index — the same convention as the
+   `describe-tasks` digest check in [`TROUBLESHOOTING.md` §1.9](TROUBLESHOOTING.md), robust to
+   sidecar/ordering changes) and repoints the service at the new revision. If the repoint fails,
+   the just-registered revision is deregistered again so the `max()` tracking in
+   `ecs_services.tf` cannot adopt a never-deployed revision, and any services already repointed
+   in the same run are listed so a partial deploy is visible.
 
 ```bash
 make deploy-centralhub PROD=stag                    # deploy the tip of develop to staging
@@ -316,15 +325,25 @@ runbook for feature-branch images: trigger the relevant `docker_build_*` / `fl-d
 workflow on your branch via `workflow_dispatch`, wait for green, then deploy its sha tag.
 
 `make rollback-centralhub` repoints each service at its previous ACTIVE task-definition revision —
-seconds, no rebuild. It does not touch the UI bundle; re-run `make deploy-ui` from the matching
-commit if the UI must move too.
+seconds, no rebuild — then **deregisters the revision it rolled away from** (it stays describable
+for forensics). The deregistration is what makes the rollback durable: `ecs_services.tf` tracks the
+*latest ACTIVE* revision, so leaving the bad revision ACTIVE would have the next `terraform apply`
+silently re-adopt it. It does not touch the UI bundle; re-run `make deploy-ui` from the matching
+commit if the UI must move too. After a *partial* deploy (some services repointed before a
+failure), don't roll back blindly — rollback moves **every** service down one revision, including
+the ones the failed deploy never touched; fix the missing build and re-run the deploy instead.
+
+The deploy ends by publishing the UI (same as `make deploy-ui`), which builds `flip-ui` **from your
+local working tree** — deploy from a clean checkout of the branch you are deploying.
 
 Terraform stays the owner of the task-definition *skeleton* (roles, env wiring, volumes). The
-services track `max(Terraform revision, live revision)` (see `ecs_services.tf`), so an unrelated
-`terraform apply` does not roll a CLI-deployed image back. When an apply *does* re-register a task
-definition, the new Terraform revision goes live with the bootstrap image tags from the env file
-(`DOCKER_TAG`, `DOCKER_FL_TAG`) — re-run `make deploy-centralhub` afterwards to roll the sha-pinned
-image forward again.
+services track `max(Terraform revision, latest ACTIVE revision)` (see `ecs_services.tf`), so an
+unrelated `terraform apply` does not roll a CLI-deployed image back. When an apply *does*
+re-register a task definition, the new Terraform revision goes live with the bootstrap image tags
+from the env file (`DOCKER_TAG`, `DOCKER_FL_TAG`) — re-run `make deploy-centralhub` afterwards to
+roll the sha-pinned image forward again. And because `make apply` applies the saved `plan.tfplan`,
+a plan generated **before** a CLI deploy snapshots the older revision and applying it would roll
+the image back — re-run `make plan` after any `make deploy-centralhub`.
 
 > **Prod rollout note:** switch *production* deploys to this flow only after the 24 Jul 2026 DECAF
 > deadline (BDMS is live on legacy prod until then). Staging can adopt it immediately.

--- a/deploy/providers/AWS/README.md
+++ b/deploy/providers/AWS/README.md
@@ -104,7 +104,7 @@ This command executes the following steps in order:
 8. **`update-env`**: Refresh the root environment file with Terraform outputs
 9. **`ssh-config`**: Update `~/.ssh/config` with SSM-managed EC2 instance IDs
 10. **`ansible-init`**: Patch both hosts, install `psql` on the Central Hub bastion, and provision Docker, AWS CLI, CloudWatch, and FL assets on the Trust EC2
-11. **`deploy-centralhub`**: Force-redeploy the Central Hub ECS Fargate services (`flip-api`, `fl-api-net-1`, `fl-server-net-1`) and sync the UI to S3 + invalidate CloudFront
+11. **`deploy-centralhub`**: Deploy the Central Hub ECS Fargate services (`flip-api`, `fl-api-net-1`, `fl-server-net-1`) at the tip of the env's branch via new task-definition revisions (see [Central Hub deploys and rollback](#central-hub-deploys-and-rollback-immutable-sha-tags)) and sync the UI to S3 + invalidate CloudFront
 12. **`register-trusts`**: Register every locally-present trust kit file (`trust/.env.<CODE>.<env>`) on the running hub and fill each kit with hub-shared values
 13. **`deploy-trust`**: Deploy Trust services via Docker Compose to the Trust EC2
 14. **`status`**: Run comprehensive health checks
@@ -231,7 +231,7 @@ aws s3 rb s3://flipstag
 Two stag-specific watch-outs:
 
 - **`make import-persistent` failing partway through** is fine on a re-run — every import in `scripts/import-resources.sh` is idempotent (probes `terraform state list` before importing). The script will skip already-imported resources and only attempt the missing ones.
-- **The task definitions applied before `deploy-centralhub` need image tags from `.env.stag`** (`DOCKER_TAG`, `DOCKER_FL_TAG`) that exist in GHCR. Branch tags do **not** auto-build on push — trigger the relevant `docker_build_*` workflows via `workflow_dispatch` before applying a branch image tag (see [the build trigger note in CLAUDE.md](../../../CLAUDE.md#docker-image-builds-manual-trigger-required-for-branches)).
+- **The task definitions applied before `deploy-centralhub` need image tags from `.env.stag`** (`DOCKER_TAG`, `DOCKER_FL_TAG`) that exist in GHCR. Branch tags do **not** auto-build on push — trigger the relevant `docker_build_*` workflows via `workflow_dispatch` before applying a branch image tag (see [the build trigger note in CLAUDE.md](../../../CLAUDE.md#docker-image-builds-manual-trigger-required-for-branches)). These env-file tags are only Terraform's bootstrap defaults — day-to-day image deploys pin immutable `sha-<short7>` tags instead (see [Central Hub deploys and rollback](#central-hub-deploys-and-rollback-immutable-sha-tags)).
 
 For a **future fresh prod or dev** account that needs the same migration, the flow is the stag runbook above minus step 1 (`make import-persistent` is only needed on environments with the stag-style state gap) and with `PROD=true` on every `make` call for prod (dev uses the separate `deploy/providers/AWS/dev/` Terraform root, no `PROD=` flag).
 
@@ -285,6 +285,49 @@ make deploy-trust
 # 12. Check status
 make status
 ```
+
+### Central Hub deploys and rollback (immutable SHA tags)
+
+`make deploy-centralhub` deploys the Central Hub ECS services (`flip-api`, `fl-api-net-1`,
+`fl-server-net-1`) by **immutable image tag + task-definition revision** (FLIP#751), then publishes
+the UI (same as `make deploy-ui`):
+
+1. Resolves `TAG=sha-<short7>` from the tip of the env's branch — `PROD=true` → `origin/main`,
+   `PROD=stag` → `origin/develop` (`git fetch` runs inside the target).
+2. Verifies each service's image exists in GHCR at that tag. Builds are test-gated (`workflow_run`
+   on the service's test suite), so right after a merge the tag may not exist yet — the guard fails
+   fast and names the workflow to check. The build workflows are also path-filtered, so a merge that
+   didn't touch a service leaves that service without an image at the new tip; trigger the missing
+   build manually (`gh workflow run <workflow>.yml --ref <branch>` builds the branch tip and
+   publishes its sha tag), then re-run the deploy.
+3. Per service: registers a new task-definition revision with only the app container's image tag
+   swapped (containers are selected **by name** — prod task defs carry a GuardDuty sidecar) and
+   repoints the service at the new revision.
+
+```bash
+make deploy-centralhub PROD=stag                    # deploy the tip of develop to staging
+make deploy-centralhub PROD=true                    # deploy the tip of main to production
+make deploy-centralhub PROD=stag TAG=sha-1a2b3c4    # pin a specific / hotfix build
+make rollback-centralhub PROD=stag                  # repoint services at the previous revision
+```
+
+`TAG=sha-<short7>` overrides the branch-tip resolution — this automates the previously manual
+runbook for feature-branch images: trigger the relevant `docker_build_*` / `fl-docker-build-*`
+workflow on your branch via `workflow_dispatch`, wait for green, then deploy its sha tag.
+
+`make rollback-centralhub` repoints each service at its previous ACTIVE task-definition revision —
+seconds, no rebuild. It does not touch the UI bundle; re-run `make deploy-ui` from the matching
+commit if the UI must move too.
+
+Terraform stays the owner of the task-definition *skeleton* (roles, env wiring, volumes). The
+services track `max(Terraform revision, live revision)` (see `ecs_services.tf`), so an unrelated
+`terraform apply` does not roll a CLI-deployed image back. When an apply *does* re-register a task
+definition, the new Terraform revision goes live with the bootstrap image tags from the env file
+(`DOCKER_TAG`, `DOCKER_FL_TAG`) — re-run `make deploy-centralhub` afterwards to roll the sha-pinned
+image forward again.
+
+> **Prod rollout note:** switch *production* deploys to this flow only after the 24 Jul 2026 DECAF
+> deadline (BDMS is live on legacy prod until then). Staging can adopt it immediately.
 
 ### Deployment to Different Environments
 

--- a/deploy/providers/AWS/TROUBLESHOOTING.md
+++ b/deploy/providers/AWS/TROUBLESHOOTING.md
@@ -179,7 +179,7 @@ If you regress this: confirm the ALB listener rule's `target_group_arn` is `aws_
 
 ### 1.9 Verifying which FL image an ECS task pulled — GuardDuty sidecar digest trap
 
-**Symptom**: After a `force-new-deployment` of `fl-server-net-1` / `fl-api-net-1`, you check the running task's image digest against the GHCR tag to confirm the new build is live. One container's `imageDigest` does **not** match the GHCR `:stag`/`:prod` manifest, and worse, querying GHCR for that digest returns **HTTP 404** (it does not exist in GHCR at all). Looks like the task is running a stale/unknown image.
+**Symptom**: After a `make deploy-centralhub` (or a legacy `--force-new-deployment`) of `fl-server-net-1` / `fl-api-net-1`, you check the running task's image digest against the GHCR tag — the pinned `sha-<short7>` tag since FLIP#751, the mutable `:stag`/`:prod` tag before it — to confirm the new build is live. One container's `imageDigest` does **not** match the GHCR manifest, and worse, querying GHCR for that digest returns **HTTP 404** (it does not exist in GHCR at all). Looks like the task is running a stale/unknown image.
 
 **Root cause**: GuardDuty Runtime Monitoring injects a sidecar container (`aws-guardduty-agent-*`) into every Fargate task. `aws ecs describe-tasks` returns `containers` as an **array**, and the GuardDuty agent often sorts **first** — so a query like `containers[0].imageDigest` reads the *agent's* digest, not the FL app container's. The GuardDuty agent image lives in an **AWS-internal ECR**, never GHCR, which is exactly why its digest 404s when you look it up in `ghcr.io`. The FL app container is a *different* element of the same array and its digest matches GHCR fine.
 

--- a/deploy/providers/AWS/ecs_services.tf
+++ b/deploy/providers/AWS/ecs_services.tf
@@ -19,15 +19,50 @@
 #   - Assigns a public IP only if explicitly enabled (never by default)
 
 ############################
+# Task-definition revision tracking (FLIP#751)
+############################
+# `make deploy-centralhub` rolls services forward by registering new task-definition
+# revisions via the AWS CLI, outside Terraform. Each data source below looks up the
+# latest ACTIVE revision of its family, and every service tracks
+#   max(<Terraform-owned revision>, <latest ACTIVE revision>)
+# (the provider-documented pattern for externally-updated task definitions), so an
+# unrelated `terraform apply` no longer repoints services at the older Terraform
+# revision — i.e. it does not roll back a CLI-deployed image. When Terraform itself
+# changes a task-definition config (new revision registered at apply), its revision
+# wins the max() and goes live with the env-file bootstrap image tag — re-run
+# `make deploy-centralhub` afterwards to roll the sha-pinned image forward again.
+# On first creation the reads are deferred to apply (they reference managed resources
+# with pending changes), so a fresh environment bootstraps cleanly.
+
+data "aws_ecs_task_definition" "flip_api" {
+  task_definition = aws_ecs_task_definition.flip_api.family
+}
+
+data "aws_ecs_task_definition" "fl_api_net_1" {
+  count           = var.enable_efs ? 1 : 0
+  task_definition = aws_ecs_task_definition.fl_api_net_1[0].family
+}
+
+data "aws_ecs_task_definition" "fl_server_net_1" {
+  count           = var.enable_efs ? 1 : 0
+  task_definition = aws_ecs_task_definition.fl_server_net_1[0].family
+}
+
+############################
 # flip-api
 ############################
 
 resource "aws_ecs_service" "flip_api" {
   count = var.enable_service_discovery ? 1 : 0
 
-  name                   = "flip-api"
-  cluster                = aws_ecs_cluster.flip.id
-  task_definition        = aws_ecs_task_definition.flip_api.arn
+  name    = "flip-api"
+  cluster = aws_ecs_cluster.flip.id
+  # Track whichever revision is newer: Terraform's or the live one deployed by
+  # `make deploy-centralhub` (see the revision-tracking block above, FLIP#751).
+  task_definition = "${aws_ecs_task_definition.flip_api.family}:${max(
+    aws_ecs_task_definition.flip_api.revision,
+    data.aws_ecs_task_definition.flip_api.revision,
+  )}"
   desired_count          = 1
   launch_type            = "FARGATE"
   enable_execute_command = var.ecs_exec_enabled
@@ -69,9 +104,14 @@ resource "aws_ecs_service" "flip_api" {
 resource "aws_ecs_service" "fl_api_net_1" {
   count = var.enable_service_discovery ? 1 : 0
 
-  name                   = "fl-api-net-1"
-  cluster                = aws_ecs_cluster.flip.id
-  task_definition        = aws_ecs_task_definition.fl_api_net_1[0].arn
+  name    = "fl-api-net-1"
+  cluster = aws_ecs_cluster.flip.id
+  # Track whichever revision is newer: Terraform's or the live one deployed by
+  # `make deploy-centralhub` (see the revision-tracking block above, FLIP#751).
+  task_definition = "${aws_ecs_task_definition.fl_api_net_1[0].family}:${max(
+    aws_ecs_task_definition.fl_api_net_1[0].revision,
+    data.aws_ecs_task_definition.fl_api_net_1[0].revision,
+  )}"
   desired_count          = 1
   launch_type            = "FARGATE"
   enable_execute_command = var.ecs_exec_enabled
@@ -102,9 +142,14 @@ resource "aws_ecs_service" "fl_api_net_1" {
 resource "aws_ecs_service" "fl_server_net_1" {
   count = var.enable_service_discovery ? 1 : 0
 
-  name                   = "fl-server-net-1"
-  cluster                = aws_ecs_cluster.flip.id
-  task_definition        = aws_ecs_task_definition.fl_server_net_1[0].arn
+  name    = "fl-server-net-1"
+  cluster = aws_ecs_cluster.flip.id
+  # Track whichever revision is newer: Terraform's or the live one deployed by
+  # `make deploy-centralhub` (see the revision-tracking block above, FLIP#751).
+  task_definition = "${aws_ecs_task_definition.fl_server_net_1[0].family}:${max(
+    aws_ecs_task_definition.fl_server_net_1[0].revision,
+    data.aws_ecs_task_definition.fl_server_net_1[0].revision,
+  )}"
   desired_count          = 1
   launch_type            = "FARGATE"
   enable_execute_command = var.ecs_exec_enabled

--- a/deploy/providers/AWS/ecs_services.tf
+++ b/deploy/providers/AWS/ecs_services.tf
@@ -33,6 +33,14 @@
 # `make deploy-centralhub` afterwards to roll the sha-pinned image forward again.
 # On first creation the reads are deferred to apply (they reference managed resources
 # with pending changes), so a fresh environment bootstraps cleanly.
+#
+# Latest ACTIVE is not necessarily what a service RUNS — the two invariants that keep
+# them converged: `make rollback-centralhub` DEREGISTERS the revision it rolls away
+# from, and a failed deploy deregisters the revision it just registered. Without
+# that, the next apply would re-adopt the abandoned (bad/unvalidated) revision.
+# Also note `make apply` applies the saved plan.tfplan: a plan generated BEFORE a
+# `make deploy-centralhub` snapshots the older revision, and applying it rolls the
+# image back — re-run `make plan` after any CLI deploy.
 
 data "aws_ecs_task_definition" "flip_api" {
   task_definition = aws_ecs_task_definition.flip_api.family

--- a/docs/source/deploy-flip/deploy-central-hub.rst
+++ b/docs/source/deploy-flip/deploy-central-hub.rst
@@ -92,8 +92,12 @@ This runs, in order:
 7. ``ssh-config`` — write SSH config blocks with SSM ProxyCommand.
 8. ``ansible-init`` — install ``psql`` on the minimal Central Hub SSM bastion
    and provision Docker, CloudWatch, and FL assets on the Trust EC2.
-9. ``deploy-centralhub`` — force-redeploy the Central Hub ECS Fargate services
-   and publish the UI to S3/CloudFront.
+9. ``deploy-centralhub`` — deploy the Central Hub ECS Fargate services at the
+   tip of the env's branch via immutable ``sha-<short7>`` task-definition
+   revisions, and publish the UI to S3/CloudFront. ``make rollback-centralhub``
+   repoints the services at the previous revision; see the "Central Hub deploys
+   and rollback" section of ``deploy/providers/AWS/README.md`` for the tag
+   resolution, the ``TAG=`` override, and the production rollout timing.
 10. ``deploy-trust`` — deploy any AWS-hosted trust services (skip when only using on-prem trusts).
 11. ``status`` — comprehensive health checks.
 

--- a/fl-tutorials/nvflare/ARKPLUS_EXPERIMENTS_GUIDE.md
+++ b/fl-tutorials/nvflare/ARKPLUS_EXPERIMENTS_GUIDE.md
@@ -94,7 +94,7 @@ export AWS_PROFILE=stag                 # must match; the Makefile enforces it
 make aws-login                          # SSO
 make plan  PROD=stag DEPLOY_TRUST_EC2=false   # hub-only (trusts run on the desktop)
 make apply PROD=stag DEPLOY_TRUST_EC2=false   # run plan + apply as SEPARATE commands
-make deploy-centralhub                  # force a fresh ECS rollout of the hub services
+make deploy-centralhub                  # roll the hub services to the develop tip (sha-<short7> task-def revisions)
 make deploy-ui                          # ship the UI (S3 + CloudFront)
 ```
 


### PR DESCRIPTION
Closes #751.

## Summary

Hub (ECS) deploys move from mutable tags + `--force-new-deployment` to **immutable `sha-<short7>` image tags deployed as task-definition revisions**, keeping the single-command UX and leaving `:stag`/`:prod` publishing untouched.

- **CI** (`.github/workflows/docker_build_*.yml`, FL image workflows): every image publish also pushes `sha-<short7>`. The `workflow_run`-gated builds tag the **tested commit's** `head_sha`, push-triggered and FL multi-image workflows compute the short sha natively. Each workflow refuses to publish if the commit SHA is ever empty (which would mint a mutable literal `sha-` tag). `flip-ui` excluded (CI smoke, never publishes).
- **`make deploy-centralhub`** (`deploy/providers/AWS/Makefile`): resolves the tag in-recipe from the env's branch (`PROD=true` → `origin/main`, else `origin/develop`; `TAG=sha-…` overrides, validated as `sha-<7 hex>` — mutable tags and a failed `rev-parse` are rejected before any AWS call), then runs in **two phases**: every service's image is resolved and its GHCR manifest verified **before any service is mutated**, so a path-filtered merge that didn't rebuild a service (e.g. a flip-api-only merge leaving no FL-image tag) aborts with nothing deployed. The GHCR check is status-coded: 404 names the exact build workflow to dispatch; token failures / non-404 errors are reported as registry problems, not missing builds. Mutation phase per service: swaps the image **only on the app container selected by name** (never by index — the `describe-tasks` convention of TROUBLESHOOTING.md §1.9; task definitions themselves carry only the app container, the GuardDuty agent is injected at task launch, not registered), strips non-registerable fields, registers a new task-definition revision (task-def tags carried over) and updates the service to it. A failed `update-service` **deregisters the just-registered revision** (no orphan for Terraform to adopt), and partial failures list the services already repointed with a warning not to rollback blindly. Non-`ghcr.io` registries skip the manifest check with a notice — registry-agnostic for the LZA ECR pull-through cache (#749).
- **`make rollback-centralhub`**: repoints each service at the highest ACTIVE revision numerically below the current one, then **deregisters the rolled-away revision** (it stays describable for forensics). The deregistration makes the rollback durable: the Terraform data sources track *latest ACTIVE*, so leaving the bad revision ACTIVE would have the next `terraform apply` silently re-adopt it. Seconds, no rebuild; UI not affected.
- **Terraform** (`deploy/providers/AWS/ecs_services.tf`): max-revision pattern — `data "aws_ecs_task_definition"` per family, services track `max(TF revision, latest ACTIVE revision)` — so `terraform apply` neither rolls back CLI deploys nor loses the ability to ship TF-side task-def changes; the rollback / failed-deploy deregistration keeps "latest ACTIVE" converged with what actually runs. When an apply legitimately re-registers a family, TF's revision wins with the env-file bootstrap tag; remediation (documented) is re-running `make deploy-centralhub`. The stale-plan trap is documented in-code and in the README (`make apply` applies the saved `plan.tfplan` — re-run `make plan` after any CLI deploy). Env files are bootstrap-only — deploys never edit them.
- **Docs**: AWS README/CLAUDE/AGENTS (incl. the deploy's side effects: also rolls `flip-api` and republishes the UI from the local working tree — deploy from a clean checkout), TROUBLESHOOTING §1.9 refreshed for the sha-tag flow, root CLAUDE/README, `docs/source/deploy-flip/deploy-central-hub.rst`, Ark+ guide.

## Rollout note

Merging this changes deploy **mechanics**, not any running service. Per #751: stag can adopt immediately; **first prod use waits until after the 24 Jul DECAF deadline** (BDMS live on prod).

## Verification

Offline (in this PR):
- YAML parse + actionlint on all modified workflows (no new findings; only pre-existing style infos).
- `make -n` expansion for `PROD=stag` and `PROD=true` (ref flips correctly); recipes pass `sh -n` and `bash -n`.
- Stubbed end-to-end harness (fake `aws`/`curl`/`git`, real `jq`) — **56 assertions across 13 scenarios**: two-phase abort on a missing FL tag (zero mutations); image swapped only on the by-name container (decoy sidecar untouched); all 8 non-registerable fields stripped with `runtimePlatform`/`cpu`/`memory` retained; tags carried over only when non-empty; GHCR 404 vs token-failure vs 503 diagnosed distinctly; `TAG=stag` and failed `rev-parse` rejected before any AWS call; missing service and digest-pinned images fail with named errors; failed `update-service` deregisters the orphan revision and names the partial state; rollback picks the numerically-previous ACTIVE revision (sibling-family prefixes and revision gaps handled), deregisters the rolled-away revision, and fails loudly on revision 1, failed deregistration, and expired-credential listing (no misdiagnosis).
- `terraform init -backend=false && terraform validate` clean; `terraform fmt -check -recursive` clean.

Still to verify online (real AWS, tracked before prod adoption):
- [ ] Post-merge: `sha-<short7>` tags appear on GHCR for each workflow shape (and match the tested commit on `workflow_run` builds)
- [ ] `make deploy-centralhub PROD=stag` end-to-end against live task definitions (full field set, e.g. `runtimePlatform`)
- [ ] GHCR manifest check hit + 404 paths against the live registry
- [ ] `make rollback-centralhub` against live revision history (incl. the rolled-away revision showing INACTIVE)
- [ ] `terraform plan` after a CLI deploy shows no service rollback diff; after a rollback shows no re-adoption diff


## Acceptance Criteria

*Imported from issue #751*

- [x] Every `docker_build_*` workflow that publishes hub ECS images (flip-api, fl-api, fl-server; applied uniformly to the rest) also pushes a `sha-<short7>` tag; `:stag`/`:prod` behaviour unchanged
- [x] `make deploy-centralhub` (stag + prod) deploys the tip of the env's branch via a new task-definition revision — single command, no env-file edits
- [x] Pre-registration guard fails fast with a helpful message when the resolved tag is not yet in GHCR
- [x] Image swap selects containers by name; the GuardDuty sidecar definition is untouched
- [x] `make rollback-centralhub` repoints services at the previous revision
- [x] `terraform apply` after a CLI deploy does not revert the running image (validated with `terraform validate` + plan reasoning documented in the PR)
- [x] Docs updated (`deploy/providers/AWS/README.md`, CLAUDE.md deploy sections)
