### PR TITLE
[Bug]: Evaluation job reports RESULTS_UPLOADED with empty results when every validate task aborts

### DIFF
--- a/fl-apps/nvflare/evaluation/README.md
+++ b/fl-apps/nvflare/evaluation/README.md
@@ -51,6 +51,13 @@ and retrieves a DXO with the metrics.
   they are saved verbatim into `evaluation_results.json`, keyed by data site (then by the model name your
   evaluator returns), so there is no output schema to declare.
 
+  Every `validate` task that does not return metrics is recorded alongside it in
+  `evaluation_failures.json` as `{"model": ..., "client": ..., "return_code": ...}` (`model` is `null`
+  here — this job type sends all models in one task, so failures are per client). The file is always
+  written, so an empty list `[]` positively means no task failed. If **every** task fails, the model
+  ends in `ERROR` rather than `RESULTS_UPLOADED`; the results are still uploaded so the zip can carry
+  `evaluation_failures.json` and `error_log.txt`.
+
 ## Test it with the spleen MSD dataset
 
 The evaluation tutorial (`evaluation` job type) runs on the local NVFLARE simulator via:

--- a/fl-apps/nvflare/evaluation_client_api/README.md
+++ b/fl-apps/nvflare/evaluation_client_api/README.md
@@ -40,11 +40,41 @@ regenerate via `recipe.py` after any recipe change and commit the result.
 3. Each site runs the user's `evaluator.py` via `InProcessClientAPIExecutor`, using the NVFLARE Client
    API `is_evaluate()` path (`flare.receive()` / `flare.send()`) to receive the model and return
    **aggregate-only** metrics (`DataKind.METRICS`).
-4. `EvaluationJsonGenerator` collects the metrics into `evaluation_results.json`, and
-   `PersistToS3AndCleanup` zips + uploads the run directory to S3.
+4. `EvaluationJsonGenerator` collects the metrics into `evaluation_results.json` and every failed
+   `validate` task into `evaluation_failures.json`, and `PersistToS3AndCleanup` zips + uploads the
+   run directory to S3.
 
 There is **no `validator.py`** and no client model submission — the evaluator only scores the
 server-provided model.
+
+## Outputs
+
+Both files land in `evaluation_results/` inside the results zip.
+
+`evaluation_results.json` is keyed by data site, then by the validated model's name (`GlobalModelEval`
+sends one `validate` task per (model, client), so each model gets its own entry):
+
+```json
+{
+  "Trust_1": {
+    "SRV_arkplus_pretrained": { "auroc": 0.839 },
+    "SRV_arkplus_finetuned": { "auroc": 0.871 }
+  }
+}
+```
+
+`evaluation_failures.json` lists every `validate` task that did not return metrics. It is always
+written, so an empty list `[]` positively means "no task failed" rather than "this FLIP version
+didn't record them":
+
+```json
+[{ "model": "SRV_arkplus_pretrained", "client": "Trust_1", "return_code": "TASK_ABORTED" }]
+```
+
+When **every** `validate` task fails the model ends in `ERROR`, not `RESULTS_UPLOADED`. The results
+are still uploaded either way — the zip is what carries `evaluation_failures.json` and `error_log.txt`.
+A partial failure (some tasks succeeded) uploads the successful metrics and reports `RESULTS_UPLOADED`,
+with the failed tasks recorded in `evaluation_failures.json`.
 
 ## Execution sequence
 

--- a/fl-tutorials/nvflare/ARKPLUS_EXPERIMENTS_GUIDE.md
+++ b/fl-tutorials/nvflare/ARKPLUS_EXPERIMENTS_GUIDE.md
@@ -278,7 +278,14 @@ Results (cross-site metrics) are on the model's page in the UI, or via
 
 Pretrained Ark+ checkpoint scored against each trust's **holdout** cohort
 (GSTT/Trust_1 n=478, KCH/Trust_2 n=468). Read from
-`evaluation_results/evaluation_results.json` in the downloaded results zip:
+`evaluation_results/evaluation_results.json` in the downloaded results zip.
+
+> **Shape change (FLIP#754).** Runs from that fix onwards nest the metrics one level deeper —
+> `{"<trust>": {"SRV_<model_name>": {...}}}` rather than `{"<trust>": {...}}`. Keying on the trust
+> alone made each evaluated model overwrite the previous one, so a multimodel evaluation only ever
+> reported its last model. The zip also carries `evaluation_results/evaluation_failures.json`, and a
+> run whose every `validate` task fails now ends in `ERROR` instead of `RESULTS_UPLOADED`. The table
+> below predates the change and is single-model, so its numbers are unaffected.
 
 | Lesion | GSTT (Trust_1) AUROC | KCH (Trust_2) AUROC |
 |---|---|---|

--- a/flip-utils/flip/constants/pt_constants.py
+++ b/flip-utils/flip/constants/pt_constants.py
@@ -32,5 +32,6 @@ class PTConstants:
 
     # Evaluation results (evaluation job type)
     EvalResultsFilename = "evaluation_results.json"
+    EvalFailuresFilename = "evaluation_failures.json"
     EvalDir = "evaluation_results"
     EvalTaskName = "evaluation"

--- a/flip-utils/flip/nvflare/components/evaluation_json_generator.py
+++ b/flip-utils/flip/nvflare/components/evaluation_json_generator.py
@@ -12,9 +12,11 @@
 
 import json
 import os.path
+from typing import Any
 
 from nvflare.apis.dxo import DataKind, from_shareable
 from nvflare.apis.event_type import EventType
+from nvflare.apis.fl_constant import ReturnCode
 from nvflare.apis.fl_context import FLContext
 from nvflare.app_common.app_constant import AppConstants
 from nvflare.app_common.app_event_type import AppEventType
@@ -26,61 +28,132 @@ from flip.nvflare.components.validation_json_generator import ValidationJsonGene
 
 
 class EvaluationJsonGenerator(ValidationJsonGenerator):
-    """Flat-shape evaluation results generator.
+    """Evaluation results generator, recording both the metrics and the failed validate tasks.
 
     Deduped against FLIP's :class:`ValidationJsonGenerator`: it inherits the manual-dispatch
     mechanism (the no-op ``handle_event`` — ServerEventHandler drives ``handle_evaluation_events``)
-    and the numpy-float JSON encoding / path-safe output. It differs only in shape — evaluation
-    records one aggregate metrics result per client (``_eval_results[data_client] = metrics``)
-    rather than a cross-validation matrix keyed by (data_client, model_owner) — and in the results
-    directory / file name.
+    and the numpy-float JSON encoding / path-safe output. It differs in the results directory / file
+    name, in tracking per-task failures, and in how results are keyed.
+
+    **Results shape.** Each entry is keyed by data site, then by model name. Which controller drives
+    the run decides where the model name comes from:
+
+    - ``GlobalModelEval`` (``evaluation_client_api``) sends one ``validate`` task per (model, client)
+      and sets ``AppConstants.MODEL_OWNER``, so results nest under it. Keying on the client alone
+      would let each model's metrics overwrite the previous model's (FLIP#754).
+    - FLIP's own ``ModelEval`` (``evaluation``) sends every model in one task and sets no
+      ``MODEL_OWNER``; the evaluator returns its own model-keyed dict, which is stored as-is.
+
+    **Failures.** Both eval controllers fire ``VALIDATION_RESULT_RECEIVED`` *before* they inspect the
+    result's return code, so a failed or aborted task arrives here carrying no DXO. Each such task is
+    recorded in ``_eval_failures`` and written to ``PTConstants.EvalFailuresFilename``, and
+    :meth:`all_tasks_failed` lets ServerEventHandler fail the run rather than report success on an
+    empty results file (FLIP#754).
     """
 
-    def __init__(self, results_dir=PTConstants.EvalDir, json_file_name=PTConstants.EvalResultsFilename):
+    def __init__(
+        self,
+        results_dir=PTConstants.EvalDir,
+        json_file_name=PTConstants.EvalResultsFilename,
+        failures_file_name=PTConstants.EvalFailuresFilename,
+    ):
         """Initialise the evaluation results generator.
 
         Args:
             results_dir (str): Name of the results directory. Defaults to ``PTConstants.EvalDir``.
             json_file_name (str): Name of the json file. Defaults to ``PTConstants.EvalResultsFilename``.
+            failures_file_name (str): Name of the failed-task json file. Defaults to
+                ``PTConstants.EvalFailuresFilename``.
         """
         super().__init__(results_dir=results_dir, json_file_name=json_file_name)
-        # Flat per-client store (not the base's nested self._val_results).
+        # Per-client store (not the base's nested self._val_results).
         self._eval_results: dict = {}
+        self._eval_failures: list[dict] = []
+        self._failures_file_name = failures_file_name
+
+    def all_tasks_failed(self) -> bool:
+        """Whether every validate task this run produced a failure and none produced metrics.
+
+        Returns:
+            bool: True when at least one task failed and none succeeded. False for a clean run, for a
+                partial failure (there are still results worth uploading), and for a job that ran no
+                validate tasks at all — a training job's END_RUN must not be reported as a failure.
+        """
+        return bool(self._eval_failures) and not self._eval_results
+
+    def _record_failure(self, fl_ctx: FLContext, model_owner: str | None, data_client: str, return_code: str) -> None:
+        """Record one failed validate task so it survives into the results bundle."""
+        self._eval_failures.append({"model": model_owner, "client": data_client, "return_code": return_code})
+        self.log_error(
+            fl_ctx,
+            f"Evaluation task failed (model={model_owner}, client={data_client}, return_code={return_code}). "
+            f"Recorded in {self._failures_file_name}.",
+            fire_event=False,
+        )
+
+    def _record_result(self, model_owner: str | None, data_client: str, metrics: Any) -> None:
+        """Store one client's metrics, nesting under the model name when the controller supplies one."""
+        if model_owner:
+            self._eval_results.setdefault(data_client, {})[model_owner] = metrics
+        else:
+            self._eval_results[data_client] = metrics
+
+    def _handle_validation_result(self, fl_ctx: FLContext) -> None:
+        """Sort one received validate result into either the metrics store or the failure list."""
+        data_client = fl_ctx.get_prop(AppConstants.DATA_CLIENT, None)
+        model_owner = fl_ctx.get_prop(AppConstants.MODEL_OWNER, None)
+        eval_results = fl_ctx.get_prop(AppConstants.VALIDATION_RESULT, None)
+
+        if not data_client:
+            self.log_error(fl_ctx, "data_client unknown. Evaluation result will not be saved to json", fire_event=False)
+            return
+
+        if not eval_results:
+            self.log_error(fl_ctx, "Evaluation result not found.", fire_event=False)
+            return
+
+        try:
+            # The return code must be read before the DXO conversion: an aborted task carries no DXO,
+            # so from_shareable() raises on it, and that exception used to be the only trace the
+            # failure ever left (FLIP#754).
+            return_code = eval_results.get_return_code()
+            if return_code != ReturnCode.OK:
+                self._record_failure(fl_ctx, model_owner, data_client, return_code)
+                return
+
+            dxo = from_shareable(eval_results)
+            if dxo.data_kind != DataKind.METRICS:
+                self.log_error(
+                    fl_ctx, f"Expected dxo of kind METRICS but got {dxo.data_kind} instead.", fire_event=False
+                )
+                self._record_failure(fl_ctx, model_owner, data_client, ReturnCode.EXECUTION_RESULT_ERROR)
+                return
+        except Exception:
+            self.log_exception(fl_ctx, "Exception in handling evaluation result.", fire_event=False)
+            self._record_failure(fl_ctx, model_owner, data_client, ReturnCode.EXECUTION_RESULT_ERROR)
+            return
+
+        self._record_result(model_owner, data_client, dxo.data)
+
+    def _write_json(self, fl_ctx: FLContext, run_dir: str, file_name: str, payload: Any, description: str) -> None:
+        """Write one json artefact into the run's evaluation results directory."""
+        res_file_path = resolve_path_under_root(run_dir, os.path.join(self._results_dir, file_name), description)
+        eval_res_dir = os.path.dirname(res_file_path)
+        if not os.path.exists(eval_res_dir):
+            self.log_info(fl_ctx, f"Creating evaluation results directory at {eval_res_dir}")
+            os.makedirs(eval_res_dir)
+        with open(res_file_path, "w") as f:
+            json.dump(payload, f, indent=4, default=to_serializable)
 
     def handle_evaluation_events(self, event_type: str, fl_ctx: FLContext) -> None:
         """FLIP integration point — ServerEventHandler dispatches events here, not via handle_event."""
         if event_type == EventType.START_RUN:
             self._eval_results.clear()
+            self._eval_failures.clear()
         elif event_type == AppEventType.VALIDATION_RESULT_RECEIVED:
-            data_client = fl_ctx.get_prop(AppConstants.DATA_CLIENT, None)
-            eval_results = fl_ctx.get_prop(AppConstants.VALIDATION_RESULT, None)
-
-            if not data_client:
-                self.log_error(
-                    fl_ctx, "data_client unknown. Evaluation result will not be saved to json", fire_event=False
-                )
-
-            if eval_results:
-                try:
-                    dxo = from_shareable(eval_results)
-                    if dxo.data_kind == DataKind.METRICS:
-                        self._eval_results[data_client] = dxo.data
-                    else:
-                        self.log_error(
-                            fl_ctx, f"Expected dxo of kind METRICS but got {dxo.data_kind} instead.", fire_event=False
-                        )
-                except Exception:
-                    self.log_exception(fl_ctx, "Exception in handling evaluation result.", fire_event=False)
-            else:
-                self.log_error(fl_ctx, "Evaluation result not found.", fire_event=False)
+            self._handle_validation_result(fl_ctx)
         elif event_type == EventType.END_RUN:
             run_dir = fl_ctx.get_engine().get_workspace().get_run_dir(fl_ctx.get_job_id())
-            res_file_path = resolve_path_under_root(
-                run_dir, os.path.join(self._results_dir, self._json_file_name), "evaluation results path"
-            )
-            eval_res_dir = os.path.dirname(res_file_path)
-            if not os.path.exists(eval_res_dir):
-                self.log_info(fl_ctx, f"Creating evaluation results directory at {eval_res_dir}")
-                os.makedirs(eval_res_dir)
-            with open(res_file_path, "w") as f:
-                json.dump(self._eval_results, f, indent=4, default=to_serializable)
+            self._write_json(fl_ctx, run_dir, self._json_file_name, self._eval_results, "evaluation results path")
+            # Always written, even when empty, so its absence never has to be interpreted.
+            self._write_json(fl_ctx, run_dir, self._failures_file_name, self._eval_failures, "evaluation failures path")

--- a/flip-utils/flip/nvflare/components/flip_server_event_handler.py
+++ b/flip-utils/flip/nvflare/components/flip_server_event_handler.py
@@ -18,6 +18,7 @@ from nvflare.app_common.app_event_type import AppEventType
 from flip import FLIP
 from flip.constants import FlipEvents, ModelStatus
 from flip.exceptions import ResultsUploadError
+from flip.nvflare.components.evaluation_json_generator import EvaluationJsonGenerator
 from flip.nvflare.components.persist_and_cleanup import PersistToS3AndCleanup
 from flip.nvflare.runtime import get_flip_model_id
 
@@ -78,6 +79,42 @@ class ServerEventHandler(FLComponent):
         """
         self.flip.update_status(self._resolve_model_id(fl_ctx), status)
 
+    def _evaluation_wholly_failed(self) -> bool:
+        """Whether this is an evaluation job in which every validate task failed.
+
+        Training jobs wire the base ``ValidationJsonGenerator``, which tracks no failures, so the
+        isinstance check also serves as the "is this an evaluation job" test.
+
+        Returns:
+            bool: True when the evaluation produced failures and no results at all.
+        """
+        generator = self.validation_json_generator
+        return isinstance(generator, EvaluationJsonGenerator) and generator.all_tasks_failed()
+
+    def _terminal_status(self, default: ModelStatus) -> ModelStatus:
+        """Resolve the run's terminal status, most salient cause first.
+
+        A recorded fatal system error is the root cause and outranks everything. A user-requested
+        abort outranks the evaluation failures it necessarily caused (aborting a run cancels its
+        in-flight validate tasks, which must not be reported as ERROR). An evaluation in which every
+        validate task failed outranks ``default`` — otherwise a wholly failed run reports success on
+        an empty results file (FLIP#754), or reports a trailing upload failure as its cause.
+
+        Args:
+            default (ModelStatus): The status to use when no failure cause is recorded — the outcome
+                of the upload itself.
+
+        Returns:
+            ModelStatus: The status to report to the hub.
+        """
+        if self.fatal_error:
+            return ModelStatus.ERROR
+        if self.final_status == ModelStatus.STOPPED:
+            return ModelStatus.STOPPED
+        if self._evaluation_wholly_failed():
+            return ModelStatus.ERROR
+        return default
+
     def handle_event(self, event_type: str, fl_ctx: FLContext) -> None:
         self.__set_dependencies(fl_ctx)
 
@@ -116,21 +153,12 @@ class ServerEventHandler(FLComponent):
             self.log_info(fl_ctx, "End run event received")
 
             try:
+                # The results are uploaded even when the evaluation wholly failed: the zip carries
+                # the error_log.txt and evaluation_failures.json that explain why.
                 self.persist_and_cleanup.execute(fl_ctx)
-
-                if self.final_status != ModelStatus.STOPPED:
-                    self.final_status = ModelStatus.RESULTS_UPLOADED
-
-                if self.fatal_error:
-                    self.final_status = ModelStatus.ERROR
+                self.final_status = self._terminal_status(ModelStatus.RESULTS_UPLOADED)
             except ResultsUploadError:
-                # Preserve the more salient terminal states: a recorded fatal system
-                # error (root cause) and a user-requested abort take precedence over a
-                # trailing upload failure, matching the success-path precedence above.
-                if self.fatal_error:
-                    self.final_status = ModelStatus.ERROR
-                elif self.final_status != ModelStatus.STOPPED:
-                    self.final_status = ModelStatus.RESULTS_UPLOAD_FAILED
+                self.final_status = self._terminal_status(ModelStatus.RESULTS_UPLOAD_FAILED)
             except Exception:
                 self.final_status = ModelStatus.ERROR
 

--- a/flip-utils/tests/unit/nvflare/components/test_evaluation_json_generator.py
+++ b/flip-utils/tests/unit/nvflare/components/test_evaluation_json_generator.py
@@ -18,6 +18,8 @@ from unittest.mock import MagicMock, Mock
 import numpy as np
 from nvflare.apis.dxo import DXO, DataKind
 from nvflare.apis.event_type import EventType
+from nvflare.apis.fl_constant import ReturnCode
+from nvflare.apis.shareable import make_reply
 from nvflare.app_common.app_constant import AppConstants
 from nvflare.app_common.app_event_type import AppEventType
 
@@ -32,6 +34,31 @@ class TestEvaluationJsonGenerator:
         self.generator = EvaluationJsonGenerator()
         self.fl_ctx = MagicMock()
         self.fl_ctx.get_peer_context.return_value = None
+
+    def _set_props(self, data_client, validation_result, model_owner=None):
+        """Stub the FLContext props that a controller sets before VALIDATION_RESULT_RECEIVED.
+
+        Args:
+            data_client (str | None): The client that produced the result.
+            validation_result (Shareable | None): The result shareable.
+            model_owner (str | None): The validated model's name. ``GlobalModelEval`` sets this;
+                FLIP's own ``ModelEval`` controller does not.
+        """
+        self.fl_ctx.get_prop.side_effect = lambda key, default=None: {
+            AppConstants.DATA_CLIENT: data_client,
+            AppConstants.MODEL_OWNER: model_owner,
+            AppConstants.VALIDATION_RESULT: validation_result,
+        }.get(key, default)
+
+    def _receive(self, data_client, validation_result, model_owner=None):
+        """Drive one VALIDATION_RESULT_RECEIVED event through the generator."""
+        self._set_props(data_client, validation_result, model_owner)
+        self.generator.handle_evaluation_events(AppEventType.VALIDATION_RESULT_RECEIVED, self.fl_ctx)
+
+    @staticmethod
+    def _metrics(**metrics):
+        """Build the shareable a client returns on a successful validate task."""
+        return DXO(data_kind=DataKind.METRICS, data=dict(metrics)).to_shareable()
 
     def test_init_default_values(self):
         """Test initialization with default values"""
@@ -241,3 +268,103 @@ class TestEvaluationJsonGenerator:
             with open(json_file) as f:
                 saved = json.load(f)
             assert saved["client1"]["dice"] == 0.5
+
+    # --- FLIP#754: task-level failures must be recorded, not swallowed ---
+
+    def test_aborted_validate_task_is_recorded_as_a_failure(self):
+        """An aborted task carries no DXO. Its return code is recorded rather than raising."""
+        self._receive("Trust_1", make_reply(ReturnCode.TASK_ABORTED), model_owner="SRV_arkplus_pretrained")
+
+        assert self.generator._eval_results == {}
+        assert self.generator._eval_failures == [
+            {"model": "SRV_arkplus_pretrained", "client": "Trust_1", "return_code": "TASK_ABORTED"}
+        ]
+
+    def test_result_with_ok_code_but_non_metrics_dxo_is_recorded_as_a_failure(self):
+        """A well-formed reply carrying the wrong data kind is still a failed evaluation task."""
+        weights = DXO(data_kind=DataKind.WEIGHTS, data={"w": [1, 2, 3]}).to_shareable()
+
+        self._receive("Trust_1", weights, model_owner="SRV_model")
+
+        assert self.generator._eval_results == {}
+        assert self.generator._eval_failures == [
+            {"model": "SRV_model", "client": "Trust_1", "return_code": ReturnCode.EXECUTION_RESULT_ERROR}
+        ]
+
+    def test_all_tasks_failed_when_every_validate_task_aborts(self):
+        """The all-aborted evaluation from FLIP#754: 2 models x 2 clients, every task aborted."""
+        for model in ("SRV_model_a", "SRV_model_b"):
+            for client in ("Trust_1", "Trust_2"):
+                self._receive(client, make_reply(ReturnCode.TASK_ABORTED), model_owner=model)
+
+        assert len(self.generator._eval_failures) == 4
+        assert self.generator.all_tasks_failed() is True
+
+    def test_all_tasks_failed_is_false_when_one_task_succeeded(self):
+        """A partial failure still has results to upload, so the run is not wholly failed."""
+        self._receive("Trust_1", self._metrics(accuracy=0.9), model_owner="SRV_model")
+        self._receive("Trust_2", make_reply(ReturnCode.TASK_ABORTED), model_owner="SRV_model")
+
+        assert self.generator.all_tasks_failed() is False
+
+    def test_all_tasks_failed_is_false_when_no_validate_task_ran(self):
+        """No validate tasks at all (e.g. a training job) is not an evaluation failure."""
+        assert self.generator.all_tasks_failed() is False
+
+    def test_start_run_clears_failures(self):
+        self.generator._eval_failures = [{"model": "m", "client": "c", "return_code": "TASK_ABORTED"}]
+
+        self.generator.handle_evaluation_events(EventType.START_RUN, self.fl_ctx)
+
+        assert self.generator._eval_failures == []
+
+    def test_end_run_writes_failures_file_alongside_results(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            run_dir = os.path.join(tmpdir, "run_1")
+            os.makedirs(run_dir)
+            mock_engine = Mock()
+            mock_engine.get_workspace.return_value.get_run_dir.return_value = run_dir
+            self.fl_ctx.get_engine.return_value = mock_engine
+            self.fl_ctx.get_job_id.return_value = "job_123"
+            self.generator._eval_failures = [
+                {"model": "SRV_model", "client": "Trust_1", "return_code": "TASK_ABORTED"}
+            ]
+
+            self.generator.handle_evaluation_events(EventType.END_RUN, self.fl_ctx)
+
+            failures_file = os.path.join(run_dir, self.generator._results_dir, PTConstants.EvalFailuresFilename)
+            with open(failures_file) as f:
+                assert json.load(f) == self.generator._eval_failures
+
+    def test_end_run_writes_empty_failures_file_for_a_clean_run(self):
+        """The file is always written, so its absence never has to be interpreted."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            run_dir = os.path.join(tmpdir, "run_1")
+            os.makedirs(run_dir)
+            mock_engine = Mock()
+            mock_engine.get_workspace.return_value.get_run_dir.return_value = run_dir
+            self.fl_ctx.get_engine.return_value = mock_engine
+            self.fl_ctx.get_job_id.return_value = "job_123"
+
+            self.generator.handle_evaluation_events(EventType.END_RUN, self.fl_ctx)
+
+            failures_file = os.path.join(run_dir, self.generator._results_dir, PTConstants.EvalFailuresFilename)
+            with open(failures_file) as f:
+                assert json.load(f) == []
+
+    # --- FLIP#754: GlobalModelEval sends one validate task per (model, client) ---
+
+    def test_results_are_nested_by_model_when_model_owner_is_set(self):
+        """Client-API path: without nesting, the second model's metrics overwrite the first's."""
+        self._receive("Trust_1", self._metrics(accuracy=0.9), model_owner="SRV_model_a")
+        self._receive("Trust_1", self._metrics(accuracy=0.8), model_owner="SRV_model_b")
+
+        assert self.generator._eval_results == {
+            "Trust_1": {"SRV_model_a": {"accuracy": 0.9}, "SRV_model_b": {"accuracy": 0.8}}
+        }
+
+    def test_results_stay_flat_when_model_owner_is_absent(self):
+        """FLIP's ModelEval controller sets no MODEL_OWNER: the evaluator's own dict is the shape."""
+        self._receive("Trust_1", self._metrics(**{"model_a": {"dice": 0.7}}), model_owner=None)
+
+        assert self.generator._eval_results == {"Trust_1": {"model_a": {"dice": 0.7}}}

--- a/flip-utils/tests/unit/nvflare/components/test_flip_server_event_handler.py
+++ b/flip-utils/tests/unit/nvflare/components/test_flip_server_event_handler.py
@@ -18,6 +18,7 @@ from nvflare.app_common.app_event_type import AppEventType
 
 from flip.constants import FlipEvents, ModelStatus
 from flip.exceptions import ResultsUploadError
+from flip.nvflare.components.evaluation_json_generator import EvaluationJsonGenerator
 from flip.nvflare.components.flip_server_event_handler import ServerEventHandler
 from flip.nvflare.components.persist_and_cleanup import PersistToS3AndCleanup
 from flip.nvflare.components.validation_json_generator import ValidationJsonGenerator
@@ -458,3 +459,100 @@ class TestServerEventHandler:
         assert "must be PersistToS3AndCleanup" in str(handler.system_panic.call_args)
         handler.system_panic.assert_called_once()
         assert "must be PersistToS3AndCleanup" in str(handler.system_panic.call_args)
+
+    # --- FLIP#754: an evaluation whose every validate task failed must not report success ---
+
+    @staticmethod
+    def _end_run(handler, *, all_tasks_failed, flip):
+        """Drive END_RUN with an evaluation generator reporting the given all-failed verdict."""
+        fl_ctx = MagicMock()
+        fl_ctx.get_peer_context.return_value = None
+        engine = MagicMock()
+        fl_ctx.get_engine.return_value = engine
+
+        json_generator = Mock(spec=EvaluationJsonGenerator)
+        json_generator.all_tasks_failed.return_value = all_tasks_failed
+        persist_cleanup = Mock(spec=PersistToS3AndCleanup)
+        persist_cleanup.execute.return_value = None
+        engine.get_component.side_effect = lambda comp_id: (
+            json_generator if comp_id == "json_generator" else persist_cleanup
+        )
+
+        handler.handle_event(EventType.END_RUN, fl_ctx)
+        return persist_cleanup
+
+    def test_end_run_reports_error_when_every_evaluation_task_failed(self):
+        """FLIP#754: 4/4 aborted validate tasks previously reported RESULTS_UPLOADED."""
+        model_id = "123e4567-e89b-12d3-a456-426614174000"
+        flip = MagicMock()
+        handler = ServerEventHandler(model_id=model_id, flip=flip)
+
+        self._end_run(handler, all_tasks_failed=True, flip=flip)
+
+        assert handler.final_status == ModelStatus.ERROR
+        flip.update_status.assert_called_with(model_id, ModelStatus.ERROR)
+
+    def test_end_run_still_uploads_results_when_every_evaluation_task_failed(self):
+        """The zip carries error_log.txt and evaluation_failures.json, so it must still upload."""
+        flip = MagicMock()
+        handler = ServerEventHandler(model_id="123e4567-e89b-12d3-a456-426614174000", flip=flip)
+
+        persist_cleanup = self._end_run(handler, all_tasks_failed=True, flip=flip)
+
+        persist_cleanup.execute.assert_called_once()
+
+    def test_end_run_reports_results_uploaded_on_partial_evaluation_failure(self):
+        """Some clients succeeded: the successful results still count as a completed run."""
+        model_id = "123e4567-e89b-12d3-a456-426614174000"
+        flip = MagicMock()
+        handler = ServerEventHandler(model_id=model_id, flip=flip)
+
+        self._end_run(handler, all_tasks_failed=False, flip=flip)
+
+        assert handler.final_status == ModelStatus.RESULTS_UPLOADED
+        flip.update_status.assert_called_with(model_id, ModelStatus.RESULTS_UPLOADED)
+
+    def test_end_run_keeps_stopped_when_a_user_abort_failed_every_task(self):
+        """A user-requested stop aborts every in-flight validate task; that is STOPPED, not ERROR."""
+        model_id = "123e4567-e89b-12d3-a456-426614174000"
+        flip = MagicMock()
+        handler = ServerEventHandler(model_id=model_id, flip=flip)
+        handler.final_status = ModelStatus.STOPPED
+
+        self._end_run(handler, all_tasks_failed=True, flip=flip)
+
+        assert handler.final_status == ModelStatus.STOPPED
+        flip.update_status.assert_called_with(model_id, ModelStatus.STOPPED)
+
+    def test_end_run_reports_error_when_a_fatal_error_accompanies_a_failed_evaluation(self):
+        """A fatal system error stays the most salient terminal state."""
+        model_id = "123e4567-e89b-12d3-a456-426614174000"
+        flip = MagicMock()
+        handler = ServerEventHandler(model_id=model_id, flip=flip)
+        handler.fatal_error = True
+
+        self._end_run(handler, all_tasks_failed=True, flip=flip)
+
+        assert handler.final_status == ModelStatus.ERROR
+
+    def test_end_run_reports_upload_failed_when_upload_breaks_after_a_clean_evaluation(self):
+        """Regression guard: the new all-failed branch must not shadow RESULTS_UPLOAD_FAILED."""
+        flip = MagicMock()
+        handler = ServerEventHandler(model_id="123e4567-e89b-12d3-a456-426614174000", flip=flip)
+
+        fl_ctx = MagicMock()
+        fl_ctx.get_peer_context.return_value = None
+        engine = MagicMock()
+        fl_ctx.get_engine.return_value = engine
+
+        json_generator = Mock(spec=EvaluationJsonGenerator)
+        json_generator.all_tasks_failed.return_value = False
+        persist_cleanup = Mock(spec=PersistToS3AndCleanup)
+        persist_cleanup.execute.side_effect = ResultsUploadError("boom")
+        engine.get_component.side_effect = lambda comp_id: (
+            json_generator if comp_id == "json_generator" else persist_cleanup
+        )
+
+        handler.handle_event(EventType.END_RUN, fl_ctx)
+
+        assert handler.final_status == ModelStatus.RESULTS_UPLOAD_FAILED


### PR DESCRIPTION
Closes #754.

## Problem

Both evaluation controllers fire `VALIDATION_RESULT_RECEIVED` **before** they inspect the result's
return code — stock `CrossSiteModelEval._accept_val_result` at `cross_site_model_eval.py:416-423`, and
FLIP's own `ModelEval` at `fed_evaluation.py:232-236`. An aborted `validate` task therefore reached
`EvaluationJsonGenerator` carrying no DXO at all. `from_shareable()` raised on it, the exception was
logged and discarded, and nothing recorded that a task had failed.

`ServerEventHandler` then decided the terminal status from only two signals — `fatal_error`
(`FATAL_SYSTEM_ERROR`) and `STOPPED` (`FlipEvents.ABORTED`). `TASK_ABORTED` is neither, so a run in
which *every* task failed fell through to `RESULTS_UPLOADED`: indistinguishable from success in the API
and the UI, with an empty `evaluation_results.json` and the only evidence buried in `error_log.txt`
inside the zip.

This is why the failure was eval-specific: `ScatterAndGather` `system_panic`s on any non-OK result, so
training runs already surface `ERROR`. `GlobalModelEval` merely logs "Logging empty results" and carries on.

## Changes

**Record the failures.** `EvaluationJsonGenerator` now reads the return code *before* attempting the DXO
conversion and records each failed task as `{model, client, return_code}`, written to a new
`evaluation_results/evaluation_failures.json`. The file is always written, so an empty `[]` positively
means "no task failed" rather than "this version didn't record them". A reply that arrives with `rc == OK`
but the wrong data kind counts as a failure too — otherwise an evaluation where every client returned
garbage would still report success.

**Fail the run.** `ServerEventHandler` reports `ERROR` when the evaluation produced failures and no
results at all. Results are still uploaded either way — the zip is what carries `evaluation_failures.json`
and `error_log.txt`.

Terminal-status precedence is consolidated into a single `_terminal_status` helper, most salient cause
first:

```
fatal system error  >  user abort  >  every validate task failed  >  upload outcome
```

A user-requested stop aborts every in-flight `validate` task, so `STOPPED` **must** outrank the failures
it necessarily caused — otherwise stopping an evaluation would be reported as a crash. Training jobs wire
the base `ValidationJsonGenerator`, which tracks no failures, so they are excluded by construction rather
than by a flag.

**Fix a latent bug the incident masked.** `GlobalModelEval` sends one `validate` task per (model, client)
and sets `MODEL_OWNER`, but results were keyed by client alone — so each model's metrics silently
overwrote the previous model's, and a two-model evaluation only ever reported its *last* model. Results
now nest under the model name when the controller supplies one. The legacy `ModelEval` controller sets no
`MODEL_OWNER` (it sends every model in one task, and the evaluator returns its own model-keyed dict), so
that job type keeps its existing flat shape.

> **Breaking output change.** `evaluation_results.json` for `evaluation_client_api` nests one level
> deeper: `{"<trust>": {"SRV_<model>": {...}}}` instead of `{"<trust>": {...}}`. Documented in the two
> app READMEs and the Ark+ guide.

## Verification

Driven through the real `FlipEvalRecipe` on the NVFLARE simulator (`SimEnv`, 2 models × 2 clients — the
topology of the production incident), with an `origin/develop` baseline run for comparison.

| Scenario | `develop` | this branch |
|---|---|---|
| Every `validate` task aborts | `RESULTS_UPLOADED`, `{}`, 8 swallowed `not a valid DXO` tracebacks | `ERROR`, 4 failures recorded, **0** tracebacks |
| Clean 2-model run | `{"site-1": {"weight_sum": 10.0}}` — one model's metrics lost | `{"site-1": {"SRV_arkplus_pretrained": {...}, "SRV_arkplus_finetuned": {...}}}` |
| Partial failure | — | `RESULTS_UPLOADED`, successful metrics uploaded, failures recorded |
| Clean run | — | `evaluation_failures.json == []` |

Both artefacts are written inside the uploaded run directory, so they reach the results zip. Also confirmed
that all four training app configs and `FlipFedAvgRecipe` wire the base `ValidationJsonGenerator`, so the
`isinstance` guard correctly excludes training jobs.

`503` unit tests pass; `ruff` clean.

### Stag verification (2026-07-10)

Deployed `flare-fl-server:8f8389f65eb…` (this branch's head) onto the staging hub's `fl-server-net-1`
and ran the Ark+ **multimodel** evaluation (`evaluation_client_api`, 2 models × 2 trusts — the
production incident's exact topology) end-to-end via `tests/e2e_smoke.py` against
`stag.flip.aicentre.co.uk`, with the GSTT/KCH trusts on a GPU desktop and the DeCaf holdout cohorts
(478/468 studies):

- **All-failed path (organic):** the first run's `validate` tasks all aborted client-side (the
  tutorial's evaluator needs the FLIP-Ark fork's named-broadcast meta, which upstream `flip` doesn't
  ship yet — a tutorial↔platform version gap, unrelated to this fix). The branch behaved exactly as
  designed: model ended **`ERROR`** (develop would have reported `RESULTS_UPLOADED`), the zip still
  uploaded, `evaluation_results.json == {}`, and `evaluation_failures.json` recorded all 4
  `(model, client, TASK_ABORTED)` tuples. No swallowed `from_shareable` tracebacks.
- **Clean path:** with the evaluator shimmed to infer the model from the state-dict head signature,
  the run ended **`RESULTS_UPLOADED`** with `evaluation_failures.json == []` and the nested results
  shape carrying **both** models per trust — `{"Trust_N": {"SRV_arkplus_pretrained": {…},
  "SRV_arkplus_finetuned": {…}}}`. The pretrained AUROCs reproduce the baseline table in
  `ARKPLUS_EXPERIMENTS_GUIDE.md` (GSTT: Effusion 0.839, Consolidation 0.866, Infiltration 0.845,
  Nodule/Mass 0.944, Pneumothorax 0.643; KCH matches likewise) — metrics the pre-fix keying would
  have silently overwritten for one of the two models.

The staging fl-server was restored to its previous pinned image after verification.

## Acceptance criteria

- [x] An evaluation run in which **every** `validate` task fails ends in a failure status surfaced via the
      API and UI (`ERROR`), not `RESULTS_UPLOADED`.
- [x] `EvaluationJsonGenerator` checks the peer return code before attempting DXO conversion and records
      per-task failures (model + client + rc) instead of raising and discarding them.
- [x] Partial failures still upload the successful results, with the failure set recorded in the results
      bundle (`evaluation_failures.json`), so a partially failed evaluation is detectable without reading
      `error_log.txt`.
- [x] Unit tests cover: all-tasks-aborted → failure status; partial-abort → failures recorded alongside
      results.

## Out of scope

While tracing this I found that `ClientExceptionReporter` is dead code for **both Client-API job types**,
and that a bad import in a user's evaluator hangs the job indefinitely. Neither is fixed here — filed as
#755, with the design options written up.


## Acceptance Criteria

*Imported from issue #754*

- [x] An evaluation run in which **every** `validate` task fails (rc set / aborted) ends in a failure status surfaced via the API and UI (e.g. `ERROR`), not `RESULTS_UPLOADED`.
- [x] `EvaluationJsonGenerator` checks the peer return code before attempting DXO conversion and records per-task failures (model + client + rc) instead of raising and discarding them.
- [x] Partial failures (some clients/models succeeded) still upload the successful results but the failure set is recorded in the results bundle (e.g. in `run_metadata`/results JSON), so a partially failed evaluation is detectable without reading `error_log.txt`.
- [x] Unit tests cover: all-tasks-aborted → failure status; partial-abort → failures recorded alongside results.
