### PR TITLE
chore(flip-utils): pin the folder interpreter so nvflare resolves in VS Code

### DIFF
--- a/flip-utils/.vscode/settings.json
+++ b/flip-utils/.vscode/settings.json
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2026 Guy's and St Thomas' NHS Foundation Trust & King's College London
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+{
+    "[jsonc]": {
+        "editor.defaultFormatter": "vscode.json-language-features"
+    },
+    "cSpell.autoFormatConfigFile": true,
+    "cSpell.words": [
+        "flip",
+        "flwr",
+        "nvflare"
+    ],
+    "editor.codeActionsOnSave": {
+        "source.fixAll": "explicit",
+        "source.organizeImports": "explicit"
+    },
+    "editor.defaultFormatter": "charliermarsh.ruff",
+    "editor.formatOnSave": true,
+    "editor.inlineSuggest.enabled": true,
+    "editor.inlineSuggest.showToolbar": "always",
+    "editor.rulers": [
+        120
+    ],
+    "files.autoSave": "afterDelay",
+    "git.autofetch": true,
+    "git.confirmSync": false,
+    "interactiveWindow.executeWithShiftEnter": true,
+    "makefile.configureOnOpen": true,
+    "problems.showCurrentInStatus": true,
+    "python.analysis.autoFormatStrings": true,
+    "python.analysis.extraPaths": [
+        "${workspaceFolder}"
+    ],
+    "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python",
+    "python.terminal.activateEnvInCurrentTerminal": true,
+    "python.terminal.shellIntegration.enabled": true,
+    "python.testing.autoTestDiscoverOnSaveEnabled": true,
+    "python.testing.autoTestDiscoverOnSavePattern": "**/*.py",
+    "python.testing.pytestArgs": [
+        "tests/unit",
+    ],
+    "python.testing.pytestEnabled": true,
+    "python.testing.unittestEnabled": false,
+    "remote.autoForwardPortsSource": "hybrid",
+    "ruff.configuration": "${workspaceFolder}/pyproject.toml",
+    "ruff.format.preview": true,
+    "terminal.integrated.accessibleViewPreserveCursorPosition": true,
+    "terminal.integrated.allowChords": false,
+    "terminal.integrated.env.linux": {
+        "PATH": "${workspaceFolder}/.venv/bin:${env:PATH}",
+        "VIRTUAL_ENV": "${workspaceFolder}/.venv"
+    },
+    // deactivate pylance error checking
+    "python.analysis.typeCheckingMode": "off",
+    // deactivate mypy missing library stubs errors
+}


### PR DESCRIPTION
# Description

`flip-utils` was the only Python folder in the multi-root VS Code workspace without a `.vscode/settings.json`.

`flip.code-workspace` documents the design in its own header comment — *"Pylance uses that folder's `.venv` (e.g. nvflare imports resolve in fl-api-base) ... driven by each folder's `.vscode/settings.json`"* — and every other Python folder holds up its end: `flip-api`, `fl-api-base`, `fl-api-flower`, `trust-api`, `imaging-api`, `data-access-api`, `flip-ui`, `deploy/providers/AWS`. `flip-utils` had no such file, so Pylance fell back to the interpreter carried over from the root folder's settings, which pins `flip-api/.venv`.

`flip-api/.venv` has no `nvflare`. `flip-utils/.venv` has `nvflare==2.8.0`. The result: every `from nvflare... import` across `flip/nvflare/` showed as an unresolved import in the editor, even though the package imports fine at runtime and CI is green. Purely an editor-resolution defect — no runtime or packaging bug.

This adds the missing file, mirroring `fl-services/nvflare/fl-api-base/.vscode/settings.json` (the folder the workspace comment cites as the one where nvflare imports resolve), adapted for `flip-utils`:

- `python.defaultInterpreterPath` → `${workspaceFolder}/.venv/bin/python`
- `python.testing.pytestArgs` → `tests/unit`, matching `testpaths` in `flip-utils/pyproject.toml`
- `ruff.configuration` → `flip-utils`' own `pyproject.toml`
- `python.envFile` omitted — `flip-utils` has no `.env.development`, unlike the service folders

### Note for anyone who hit this and tried to fix it in `flip.code-workspace`

Adding a folder-level override there is a silent no-op if written as:

```jsonc
{ "path": "flip-utils", "settings": { "python.defaultInterpreterPath": "${workspaceFolder}/flip-utils/.venv/bin/python" } }
```

Inside a folder's `settings` block `${workspaceFolder}` **already** resolves to that folder, so this expands to `flip-utils/flip-utils/.venv/bin/python`. VS Code does not warn — it ignores the nonexistent path and keeps the fallback interpreter. The per-folder `.vscode/settings.json` in this PR is the convention the workspace file already assumes, so no change to `flip.code-workspace` is needed.

## Linked Issues

No linked issue — follow-up to `abc4af92` (`chore(fl-api): adopt project ruff UP rules + add multi-root VS Code workspace`), which introduced the workspace file and the per-folder settings convention that `flip-utils` was missed by.

## Checklist

- [x] Follows the project's coding conventions and style guide
- [ ] Updates documentation — n/a, editor config
- [ ] I have added tests that prove my fix is effective or that my feature works — n/a, no runtime surface to test
- [x] New and existing unit tests pass locally with my changes — unaffected; this file is never read by Python
- [x] Any dependent changes have been merged and published

## Type of Change

- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make -C docs/ docs`.

## Testing

Verified through the VS Code language server rather than by assertion.

**Before:** `from nvflare.apis.client import Client` and friends flagged unresolved throughout `flip-utils/flip/nvflare/`.

**After:** with the folder settings in place, the language server reports **zero diagnostics** on every nvflare-importing module in `flip-utils`:

- `flip/nvflare/controllers/init_evaluation.py`
- `flip/nvflare/controllers/init_training.py`
- `flip/nvflare/controllers/fed_evaluation.py`
- `flip/nvflare/controllers/broadcast_task.py`
- `flip/nvflare/runtime.py`

Pylance keeps `reportMissingImports` at warning level even under `python.analysis.typeCheckingMode: "off"`, so an unresolved import would still have surfaced.

Corroborating checks:

```console
$ flip-utils/.venv/bin/python -c "import nvflare; print(nvflare.__file__)"
.../flip-utils/.venv/lib/python3.12/site-packages/nvflare/__init__.py

$ ls flip-api/.venv/lib/python3.12/site-packages/ | grep -ix nvflare
(no match)
```

The JSONC parses cleanly once comments and trailing commas are stripped, and no pre-commit hook validates `.json` strictly (so the comment header is safe, as it is in the seven sibling `settings.json` files already committed).

## Additional Notes

Reproduce by opening `flip.code-workspace` (File > Open Workspace from File…) and opening any file under `flip-utils/flip/nvflare/`.

If the fix doesn't take effect immediately after checkout, note that `python.defaultInterpreterPath` is only a *default* — if an interpreter was ever explicitly selected for the `flip-utils` folder, VS Code cached that choice in workspace storage and ignores the setting. Run **Python: Select Interpreter**, scope it to `flip-utils`, and pick `./.venv/bin/python`.
