### PR TITLE
feat(nvflare): name evaluation broadcasts in DXO meta for Client-API evaluators

### DIFF
--- a/flip-utils/flip/constants/flip_constants.py
+++ b/flip-utils/flip/constants/flip_constants.py
@@ -192,6 +192,11 @@ class FlipMetricsLabel(StrEnum):
 
 
 class FlipMetaKey(StrEnum):
-    """Metadata keys used in FLIP (diffusion model specific)."""
+    """Metadata keys FLIP components attach to DXO meta."""
 
+    # Diffusion model specific.
     STAGE = "stage"
+    # Name of the config.json['models'] entry an evaluation broadcast carries. Stamped by
+    # EvaluationModelLocator so Client-API evaluators can attribute each validate task's weights —
+    # the stock MODEL_OWNER header does not survive the Client-API FLModel conversion.
+    EVAL_MODEL_NAME = "flip_eval_model_name"

--- a/flip-utils/flip/nvflare/components/pt_model_locator.py
+++ b/flip-utils/flip/nvflare/components/pt_model_locator.py
@@ -21,7 +21,7 @@ from nvflare.app_common.abstract.model import model_learnable_to_dxo
 from nvflare.app_common.abstract.model_locator import ModelLocator
 from nvflare.app_opt.pt import PTModelPersistenceFormatManager
 
-from flip.constants import FlipConstants, PTConstants
+from flip.constants import FlipConstants, FlipMetaKey, PTConstants
 from flip.nvflare.runtime import get_flip_model_id
 
 
@@ -363,4 +363,12 @@ class EvaluationModelLocator(ModelLocator):
 
         persistence_manager = PTModelPersistenceFormatManager(weights, default_train_conf=None)
         ml = persistence_manager.to_model_learnable(exclude_vars=None)
-        return model_learnable_to_dxo(ml)
+        dxo = model_learnable_to_dxo(ml)
+        # Name the broadcast in the DXO meta itself: CrossSiteModelEval's MODEL_OWNER header does not
+        # survive the Client-API FLModel conversion, but DXO meta rides inside the payload to
+        # flare.receive() on every client. This is what lets a Client-API evaluator attribute each
+        # validate task's weights (e.g. the multimodel DeLong comparison).
+        # `.value`, not the StrEnum member: FOBS serialises meta keys by type and rejects any type not
+        # on its whitelist, so an enum key fails every task with "Type 'FlipMetaKey' is not allowed".
+        dxo.set_meta_prop(FlipMetaKey.EVAL_MODEL_NAME.value, model_name)
+        return dxo

--- a/flip-utils/tests/unit/nvflare/components/test_evaluation_model_locator.py
+++ b/flip-utils/tests/unit/nvflare/components/test_evaluation_model_locator.py
@@ -16,6 +16,7 @@ from unittest.mock import MagicMock, patch
 
 from nvflare.apis.dxo import DataKind
 
+from flip.constants import FlipMetaKey
 from flip.nvflare.components.pt_model_locator import EvaluationModelLocator
 
 
@@ -81,6 +82,14 @@ class TestEvaluationModelLocator:
         # A single WEIGHTS DXO (not a COLLECTION) is what CrossSiteModelEval broadcasts as one FLModel.
         assert result is weights_dxo
         assert result.data_kind == DataKind.WEIGHTS
+        # The model name must ride in the DXO meta — the MODEL_OWNER header does not survive the
+        # Client-API FLModel conversion, and Client-API evaluators attribute the weights by this key.
+        weights_dxo.set_meta_prop.assert_called_once_with(FlipMetaKey.EVAL_MODEL_NAME, "monai_spleen_unet")
+        # The key must be a plain str: FOBS serialises meta keys by type and rejects a StrEnum member
+        # ("Type 'FlipMetaKey' is not allowed"), failing every validate task. A StrEnum compares equal
+        # to its value, so assert on the type, not just equality.
+        meta_key = weights_dxo.set_meta_prop.call_args.args[0]
+        assert type(meta_key) is str
 
     @patch("flip.nvflare.components.pt_model_locator.torch")
     def test_locate_unknown_model_returns_none(self, mock_torch):


### PR DESCRIPTION
## Description

`EvaluationModelLocator` now stamps each evaluation broadcast's DXO meta with the name of the `config.json['models']` entry it came from (`FlipMetaKey.EVAL_MODEL_NAME`).

Server-side, `GlobalModelEval` broadcasts one `validate` task per configured model. The model's name travels only in the `MODEL_OWNER` **shareable header**, which `FLModelUtils.from_shareable` drops when converting to the Client-API `FLModel` — so a Client-API `evaluate` script receives `input_model.params` with no way to know *which* model it just got. That is fine for a single-model evaluation, but any multi-model evaluation (e.g. comparing a pretrained vs a finetuned checkpoint) cannot attribute the weights it is scoring.

DXO meta, unlike the header, rides inside the payload all the way to `flare.receive()`, so this works with the fl-client images already deployed at the trusts — no trust-side change is needed.

Without this, the only alternatives for a Client-API multimodel evaluator are to load the checkpoints client-side (impossible on the platform: the FL API de-bundles evaluation checkpoints onto the hub staging volume and clients never receive the `.pt` files) or to guess the model from its tensor shapes.

### Implementation notes

- The meta key is set as a plain `str` (`FlipMetaKey.EVAL_MODEL_NAME.value`), **not** the `StrEnum` member. FOBS serialises meta keys by type and rejects any type off its whitelist, so an enum key fails *every* validate task with `Type 'FlipMetaKey' is not allowed` before any scoring happens. The unit test asserts `type(key) is str` rather than equality alone, because a `StrEnum` member compares equal to its own value and an equality-only assertion passes on the broken code.
- `FlipMetaKey`'s docstring is corrected — it is no longer diffusion-model specific.
- Purely additive: no existing consumer reads this key, and the single-model baseline evaluator is unaffected.

## Verification

- `flip-utils` unit suite green (357 passed); `ruff` clean. `mypy` reports 6 errors in `pt_model_locator.py` — all pre-existing on `develop` (verified by running mypy against the `develop` baseline of the same file), none introduced here.
- **Simulator**: the Ark+ multimodel evaluation tutorial (ParhomEsmaeili/FLIP-Ark#11, upstream #746) runs end to end on the NVFLARE simulator against this locator, scoring both models at both sites.
- **Production**: `fl-server-net-1` was redeployed onto an image carrying this commit and the multimodel evaluation ran on the 2-trust prod federation (KCL + BDMS, 945 holdout studies). The results are **bit-identical** (max AUROC difference `0.00e+00` across 20 values) to the same evaluation run through the legacy `Executor`-based path, and the server log confirms the de-bundled path is exercised: `Loading checkpoint for model 'arkplus_pretrained' from shared volume: /app/server-checkpoints/<model_id>/…`.

## Acceptance criteria

- [x] A Client-API `evaluate` script can determine which configured model a `validate` broadcast carries, without reading checkpoint files client-side.
- [x] The meta key serialises through FOBS (plain `str`, not a `StrEnum` member), so validate tasks dispatch normally.
- [x] Existing single-model evaluation behaviour is unchanged; no fl-client / trust-side change required.
- [x] Unit tests cover the meta stamp and pin the key's type; `ruff` clean and no new `mypy` errors.
- [x] Verified on the NVFLARE simulator and against the production 2-trust federation, reproducing the legacy path's metrics exactly.

## Related

- Consumed by the Ark+ multimodel evaluation tutorial: #746 (ParhomEsmaeili/FLIP-Ark#11).
- #754 — evaluation jobs report `RESULTS_UPLOADED` with empty results when every `validate` task aborts. That bug is what made the pre-fix multimodel failure look like a successful run; it is orthogonal to this change and remains open.
