### PR TITLE
chore(deps): bump soupsieve from 2.8 to 2.8.4 in flip-utils

### DIFF
--- a/flip-utils/uv.lock
+++ b/flip-utils/uv.lock
@@ -2820,11 +2820,11 @@ wheels = [
 
 [[package]]
 name = "soupsieve"
-version = "2.8"
+version = "2.8.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6d/e6/21ccce3262dd4889aa3332e5a119a3491a95e8f60939870a3a035aabac0d/soupsieve-2.8.tar.gz", hash = "sha256:e2dd4a40a628cb5f28f6d4b0db8800b8f581b65bb380b97de22ba5ca8d72572f", size = 103472, upload-time = "2025-08-27T15:39:51.78Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/2c/0a5f6f8ee0d5589e48c7640213ed5175d52cf540a06725b628cc1a45d6ce/soupsieve-2.8.4.tar.gz", hash = "sha256:e121fd02e975c695e4e9e8774a5ee35d74714b59307868dcc5319ad2d9e3328e", size = 121110, upload-time = "2026-05-24T13:55:57.154Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/14/a0/bb38d3b76b8cae341dad93a2dd83ab7462e6dbcdd84d43f54ee60a8dc167/soupsieve-2.8-py3-none-any.whl", hash = "sha256:0cc76456a30e20f5d7f2e14a98a4ae2ee4e5abdc7c5ea0aafe795f344bc7984c", size = 36679, upload-time = "2025-08-27T15:39:50.179Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/f5/0c41cb68dcae6b7de4fac4188a3a9589e21fb31df21ea3a2e888db95e6c9/soupsieve-2.8.4-py3-none-any.whl", hash = "sha256:e7e6b0769c8f51ed59acab6e994b00621096cfb1c640a7509295987388fbaf65", size = 37304, upload-time = "2026-05-24T13:55:55.406Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Description

Bump `soupsieve` in `flip-utils/uv.lock` from 2.8 to 2.8.4 to resolve two high-severity ReDoS vulnerabilities.

## Fixed

| Package | Manifest | Severity | GHSA | CVE | Version |
|---------|----------|----------|------|-----|---------|
| soupsieve | flip-utils/uv.lock | High | [GHSA-836r-79rf-4m37](https://github.com/londonaicentre/FLIP/security/dependabot/437) | CVE-2026-49477 | 2.8 → 2.8.4 |
| soupsieve | flip-utils/uv.lock | High | [GHSA-2wc2-fm75-p42x](https://github.com/londonaicentre/FLIP/security/dependabot/436) | CVE-2026-49476 | 2.8 → 2.8.4 |

## Unable to fix automatically

| Package | Manifest | Severity | GHSA | Reason |
|---------|----------|----------|------|--------|
| flask | flip-utils/uv.lock | Low | [GHSA-68rp-wp8r-4726](https://github.com/londonaicentre/FLIP/security/dependabot/258) | nvflare==2.8.0 hard-pins flask==3.0.2; needs nvflare to relax its pin |
| flask | fl-services/nvflare/fl-api-base/uv.lock | Low | [GHSA-68rp-wp8r-4726](https://github.com/londonaicentre/FLIP/security/dependabot/400) | Same nvflare flask pin constraint |
| torch | flip-utils/uv.lock | Low | [GHSA-rrmf-rvhw-rf47](https://github.com/londonaicentre/FLIP/security/dependabot/292) | CVE-2025-3000 — no patched version available yet |

## Linked Issues

None — alerts auto-close on merge when GitHub rescans the default branch.

## Checklist

- [x] Follows the project's coding conventions and style guide
- [ ] Updates documentation — not applicable
- [ ] I have added tests that prove my fix is effective or that my feature works — not applicable (version bump only)
- [ ] New and existing unit tests pass locally with my changes — flip-utils tests require torch (unavailable in this environment)
- [ ] Any dependent changes have been merged and published — not applicable

## Type of Change

- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make -C docs/ docs`.

## Testing

- Verified `grep -A1 'name = "soupsieve"' flip-utils/uv.lock` shows `version = "2.8.4"`