### PR TITLE
fix(security): repair deploy-blocking count + Makefile guard in #499

### DIFF
--- a/deploy/providers/AWS/Makefile
+++ b/deploy/providers/AWS/Makefile
@@ -548,9 +548,9 @@ deploy-centralhub: ## Deploy Central Hub ECS services at the env branch tip (new
 	  fi; \
 	  rm -f $$tmp_td; tmp_td=""; \
 	  echo "   ↻ $$service: $${current_td##*/} → $${new_td_arn##*/} ($$new_image)"; \
-	  if ! $(_AWS_ENV) aws ecs update-service --cluster $(ECS_CLUSTER) --service $$service \
+	  if ! ( $(_AWS_ENV) aws ecs update-service --cluster $(ECS_CLUSTER) --service $$service \
 	      --task-definition "$$new_td_arn" \
-	      --query 'service.serviceName' --output text >/dev/null; then \
+	      --query 'service.serviceName' --output text >/dev/null ); then \
 	    echo "❌ $$service: update-service failed — deregistering the just-registered $${new_td_arn##*/}"; \
 	    echo "   so the latest-ACTIVE lookups in ecs_services.tf keep tracking the running revision."; \
 	    $(_AWS_ENV) aws ecs deregister-task-definition --task-definition "$$new_td_arn" >/dev/null \
@@ -607,8 +607,8 @@ rollback-centralhub: ## Repoint each Central Hub ECS service at its previous ACT
 	  $(_AWS_ENV) aws ecs update-service --cluster $(ECS_CLUSTER) --service $$service \
 	    --task-definition "$$previous" \
 	    --query 'service.serviceName' --output text >/dev/null; \
-	  if ! $(_AWS_ENV) aws ecs deregister-task-definition --task-definition "$$current_td" \
-	      --query 'taskDefinition.status' --output text >/dev/null; then \
+	  if ! ( $(_AWS_ENV) aws ecs deregister-task-definition --task-definition "$$current_td" \
+	      --query 'taskDefinition.status' --output text >/dev/null ); then \
 	    echo "❌ $$service rolled back to $${previous##*/}, but deregistering $${current_td##*/} failed —"; \
 	    echo "   it is still the latest ACTIVE revision, so the next terraform apply would re-adopt"; \
 	    echo "   it. Deregister manually:"; \
@@ -838,7 +838,7 @@ check:
 	@$(_TF) state list
 	@echo ""
 	@$(_TF) output
-	@uv run ./check_status.py || true
+	@unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN AWS_SECURITY_TOKEN; uv run ./check_status.py || true
 
 
 .PHONY: destroy

--- a/deploy/providers/AWS/TROUBLESHOOTING.md
+++ b/deploy/providers/AWS/TROUBLESHOOTING.md
@@ -355,16 +355,16 @@ make: *** [Makefile:388: deploy-ui] Error 1
 
 `aws sso login` reported success seconds earlier, and other Make targets (`make plan`, `make apply`, `make status`) work in the same shell.
 
-**Root cause**: Same class of bug as 1.6 / handoff §2 (Terraform SSO poisoning). The parent shell exports `AWS_ACCESS_KEY_ID=` (empty) or a stale value from a prior `.env*` source, and the AWS SDK's credential chain prefers env vars over the SSO profile. The other recipes were patched with an `unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN AWS_SECURITY_TOKEN;` prefix (the `_TF_AWS` macro at the top of the Makefile), but each Make recipe line runs in its own shell — so every `aws` / `terraform` invocation needs the unset on its own line. `deploy-ui` was missed.
+**Root cause**: Same class of bug as 1.6 / handoff §2 (Terraform SSO poisoning). The parent shell exports `AWS_ACCESS_KEY_ID=` (empty) or a stale value from a prior `.env*` source, and the AWS SDK's credential chain prefers env vars over the SSO profile. The other recipes were patched with an `unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN AWS_SECURITY_TOKEN;` prefix (the `_AWS_ENV` macro at the top of the Makefile, or `_TF` for `terraform` calls), but each Make recipe line runs in its own shell — so every `aws` / `terraform` invocation needs the unset on its own line. `deploy-ui` was missed.
 
-**Fix**: Prefix every `aws` call in the `deploy-ui` recipe with `$(_TF_AWS)` (which expands to `unset AWS_* … ; AWS_PROFILE=$(AWS_PROFILE)`). Already applied — if you see this on a fresh checkout, confirm the recipe matches:
+**Fix**: Prefix every `aws` call in the `deploy-ui` recipe with `$(_AWS_ENV)` (which expands to `unset AWS_* … ; AWS_PROFILE=$(AWS_PROFILE)`). Already applied — if you see this on a fresh checkout, confirm the recipe matches:
 
 ```bash
-grep -A1 'deploy-ui:' deploy/providers/AWS/Makefile | grep -c '_TF_AWS'
-# Expect ≥ 4 (s3 sync + 2× s3 cp + cloudfront create-invalidation)
+sed -n '/^deploy-ui:/,/^$/p' deploy/providers/AWS/Makefile | grep -c '_AWS_ENV'
+# Expect 6 (2× terraform output + s3 sync + 2× s3 cp + cloudfront create-invalidation)
 ```
 
-**Prevention**: When adding a new Make recipe that calls `aws`, `terraform`, `ansible`, or any script that uses boto3 / the AWS SDK, always prefix with `$(_TF_AWS)` (or `unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN AWS_SECURITY_TOKEN;` for bare lines). Never trust the parent shell's AWS env vars.
+**Prevention**: When adding a new Make recipe that calls `aws`, `terraform`, `ansible`, or any script that uses boto3 / the AWS SDK, always prefix with `$(_AWS_ENV)` (or `$(_TF)` for `terraform`, or a bare `unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN AWS_SECURITY_TOKEN;` on lines that run neither macro). Never trust the parent shell's AWS env vars.
 
 ### 2.8 Trust EC2 Orthanc is empty — all image pulls go straight to QueueFailed
 

--- a/deploy/providers/AWS/s3_logging.tf
+++ b/deploy/providers/AWS/s3_logging.tf
@@ -20,8 +20,20 @@
 # Retention: 90 days for compliance auditing.
 ############################
 
+locals {
+  # Kept as a plan-time-known string rather than referencing
+  # aws_s3_bucket.flip_access_logs.id: the module's
+  # aws_s3_bucket_logging.this is count-gated on logging_target_bucket, and a
+  # count cannot depend on a not-yet-created bucket's .id (unknown until
+  # apply) — passing .id makes `terraform plan` fail with "Invalid count
+  # argument" on any environment where this bucket does not yet exist. The
+  # module callers pass this local; first-apply ordering is still guaranteed
+  # by their `depends_on = [aws_s3_bucket_acl.flip_access_logs]`.
+  access_logs_bucket_name = "flip-access-logs-${var.flip_alb_subdomain}"
+}
+
 resource "aws_s3_bucket" "flip_access_logs" {
-  bucket = "flip-access-logs-${var.flip_alb_subdomain}"
+  bucket = local.access_logs_bucket_name
 
   tags = {
     Name = "flip-access-logs"

--- a/deploy/providers/AWS/services.tf
+++ b/deploy/providers/AWS/services.tf
@@ -51,7 +51,7 @@ module "flip_model_files_uploads_bucket" {
   cors_methods          = ["POST"]
   cors_allowed_origins  = ["https://${var.flip_alb_subdomain}"]
   kms_key_arn           = aws_kms_key.flip_app_key.arn
-  logging_target_bucket = aws_s3_bucket.flip_access_logs.id
+  logging_target_bucket = local.access_logs_bucket_name
   mfa_delete_protection = true
   # The module enables server access logging to flip_access_logs; force it
   # to wait for the LogDelivery ACL grant on that destination bucket so the
@@ -65,7 +65,7 @@ module "flip_fl_results_bucket" {
   cors_methods          = ["GET"]
   cors_allowed_origins  = ["https://${var.flip_alb_subdomain}"]
   kms_key_arn           = aws_kms_key.flip_app_key.arn
-  logging_target_bucket = aws_s3_bucket.flip_access_logs.id
+  logging_target_bucket = local.access_logs_bucket_name
   mfa_delete_protection = true
   depends_on            = [aws_s3_bucket_acl.flip_access_logs]
 }
@@ -74,7 +74,7 @@ module "flip_app_bundles_bucket" {
   source      = "./modules/flip_s3_bucket"
   bucket_name = var.FLIP_APP_BUNDLES_BUCKET_NAME
   # No CORS: flip-api is the only consumer and reaches the bucket via boto3.
-  logging_target_bucket = aws_s3_bucket.flip_access_logs.id
+  logging_target_bucket = local.access_logs_bucket_name
   kms_key_arn           = aws_kms_key.flip_app_key.arn
   depends_on            = [aws_s3_bucket_acl.flip_access_logs]
 }


### PR DESCRIPTION
Stacked on #499 (`fix/security-aws-infra-harden`) — **targets that branch, not `develop`.** Two of these are deploy-blocking and were caught during re-review by running `make plan PROD=stag` and exercising the Makefile macros in a shell; the other two are doc/consistency fixes from the same pass.

## Blocking

**1. `terraform plan`/`apply` failed on every environment without the access-logs bucket** — `modules/flip_s3_bucket/main.tf:134`
`aws_s3_bucket_logging.this` is `count`-gated on `logging_target_bucket`, but `services.tf` passed `aws_s3_bucket.flip_access_logs.id` — a *new* bucket, so its `.id` is unknown at plan time and a `count` can't depend on an unknown. Result: three `Invalid count argument` errors, so `make plan PROD=stag` fails on stag, prod, and every fresh deploy. `terraform validate` passes, which is why it slipped through. Fix: pass a plan-time-known `local.access_logs_bucket_name`; the existing `depends_on` on the ACL still guarantees first-apply ordering.

**2. `if ! $(_AWS_ENV) aws ecs …; then` inverted the deploy/rollback error guard** — `Makefile:551` (`deploy-centralhub`), `:610` (`rollback-centralhub`)
`_AWS_ENV` expands to `unset …; AWS_PROFILE=…`; the `;` split the `if` condition so `!` bound to `unset`. On a *successful* `update-service` the failure handler ran (deregistering the just-deployed task-def and aborting); a real failure was silently swallowed. Fix: subshell-wrap → `if ! ( $(_AWS_ENV) aws … ); then`.

## Non-blocking (same re-review pass)

**3. `_TF_AWS` macro doesn't exist** — `TROUBLESHOOTING.md` §2.7. Real name is `_AWS_ENV`; the doc's `grep -c '_TF_AWS'` returned 0 (not "≥ 4"), and its "fix" instruction (prefix `$(_TF_AWS)` → empty) would have stripped the `unset` protection. Corrected the references and the verification command.

**4. `make check` ran `check_status.py` with poisoned creds** — `Makefile:841`. Added the `unset …;` prefix that its sibling `status` target (line 834) already carries.

## Verification
- `terraform fmt -check` clean; `terraform validate` Success.
- `make plan PROD=stag` → `Plan: 28 to add, 6 to change, 9 to destroy`, **0 errors** (before: 3× `Invalid count argument`).
- Makefile parses (`make -n`); the wrapped guard expands to `if ! ( unset …; AWS_PROFILE=stag aws ecs … )`; guard inversion + subshell fix shell-tested directly.

## Not included — worth a follow-up on #499 itself
- `check_status.py:568-573` — the new "crashed vs SSH-unavailable" branch is effectively dead code: `run_ssh_command` returns `str(e)` (discards remote stderr), so `"Traceback" in output` is never true and a real `xnat-web`-down still reports benign INFO. Would need `run_ssh_command` to surface `e.stderr`.
- `s3_logging.tf:72-73` — the "S3 access logging does not support SSE-KMS on the destination" rationale is outdated (it's supported with an S3 Bucket Key); the AES256 decision is fine, only the stated reason.
- The #499 body still says "`$(_TF)` / `$(_TF_AWS)` macros" — worth correcting there too.

cc @garciadias — these stack onto your branch; merging this PR folds them in.
