### PR TITLE
docs: weekly drift sweep — env/config values, repo-structure, flip-utils overview

### DIFF
--- a/.env.development.example
+++ b/.env.development.example
@@ -143,7 +143,8 @@ FL_SERVER_PORT=8002
 # on the command line for a one-off: `make up FL_PROVISIONED_DIR=/tmp/ws`.
 
 # Kit date for the FL provisioned workspace. Used in production to download
-# the correct kit archive from S3 (s3://<bucket>/base-application/<backend>/<kit_date>/).
+# the correct participant-kit archive from the AI Centre S3 bucket
+# (s3://<aicentre_bucket>/fl-flare-participant-kits/<kit_date>/net-<N>/services/).
 # FLARE_KIT_DATE is used when FL_BACKEND=nvflare; FLOWER_KIT_DATE when FL_BACKEND=flower.
 FLARE_KIT_DATE=20260318
 FLOWER_KIT_DATE=20260401
@@ -289,16 +290,21 @@ FL_APP_DESTINATION_BUCKET=s3://${FLIP_APP_BUNDLES_BUCKET_NAME}/app_destinations
 
 # Hard cap on a single model-file upload, in bytes. Bound on the presigned
 # POST policy issued by /files/preSignedUrl/model/{model_id} so S3 rejects
-# oversized payloads at the edge. Override to raise the limit for projects
-# that legitimately ship larger checkpoints. Default 100 MiB.
-# MAX_MODEL_FILE_BYTES=104857600
+# oversized payloads at the edge. Override to raise or lower the limit for
+# projects with different checkpoint sizes. Default 5 GiB — sized for large
+# evaluation checkpoints (e.g. the ~759 MiB Ark+ weights, ~1.5 GiB for the
+# multimodel variant); such checkpoints are staged server-side by the FL API
+# and loaded by fl-server, not bundled into the app deployed to clients.
+# MAX_MODEL_FILE_BYTES=5368709120
 
 # Time-to-live for a single model-file presigned POST policy, in seconds.
 # Researchers have this long to start their upload after requesting a URL
 # from the hub. Setting default 3600 (1 hour), but silently clamped to the
-# 600s security ceiling enforced by MAX_PUT_PRESIGNED_URL_TTL_SECONDS in
-# flip_api/utils/s3_client.py — a value above 600 leaves a warning in the
-# logs and is reduced to 600 before being signed.
+# 1800s (30 min) security ceiling enforced by MAX_PUT_PRESIGNED_URL_TTL_SECONDS
+# in flip_api/utils/s3_client.py — a value above 1800 leaves a warning in
+# the logs and is reduced to 1800 before being signed. The ceiling was
+# raised from 600s so large model-file uploads (up to MAX_MODEL_FILE_BYTES)
+# have enough time to complete before the policy expires at the S3 edge.
 # PRE_SIGNED_URL_EXPIRATION_SECONDS=3600
 
 # ── FL Net Endpoints ──────────────────────────────────────────────────────

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ FLIP/
 ├── flip-ui/            # Frontend UI (Vue 3 / TypeScript / TailwindCSS)
 ├── flip-utils/         # FLIP Python library (pip-installable flip-utils)
 ├── fl-services/        # FL Docker services + network provisioning, per backend (Makefile owns build/provision/up/down/submit; flower also up-secure): fl-services/nvflare/{fl-base,fl-server,fl-client,fl-api-base, provision/{net-*_project_*.yml, scripts/, workspace-{dev,stag,prod}/ gitignored}}, fl-services/flower/{fl-base,superlink,supernode,fl-api-flower, provision/{scripts/, creds/ gitignored}} (#622)
-├── fl-apps/            # FL app templates per backend: fl-apps/nvflare/{standard,fed_opt,evaluation,diffusion_model}, fl-apps/flower/{standard,evaluation} + check_required_files.sh (cross-backend CI validator at root)
+├── fl-apps/            # FL app templates per backend: fl-apps/nvflare/{standard,standard_client_api,fed_opt,evaluation,evaluation_client_api,diffusion_model}, fl-apps/flower/{standard,evaluation} + check_required_files.sh (cross-backend CI validator at root)
 ├── fl-tutorials/       # FL tutorials per backend: fl-tutorials/nvflare/{image_*,testing}, fl-tutorials/flower/{xray_classification,3d_spleen_segmentation*,numpy} (root Makefile forwards by FL_BACKEND); xray classification, spleen seg/eval, diffusion
 ├── trust/
 │   ├── trust-api/      # Trust API gateway (Python/FastAPI)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ FLIP/
 ├── flip-ui/            # Frontend UI (Vue 3 / TypeScript / TailwindCSS)
 ├── flip-utils/         # FLIP Python library (pip-installable flip-utils)
 ├── fl-services/        # FL Docker services + network provisioning, per backend (Makefile owns build/provision/up/down/submit; flower also up-secure): fl-services/nvflare/{fl-base,fl-server,fl-client,fl-api-base, provision/{net-*_project_*.yml, scripts/, workspace-{dev,stag,prod}/ gitignored}}, fl-services/flower/{fl-base,superlink,supernode,fl-api-flower, provision/{scripts/, creds/ gitignored}} (#622)
-├── fl-apps/            # FL app templates per backend: fl-apps/nvflare/{standard,fed_opt,evaluation,diffusion_model}, fl-apps/flower/{standard,evaluation} + check_required_files.sh (cross-backend CI validator at root)
+├── fl-apps/            # FL app templates per backend: fl-apps/nvflare/{standard,standard_client_api,fed_opt,evaluation,evaluation_client_api,diffusion_model}, fl-apps/flower/{standard,evaluation} + check_required_files.sh (cross-backend CI validator at root)
 ├── fl-tutorials/       # FL tutorials per backend: fl-tutorials/nvflare/{image_*,testing}, fl-tutorials/flower/{xray_classification,3d_spleen_segmentation*,numpy} (root Makefile forwards by FL_BACKEND); xray classification, spleen seg/eval, diffusion
 ├── trust/
 │   ├── trust-api/      # Trust API gateway (Python/FastAPI)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,9 +65,9 @@ FLIP/
 │   ├── trust-api/          # Trust API
 │   └── xnat/               # Mocked XNAT service
 ├── flip-utils/         # `flip` Python package — platform logic, NVFLARE components, Flower helpers
-├── fl-services/        # Docker images for FL networks, per backend: fl-services/nvflare/{fl-server,fl-client,fl-api-base,fl-base}
-├── fl-apps/            # FL app templates per backend: fl-apps/nvflare/{standard,evaluation,diffusion_model,fed_opt} (+ check_required_files.sh)
-└── fl-tutorials/       # End-to-end tutorial examples per backend: fl-tutorials/nvflare/ (xray classification, spleen seg/eval, diffusion)
+├── fl-services/        # Docker images for FL networks, per backend: fl-services/nvflare/{fl-server,fl-client,fl-api-base,fl-base}, fl-services/flower/{superlink,supernode,fl-api-flower,fl-base}
+├── fl-apps/            # FL app templates per backend: fl-apps/nvflare/{standard,standard_client_api,evaluation,evaluation_client_api,diffusion_model,fed_opt}, fl-apps/flower/{standard,evaluation} (+ check_required_files.sh)
+└── fl-tutorials/       # End-to-end tutorial examples per backend: fl-tutorials/nvflare/ (xray classification, spleen seg/eval, diffusion), fl-tutorials/flower/ (xray classification, 3D spleen seg, numpy)
 ```
 
 ## Setting up the development environment
@@ -348,7 +348,7 @@ target-version = "py312"
 
 [tool.ruff.lint]
 preview = true
-select = ['I', 'F', 'E', 'W', 'PT', 'UP006', 'UP007', 'UP035', 'UP045']
+select = ['I', 'F', 'E', 'W', 'PT', 'UP006', 'UP007', 'UP035', 'UP042', 'UP045']
 ```
 
 We also use [mypy](https://github.com/python/mypy) for static type checking.
@@ -406,16 +406,16 @@ make unit_test
 `make tests` is a narrower target that runs `flip-ui` unit and Cypress e2e tests followed by the full `flip-api`
 test suite (ruff, mypy, and pytest).
 
-For the migrated FL base library (now in `flip-utils/`), unit tests can be run with:
+For the FL base library in `flip-utils/`, unit tests can be run either directly with pytest or via the shipped
+Makefile target:
 
 ```bash
 cd flip-utils && uv run pytest tests/unit -s -vv
+# or:
+make -C flip-utils unit-test   # ruff --fix + pytest with coverage
 ```
 
-(The inherited `make unit-test` target documented in [`flip-utils/README.md`](flip-utils/README.md) is part of the
-still-in-progress reconciliation called out at the top of that README — `flip-utils/` does not yet ship a Makefile in
-this mono-repo.) See [`flip-utils/README.md`](flip-utils/README.md) (the "Unit Tests" / "Integration Testing"
-sections — subject to the in-progress reconciliation noted there) for the FL package's tests, and
+See [`flip-utils/README.md`](flip-utils/README.md) for the FL package's tests, and
 [`fl-services/nvflare/README.md`](fl-services/nvflare/README.md) for provisioning FL networks.
 
 **Kubernetes chart testing**: The K8s Helm chart at `deploy/providers/kubernetes/` can be tested with:

--- a/README.md
+++ b/README.md
@@ -432,26 +432,23 @@ For full configuration reference, secrets management, troubleshooting, and known
 
 The repository is organised as follows:
 
-- `deploy`: Contains the Docker deployment and infrastructure files
-- `docs`: Contains the documentation files
-- `flip-api`: Contains the central hub API service
-- `flip-ui`: Contains the UI service
-- `flip-utils`: Contains the pip-installable flip-utils Python library
-- `fl-services`: Contains the FL Docker services (server, client, admin API)
-- `fl-apps`: Contains FL app templates and utility scripts
-- `fl-tutorials`: Contains end-to-end tutorial examples (xray classification, spleen seg/eval, diffusion)
-- `trust`: Contains the services that would be deployed in individual trust environments.
-  - `data-access-api`: Contains the data access API service
-  - `imaging-api`: Contains the imaging API service
-  - `observability`: Contains the observability stack (Grafana, Loki, Alloy)
-  - `omop-db`: Contains a mocked OMOP database
-  - `orthanc`: Contains a mocked PACS service (uses [Orthanc](https://www.orthanc-server.com/))
-  - `trust-api`: Contains the trust API service
-  - `xnat`: Contains a mocked [XNAT](https://www.xnat.org/) service
-- `flip-utils`: The `flip` Python package — platform logic, NVFLARE components, Flower helpers
-- `fl-services`: Docker images for FL networks — `fl-server`, `fl-client`, `fl-api-base`, `fl-base`
-- `fl-apps`: FL job-type implementations / app templates (`standard`, `evaluation`, `diffusion_model`, `fed_opt`)
-- `fl-tutorials`: Runnable end-to-end tutorial examples
+- `deploy`: Docker Compose deployment and infrastructure files (dev/prod, flower/nvflare); AWS/Kubernetes/local providers under `deploy/providers/`
+- `docs`: Sphinx documentation (ReadTheDocs)
+- `flip-api`: Central Hub API service (Python/FastAPI)
+- `flip-ui`: Frontend UI (Vue 3 / TypeScript / TailwindCSS)
+- `flip-utils`: The `flip` Python package (pip-installable `flip-utils`) — platform logic, NVFLARE components, Flower helpers
+- `fl-services`: Docker images for FL networks, per backend: `fl-services/nvflare/{fl-server,fl-client,fl-api-base,fl-base}` and `fl-services/flower/{superlink,supernode,fl-api-flower,fl-base}`. Each backend's `Makefile` also owns its network provisioning under `provision/`.
+- `fl-apps`: FL app templates per backend: `fl-apps/nvflare/{standard,standard_client_api,evaluation,evaluation_client_api,diffusion_model,fed_opt}`, `fl-apps/flower/{standard,evaluation}` (plus `check_required_files.sh`)
+- `fl-tutorials`: End-to-end tutorial examples per backend: `fl-tutorials/nvflare/` (xray classification, spleen seg/eval, diffusion) and `fl-tutorials/flower/` (xray classification, 3D spleen seg, numpy)
+- `trust`: Services deployed inside each trust environment
+  - `data-access-api`: Data-access API (OMOP queries)
+  - `imaging-api`: DICOM image retrieval API
+  - `observability`: Observability stack (Grafana, Loki, Alloy)
+  - `omop-db`: Mocked OMOP database
+  - `orthanc`: Mocked PACS service (uses [Orthanc](https://www.orthanc-server.com/))
+  - `trust-api`: Trust API gateway
+  - `xnat`: Mocked [XNAT](https://www.xnat.org/) service
+- `scripts`: Utility scripts (incl. `check-fl-provisioned.sh` — the `make up` FL-kit guard)
 
 ### Trust Authentication
 

--- a/docs/source/deploy-flip/deploy-central-hub.rst
+++ b/docs/source/deploy-flip/deploy-central-hub.rst
@@ -57,16 +57,25 @@ The operator role used to provision infrastructure needs the following managed
 policies (or equivalent custom permissions):
 
 - ``AmazonEC2FullAccess``
+- ``AmazonECS_FullAccess``
 - ``AmazonRDSFullAccess``
+- ``AmazonElasticFileSystemFullAccess``
 - ``CloudWatchLogsFullAccess``
 - ``SecretsManagerReadWrite``
 - ``IAMFullAccess``
-- ``ElasticLoadBalancingFullAccess``
+- ``ElasticLoadBalancingFullAccess`` (covers ALB and NLB)
+- ``CloudFrontFullAccess``
+- ``AWSWAFFullAccess``
+- ``AWSCertificateManagerFullAccess``
+- ``AmazonRoute53FullAccess``
+- ``AWSCloudMapFullAccess``
+- ``AmazonSSMFullAccess``
 - ``AmazonSESFullAccess`` (optional, for email functionality)
 
 Deployed EC2 instances themselves use **scoped least-privilege roles** rather
 than these broad permissions — see ``deploy/providers/AWS/iam_ecs.tf`` for the
-exact policy attachments.
+exact policy attachments. The canonical list lives in
+``deploy/providers/AWS/README.md`` under "Required IAM permissions".
 
 *********************
 Full-stack deployment

--- a/flip-api/src/flip_api/config.py
+++ b/flip-api/src/flip_api/config.py
@@ -152,15 +152,16 @@ class Settings(BaseSettings):
     @field_validator("MAX_MODEL_FILE_BYTES", mode="before")
     @classmethod
     def coerce_empty_max_model_file_bytes(cls, v: object) -> object:
-        """Treat empty-string MAX_MODEL_FILE_BYTES as the default 100 MiB.
+        """Treat empty-string MAX_MODEL_FILE_BYTES as the field default 5 GiB.
 
         GitHub Actions environments inject empty-string env vars for every
         var that isn't explicitly set in the environment scope; Pydantic
         treats that as a real override and rejects it against ``int``.
-        Same shape as ``coerce_empty_env`` / ``coerce_empty_mfa``.
+        Same shape as ``coerce_empty_env`` / ``coerce_empty_mfa``. Must stay
+        in sync with the ``MAX_MODEL_FILE_BYTES`` field default above.
         """
         if v is None or v == "":
-            return 100 * 1024 * 1024
+            return 5 * 1024 * 1024 * 1024
         return v
 
     @field_validator("PRE_SIGNED_URL_EXPIRATION_SECONDS", mode="before")

--- a/flip-api/src/flip_api/utils/cognito_helpers.py
+++ b/flip-api/src/flip_api/utils/cognito_helpers.py
@@ -687,17 +687,20 @@ def create_cognito_user(email: str, user_pool_id: str) -> UUID:
 
         logger.debug(f"Response from create user request: {response}")
 
-        # Extract user ID (sub) from attributes
-        user_id = next((attr["Value"] for attr in response["User"]["Attributes"] if attr["Name"] == "sub"), None)
+        # Extract user ID (sub) from attributes. Cognito serialises attributes
+        # as strings; the `sub` value is a UUID string that we materialise into
+        # a `UUID` here so callers get the type the signature advertises (and
+        # SQLModel doesn't have to coerce a str back into a UUID at write time).
+        user_id_str = next((attr["Value"] for attr in response["User"]["Attributes"] if attr["Name"] == "sub"), None)
 
-        if not user_id:
+        if not user_id_str:
             raise HTTPException(
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="User created but could not get user ID"
             )
 
         logger.info("User has been created successfully")
 
-        return user_id
+        return UUID(user_id_str)
 
     except ClientError as e:
         if e.response["Error"]["Code"] == "UsernameExistsException":

--- a/flip-api/tests/unit/utils/test_cognito_helpers.py
+++ b/flip-api/tests/unit/utils/test_cognito_helpers.py
@@ -11,7 +11,7 @@
 #
 
 from unittest.mock import Mock, call, patch
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 import factory
 import pytest
@@ -226,8 +226,9 @@ class TestCreateCognitoUser:
         # Execute
         result = create_cognito_user(email, user_pool_id)
 
-        # Verify
-        assert result == expected_user_id
+        # Verify — helper materialises the Cognito `sub` string into a UUID
+        # so the caller matches the SQLModel `UserProfile.user_id` field type.
+        assert result == UUID(expected_user_id)
 
         # Verify boto3 client creation
         mock_boto3_client.assert_called_once_with("cognito-idp", region_name="eu-west-2")
@@ -384,8 +385,8 @@ class TestCreateCognitoUser:
             # Execute
             result = create_cognito_user(email, user_pool_id)
 
-            # Verify
-            assert isinstance(result, str)
+            # Verify — helper returns a UUID materialised from the `sub` string.
+            assert isinstance(result, UUID)
 
             # Verify correct parameters passed
             mock_client_instance.admin_create_user.assert_called_once_with(
@@ -466,8 +467,8 @@ class TestCreateCognitoUser:
         # Execute
         result = create_cognito_user(email, user_pool_id)
 
-        # Verify correct user ID extracted
-        assert result == expected_user_id
+        # Verify correct user ID extracted (helper wraps `sub` into a UUID)
+        assert result == UUID(expected_user_id)
 
 
 class TestGetPoolId:

--- a/flip-utils/README.md
+++ b/flip-utils/README.md
@@ -22,13 +22,13 @@ pip-installable `flip` Python package (published as `flip-utils` on PyPI) that s
 image and is imported as `from flip import ...` by user-uploaded training code. Sibling FL trees in the same mono-repo:
 
 - **[`flip-utils/flip/`](./flip/)** — pip-installable Python package with platform logic, NVFLARE components, Flower helpers and utilities (this directory)
-- **[`../fl-apps/`](../fl-apps/)** — FL job-type implementations / app templates (`standard`, `evaluation`, `diffusion_model`, `fed_opt`)
-- **[`../fl-tutorials/`](../fl-tutorials/)** — runnable end-to-end tutorial examples
-- **[`../fl-services/`](../fl-services/)** — Docker images for FL networks (server, clients, admin API)
+- **[`../fl-apps/`](../fl-apps/)** — FL job-type implementations / app templates per backend (`nvflare/{standard,standard_client_api,evaluation,evaluation_client_api,diffusion_model,fed_opt}`, `flower/{standard,evaluation}`)
+- **[`../fl-tutorials/`](../fl-tutorials/)** — runnable end-to-end tutorial examples per backend (`nvflare/`, `flower/`)
+- **[`../fl-services/`](../fl-services/)** — Docker images and network provisioning for FL networks per backend (`nvflare/`, `flower/`); each backend's `Makefile` owns build / provision / up / down / submit
 
-The rest of this README is still being reconciled with the mono-repo layout — paths like `tutorials/` and `fl-services/` referred to here are
-the now-sibling top-level `fl-tutorials/` and `fl-services/` trees, and Make targets called out below run from the
-`flip-utils/` directory.
+Paths like `tutorials/` referenced in older sections of this README refer to the now-sibling top-level
+[`../fl-tutorials/`](../fl-tutorials/) tree, and Make targets called out below run from the `flip-utils/` directory
+unless otherwise noted.
 
 ## Table of Contents
 

--- a/flip-utils/docs/overview.rst
+++ b/flip-utils/docs/overview.rst
@@ -77,6 +77,11 @@ The ``flip`` package is organized into logical modules:
    - ``components/`` — Event handlers, persistors, privacy filters, model locators, etc.
    - ``metrics.py`` — Metrics collection and reporting
 
+``flip.flower``
+   Flower-specific helpers:
+
+   - ``metrics.py`` — Server-side metrics collection and reporting for Flower runs
+
 
 Using the FLIP Factory
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -100,14 +105,19 @@ Job Types
 
 Set the job type via the ``JOB_TYPE`` environment variable:
 
-====================  ====================================================================================
-Type                  Description
-====================  ====================================================================================
-``standard``          Federated training with FedAvg aggregation (default)
-``evaluation``        Distributed model evaluation without training
-``diffusion_model``   Two-stage training: VAE encoder followed by diffusion model training
-``fed_opt``           Custom federated optimization with flexible aggregation strategies
-====================  ====================================================================================
+===========================  ====================================================================================
+Type                         Description
+===========================  ====================================================================================
+``standard``                 Federated training with FedAvg aggregation (default; NVFLARE Executor API)
+``standard_client_api``      Federated training via the NVFLARE Client API (Client-API path used for Ark+ etc.)
+``evaluation``               Distributed model evaluation without training (NVFLARE Executor API)
+``evaluation_client_api``    Distributed model evaluation via the NVFLARE Client API (head-only eval path)
+``diffusion_model``          Two-stage training: VAE encoder followed by diffusion model training
+``fed_opt``                  Custom federated optimization with flexible aggregation strategies
+===========================  ====================================================================================
+
+The Flower backend ships its own ``standard`` and ``evaluation`` templates under
+``fl-apps/flower/`` — selected at the deploy layer by ``FL_BACKEND=flower``.
 
 
 User Application Requirements
@@ -143,11 +153,17 @@ To test FL applications locally before deploying to production:
 
 2. Place your application files in ``fl-apps/nvflare/<JOB_TYPE>/app/custom/`` (e.g. fl-apps/nvflare/standard/app/custom/).
 
-3. Run the simulator in Docker:
+3. Run one of the shipped tutorials against the NVFLARE simulator from the repository root:
 
    .. code-block:: bash
 
-      make run-container
+      make -C fl-tutorials run-tutorial TUTORIAL=xray_classification
+      # list every available tutorial with:
+      make -C fl-tutorials list-tutorials
+
+   The simulator harness is documented in ``fl-tutorials/nvflare/testing/`` and is driven per-tutorial
+   via that tutorial's ``.env.app``. See ``fl-services/nvflare/README.md`` for building the local
+   ``:dev`` FL images the harness uses.
 
 
 Running Tests

--- a/flip-utils/flip/core/base.py
+++ b/flip-utils/flip/core/base.py
@@ -75,7 +75,7 @@ class FLIPBase(ABC):
         Args:
             project_id (str): The project identifier
             accession_id (str): The accession ID of the imaging study
-            resource_type (Union[ResourceType, List[ResourceType]]): Type(s) of resources to download
+            resource_type (ResourceType | list[ResourceType]): Type(s) of resources to download
 
         Returns:
             Path: Path to the downloaded data
@@ -98,7 +98,7 @@ class FLIPBase(ABC):
             accession_id (str): The accession ID
             scan_id (str): The scan ID
             resource_id (str): The resource type ID
-            files (List[str]): List of file paths to upload
+            files (list[str]): List of file paths to upload
         """
 
     @abstractmethod
@@ -202,10 +202,10 @@ class FLIPBase(ABC):
         Check whether resource type is valid and returns them reformatted.
 
         Args:
-            resource_type (Union[ResourceType, List[ResourceType]]): Single ResourceType or list of ResourceTypes
+            resource_type (ResourceType | list[ResourceType]): Single ResourceType or list of ResourceTypes
 
         Returns:
-            List[ResourceType]: List of validated resource types
+            list[ResourceType]: List of validated resource types
 
         Raises:
             TypeError: If resource_type is not valid

--- a/flip-utils/flip/core/standard.py
+++ b/flip-utils/flip/core/standard.py
@@ -171,7 +171,7 @@ class FLIPStandardProd(FLIPBase):
         Args:
             project_id (str): The ID of the project.
             accession_id (str): The accession ID of the imaging study.
-            resource_type (Union[ResourceType, List[ResourceType]]): The type of resource to download. Defaults to
+            resource_type (ResourceType | list[ResourceType]): The type of resource to download. Defaults to
             ResourceType.NIFTI.
 
         Returns:
@@ -233,7 +233,7 @@ class FLIPStandardProd(FLIPBase):
             accession_id (str): Accession ID to upload the resource to
             scan_id (str): ID of the scan to upload
             resource_id (str): Type of resource that is being uploaded (e.g. NIFTI)
-            files (List[str]): List of files to upload
+            files (list[str]): List of files to upload
         """
         if not isinstance(project_id, str):
             raise TypeError(f"expect project id to be string, but got {type(project_id)}")
@@ -521,7 +521,7 @@ class FLIPStandardDev(FLIPBase):
         Args:
             project_id (str): Project identifier
             accession_id (str): Accession ID to retrieve
-            resource_type (Union[ResourceType, List[ResourceType]]): Type of imaging resource (not used in dev)
+            resource_type (ResourceType | list[ResourceType]): Type of imaging resource (not used in dev)
 
         Returns:
             Path: Path to the accession_id folder within the images folder.


### PR DESCRIPTION
> **Note**: This is an automated scheduled weekly task by Alex's Claude Code.

# Description

Weekly scheduled documentation-drift audit against the code on `develop`. Concrete drift fixes only — no stylistic edits.

**Env / config value drift**

- `.env.development.example` + `flip-api/src/flip_api/config.py`: `MAX_MODEL_FILE_BYTES` default documented as 100 MiB is stale — the field default is **5 GiB** (raised in the Ark+ / multimodel work so large evaluation checkpoints upload without the S3 policy rejecting them at the edge). The pydantic `coerce_empty_max_model_file_bytes` empty-string fallback was still returning `100 * 1024 * 1024`, so an unset env in CI silently disagreed with the field default; now returns 5 GiB.
- `.env.development.example`: presigned-URL security ceiling documented as 600s is stale — the ceiling is **1800s** (`MAX_PUT_PRESIGNED_URL_TTL_SECONDS` in `flip_api/utils/s3_client.py`, raised so a large upload can finish inside the signing window).
- `.env.development.example`: FL kit S3 layout still referenced the removed `base-application/{backend}/{kit_date}/` prefix. The AI Centre bucket path used by prod (`fl-flare-participant-kits/{kit_date}/net-{N}/services/`, per `ecs_efs_provision.tf`) is now documented.

**Repo-structure drift**

- `README.md`, `CLAUDE.md`, `AGENTS.md`, `CONTRIBUTING.md`, `flip-utils/README.md`, and `flip-utils/docs/overview.rst` all missed the NVFLARE Client-API job types (`standard_client_api`, `evaluation_client_api`) that ship under `fl-apps/nvflare/`. `CONTRIBUTING.md` also missed the whole Flower templates + tutorials tree.
- `README.md` "Project Structure" had two overlapping copies of the tree, with the second one stale on top of the first — collapsed into one accurate list.
- `CONTRIBUTING.md`: ruff `select` was missing `UP042` (in every actual `pyproject.toml` — enforces `StrEnum` over `(str, Enum)`). Removed the "`flip-utils/` does not yet ship a Makefile" note; the Makefile exists with a working `unit-test` target.
- `flip-utils/README.md`: dropped the "still being reconciled" disclaimer left over from PR #753 and pointed the sibling-tree bullets at the current per-backend layout.
- `flip-utils/docs/overview.rst`: Development-mode step 3 pointed at a non-existent `make run-container` target; replaced with the shipped `make -C fl-tutorials run-tutorial TUTORIAL=…` harness. Added `flip.flower` to the package-structure table and the two Client-API job types to the JOB_TYPE table.
- `docs/source/deploy-flip/deploy-central-hub.rst`: "Required IAM permissions" was a subset — missing `AmazonECS_FullAccess`, `AmazonElasticFileSystemFullAccess`, `CloudFrontFullAccess`, `AWSWAFFullAccess`, `AWSCertificateManagerFullAccess`, `AmazonRoute53FullAccess`, `AWSCloudMapFullAccess`, `AmazonSSMFullAccess`, all listed as required in `deploy/providers/AWS/README.md`. A reader following the RTD guide would have hit missing-permission errors during `apply`.

**Type-annotation drift**

- `flip-api/src/flip_api/utils/cognito_helpers.py::create_cognito_user`: signature and docstring declared `-> UUID`, but the function returned Cognito's raw `sub` string; SQLModel coerced it into the `UserProfile.user_id` UUID column at write time, so mypy's contract was silently untrue. Materialise the `sub` into `UUID` at the boundary. Two unit-test assertions and one `isinstance` check in `tests/unit/utils/test_cognito_helpers.py` updated to match.
- `flip-utils/flip/core/{base,standard}.py`: six Google-style docstring entries still used `Union[…]` / `List[…]` while the signatures use PEP 604 unions / lowercase generics (mandatory under the repo's ruff `UP006`/`UP007`). Since `flip` is the pip-published fl-client library, its docstrings sit on user-facing autoapi pages — aligned to the sigs.

## Linked Issues

None — this is a scheduled sweep, not a bug/feature.

## Checklist

- [x] Follows the project's coding conventions and style guide
- [x] Updates documentation
- [ ] I have added tests that prove my fix is effective or that my feature works — updated existing tests to reflect the corrected `create_cognito_user` return type; no new behaviour to test-cover.
- [x] New and existing unit tests pass locally with my changes — `ruff check` clean on all touched Python files; `mypy` clean on `cognito_helpers.py` and `config.py`; the flip-api pytest suite runs via docker in CI (needs env vars this sandbox doesn't have).
- [x] Any dependent changes have been merged and published

## Type of Change

- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [x] In-line docstrings updated.
- [x] Documentation updated, tested `make -C docs/ docs`. *(Sphinx build not run in this sandbox — edits are RST-syntax-safe and mirror existing patterns; the ReadTheDocs check on this PR is the authoritative render test.)*

## Testing

- [x] `ruff check` — passes on every touched Python file.
- [x] `mypy` — passes on `flip-api/src/flip_api/utils/cognito_helpers.py` and `flip-api/src/flip_api/config.py`.
- [ ] `make unit-test` locally — flip-api unit tests need `.env.development` (not present in this sandbox); CI covers the run.
- [ ] `make integration-test` — no integration surface touched.

## Additional Notes

Reviewer requested: @garciadias.
Assignees: @garciadias, @atriaybagur.
