### PR TITLE
fix(security): isolate XNAT Container Service behind a Docker socket proxy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,8 +165,11 @@ cd flip-api && uv run python -m tests.e2e_smoke \
   --data-enrichment-cmd 'uv run upload_labels_to_XNAT.py --flip-project-id "$FLIP_PROJECT_ID"'
 ```
 
-(Through `make e2e_smoke`, pass the id literally instead — `--data-enrichment-cmd 'uv run
-upload_labels_to_XNAT.py --flip-project-id <uuid>'` — which works when reusing a project via `--project-id`.)
+(Through `make` there are two working forms: `make -C flip-api e2e_smoke_spleen`, whose in-Makefile
+`EXTRA_ARGS` carries `$$FLIP_PROJECT_ID` — a `$$` escape survives the single make expansion; or the root
+`make e2e_smoke` with the id passed literally — `--flip-project-id <uuid>` — when reusing a project via
+`--project-id`. The root wrapper re-expands `EXTRA_ARGS` through a second make and shell, so no `$`-escape
+survives it: `$$` lands empty and `$$$$` injects the recipe shell's PID.)
 
 Enrichment must land **after** the pull and after DICOM→NIfTI conversion; the hook's position guarantees that.
 The uploader derives each target filename from the converted `input_*.nii.gz`, so with no `NIFTI` resource it

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,6 +140,41 @@ create → upload → train → download. The image-pull wait still runs but ret
 studies are already pulled — so it lets you iterate on training/app code (and re-run after an upload
 or fl-api change) without re-creating the project and re-pulling DICOM (~6 min/backend) each time.
 
+**Smoking the spleen segmentation app requires a data-enrichment step (it needs labels).** *Data enrichment*
+is the platform stage where a model developer adds whatever an app needs on top of the pulled imaging data in
+XNAT (`docs/source/user-guides/user-common.rst` — a project cannot start training until enrichment is
+confirmed complete, even when nothing was added). **Segmentation apps need one:** the trust PACS supplies CT
+*images* only, while the spleen apps (`fl-tutorials/<backend>/3d_spleen_segmentation*`) pair each converted
+`input_*.nii.gz` with a sibling `label_*.nii.gz`. Skip it and the smoke pulls, converts, starts training and
+then dies with `num_samples=0` (preceded by `⚠️ No matching segmentation for input_*.nii.gz`) — which reads
+like an app or data-pull bug.
+
+`e2e_smoke` has a hook for exactly this: `--data-enrichment-cwd` + `--data-enrichment-cmd` run a shell command
+**between the image pull and training**, with `FLIP_PROJECT_ID` exported. For spleen the enrichment is
+`upload_labels_to_XNAT.py` from the **private** repo `londonaicentre/flip_project_spleen_segmentation` (needs
+its `.xnat1.cfg` / `.xnat2.cfg` — one per trust XNAT — and its MSD labels); it resolves each trust's XNAT
+project by `secondary_ID == <FLIP project_id>` and writes each label into the scan's existing `NIFTI` resource,
+renaming `input_` → `label_`. Invoke the smoke **directly** rather than through `make`, because `make` mangles
+the `$` in `EXTRA_ARGS` before the enrichment command reaches the shell:
+
+```bash
+cd flip-api && uv run python -m tests.e2e_smoke \
+  --model-files-dir ../fl-tutorials/nvflare/image_segmentation/3d_spleen_segmentation/app_files \
+  --query-file ../fl-tutorials/nvflare/image_segmentation/3d_spleen_segmentation/query.sql \
+  --data-enrichment-cwd <path-to>/flip_project_spleen_segmentation \
+  --data-enrichment-cmd 'uv run upload_labels_to_XNAT.py --flip-project-id "$FLIP_PROJECT_ID"'
+```
+
+(Through `make e2e_smoke`, pass the id literally instead — `--data-enrichment-cmd 'uv run
+upload_labels_to_XNAT.py --flip-project-id <uuid>'` — which works when reusing a project via `--project-id`.)
+
+Enrichment must land **after** the pull and after DICOM→NIfTI conversion; the hook's position guarantees that.
+The uploader derives each target filename from the converted `input_*.nii.gz`, so with no `NIFTI` resource it
+silently skips every scan (`-> skipped: no NIFTI resource`) and you get the same opaque `num_samples=0` — i.e.
+a broken XNAT Container Service surfaces as "no labels". Removing the private-repo dependency (so spleen is
+runnable outside the org and in CI) is tracked in FLIP#776. The xray classification tutorial reads DICOM
+directly and needs no enrichment.
+
 **Testing a change on BOTH FL backends in one sitting (the backend switch).** The pulled DICOM lives in
 each trust's Orthanc/XNAT, which `make restart-fl` leaves untouched — so you can pull once on the first
 backend and *reuse the same project* for the second, skipping the second image pull entirely:

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -316,8 +316,11 @@ on the host, start privileged containers, or mount arbitrary host paths.
 `xnat-web` no longer mounts the socket. The XNAT stack instead runs a
 [`tecnativa/docker-socket-proxy`](https://github.com/Tecnativa/docker-socket-proxy) sidecar
 (`xnat-socket-proxy` in `trust/xnat/docker-compose-stack.yml`) that holds the socket read-only
-and serves a filtered Docker API on the stack-internal network only (`tcp://xnat-socket-proxy:2375`,
-no published host port). The Container Service is pointed at that endpoint by
+and serves a filtered Docker API (`tcp://xnat-socket-proxy:2375`) on a dedicated stack-scoped
+overlay network (`<stack>_socket-proxy`, `internal: true`, no published host port). Only
+`xnat-web` is dual-homed onto that network — the other containers on the shared trust overlay
+(`trust-api`, `imaging-api`, `data-access-api`, `orthanc`, the fl-client) have no route to the
+proxy at all. The Container Service is pointed at that endpoint by
 `trust/xnat/xnat/config/container-service-backend-configuration.json`, which
 `configure-dcm2niix.sh` POSTs to `/xapi/docker/server` — and the configure run now hard-fails if
 `/xapi/docker/server/ping` cannot reach Docker through the proxy, instead of leaving a
@@ -329,13 +332,13 @@ The proxy allowlists only what a swarm-mode Container Service launch needs — `
 `PING`/`VERSION`/`EVENTS`. Everything else is refused with a 403: `exec`, the container API,
 volumes, networks, secrets, configs, plugins, and build.
 
-**Multiple trusts on one host.** Each trust's XNAT is a separate swarm stack on its own overlay
-network (`xnat<N>` on `deploy_trust-network-<N>`), so each gets its **own** proxy — they are not
-shared, which keeps the trust boundary intact. The identical `xnat-socket-proxy` service name in
-both stacks does not collide: swarm resolves it per-network, so each `xnat-web` reaches only its
-own proxy (cross-stack access is refused), and the proxy publishes no host port. Both proxies
-holding the same host socket is fine — it serves concurrent clients, exactly as it did when each
-`xnat-web` mounted it directly.
+**Multiple trusts on one host.** Each trust's XNAT is a separate swarm stack (`xnat<N>`), so each
+gets its **own** proxy on its **own** `xnat<N>_socket-proxy` network — they are not shared, which
+keeps the trust boundary intact. The identical `xnat-socket-proxy` service name in both stacks
+does not collide: swarm resolves it per-network, so each `xnat-web` reaches only its own proxy
+(cross-stack access is refused), and the proxy publishes no host port. Both proxies holding the
+same host socket is fine — it serves concurrent clients, exactly as it did when each `xnat-web`
+mounted it directly.
 
 This is a choke point, not a sandbox. Two residual powers are worth stating plainly: the services
 API the Container Service depends on can itself create a service with an arbitrary host bind

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -255,6 +255,7 @@ Each Dockerfile explicitly drops root privileges by running the application as a
 | xnat-web | `xnat` | Created in the XNAT Dockerfile (UID 1001) |
 | xnat-nginx | `nginx` | Pre-existing in the base image (`nginx`) |
 | xnat-db | `postgres` | Pre-existing in the base image (`postgres`) |
+| xnat-socket-proxy | `root` | Upstream `tecnativa/docker-socket-proxy` image — HAProxy connects to the root-owned Docker socket as its owner. Runs under `cap_drop: ALL` with no capabilities added back. |
 | flip-db / omop-db | `postgres` | Pre-existing in the base image (`postgres`) |
 
 **Bind-mount ownership.** Because XNAT (`xnat`, UID 1001) and Orthanc (`orthanc`, UID 999) no
@@ -283,6 +284,7 @@ crash-loop under `cap_drop: ALL`. The per-service grants in the compose files ar
 | flip-db, omop-db, xnat-db | `CHOWN`, `DAC_OVERRIDE`, `FOWNER`, `SETUID`, `SETGID` | The official postgres entrypoint runs as root and `gosu`-drops to the `postgres` user (`SETUID`/`SETGID`). On every start it re-runs `chmod 00700 $PGDATA` and a `chown` sweep over the persisted data dir, which on subsequent boots is already owned by `postgres` with mode `0700` — `chmod` on a dir owned by another uid needs `FOWNER` and traversing it needs `DAC_OVERRIDE`. Without them the container exits 1 on a persisted volume (see commit history, FLIP#485). |
 | orthanc | `CHOWN` | Runs non-root (UID 999) from PID 1, so no capabilities survive into the process anyway; the storage bind mount is made 999-writable at the provisioning layer rather than fixed up with in-container caps. `CHOWN` is kept only as the shared baseline. |
 | xnat-nginx | `CHOWN`, `NET_BIND_SERVICE` | `NET_BIND_SERVICE` lets the non-root `nginx` user bind port 80 (Docker sets `net.ipv4.ip_unprivileged_port_start=0`, but capabilities are still checked). |
+| xnat-socket-proxy | *(none)* | HAProxy runs as root, which owns the mounted Docker socket, so it connects with an empty capability set — nothing needs adding back on top of `cap_drop: ALL`. See [Docker Socket Isolation](#docker-socket-isolation-xnat-container-service). |
 | flip-ui (development only) | `CHOWN`, `DAC_OVERRIDE`, `SETUID`, `SETGID`, `NET_BIND_SERVICE` | Vite dev server with bind-mounted source; not present in production where the UI ships as static files served by CloudFront. |
 
 Notably **not** granted anywhere: `SYS_ADMIN`, `SYS_PTRACE`, `SYS_MODULE`, `MAC_*`, `AUDIT_*`,
@@ -303,6 +305,38 @@ container.
 > stack with the same `DOCKER_REGISTRY=`/`XNAT_TAG=dev` overrides so `docker stack deploy`
 > resolves the locally built image instead of the GHCR one.
 
+### Docker Socket Isolation (XNAT Container Service)
+
+XNAT's Container Service plugin launches processing containers — currently `xnat/dcm2niix`,
+which every project created with DICOM→NIfTI conversion enabled triggers automatically on scan
+archive. It used to do this through `/var/run/docker.sock` mounted straight into `xnat-web`,
+which is a root-equivalent capability: anything that compromises XNAT can exec into any container
+on the host, start privileged containers, or mount arbitrary host paths.
+
+`xnat-web` no longer mounts the socket. The XNAT stack instead runs a
+[`tecnativa/docker-socket-proxy`](https://github.com/Tecnativa/docker-socket-proxy) sidecar
+(`xnat-socket-proxy` in `trust/xnat/docker-compose-stack.yml`) that holds the socket read-only
+and serves a filtered Docker API on the stack-internal network only (`tcp://xnat-socket-proxy:2375`,
+no published host port). The Container Service is pointed at that endpoint by
+`trust/xnat/xnat/config/container-service-backend-configuration.json`, which
+`configure-dcm2niix.sh` POSTs to `/xapi/docker/server` — and the configure run now hard-fails if
+`/xapi/docker/server/ping` cannot reach Docker through the proxy, instead of leaving a
+registered-but-unlaunchable dcm2niix command behind.
+
+The proxy allowlists only what a swarm-mode Container Service launch needs — `SERVICES`
+(+ `POST` for the mutating calls), `TASKS`, `NODES`, `IMAGES` (pull-on-init), `INFO`, `SWARM`
+(the plugin's swarm-mode connection test is a `GET /swarm` inspect), plus the proxy's default
+`PING`/`VERSION`/`EVENTS`. Everything else is refused with a 403: `exec`, the container API,
+volumes, networks, secrets, configs, plugins, and build.
+
+This is a choke point, not a sandbox. Two residual powers are worth stating plainly: the services
+API the Container Service depends on can itself create a service with an arbitrary host bind
+mount, and because the proxy's `POST` switch is global, granting `SWARM` also exposes
+`POST /swarm/*`. So a fully compromised `xnat-web` is not contained — but it loses direct
+container/exec access entirely, and every remaining call now crosses one auditable gateway
+(`docker service logs <stack>_xnat-socket-proxy` shows the full request log) instead of speaking
+to the raw socket.
+
 ### No New Privileges
 
 Nearly every container declares `security_opt: [no-new-privileges:true]` to prevent privilege escalation
@@ -310,9 +344,10 @@ via `setuid` binaries or `LD_PRELOAD` injection. The same dev-only services exem
 (pgadmin, register-supernode-keys, fl-clients) also omit `no-new-privileges`, and the XNAT swarm
 stack ignores the `security_opt` key (see caveat below).
 
-> **XNAT swarm caveat.** The XNAT stack (`xnat-web`, `xnat-db`, `xnat-nginx`) is deployed with
+> **XNAT swarm caveat.** The XNAT stack (`xnat-web`, `xnat-db`, `xnat-nginx`, `xnat-socket-proxy`)
+> is deployed with
 > `docker stack deploy` (see `trust/xnat/Makefile`), and swarm **ignores** the `security_opt` key —
-> so `no-new-privileges` is *not* applied to those three services from the compose file. The
+> so `no-new-privileges` is *not* applied to those four services from the compose file. The
 > `cap_drop`/`cap_add` hardening still takes effect (swarm honours those). To enforce
 > no-new-privileges on XNAT hosts, set it as the Docker daemon default in `/etc/docker/daemon.json`:
 > `{ "no-new-privileges": true }`. Verify with the `docker inspect` command below.

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -329,6 +329,14 @@ The proxy allowlists only what a swarm-mode Container Service launch needs — `
 `PING`/`VERSION`/`EVENTS`. Everything else is refused with a 403: `exec`, the container API,
 volumes, networks, secrets, configs, plugins, and build.
 
+**Multiple trusts on one host.** Each trust's XNAT is a separate swarm stack on its own overlay
+network (`xnat<N>` on `deploy_trust-network-<N>`), so each gets its **own** proxy — they are not
+shared, which keeps the trust boundary intact. The identical `xnat-socket-proxy` service name in
+both stacks does not collide: swarm resolves it per-network, so each `xnat-web` reaches only its
+own proxy (cross-stack access is refused), and the proxy publishes no host port. Both proxies
+holding the same host socket is fine — it serves concurrent clients, exactly as it did when each
+`xnat-web` mounted it directly.
+
 This is a choke point, not a sandbox. Two residual powers are worth stating plainly: the services
 API the Container Service depends on can itself create a service with an arbitrary host bind
 mount, and because the proxy's `POST` switch is global, granting `SWARM` also exposes

--- a/trust/xnat/docker-compose-stack.yml
+++ b/trust/xnat/docker-compose-stack.yml
@@ -34,6 +34,11 @@ services:
       - XNAT_SERVICE_PASSWORD=${XNAT_SERVICE_PASSWORD}
       - XNAT_PORT=${XNAT_PORT}
       - PACS_DICOM_PORT=${PACS_DICOM_PORT}
+    # Dual-homed: the trust overlay for everything else, plus the stack-scoped
+    # socket-proxy network — the only route to the Docker API proxy below.
+    networks:
+      - default
+      - socket-proxy
 
   xnat-db:
     image: ${DOCKER_REGISTRY}xnat-db:${XNAT_TAG}
@@ -92,6 +97,9 @@ services:
   # xnat-web does not mount the Docker socket: the plugin reaches Docker over
   # tcp://xnat-socket-proxy:2375 (set in xnat/config/container-service-backend-
   # configuration.json), and only this proxy holds the (root-equivalent) socket.
+  # The proxy lives on the stack-scoped internal socket-proxy network (below),
+  # NOT the shared trust overlay — only the dual-homed xnat-web can reach it;
+  # trust-api, imaging-api, data-access-api, fl-client etc. have no route.
   # A compromised xnat-web is left with the allowlisted API groups below —
   # notably it can no longer exec into containers or reach the container,
   # volume, network and secret APIs at all. It is a choke point, not a sandbox:
@@ -135,8 +143,16 @@ services:
       - SWARM=1
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
+    networks:
+      - socket-proxy
 
 networks:
   default:
     name: ${DOCKER_NETWORK_NAME}
     external: true
+  # Dedicated network for xnat-web -> xnat-socket-proxy traffic. Swarm prefixes
+  # it per stack (<stack>_socket-proxy), so each trust's proxy is reachable only
+  # from its own xnat-web. internal: the proxy needs no egress, only the socket.
+  socket-proxy:
+    driver: overlay
+    internal: true

--- a/trust/xnat/docker-compose-stack.yml
+++ b/trust/xnat/docker-compose-stack.yml
@@ -34,8 +34,6 @@ services:
       - XNAT_SERVICE_PASSWORD=${XNAT_SERVICE_PASSWORD}
       - XNAT_PORT=${XNAT_PORT}
       - PACS_DICOM_PORT=${PACS_DICOM_PORT}
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
 
   xnat-db:
     image: ${DOCKER_REGISTRY}xnat-db:${XNAT_TAG}
@@ -89,6 +87,54 @@ services:
       - NET_BIND_SERVICE
     # ports:
     #   - "80:80"
+
+  # Filtered gateway to the host Docker API for the Container Service plugin.
+  # xnat-web does not mount the Docker socket: the plugin reaches Docker over
+  # tcp://xnat-socket-proxy:2375 (set in xnat/config/container-service-backend-
+  # configuration.json), and only this proxy holds the (root-equivalent) socket.
+  # A compromised xnat-web is left with the allowlisted API groups below —
+  # notably it can no longer exec into containers or reach the container,
+  # volume, network and secret APIs at all. It is a choke point, not a sandbox:
+  # the services API that dcm2niix launches require can itself create services
+  # with host bind mounts (FLIP#485).
+  xnat-socket-proxy:
+    image: tecnativa/docker-socket-proxy:v0.4.2
+    deploy:
+      replicas: 1
+      restart_policy:
+        condition: any
+      placement:
+        # The services API is only served by a manager's Docker socket.
+        constraints: [node.role == manager]
+    security_opt:
+      - no-new-privileges:true
+    # No cap_add at all: haproxy (v0.4.2) runs as root, which owns the socket,
+    # so it connects with an empty capability set.
+    cap_drop:
+      - ALL
+    environment:
+      # The Container Service (swarm mode) launches dcm2niix as a one-shot swarm
+      # service: create/inspect/logs/remove need SERVICES (+ POST for the
+      # mutating calls), job state tracking needs TASKS, scheduling info needs
+      # NODES, and pull-images-on-xnat-init needs IMAGES. PING/VERSION/EVENTS
+      # are the proxy's defaults; the container, exec, volume, network, secret,
+      # config, plugin and build APIs all stay blocked (verified 403 from
+      # xnat-web).
+      - POST=1
+      - SERVICES=1
+      - TASKS=1
+      - NODES=1
+      - IMAGES=1
+      - INFO=1
+      # The Container Service's swarm-mode connection test is a swarm inspect
+      # (GET /swarm) — without this the /xapi/docker/server/ping gate in
+      # configure-dcm2niix.sh fails 403. The proxy's POST switch is global, so
+      # this also exposes POST /swarm/* (join/leave/update); that is strictly
+      # weaker than the services API the Container Service already requires,
+      # which can create services with arbitrary host mounts.
+      - SWARM=1
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
 
 networks:
   default:

--- a/trust/xnat/xnat/config/configure-dcm2niix.sh
+++ b/trust/xnat/xnat/config/configure-dcm2niix.sh
@@ -50,6 +50,19 @@ curl -s -X POST "$XNAT_URL/xapi/docker/server" \
   -H "Content-Type: application/json" \
   -d "$backend_config"
 
+# The Container Service reaches Docker through the xnat-socket-proxy sidecar
+# (see docker-compose-stack.yml), not a socket mounted into xnat-web. Fail loudly
+# here if that path is broken — the command registration below would still
+# "succeed", but every dcm2niix launch would then fail at conversion time.
+echo "Pinging Docker through the socket proxy..."
+ping_status=$(curl -s -o /dev/null -w "%{http_code}" "$XNAT_URL/xapi/docker/server/ping" \
+  -u "${XNAT_ADMIN_USER}:${XNAT_ADMIN_PASSWORD}")
+if [[ "$ping_status" != "200" ]]; then
+  echo "ERROR: Container Service cannot reach Docker via xnat-socket-proxy (HTTP $ping_status)"
+  exit 1
+fi
+echo "Container Service -> Docker (via xnat-socket-proxy): OK"
+
 # ----------------------------------------------------------------
 # CONTAINER SERVICE
 # ----------------------------------------------------------------

--- a/trust/xnat/xnat/config/configure-dcm2niix.sh
+++ b/trust/xnat/xnat/config/configure-dcm2niix.sh
@@ -45,18 +45,27 @@ echo "Path translation with DATA_PATH=$DATA_PATH"
 backend_config=$(jq --arg data_path "$DATA_PATH" '.["path-translation-docker-prefix"] = $data_path' container-service-backend-configuration.json)
 
 echo "backend_config: $backend_config"
-curl -s -X POST "$XNAT_URL/xapi/docker/server" \
+# curl exits 0 on HTTP 4xx/5xx (no --fail), so check the status explicitly — if XNAT
+# rejects the new backend config, the ping below could still pass against a previously
+# registered backend and mask the failure. "000" = transport error / timeout.
+post_status=$(curl -s -o /tmp/docker-server-post.json --max-time 60 -w "%{http_code}" \
+  -X POST "$XNAT_URL/xapi/docker/server" \
   -u "${XNAT_ADMIN_USER}:${XNAT_ADMIN_PASSWORD}" \
   -H "Content-Type: application/json" \
-  -d "$backend_config"
+  -d "$backend_config") || post_status="000"
+if [[ "$post_status" != 2* ]]; then
+  echo "ERROR: POST /xapi/docker/server returned HTTP $post_status"
+  cat /tmp/docker-server-post.json 2>/dev/null || true
+  exit 1
+fi
 
 # The Container Service reaches Docker through the xnat-socket-proxy sidecar
 # (see docker-compose-stack.yml), not a socket mounted into xnat-web. Fail loudly
 # here if that path is broken — the command registration below would still
 # "succeed", but every dcm2niix launch would then fail at conversion time.
 echo "Pinging Docker through the socket proxy..."
-ping_status=$(curl -s -o /dev/null -w "%{http_code}" "$XNAT_URL/xapi/docker/server/ping" \
-  -u "${XNAT_ADMIN_USER}:${XNAT_ADMIN_PASSWORD}")
+ping_status=$(curl -s -o /dev/null --max-time 60 -w "%{http_code}" "$XNAT_URL/xapi/docker/server/ping" \
+  -u "${XNAT_ADMIN_USER}:${XNAT_ADMIN_PASSWORD}") || ping_status="000"
 if [[ "$ping_status" != "200" ]]; then
   echo "ERROR: Container Service cannot reach Docker via xnat-socket-proxy (HTTP $ping_status)"
   exit 1

--- a/trust/xnat/xnat/config/container-service-backend-configuration.json
+++ b/trust/xnat/xnat/config/container-service-backend-configuration.json
@@ -1,6 +1,6 @@
 {
-    "name": "Local socket",
-    "host": "unix:///var/run/docker.sock",
+    "name": "Socket proxy",
+    "host": "tcp://xnat-socket-proxy:2375",
     "cert-path": "",
     "swarm-mode": true,
     "path-translation-xnat-prefix": "/data/xnat",


### PR DESCRIPTION
# Description

Targets `485/security-docker-hardening-v2` (#501). Fixes the **blocking functional regression** that finding #4 of the [2026-07-10 re-review](https://github.com/londonaicentre/FLIP/pull/501#issuecomment-4913500000) flagged as a follow-up — on closer inspection it breaks DICOM→NIfTI conversion for every project created with `dicom_to_nifti=true`.

**The break.** #501 makes `xnat-web` run as UID 1001. `/var/run/docker.sock` is `root:docker` 0660 and the container's only group is 1001, so XNAT's Container Service can no longer launch containers (errno 13). `imaging-api` creates an **active** event subscription that fires `xnat/dcm2niix:latest` on every `ScanEvent:CREATED` (`trust/imaging-api/imaging_api/routers/projects.py:152`), so under the hardened image every such project silently loses NIfTI conversion — the DICOM pull still reports success, nothing surfaces to the hub, and the app fails later at data loading. `group_add` is not an option: `docker stack config` rejects it (swarm schema), and it would be root-equivalent anyway.

**The fix.** `xnat-web` no longer mounts the Docker socket at all. A `tecnativa/docker-socket-proxy` sidecar holds it read-only and serves a filtered Docker API on a dedicated stack-scoped `internal: true` overlay network (`<stack>_socket-proxy`) that only the dual-homed `xnat-web` joins — no published port, and no route from the other trust containers (review follow-up: the proxy originally sat on the shared trust overlay); the Container Service is pointed at `tcp://xnat-socket-proxy:2375` via the `container-service-backend-configuration.json` we already POST to `/xapi/docker/server`. Allowlisted: `SERVICES`, `TASKS`, `NODES`, `IMAGES`, `INFO`, `SWARM`, `POST` — what a swarm-mode launch needs. Refused (403): `exec`, the container API, volumes, networks, secrets, configs, plugins, build. `configure-dcm2niix.sh` now hard-fails on the backend-config POST status and on `GET /xapi/docker/server/ping` (both time-bounded), so a broken Docker path can no longer leave a registered-but-unlaunchable dcm2niix command behind — which is exactly how this regression stayed invisible.

**Honest scope:** a choke point, not a sandbox. The services API can itself create a service with a host bind mount, and the proxy's `POST` switch is global so `SWARM=1` also exposes `POST /swarm/*`. A fully compromised `xnat-web` is not *contained* — it loses direct container/exec access and every remaining call crosses one auditable gateway. Both caveats are stated in `deploy/README.md` and the compose comments rather than papered over.

Also documents the **data-enrichment** step for the spleen e2e (`CLAUDE.md`), which belongs here: the enrichment uploader keys its uploads off the converted `input_*.nii.gz`, so a broken Container Service path makes it skip every scan silently and surface as `num_samples=0`. (Was #777; folded in on review feedback.)

## Linked Issues

Part of #485. Follow-up tracked in #776 (spleen enrichment assets live in a private repo).

## Checklist

- [x] Follows the project's coding conventions and style guide
- [x] Updates documentation
- [ ] I have added tests that prove my fix is effective or that my feature works — *no automated test: this is compose/Dockerfile/shell wiring around a swarm-deployed XNAT + host Docker socket, which CI has no fixture for. Verified end-to-end on a live dual-trust stack instead (below), and `configure-dcm2niix.sh` now hard-fails on the ping so the path is guarded at deploy time.*
- [x] New and existing unit tests pass locally with my changes (no application code touched)
- [x] Any dependent changes have been merged and published

## Type of Change

- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change.
- [ ] New tests added to cover the changes.
- [ ] In-line docstrings updated.
- [x] Documentation updated (`deploy/README.md`, `CLAUDE.md`).

## Testing

**Full dual-trust dev stack (GSTT + KCH), hardened images, `FL_BACKEND=nvflare` — spleen segmentation e2e passed end-to-end:**

```
project_id   = 9fc2af48-1d4e-4e08-8ae6-04cdb6f0f729
model_id     = f0f7c15c-0611-4576-82c9-f1cf714aa858
final_status = RESULTS_UPLOADED   (results downloaded)
```

Spleen is the decisive app here — it *cannot* train unless the Container Service path works, since it pairs each converted `input_*.nii.gz` with a `label_*.nii.gz`:

- **37 dcm2niix conversions launched through the two socket proxies** (20 GSTT / 17 KCH). Proxy logs show the whole lifecycle crossing the gateway: `POST /services/create` → `GET /tasks` → `GET /services/<id>/logs` → `DELETE /services/<id>`.
- Data enrichment then uploaded 20 + 17 labels with **`0 skipped (no NIFTI)`** — i.e. every scan had a converted NIfTI resource.
- Both trusts trained the 3D UNet concurrently (one RTX 5090, ~3.6 GB each) → aggregated results uploaded and downloaded.
- **Hardening assertions, live:** `xnat-web` uid 1001, `CapEff=0000000000000000`, **no `/var/run/docker.sock`**; proxy `CapDrop=[ALL]`, `CapAdd=[]`, socket mounted `rw=false`, no published ports; from inside `xnat-web`, **403** on `containers/json`, `exec`, `volumes`, `networks`, `secrets` and `POST /containers/create`.
- `docker stack config` parses clean for the dev and prod overlays; `bash -n` on the script; JSON valid.
- **Network isolation (review follow-up), live on both trusts:** `docker network inspect <stack>_socket-proxy` shows `internal=true` with exactly `xnat-web` + the proxy attached; from `imaging-api` the proxy hostname no longer resolves while `xnat-web:8080` stays reachable; the Container Service ping and a full `make up-xnat` configure pass green through the new network on both stacks.
- Before the fix, on this same stack: `xnat-configure` failed with `tee: Permission denied` on the 1001-owned bind (root without `DAC_OVERRIDE`), confirming the regression is real.

- [ ] Quick tests passed locally by running `make unit-test` — n/a, no application code changed.
- [ ] Integration tests — n/a (see above).

## Additional Notes

- **Only 2 CI checks run here** because the PR targets `485/security-docker-hardening-v2` rather than `develop`; the workflows are gated on the base branch. The full suite runs on #501 itself (currently green).
- Two facts worth keeping when reviewing the caps: the proxy needs **no** capabilities (HAProxy runs as root, which owns the socket, so it works under `cap_drop: ALL` with an empty `cap_add`), and the Container Service's swarm-mode connection test is a `GET /swarm` **inspect** — without `SWARM=1` the new ping gate 403s even though launches would succeed.
