### PR TITLE
[Bug]: flip-api DB pool exhausted by leaked idle-in-transaction sessions under Flower metrics burst

### DIFF
--- a/flip-api/src/flip_api/db/database.py
+++ b/flip-api/src/flip_api/db/database.py
@@ -173,9 +173,16 @@ def get_session() -> Generator[Session, None, None]:
     """
     Create a new SQLModel session.
 
+    The ``with`` block is load-bearing: FastAPI finalises this dependency by
+    throwing the endpoint's exception into the generator at the ``yield`` (or
+    closing it on disconnect/cancellation), so a bare ``yield`` followed by
+    ``session.close()`` never closes the session on those paths — the
+    checked-out connection is stranded ``idle in transaction`` until the
+    process restarts, and enough of them exhaust the pool and take the whole
+    API down (FLIP#773).
+
     Yields:
         Session: A new SQLModel session.
     """
-    session = Session(get_engine())
-    yield session
-    session.close()
+    with Session(get_engine()) as session:
+        yield session

--- a/flip-api/tests/integration/test_db_session_release.py
+++ b/flip-api/tests/integration/test_db_session_release.py
@@ -1,0 +1,106 @@
+# Copyright (c) Guy's and St Thomas' NHS Foundation Trust & King's College London
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Regression tests for the ``get_session`` connection leak (FLIP#773).
+
+FastAPI finalises a yield-dependency by throwing the endpoint's exception into
+the generator at the ``yield`` (endpoint raised) or by closing it
+(``GeneratorExit`` — client disconnect / task cancellation). If ``get_session``
+does not guard the ``yield`` with a ``with`` block (or ``try/finally``),
+``session.close()`` is skipped on those paths and the checked-out connection is
+stranded ``idle in transaction`` until the process restarts. Under a Flower
+training-metrics burst this exhausted the whole pool (5 + 10 overflow) and took
+the hub down — see FLIP#773 for the incident evidence.
+
+These tests drive the generator exactly the way FastAPI's dependency teardown
+does and assert the pool's checked-out count returns to baseline. The leaked
+``Session`` is deliberately kept referenced so CPython refcounting cannot mask
+a leak by collecting it early.
+
+The suite's shared engine uses ``StaticPool`` (one shared connection), which
+cannot observe checkout leaks — so these tests install a ``QueuePool`` engine
+(the pool class dev and prod actually run) on the same throwaway database for
+their duration.
+"""
+
+from collections.abc import Generator
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy import create_engine, text
+from sqlalchemy.engine import Engine
+from sqlalchemy.pool import QueuePool
+
+from flip_api.db import database as db_module
+from flip_api.db.database import get_session
+
+
+@pytest.fixture
+def queue_pool_engine(integration_engine) -> Generator[Engine, None, None]:
+    """Install a QueuePool engine on the throwaway DB as flip-api's engine.
+
+    Args:
+        integration_engine: The suite's shared StaticPool engine (provides the
+            throwaway database URL).
+
+    Yields:
+        Engine: A QueuePool-backed engine that ``get_session`` will use.
+    """
+    engine = create_engine(integration_engine.url, poolclass=QueuePool)
+    previous = db_module._engine
+    db_module._engine = engine
+    yield engine
+    db_module._engine = previous
+    engine.dispose()
+
+
+def test_get_session_releases_connection_when_endpoint_raises(queue_pool_engine: Engine) -> None:
+    """A request that raises after querying must not strand its connection.
+
+    FastAPI throws the endpoint's exception into the dependency generator at the
+    ``yield``; the session must still be closed so its connection returns to the
+    pool (FLIP#773).
+    """
+    pool = queue_pool_engine.pool
+    assert isinstance(pool, QueuePool)
+    baseline = pool.checkedout()
+    gen = get_session()
+    db = next(gen)
+    db.execute(text("SELECT 1"))  # autobegin: the session now holds a connection
+    assert pool.checkedout() == baseline + 1
+
+    with pytest.raises(HTTPException):
+        gen.throw(HTTPException(status_code=400, detail="endpoint error"))
+
+    assert pool.checkedout() == baseline, "session leaked its pooled connection on the exception path"
+    assert db is not None  # keep the Session referenced: no refcount rescue
+
+
+def test_get_session_releases_connection_on_generator_close(queue_pool_engine: Engine) -> None:
+    """A cancelled/disconnected request must not strand its connection.
+
+    When a request is torn down without a response (client disconnect,
+    cancellation), the dependency generator is closed — ``GeneratorExit`` is
+    raised at the ``yield``. The session must still be closed (FLIP#773).
+    """
+    pool = queue_pool_engine.pool
+    assert isinstance(pool, QueuePool)
+    baseline = pool.checkedout()
+    gen = get_session()
+    db = next(gen)
+    db.execute(text("SELECT 1"))
+    assert pool.checkedout() == baseline + 1
+
+    gen.close()
+
+    assert pool.checkedout() == baseline, "session leaked its pooled connection on the GeneratorExit path"
+    assert db is not None  # keep the Session referenced: no refcount rescue


### PR DESCRIPTION
Closes #773.

## Root cause

`get_session` — the `Depends()` DB dependency behind every endpoint — did not guard its `yield`:

```python
session = Session(get_engine())
yield session
session.close()
```

FastAPI finalises a yield-dependency by **throwing the endpoint's exception into the generator at the `yield`** (any 4xx/5xx-raising request) or by **closing it** (`GeneratorExit` — client disconnect / cancellation). On both paths the bare `yield` propagates immediately and `session.close()` never runs. The abandoned `Session` — holding an open transaction from its first query — strands its pooled connection **`idle in transaction`** indefinitely (the leaked sessions sit in reference cycles that quiet processes don't collect; observed parked for 11+ minutes in the #773 incident).

The pool is 5 + 10 overflow: fifteen error responses are a total hub outage. Worse, once the pool is short, healthy requests hit the 30s pool timeout and *themselves* error — leaking further sessions. That feedback loop is why the incident wedged permanently instead of recovering when the metrics burst ended, and why every parked connection showed the trust-lookup SELECT as its last query (it's the first query of both the trust-auth dependency and the metrics endpoint — the requests died right after it).

## Fix

Wrap the yield in the session's context manager (the same pattern the scheduler jobs already use):

```python
with Session(get_engine()) as session:
    yield session
```

`Session.__exit__` runs on normal completion, exception throw, and `GeneratorExit` alike — rollback + connection returned on every path.

## Verification

- **Deterministic repro before the fix**, live on the dev stack: 40 error-returning metric POSTs (unresolvable `fl_client_name` → 400 after the trust lookup) stranded **13 connections** `idle in transaction`, stable for 60+ seconds — the incident in miniature. **After the fix: the identical hammer strands 0.**
- **Two integration regression tests** (`test_db_session_release.py`) drive the generator exactly as FastAPI's teardown does — `gen.throw(HTTPException)` and `gen.close()` — against a `QueuePool` engine (the suite's shared engine is `StaticPool`, which can't observe checkout leaks) and assert the pool returns to baseline. Both red on the old code, green on the fix.
- **Full training-burst rerun:** attempted (reusing the previous approved project with `pg_stat_activity` watched), but the shared dev stack was replaced from another worktree mid-run, so it could not complete. The deterministic error-path hammer above reproduces the incident's exact leak mechanism more directly than the burst does; the burst rerun can be repeated once a stack is available. Notably, while the interrupted run's orphaned client was erroring against the replacement hub (which runs *without* this fix), `idle in transaction` connections were observed accumulating monotonically there — the bug demonstrating itself on unfixed code one more time.
- **Separate observation (not this bug):** the APScheduler jobs hold a `Session` open across S3/HTTP I/O (`run_jobs`, `keep_fl_api_session_alive`), parking one connection each `idle in transaction` for the duration of their tick. These holds are bounded and recycle — unlike the #773 leak they cannot exhaust the pool — but they're worth a hygiene follow-up.
- flip-api suite: ruff + mypy + 1200 unit tests + 92 integration tests green.

## Scope notes

The issue's defensive-hardening criteria (`pool_pre_ping`/pool sizing for dev parity, Postgres `idle_in_transaction_session_timeout` backstop) are deliberately **not** bundled here — this PR is the single root-cause fix plus regression coverage. With the leak gone they're optional insurance; happy to file a follow-up if we want them.


## Acceptance Criteria

*Imported from issue #773*

- [ ] DB sessions are always released (rollback/close on every exit path, including client-disconnect / `CancelledError` during a request).
- [ ] flip-api survives a full 2-trust Flower training run's metrics burst with no `idle in transaction` accumulation (verify via `pg_stat_activity` during an e2e smoke).
- [ ] Regression coverage: a test (or documented load probe) that fails on session leak under cancelled requests.
- [ ] Consider defensive engine settings (`pool_pre_ping`, sane `pool_size`/`max_overflow`/`pool_timeout`) and a Postgres `idle_in_transaction_session_timeout` backstop.