### PR TITLE
Rename TRAINING_STARTED → RUNNING and emit it for evaluation jobs (eval runs stuck at INITIATED; e2e false alarm)

### DIFF
--- a/docs/source/working-with-flip-apps/create-flip-app-from-flower.rst
+++ b/docs/source/working-with-flip-apps/create-flip-app-from-flower.rst
@@ -108,14 +108,15 @@ Wrap your training entry point with four ``update_status`` calls. These drive th
    arrays = ArrayRecord(model.state_dict())
    strategy = FedAvg(fraction_train=1.0, fraction_evaluate=0.0)
 
+   flip.update_status(model_id, ModelStatus.RUNNING)            # the rounds start here
+
    strategy.start(grid=grid, initial_arrays=arrays, num_rounds=num_rounds)
 
-   flip.update_status(model_id, ModelStatus.TRAINING_STARTED)   # after strategy.start returns
    flip.update_status(model_id, ModelStatus.RESULTS_UPLOADED)   # after post-training finalisation
 
 .. warning::
 
-   Forgetting the final ``ModelStatus.RESULTS_UPLOADED`` transition will leave the model indefinitely in the "training" state in the FLIP UI even though execution has ended.
+   Forgetting the final ``ModelStatus.RESULTS_UPLOADED`` transition will leave the model indefinitely in the "running" state in the FLIP UI even though execution has ended.
 
 Full minimal example
 =====================
@@ -149,9 +150,10 @@ Reproduced from ``fl-apps/flower/standard/app/server_app.py``:
        arrays = ArrayRecord(model.state_dict())
        strategy = FedAvg(fraction_train=1.0, fraction_evaluate=0.0)
 
+       flip.update_status(flip_model_id, ModelStatus.RUNNING)
+
        strategy.start(grid=grid, initial_arrays=arrays, num_rounds=num_rounds)
 
-       flip.update_status(flip_model_id, ModelStatus.TRAINING_STARTED)
        flip.update_status(flip_model_id, ModelStatus.RESULTS_UPLOADED)
 
 ***********************

--- a/fl-apps/flower/evaluation/app/server_app.py
+++ b/fl-apps/flower/evaluation/app/server_app.py
@@ -94,6 +94,10 @@ def main(grid: Grid, context: Context, flip: FLIP = FLIP()) -> None:
         fraction_evaluate=1.0,  # All clients evaluate
     )
 
+    # The evaluation rounds start here — mirrors the standard template's strategy,
+    # which reports RUNNING when its rounds start (#782).
+    flip.update_status(model_id, ModelStatus.RUNNING)
+
     _ = strategy.start(
         grid=grid,
         initial_arrays=arrays,

--- a/fl-apps/flower/standard/app/strategy.py
+++ b/fl-apps/flower/standard/app/strategy.py
@@ -45,7 +45,7 @@ class FedAvgWithClientMetrics(FedAvg):
     def start(self, grid: Grid, initial_arrays: ArrayRecord, num_rounds: int = 3, **kwargs):
         """Override start to capture num_rounds for evaluation control."""
         self.num_rounds = num_rounds
-        self.flip.update_status(self.model_id, ModelStatus.TRAINING_STARTED)
+        self.flip.update_status(self.model_id, ModelStatus.RUNNING)
         return super().start(grid, initial_arrays, num_rounds, **kwargs)
 
     def configure_evaluate(

--- a/fl-tutorials/flower/3d_spleen_segmentation/app/strategy.py
+++ b/fl-tutorials/flower/3d_spleen_segmentation/app/strategy.py
@@ -45,7 +45,7 @@ class FedAvgWithClientMetrics(FedAvg):
     def start(self, grid: Grid, initial_arrays: ArrayRecord, num_rounds: int = 3, **kwargs):
         """Override start to capture num_rounds for evaluation control."""
         self.num_rounds = num_rounds
-        self.flip.update_status(self.model_id, ModelStatus.TRAINING_STARTED)
+        self.flip.update_status(self.model_id, ModelStatus.RUNNING)
         return super().start(grid, initial_arrays, num_rounds, **kwargs)
 
     def configure_evaluate(

--- a/fl-tutorials/flower/3d_spleen_segmentation_evaluation/app/server_app.py
+++ b/fl-tutorials/flower/3d_spleen_segmentation_evaluation/app/server_app.py
@@ -94,6 +94,10 @@ def main(grid: Grid, context: Context, flip: FLIP = FLIP()) -> None:
         fraction_evaluate=1.0,  # All clients evaluate
     )
 
+    # The evaluation rounds start here — mirrors the standard template's strategy,
+    # which reports RUNNING when its rounds start (#782).
+    flip.update_status(model_id, ModelStatus.RUNNING)
+
     _ = strategy.start(
         grid=grid,
         initial_arrays=arrays,

--- a/fl-tutorials/flower/xray_classification/app/strategy.py
+++ b/fl-tutorials/flower/xray_classification/app/strategy.py
@@ -45,7 +45,7 @@ class FedAvgWithClientMetrics(FedAvg):
     def start(self, grid: Grid, initial_arrays: ArrayRecord, num_rounds: int = 3, **kwargs):
         """Override start to capture num_rounds for evaluation control."""
         self.num_rounds = num_rounds
-        self.flip.update_status(self.model_id, ModelStatus.TRAINING_STARTED)
+        self.flip.update_status(self.model_id, ModelStatus.RUNNING)
         return super().start(grid, initial_arrays, num_rounds, **kwargs)
 
     def configure_evaluate(

--- a/flip-api/src/flip_api/db/migrations/versions/8c41d0f2ab5e_rename_training_started_to_running.py
+++ b/flip-api/src/flip_api/db/migrations/versions/8c41d0f2ab5e_rename_training_started_to_running.py
@@ -1,0 +1,46 @@
+# Copyright (c) 2026 Guy's and St Thomas' NHS Foundation Trust & King's College London
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""rename TRAINING_STARTED to RUNNING
+
+Renames the TRAINING_STARTED member of the native ``modelstatus`` and
+``modelauditaction`` Postgres enums to RUNNING (#782): the status is
+job-type-neutral so evaluation jobs can report it too. RENAME VALUE keeps the
+member's position and rewrites existing rows in place, and (unlike ADD VALUE)
+runs fine inside the migration transaction.
+
+Revision ID: 8c41d0f2ab5e
+Revises: 23aff57898a0
+Create Date: 2026-07-14 12:00:00.000000
+
+"""
+from collections.abc import Sequence
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = '8c41d0f2ab5e'
+down_revision: str | None = '23aff57898a0'
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Apply this revision."""
+    op.execute("ALTER TYPE modelstatus RENAME VALUE 'TRAINING_STARTED' TO 'RUNNING'")
+    op.execute("ALTER TYPE modelauditaction RENAME VALUE 'TRAINING_STARTED' TO 'RUNNING'")
+
+
+def downgrade() -> None:
+    """Revert this revision."""
+    op.execute("ALTER TYPE modelstatus RENAME VALUE 'RUNNING' TO 'TRAINING_STARTED'")
+    op.execute("ALTER TYPE modelauditaction RENAME VALUE 'RUNNING' TO 'TRAINING_STARTED'")

--- a/flip-api/src/flip_api/domain/interfaces/model.py
+++ b/flip-api/src/flip_api/domain/interfaces/model.py
@@ -162,7 +162,7 @@ class IModelResponse(BaseModel):
     # stage. ``creation_timestamp`` is just ``Model.creation_timestamp``.
     creation_timestamp: str | None = Field(default=None, alias="creationTimestamp")
     prepared_at: str | None = Field(default=None, alias="preparedAt")
-    training_started_at: str | None = Field(default=None, alias="trainingStartedAt")
+    running_at: str | None = Field(default=None, alias="runningAt")
     results_uploaded_at: str | None = Field(default=None, alias="resultsUploadedAt")
 
     model_config = ConfigDict(

--- a/flip-api/src/flip_api/domain/schemas/actions.py
+++ b/flip-api/src/flip_api/domain/schemas/actions.py
@@ -26,10 +26,10 @@ class ModelAuditAction(StrEnum):
     EDIT = "EDIT"
     # Status-transition audits keyed by the new ModelStatus value. Recorded in
     # update_model_status so the model lifecycle UI can render real dates for
-    # "Prepared / Training started / Results uploaded" instead of static "done"
+    # "Prepared / Running / Results uploaded" instead of static "done"
     # labels. Only stages surfaced in the lifecycle bar are tracked.
     PREPARED = "PREPARED"
-    TRAINING_STARTED = "TRAINING_STARTED"
+    RUNNING = "RUNNING"
     RESULTS_UPLOADED = "RESULTS_UPLOADED"
 
 

--- a/flip-api/src/flip_api/domain/schemas/status.py
+++ b/flip-api/src/flip_api/domain/schemas/status.py
@@ -83,7 +83,8 @@ class ModelStatus(Enum):
     def _missing_(cls, value: object) -> "ModelStatus | None":
         # Back-compat alias: fl-server images deploy separately from flip-api, so a
         # pre-rename fl-server may still report "TRAINING_STARTED" (#782). Accept it
-        # as RUNNING until every deployed FL image is post-rename.
+        # as RUNNING until every deployed FL image is post-rename — removal is
+        # tracked in #803.
         if value == "TRAINING_STARTED":
             return cls.RUNNING
         return None

--- a/flip-api/src/flip_api/domain/schemas/status.py
+++ b/flip-api/src/flip_api/domain/schemas/status.py
@@ -68,13 +68,25 @@ class ModelStatus(Enum):
     PENDING = "PENDING"
     INITIATED = "INITIATED"
     PREPARED = "PREPARED"
-    TRAINING_STARTED = "TRAINING_STARTED"
+    # Job-type-neutral "the FL job is executing" status (renamed from TRAINING_STARTED
+    # so evaluation jobs can report it honestly, #782). Keeps TRAINING_STARTED's slot in
+    # the native Postgres enum — the migration is ALTER TYPE ... RENAME VALUE.
+    RUNNING = "RUNNING"
     RESULTS_UPLOADED = "RESULTS_UPLOADED"
     # Training finished but the post-training results upload to S3 failed. Distinct
-    # from ERROR so the UI keeps "Training Started" complete and only flags the
+    # from ERROR so the UI keeps "Running" complete and only flags the
     # upload step. Appended last to keep the native Postgres enum order consistent
     # between fresh databases and ones migrated via ALTER TYPE ... ADD VALUE.
     RESULTS_UPLOAD_FAILED = "RESULTS_UPLOAD_FAILED"
+
+    @classmethod
+    def _missing_(cls, value: object) -> "ModelStatus | None":
+        # Back-compat alias: fl-server images deploy separately from flip-api, so a
+        # pre-rename fl-server may still report "TRAINING_STARTED" (#782). Accept it
+        # as RUNNING until every deployed FL image is post-rename.
+        if value == "TRAINING_STARTED":
+            return cls.RUNNING
+        return None
 
 
 class NetStatus(Enum):

--- a/flip-api/src/flip_api/model_services/retrieve_model.py
+++ b/flip-api/src/flip_api/model_services/retrieve_model.py
@@ -170,7 +170,7 @@ def retrieve_model(
                 col(ModelsAudit.action).in_(
                     [
                         ModelAuditAction.PREPARED,
-                        ModelAuditAction.TRAINING_STARTED,
+                        ModelAuditAction.RUNNING,
                         ModelAuditAction.RESULTS_UPLOADED,
                     ]
                 ),
@@ -196,7 +196,7 @@ def retrieve_model(
             files=files,
             creation_timestamp=creation_timestamp,
             prepared_at=latest_per_action.get(ModelAuditAction.PREPARED),
-            training_started_at=latest_per_action.get(ModelAuditAction.TRAINING_STARTED),
+            running_at=latest_per_action.get(ModelAuditAction.RUNNING),
             results_uploaded_at=latest_per_action.get(ModelAuditAction.RESULTS_UPLOADED),
         )  # type: ignore[call-arg]
 

--- a/flip-api/src/flip_api/model_services/services/model_service.py
+++ b/flip-api/src/flip_api/model_services/services/model_service.py
@@ -78,7 +78,7 @@ def edit_model(model_id: UUID, model_details: IModelDetails, user_id: UUID, sess
 
 _STATUS_AUDIT_MAP: dict[ModelStatus, ModelAuditAction] = {
     ModelStatus.PREPARED: ModelAuditAction.PREPARED,
-    ModelStatus.TRAINING_STARTED: ModelAuditAction.TRAINING_STARTED,
+    ModelStatus.RUNNING: ModelAuditAction.RUNNING,
     ModelStatus.RESULTS_UPLOADED: ModelAuditAction.RESULTS_UPLOADED,
 }
 

--- a/flip-api/src/flip_api/private_services/invoke_model_status_update.py
+++ b/flip-api/src/flip_api/private_services/invoke_model_status_update.py
@@ -62,13 +62,13 @@ def invoke_model_status_update_endpoint(
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"Model ID: {model_id} does not exist")
 
         log_message = {
-            ModelStatus.ERROR: "There has been an error whilst running training for this model.",
-            ModelStatus.STOPPED: "Training has been stopped for this model.",
-            ModelStatus.INITIATED: "This model has been selected from the queue and will be prepared for training.",
-            ModelStatus.PREPARED: "This model has been prepared and will begin training.",
+            ModelStatus.ERROR: "There has been an error whilst running the job for this model.",
+            ModelStatus.STOPPED: "The job for this model has been stopped.",
+            ModelStatus.INITIATED: "This model has been selected from the queue and will be prepared to run.",
+            ModelStatus.PREPARED: "This model has been prepared and its job will begin shortly.",
             ModelStatus.RUNNING: "The job for this model is now running.",
             ModelStatus.RESULTS_UPLOADED: "The results of this model have been uploaded and can now be downloaded.",
-            ModelStatus.RESULTS_UPLOAD_FAILED: "Training completed successfully, but uploading the results failed.",
+            ModelStatus.RESULTS_UPLOAD_FAILED: "The job completed successfully, but uploading the results failed.",
         }.get(model_status)
 
         if log_message:

--- a/flip-api/src/flip_api/private_services/invoke_model_status_update.py
+++ b/flip-api/src/flip_api/private_services/invoke_model_status_update.py
@@ -66,7 +66,7 @@ def invoke_model_status_update_endpoint(
             ModelStatus.STOPPED: "Training has been stopped for this model.",
             ModelStatus.INITIATED: "This model has been selected from the queue and will be prepared for training.",
             ModelStatus.PREPARED: "This model has been prepared and will begin training.",
-            ModelStatus.TRAINING_STARTED: "Training has started for this model.",
+            ModelStatus.RUNNING: "The job for this model is now running.",
             ModelStatus.RESULTS_UPLOADED: "The results of this model have been uploaded and can now be downloaded.",
             ModelStatus.RESULTS_UPLOAD_FAILED: "Training completed successfully, but uploading the results failed.",
         }.get(model_status)

--- a/flip-api/tests/e2e_smoke.py
+++ b/flip-api/tests/e2e_smoke.py
@@ -545,9 +545,14 @@ def initiate_training(
     _log("  ✅ training initiated (model status now INITIATED)")
 
 
-def wait_for_training_started(
+def wait_for_model_advanced(
     client: requests.Session, headers: dict[str, str], model_id: str, timeout_s: int
 ) -> str:
+    """Block until the model reports any status past INITIATED (PREPARED counts).
+
+    This is the "did the FL scheduler pick the job up at all" gate, not a wait for
+    RUNNING — that lives in ``wait_for_model_running``.
+    """
     _log(f"⏳ Waiting for FL pipeline to advance the model (timeout {timeout_s}s)")
     deadline = time.monotonic() + timeout_s
     last_status = ""
@@ -605,12 +610,12 @@ def wait_for_training_finished(
     )
 
 
-def wait_for_training_running(
+def wait_for_model_running(
     client: requests.Session, headers: dict[str, str], model_id: str, timeout_s: int
 ) -> str:
     """Block until the model reports RUNNING — a genuinely live FL job.
 
-    ``wait_for_training_started`` returns on the first status past INITIATED, which
+    ``wait_for_model_advanced`` returns on the first status past INITIATED, which
     can be the transient PREPARED. The --abort-midway stop test wants a running job,
     so poll on for RUNNING specifically. If training races to RESULTS_UPLOADED
     first, return that — stopping an already-finished job is still a valid idempotency
@@ -883,7 +888,7 @@ def main(argv: list[str] | None = None) -> int:
         # Always wait for image pull, including on --project-id reuse: a prior
         # run on this project may have left pulls in flight (aborted midway,
         # failed, or simply queued back-to-back before the first pull finished),
-        # in which case skipping the wait here would have wait_for_training_started
+        # in which case skipping the wait here would have wait_for_model_advanced
         # sit blocked on the (still pulling) FL clients until it times out.
         wait_for_image_pull(
             client,
@@ -896,10 +901,10 @@ def main(argv: list[str] | None = None) -> int:
         if args.data_enrichment_cmd:
             run_data_enrichment(args.data_enrichment_cwd, args.data_enrichment_cmd, project_id)
         initiate_training(client, headers, model_id, trusts)
-        wait_for_training_started(client, headers, model_id, args.training_start_timeout)
+        wait_for_model_advanced(client, headers, model_id, args.training_start_timeout)
         if args.abort_midway:
             # #490: exercise the FL "stop training" path instead of running to completion.
-            running_status = wait_for_training_running(
+            running_status = wait_for_model_running(
                 client, headers, model_id, args.training_start_timeout
             )
             if running_status == ModelStatus.RESULTS_UPLOADED.value:

--- a/flip-api/tests/e2e_smoke.py
+++ b/flip-api/tests/e2e_smoke.py
@@ -630,7 +630,7 @@ def wait_for_training_running(
             _log(f"  📊 status={status}")
             last_status = status
         if status == ModelStatus.ERROR.value:
-            raise SmokeFailure("Model entered ERROR state before training started — check fl-server logs")
+            raise SmokeFailure("Model entered ERROR state before reaching RUNNING — check fl-server logs")
         if status in (ModelStatus.RUNNING.value, ModelStatus.RESULTS_UPLOADED.value):
             return status
         time.sleep(poll_interval)

--- a/flip-api/tests/e2e_smoke.py
+++ b/flip-api/tests/e2e_smoke.py
@@ -74,7 +74,7 @@ ABORT_MIDWAY_NAME_SUFFIX = " (abort-midway)"
 # finish short-circuits wait_for_training_finished cleanly on the first poll.
 TRAINING_PROGRESS_STATUSES = {
     ModelStatus.PREPARED.value,
-    ModelStatus.TRAINING_STARTED.value,
+    ModelStatus.RUNNING.value,
     ModelStatus.RESULTS_UPLOADED.value,
 }
 
@@ -608,15 +608,15 @@ def wait_for_training_finished(
 def wait_for_training_running(
     client: requests.Session, headers: dict[str, str], model_id: str, timeout_s: int
 ) -> str:
-    """Block until the model reports TRAINING_STARTED — a genuinely live FL job.
+    """Block until the model reports RUNNING — a genuinely live FL job.
 
     ``wait_for_training_started`` returns on the first status past INITIATED, which
     can be the transient PREPARED. The --abort-midway stop test wants a running job,
-    so poll on for TRAINING_STARTED specifically. If training races to RESULTS_UPLOADED
+    so poll on for RUNNING specifically. If training races to RESULTS_UPLOADED
     first, return that — stopping an already-finished job is still a valid idempotency
     check, the caller just notes it.
     """
-    _log(f"⏳ Waiting for model to reach TRAINING_STARTED (timeout {timeout_s}s)")
+    _log(f"⏳ Waiting for model to reach RUNNING (timeout {timeout_s}s)")
     deadline = time.monotonic() + timeout_s
     last_status = ""
     poll_interval = 5
@@ -631,11 +631,11 @@ def wait_for_training_running(
             last_status = status
         if status == ModelStatus.ERROR.value:
             raise SmokeFailure("Model entered ERROR state before training started — check fl-server logs")
-        if status in (ModelStatus.TRAINING_STARTED.value, ModelStatus.RESULTS_UPLOADED.value):
+        if status in (ModelStatus.RUNNING.value, ModelStatus.RESULTS_UPLOADED.value):
             return status
         time.sleep(poll_interval)
     raise SmokeFailure(
-        f"Model did not reach TRAINING_STARTED within {timeout_s}s (last status: {last_status or 'unknown'})."
+        f"Model did not reach RUNNING within {timeout_s}s (last status: {last_status or 'unknown'})."
     )
 
 

--- a/flip-api/tests/integration/test_all_models_endpoint.py
+++ b/flip-api/tests/integration/test_all_models_endpoint.py
@@ -177,7 +177,7 @@ def test_status_filter_narrows_results(client: TestClient, session, project_fact
     project = _add_project(session, project_factory, owner_id=user_id, name="Mixed")
     training = _add_model(
         session, model_factory, project_id=project.id, owner_id=user_id,
-        name="live", status=ModelStatus.TRAINING_STARTED,
+        name="live", status=ModelStatus.RUNNING,
     )
     _add_model(
         session, model_factory, project_id=project.id, owner_id=user_id,
@@ -185,7 +185,7 @@ def test_status_filter_narrows_results(client: TestClient, session, project_fact
     )
 
     override_verify_token_as(user_id)
-    response = client.get(MODELS_URL, params={"status": "TRAINING_STARTED"})
+    response = client.get(MODELS_URL, params={"status": "RUNNING"})
 
     assert response.status_code == 200
     assert _ids(response.json()) == {str(training.id)}
@@ -308,13 +308,13 @@ def test_response_carries_per_status_counts(client: TestClient, session, project
     project = _add_project(session, project_factory, owner_id=user_id, name="Counts")
     for _ in range(2):
         _add_model(session, model_factory, project_id=project.id, owner_id=user_id, status=ModelStatus.PENDING)
-    _add_model(session, model_factory, project_id=project.id, owner_id=user_id, status=ModelStatus.TRAINING_STARTED)
+    _add_model(session, model_factory, project_id=project.id, owner_id=user_id, status=ModelStatus.RUNNING)
 
     override_verify_token_as(user_id)
     counts = client.get(MODELS_URL).json()["statusCounts"]
 
     assert counts.get("PENDING") == 2
-    assert counts.get("TRAINING_STARTED") == 1
+    assert counts.get("RUNNING") == 1
 
 
 def test_status_counts_ignore_the_active_status_filter(
@@ -326,7 +326,7 @@ def test_status_counts_ignore_the_active_status_filter(
     pending = _add_model(
         session, model_factory, project_id=project.id, owner_id=user_id, status=ModelStatus.PENDING
     )
-    _add_model(session, model_factory, project_id=project.id, owner_id=user_id, status=ModelStatus.TRAINING_STARTED)
+    _add_model(session, model_factory, project_id=project.id, owner_id=user_id, status=ModelStatus.RUNNING)
 
     override_verify_token_as(user_id)
     body = client.get(MODELS_URL, params={"status": "PENDING"}).json()
@@ -335,7 +335,7 @@ def test_status_counts_ignore_the_active_status_filter(
     assert _ids(body) == {str(pending.id)}
     # ...but the tiles still see the full breakdown.
     assert body["statusCounts"].get("PENDING") == 1
-    assert body["statusCounts"].get("TRAINING_STARTED") == 1
+    assert body["statusCounts"].get("RUNNING") == 1
 
 
 def test_status_counts_exclude_inaccessible_projects(

--- a/flip-api/tests/step_functions_services/test_retrieve_model_step_function.py
+++ b/flip-api/tests/step_functions_services/test_retrieve_model_step_function.py
@@ -48,7 +48,7 @@ def mock_model_response(model_id):
         model_name="Test Model",
         model_description="This is a test model",
         project_id=uuid4(),
-        status="TRAINING_STARTED",
+        status="RUNNING",
         query=None,
         files=[],
     ).model_dump(mode="json", by_alias=True)
@@ -60,7 +60,7 @@ def mock_model_response(model_id):
 #     with patch(
 #         "flip_api.step_functions_services.retrieve_model_step_function.retrieve_model_status_from_logs"
 #     ) as mock:
-#         mock.return_value = {"modelStatus": "TRAINING_STARTED"}
+#         mock.return_value = {"modelStatus": "RUNNING"}
 #         yield mock
 
 

--- a/flip-api/tests/unit/domain/interfaces/test_project_interfaces.py
+++ b/flip-api/tests/unit/domain/interfaces/test_project_interfaces.py
@@ -201,11 +201,11 @@ class TestIModelsInfoResponseSchema:
             id=model_id,
             name="Clinical Model",
             description="Predicts outcomes",
-            status=ModelStatus.TRAINING_STARTED,
+            status=ModelStatus.RUNNING,
             owner_id=owner_id,  # Renamed from owner_id
         )
         assert info.id == UUID(model_id)
-        assert info.status == ModelStatus.TRAINING_STARTED
+        assert info.status == ModelStatus.RUNNING
         assert info.owner_id == UUID(owner_id)
 
 

--- a/flip-api/tests/unit/model_services/services/test_model_service.py
+++ b/flip-api/tests/unit/model_services/services/test_model_service.py
@@ -339,7 +339,7 @@ def test_update_model_status_notifies_scheduler_on_terminal_status(mock_audit, m
     to retire the run — confirms the side-effect on transition.
     """
     session = MagicMock()
-    mock_model = MagicMock(status=ModelStatus.TRAINING_STARTED)
+    mock_model = MagicMock(status=ModelStatus.RUNNING)
     session.get.return_value = mock_model
     model_id = uuid4()
 

--- a/flip-api/tests/unit/model_services/test_edit_model.py
+++ b/flip-api/tests/unit/model_services/test_edit_model.py
@@ -76,7 +76,7 @@ def mock_model_status_none():
 
 @pytest.fixture
 def mock_model_status_uneditable():
-    mock_status = MagicMock(deleted=False, status=ModelStatus.TRAINING_STARTED)
+    mock_status = MagicMock(deleted=False, status=ModelStatus.RUNNING)
     with patch("flip_api.model_services.edit_model.get_model_status", return_value=mock_status):
         yield
 

--- a/flip-api/tests/unit/private_services/test_invoke_model_status_update.py
+++ b/flip-api/tests/unit/private_services/test_invoke_model_status_update.py
@@ -67,6 +67,27 @@ class TestInvokeModelStatusUpdateEndpoint:
 
     @patch(MOCKED_ADD_LOG_PATH)
     @patch(MOCKED_UPDATE_STATUS_PATH)
+    def test_invoke_update_accepts_legacy_training_started_as_running(
+        self,
+        mock_update: MagicMock,
+        mock_add_log: MagicMock,
+        client: TestClient,
+        model_id: UUID,
+        mock_db_session: MagicMock,
+    ):
+        # A pre-rename fl-server image still reports TRAINING_STARTED; the hub must
+        # accept it as RUNNING (#782) because FL images deploy separately from flip-api.
+        mock_update.return_value = ModelStatus.RUNNING
+
+        response = client.put(f"/api/model/{model_id}/status/TRAINING_STARTED")
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json() == {"success": "status set"}
+        mock_update.assert_called_once_with(model_id, ModelStatus.RUNNING, mock_db_session)
+        assert "running" in mock_add_log.call_args.args[1].lower()
+
+    @patch(MOCKED_ADD_LOG_PATH)
+    @patch(MOCKED_UPDATE_STATUS_PATH)
     def test_invoke_update_results_upload_failed_logs_specific_failure(
         self,
         mock_update: MagicMock,

--- a/flip-ui/src/pages/__tests__/models.spec.ts
+++ b/flip-ui/src/pages/__tests__/models.spec.ts
@@ -170,17 +170,17 @@ describe("Models Page", () => {
     });
 
     test("renders a human-readable status label", async () => {
-        setModels([makeModel({ status: "TRAINING_STARTED" })]);
+        setModels([makeModel({ status: "RUNNING" })]);
         const wrapper = mountPage();
         await wrapper.vm.$nextTick();
 
-        expect(wrapper.find("[data-test='model-status-indicator']").text()).toBe("Training Started");
+        expect(wrapper.find("[data-test='model-status-indicator']").text()).toBe("Running");
     });
 
     test("stacks mobile rows with the status pill and green-dot trust chips below sm", async () => {
         setModels([makeModel({
             trusts: [trust("GSTT"), trust("KCH")],
-            status: "TRAINING_STARTED",
+            status: "RUNNING",
             description: "Predicts stroke outcomes"
         })]);
         const wrapper = mountPage();
@@ -197,7 +197,7 @@ describe("Models Page", () => {
         const pill = mobile.find("[data-test='model-status-indicator-mobile']");
         expect(pill.classes()).toContain("rounded-full");
         expect(pill.classes().join(" ")).toContain("bg-fuchsia-100");
-        expect(pill.text()).toBe("Training Started");
+        expect(pill.text()).toBe("Running");
         // …and the same green-dot trust chips.
         const chips = mobile.findAll("[data-test='model-trust-chip-mobile']");
         expect(chips).toHaveLength(2);
@@ -250,8 +250,8 @@ describe("Models Page", () => {
     });
 
     test("renders a filter tile per group with counts summed from statusCounts", async () => {
-        setModels([makeModel({ status: "TRAINING_STARTED" })], {
-            TRAINING_STARTED: 3,
+        setModels([makeModel({ status: "RUNNING" })], {
+            RUNNING: 3,
             PENDING: 1,
             INITIATED: 2,
             ERROR: 1,
@@ -260,8 +260,8 @@ describe("Models Page", () => {
         const wrapper = mountPage();
         await wrapper.vm.$nextTick();
 
-        expect(wrapper.find("[data-test='filter-tile-training']").exists()).toBe(true);
-        expect(wrapper.find("[data-test='filter-tile-count-training']").text()).toBe("3");
+        expect(wrapper.find("[data-test='filter-tile-running']").exists()).toBe(true);
+        expect(wrapper.find("[data-test='filter-tile-count-running']").text()).toBe("3");
         // Preparing groups PENDING + PREPARED = 1 (a just-created model is being prepared, not queued).
         expect(wrapper.find("[data-test='filter-tile-count-preparing']").text()).toBe("1");
         // Queued is INITIATED only = 2.
@@ -270,7 +270,7 @@ describe("Models Page", () => {
         expect(wrapper.find("[data-test='filter-tile-count-attention']").text()).toBe("2");
     });
 
-    test("orders the tiles with Preparing before In training", async () => {
+    test("orders the tiles with Preparing before Running", async () => {
         setModels([makeModel()]);
         const wrapper = mountPage();
         await wrapper.vm.$nextTick();
@@ -278,29 +278,29 @@ describe("Models Page", () => {
         const keys = wrapper.findAll("button[data-test^='filter-tile-']").map(b => b.attributes("data-test"));
         expect(keys).toEqual([
             "filter-tile-preparing",
-            "filter-tile-training",
+            "filter-tile-running",
             "filter-tile-queued",
             "filter-tile-completed",
             "filter-tile-attention"
         ]);
     });
 
-    test("opens with In training + Queued selected and unions further tile clicks", async () => {
+    test("opens with Running + Queued selected and unions further tile clicks", async () => {
         setModels([makeModel()]);
         const wrapper = mountPage();
         await wrapper.vm.$nextTick();
 
-        expect(wrapper.find("[data-test='filter-tile-training']").attributes("aria-pressed")).toBe("true");
+        expect(wrapper.find("[data-test='filter-tile-running']").attributes("aria-pressed")).toBe("true");
         expect(wrapper.find("[data-test='filter-tile-queued']").attributes("aria-pressed")).toBe("true");
         expect(wrapper.find("[data-test='filter-tile-completed']").attributes("aria-pressed")).toBe("false");
-        expect(swrvKey.fn!()).toContain("status=TRAINING_STARTED,INITIATED");
+        expect(swrvKey.fn!()).toContain("status=RUNNING,INITIATED");
 
         // Adding a tile unions its statuses into the filter…
         await wrapper.find("[data-test='filter-tile-completed']").trigger("click");
-        expect(swrvKey.fn!()).toContain("status=TRAINING_STARTED,INITIATED,RESULTS_UPLOADED");
+        expect(swrvKey.fn!()).toContain("status=RUNNING,INITIATED,RESULTS_UPLOADED");
 
         // …and deselecting everything clears the status filter entirely.
-        await wrapper.find("[data-test='filter-tile-training']").trigger("click");
+        await wrapper.find("[data-test='filter-tile-running']").trigger("click");
         await wrapper.find("[data-test='filter-tile-queued']").trigger("click");
         await wrapper.find("[data-test='filter-tile-completed']").trigger("click");
         expect(swrvKey.fn!()).not.toContain("status=");
@@ -377,7 +377,7 @@ describe("Models Page", () => {
     });
 
     test("each row carries a status-coloured left rail", async () => {
-        setModels([makeModel({ status: "TRAINING_STARTED" })]);
+        setModels([makeModel({ status: "RUNNING" })]);
         const wrapper = mountPage();
         await wrapper.vm.$nextTick();
 
@@ -387,8 +387,8 @@ describe("Models Page", () => {
         expect(rail.classes().some(c => c.includes("fuchsia"))).toBe(true);
     });
 
-    test("TRAINING_STARTED status pill matches the In-training fuchsia, not amber", async () => {
-        setModels([makeModel({ status: "TRAINING_STARTED" })]);
+    test("RUNNING status pill matches the Running-tile fuchsia, not amber", async () => {
+        setModels([makeModel({ status: "RUNNING" })]);
         const wrapper = mountPage();
         await wrapper.vm.$nextTick();
 

--- a/flip-ui/src/pages/models.vue
+++ b/flip-ui/src/pages/models.vue
@@ -297,7 +297,7 @@ const pageNumber = ref(1);
 const searchQueryParam = ref("");
 const statusQueryParam = ref("");
 
-type GroupKey = "training" | "preparing" | "queued" | "completed" | "attention";
+type GroupKey = "running" | "preparing" | "queued" | "completed" | "attention";
 
 interface ITile {
     key: GroupKey;
@@ -320,9 +320,9 @@ const TILES: ITile[] = [
         ring: "border-amber-500 ring-amber-500/40"
     },
     {
-        key: "training",
-        label: "In training",
-        statuses: ["TRAINING_STARTED"],
+        key: "running",
+        label: "Running",
+        statuses: ["RUNNING"],
         dot: "bg-fuchsia-500",
         ring: "border-fuchsia-500 ring-fuchsia-500/40"
     },
@@ -351,8 +351,8 @@ const TILES: ITile[] = [
 
 // Tiles are accumulative: each click toggles a group in or out of the selection
 // and the list shows the union. An empty selection means no status filter (all
-// models). The page opens on the active work: In training + Queued.
-const activeTiles = ref<Set<GroupKey>>(new Set(["training", "queued"]));
+// models). The page opens on the active work: Running + Queued.
+const activeTiles = ref<Set<GroupKey>>(new Set(["running", "queued"]));
 
 const syncStatusFilter = (): void => {
     const statuses = TILES.filter(t => activeTiles.value.has(t.key)).flatMap(t => t.statuses);
@@ -453,7 +453,7 @@ const STATUS_RANK: Record<ModelStatus, number> = {
     PENDING: 0,
     INITIATED: 1,
     PREPARED: 2,
-    TRAINING_STARTED: 3,
+    RUNNING: 3,
     RESULTS_UPLOADED: 4,
     RESULTS_UPLOAD_FAILED: 5,
     ERROR: 6,
@@ -476,13 +476,13 @@ const sortedModels = computed<IModelSummary[]>(() => {
     return [...models.value].sort(sortDir.value === "asc" ? cmp : (a, b) => cmp(b, a));
 });
 
-// Status-toned left rail: magenta = live training, amber = preparing, emerald =
+// Status-toned left rail: magenta = running, amber = preparing, emerald =
 // completed, red = needs attention, neutral = created/queued. PENDING groups under
 // the Preparing tile but keeps the neutral tone — nothing is running yet.
 const railClass = (status: ModelStatus | undefined): string => {
     if (isModelStatusError(status)) return "bg-red-500";
     if (status === "RESULTS_UPLOADED") return "bg-emerald-500";
-    if (status === "TRAINING_STARTED") return "bg-fuchsia-500";
+    if (status === "RUNNING") return "bg-fuchsia-500";
     if (status === "PREPARED") return "bg-amber-500";
 
     return "bg-gray-300 dark:bg-gray-600";

--- a/flip-ui/src/pages/project/[projectId]/model/[modelId]/__tests__/index.spec.ts
+++ b/flip-ui/src/pages/project/[projectId]/model/[modelId]/__tests__/index.spec.ts
@@ -405,7 +405,7 @@ describe("pages/project/[projectId]/model/[modelId]", () => {
                 name: "config.json",
                 status: FileUploadStatus.COMPLETED
             }],
-            { status: "TRAINING_STARTED" }
+            { status: "RUNNING" }
         );
         const wrapper = await mountPage();
         await flushPromises();
@@ -526,7 +526,7 @@ describe("pages/project/[projectId]/model/[modelId]", () => {
                 name: "config.json",
                 status: FileUploadStatus.COMPLETED
             }],
-            { status: "TRAINING_STARTED" }
+            { status: "RUNNING" }
         );
         const wrapper = await mountPage();
         await flushPromises();

--- a/flip-ui/src/pages/project/[projectId]/model/[modelId]/index.vue
+++ b/flip-ui/src/pages/project/[projectId]/model/[modelId]/index.vue
@@ -251,7 +251,7 @@ const steps = computed((): IStep[] => {
     const dates = [
         modelData.value?.creationTimestamp,
         modelData.value?.preparedAt,
-        modelData.value?.trainingStartedAt,
+        modelData.value?.runningAt,
         modelData.value?.resultsUploadedAt
     ];
 

--- a/flip-ui/src/partials/models/__tests__/LatestModels.spec.ts
+++ b/flip-ui/src/partials/models/__tests__/LatestModels.spec.ts
@@ -197,7 +197,7 @@ describe("LatestModels — defensive data access", () => {
                 id: "m1",
                 name: "Alpha",
                 description: "",
-                status: "TRAINING_STARTED"
+                status: "RUNNING"
             }]
         });
         const wrapper = mountLatestModels();
@@ -206,7 +206,7 @@ describe("LatestModels — defensive data access", () => {
         const chip = wrapper.find("[data-test='latest-model-status-chip']");
         expect(chip.classes()).toContain("rounded-full");
         expect(chip.classes().join(" ")).toContain("bg-fuchsia-100");
-        expect(chip.text()).toBe("Training Started");
+        expect(chip.text()).toBe("Running");
         // Same row as the name: they share a flex parent.
         const nameRow = chip.element.parentElement;
         expect(nameRow?.textContent).toContain("Alpha");

--- a/flip-ui/src/partials/models/__tests__/ModelList.spec.ts
+++ b/flip-ui/src/partials/models/__tests__/ModelList.spec.ts
@@ -199,20 +199,20 @@ describe("ModelList — Status column", () => {
         expect(cell.find("[data-test='model-status-icon-tick']").exists()).toBe(true);
     });
 
-    test("TRAINING_STARTED renders 'Training Started' with a tick", async () => {
+    test("RUNNING renders 'Running' with a tick", async () => {
         setData({
             data: [{
                 id: "m1",
                 name: "A",
                 description: "",
-                status: "TRAINING_STARTED"
+                status: "RUNNING"
             }]
         });
         const wrapper = mountModelList();
         await flushPromises();
 
         const cell = wrapper.find("[data-test='model-status-m1']");
-        expect(cell.text()).toContain("Training Started");
+        expect(cell.text()).toContain("Running");
         expect(cell.find("[data-test='model-status-icon-tick']").exists()).toBe(true);
     });
 
@@ -300,7 +300,7 @@ describe("ModelList — mobile stacked rows (design 5a)", () => {
             id: "m1",
             name: "Alpha",
             description: "First model",
-            status: "TRAINING_STARTED",
+            status: "RUNNING",
             trusts: [
                 {
                     id: "t1",
@@ -358,7 +358,7 @@ describe("ModelList — mobile stacked rows (design 5a)", () => {
         // The /models pill idiom: coloured chip + status dot inside it.
         expect(chip.classes().join(" ")).toContain("bg-fuchsia-100");
         expect(chip.find("span.rounded-full").classes().join(" ")).toContain("bg-fuchsia-500");
-        expect(chip.text()).toContain("Training Started");
+        expect(chip.text()).toContain("Running");
     });
 
     test("clamps the description to two lines and falls back to the placeholder", async () => {

--- a/flip-ui/src/partials/models/__tests__/Training.spec.ts
+++ b/flip-ui/src/partials/models/__tests__/Training.spec.ts
@@ -209,7 +209,7 @@ describe("Training metrics + live-activity responsive layout", () => {
     }
 
     it("stacks the cards by default and only goes side-by-side on wide (xl) screens", () => {
-        const wrapper = mountTraining({ status: "TRAINING_STARTED" });
+        const wrapper = mountTraining({ status: "RUNNING" });
 
         const { container } = layoutParts(wrapper);
 
@@ -218,7 +218,7 @@ describe("Training metrics + live-activity responsive layout", () => {
     });
 
     it("makes the live-activity card full-width when stacked and a fixed column only at xl+", () => {
-        const wrapper = mountTraining({ status: "TRAINING_STARTED" });
+        const wrapper = mountTraining({ status: "RUNNING" });
 
         const { liveCard } = layoutParts(wrapper);
 
@@ -228,7 +228,7 @@ describe("Training metrics + live-activity responsive layout", () => {
     });
 
     it("lets the metrics card take the remaining width beside the activity card", () => {
-        const wrapper = mountTraining({ status: "TRAINING_STARTED" });
+        const wrapper = mountTraining({ status: "RUNNING" });
 
         const { metricsCard } = layoutParts(wrapper);
 
@@ -237,7 +237,7 @@ describe("Training metrics + live-activity responsive layout", () => {
     });
 
     it("matches the sibling card heights at xl instead of letting the timeline set them", () => {
-        const wrapper = mountTraining({ status: "TRAINING_STARTED" });
+        const wrapper = mountTraining({ status: "RUNNING" });
 
         const { liveCard, innerColumn } = layoutParts(wrapper);
 
@@ -251,7 +251,7 @@ describe("Training metrics + live-activity responsive layout", () => {
     });
 
     it("never lets the timeline scroll horizontally", () => {
-        const wrapper = mountTraining({ status: "TRAINING_STARTED" });
+        const wrapper = mountTraining({ status: "RUNNING" });
 
         const { scrollWrap } = layoutParts(wrapper);
 
@@ -263,7 +263,7 @@ describe("Training Live activity status dot", () => {
     const dotSelector = "[data-test=live-activity-dot]";
 
     it("is primary (in-progress) when training is running", () => {
-        const wrapper = mountTraining({ status: "TRAINING_STARTED" });
+        const wrapper = mountTraining({ status: "RUNNING" });
 
         const dot = wrapper.find(dotSelector);
 

--- a/flip-ui/src/partials/models/__tests__/TrainingActionsMenu.spec.ts
+++ b/flip-ui/src/partials/models/__tests__/TrainingActionsMenu.spec.ts
@@ -40,7 +40,7 @@ vi.mock("@/services/model-service", async (importOriginal) => {
     };
 });
 
-function mountMenu(status: ModelStatusEnum = ModelStatusEnum.TRAINING_STARTED) {
+function mountMenu(status: ModelStatusEnum = ModelStatusEnum.RUNNING) {
     return mount(TrainingActionsMenu, {
         global: {
             stubs: {

--- a/flip-ui/src/services/__tests__/model-service.spec.ts
+++ b/flip-ui/src/services/__tests__/model-service.spec.ts
@@ -458,7 +458,7 @@ describe("model-service", () => {
             expect(buildModelSteps("PENDING").map(s => s.name)).toEqual([
                 "Model Created",
                 "Model Prepared",
-                "Training",
+                "Running",
                 "Results Uploaded"
             ]);
         });
@@ -467,17 +467,17 @@ describe("model-service", () => {
             expect(buildModelSteps("RESULTS_UPLOADED").every(s => s.completed)).toBe(true);
         });
 
-        it("ERROR flags Training as an error", () => {
-            // A genuine training failure should still surface on the Training milestone.
-            const step = stepByName("ERROR", "Training");
+        it("ERROR flags Running as an error", () => {
+            // A genuine job failure should still surface on the Running milestone.
+            const step = stepByName("ERROR", "Running");
             expect(step.error).toBe(true);
             expect(step.completed).toBeFalsy();
         });
 
-        it("RESULTS_UPLOAD_FAILED keeps Training completed (training did finish)", () => {
-            // The bug this fixes: an upload failure must not paint the Training
-            // milestone as failed, because training itself completed successfully.
-            const step = stepByName("RESULTS_UPLOAD_FAILED", "Training");
+        it("RESULTS_UPLOAD_FAILED keeps Running completed (the job did finish)", () => {
+            // The bug this fixes: an upload failure must not paint the Running
+            // milestone as failed, because the job itself completed successfully.
+            const step = stepByName("RESULTS_UPLOAD_FAILED", "Running");
             expect(step.completed).toBe(true);
             expect(step.error).toBeFalsy();
             expect(step.inProgress).toBeFalsy();
@@ -497,7 +497,7 @@ describe("model-service", () => {
             // getStatusEnumValue maps anything unknown to ERROR so a stale UI bundle
             // receiving a newer status degrades gracefully rather than crashing.
             expect(() => buildModelSteps("NONSENSE" as ModelStatus)).not.toThrow();
-            expect(stepByName("NONSENSE" as ModelStatus, "Training").error).toBe(true);
+            expect(stepByName("NONSENSE" as ModelStatus, "Running").error).toBe(true);
         });
     });
 

--- a/flip-ui/src/services/__tests__/model-service.spec.ts
+++ b/flip-ui/src/services/__tests__/model-service.spec.ts
@@ -493,6 +493,22 @@ describe("model-service", () => {
             expect(stepByName("RESULTS_UPLOAD_FAILED", "Model Prepared").completed).toBe(true);
         });
 
+        it("PREPARED shows Running as Starting — the job is staged but not yet executing", () => {
+            const step = stepByName("PREPARED", "Running");
+            expect(step.description).toBe("Starting");
+            expect(step.inProgress).toBe(true);
+        });
+
+        it("RUNNING shows Running as In Progress", () => {
+            const step = stepByName("RUNNING", "Running");
+            expect(step.description).toBe("In Progress");
+            expect(step.inProgress).toBe(true);
+        });
+
+        it("RESULTS_UPLOADED clears the Running description", () => {
+            expect(stepByName("RESULTS_UPLOADED", "Running").description).toBeUndefined();
+        });
+
         it("an unrecognised status degrades to error handling without throwing", () => {
             // getStatusEnumValue maps anything unknown to ERROR so a stale UI bundle
             // receiving a newer status degrades gracefully rather than crashing.

--- a/flip-ui/src/services/model-service.ts
+++ b/flip-ui/src/services/model-service.ts
@@ -75,7 +75,7 @@ export interface IModelDashboard {
     files: FileInfo[];
     creationTimestamp?: string | null;
     preparedAt?: string | null;
-    trainingStartedAt?: string | null;
+    runningAt?: string | null;
     resultsUploadedAt?: string | null;
 }
 
@@ -119,7 +119,7 @@ export type ModelStatus =
     "PENDING" |
     "INITIATED" |
     "PREPARED" |
-    "TRAINING_STARTED" |
+    "RUNNING" |
     "RESULTS_UPLOADED" |
     "RESULTS_UPLOAD_FAILED" |
     "ERROR" |
@@ -131,7 +131,7 @@ export enum ModelStatusEnum {
     "PENDING",
     "INITIATED",
     "PREPARED",
-    "TRAINING_STARTED",
+    "RUNNING",
     "RESULTS_UPLOADED",
     // Appended last so the existing ordinal comparisons keep working: training
     // finished but the results upload failed, so it sorts after RESULTS_UPLOADED.
@@ -142,7 +142,7 @@ const MODEL_STATUS_LABELS: Record<ModelStatus, string> = {
     PENDING: "Model Created",
     INITIATED: "Model Queued",
     PREPARED: "Model Prepared",
-    TRAINING_STARTED: "Training Started",
+    RUNNING: "Running",
     RESULTS_UPLOADED: "Results Uploaded",
     RESULTS_UPLOAD_FAILED: "Results Upload Failed",
     ERROR: "Error",
@@ -171,7 +171,7 @@ export function modelStatusPillClass(status: ModelStatus | undefined): string {
     if (status === "RESULTS_UPLOADED") {
         return "bg-emerald-100 text-emerald-900 dark:bg-emerald-900/40 dark:text-emerald-100";
     }
-    if (status === "TRAINING_STARTED") {
+    if (status === "RUNNING") {
         return "bg-fuchsia-100 text-fuchsia-800 dark:bg-fuchsia-900/40 dark:text-fuchsia-200";
     }
     if (status === "PREPARED") {
@@ -185,7 +185,7 @@ export function modelStatusPillClass(status: ModelStatus | undefined): string {
 export function modelStatusDotClass(status: ModelStatus | undefined): string {
     if (isModelStatusError(status)) return "bg-red-500";
     if (status === "RESULTS_UPLOADED") return "bg-emerald-500";
-    if (status === "TRAINING_STARTED") return "bg-fuchsia-500";
+    if (status === "RUNNING") return "bg-fuchsia-500";
     if (status === "PREPARED") return "bg-amber-500";
 
     return "bg-gray-400";
@@ -211,12 +211,12 @@ export function getStatusEnumValue(status: string | undefined): number {
 }
 
 /**
- * Builds the four-step lifecycle tracker (Created → Prepared → Training → Uploaded)
+ * Builds the four-step lifecycle tracker (Created → Prepared → Running → Uploaded)
  * shown on the model page, derived from the model's single status value.
  *
- * When training is stopped or errors, prior completed steps stay completed (✅)
- * rather than showing 🚫. RESULTS_UPLOAD_FAILED means training finished but the
- * post-training results upload failed, so "Training" stays completed and only
+ * When the job is stopped or errors, prior completed steps stay completed (✅)
+ * rather than showing 🚫. RESULTS_UPLOAD_FAILED means the job finished but the
+ * post-run results upload failed, so "Running" stays completed and only
  * "Results Uploaded" shows the error. See issue #29.
  *
  * Per-step dates (creation/prepared/training/results timestamps) are layered on
@@ -227,7 +227,7 @@ export function buildModelSteps(status: ModelStatus | undefined): IStep[] {
     const isStopped = statusValue === ModelStatusEnum.STOPPED;
     const isError = statusValue === ModelStatusEnum.ERROR;
     const isUploadFailed = statusValue === ModelStatusEnum.RESULTS_UPLOAD_FAILED;
-    // RESULTS_UPLOAD_FAILED (ordinal 7) already satisfies the >= PREPARED / > TRAINING_STARTED
+    // RESULTS_UPLOAD_FAILED (ordinal 7) already satisfies the >= PREPARED / > RUNNING
     // comparisons in the "completed" flags below, so isUploadFailed is technically redundant
     // there today. It is kept explicit so the steps stay correct if the enum is reordered, and
     // to mirror its load-bearing use in the inProgress / error flags.
@@ -247,12 +247,12 @@ export function buildModelSteps(status: ModelStatus | undefined): IStep[] {
         },
         {
             id: "03",
-            name: "Training",
+            name: "Running",
             description:
                 (statusValue >= ModelStatusEnum.PREPARED && statusValue < ModelStatusEnum.RESULTS_UPLOADED)
                     ? "In Progress" : undefined,
             inProgress: statusValue >= ModelStatusEnum.PREPARED && !isStopped && !isError && !isUploadFailed,
-            completed: statusValue > ModelStatusEnum.TRAINING_STARTED || isUploadFailed,
+            completed: statusValue > ModelStatusEnum.RUNNING || isUploadFailed,
             error: isError,
             stopped: isStopped
         },

--- a/flip-ui/src/services/model-service.ts
+++ b/flip-ui/src/services/model-service.ts
@@ -248,9 +248,12 @@ export function buildModelSteps(status: ModelStatus | undefined): IStep[] {
         {
             id: "03",
             name: "Running",
+            // PREPARED means the job is staged but not yet executing (the fl-server flips it to
+            // RUNNING once the run is live), so the step reads "Starting" until then — mirroring
+            // the "Model Queued" sub-state on the Model Prepared step.
             description:
-                (statusValue >= ModelStatusEnum.PREPARED && statusValue < ModelStatusEnum.RESULTS_UPLOADED)
-                    ? "In Progress" : undefined,
+                statusValue === ModelStatusEnum.PREPARED ? "Starting"
+                    : statusValue === ModelStatusEnum.RUNNING ? "In Progress" : undefined,
             inProgress: statusValue >= ModelStatusEnum.PREPARED && !isStopped && !isError && !isUploadFailed,
             completed: statusValue > ModelStatusEnum.RUNNING || isUploadFailed,
             error: isError,

--- a/flip-utils/flip/__init__.py
+++ b/flip-utils/flip/__init__.py
@@ -37,4 +37,4 @@ from flip.exceptions import ResultsUploadError
 
 __all__ = ["FLIP", "FLIPBase", "ResultsUploadError"]
 
-__version__ = "0.3.0"
+__version__ = "0.4.0"

--- a/flip-utils/flip/constants/flip_constants.py
+++ b/flip-utils/flip/constants/flip_constants.py
@@ -169,12 +169,14 @@ class FlipEvents:
 
 
 class ModelStatus(StrEnum):
-    """Model training status values."""
+    """Model job status values."""
 
     PENDING = "PENDING"
     INITIATED = "INITIATED"
     PREPARED = "PREPARED"
-    TRAINING_STARTED = "TRAINING_STARTED"
+    # Job-type-neutral "the FL job is executing" status (renamed from
+    # TRAINING_STARTED, #782) — evaluation jobs report it too.
+    RUNNING = "RUNNING"
     RESULTS_UPLOADED = "RESULTS_UPLOADED"
     ERROR = "ERROR"
     STOPPED = "STOPPED"

--- a/flip-utils/flip/nvflare/components/flip_server_event_handler.py
+++ b/flip-utils/flip/nvflare/components/flip_server_event_handler.py
@@ -97,7 +97,15 @@ class ServerEventHandler(FLComponent):
 
         elif event_type == AppEventType.TRAINING_STARTED:
             self.log_info(fl_ctx, "Training started event received")
-            self._update_status(fl_ctx, ModelStatus.TRAINING_STARTED)
+            self._update_status(fl_ctx, ModelStatus.RUNNING)
+
+        elif event_type == FlipEvents.TASK_INITIATED:
+            # Fired by InitEvaluation when an evaluation job finishes initialising.
+            # Evaluation workflows never fire the training events above, so this is
+            # the only mid-run transition an eval job gets (#782). Training templates
+            # don't run InitEvaluation, so there is no RUNNING → PREPARED zigzag.
+            self.log_info(fl_ctx, "Task initiated event received")
+            self._update_status(fl_ctx, ModelStatus.RUNNING)
 
         elif event_type == AppEventType.TRAINING_FINISHED:
             self.log_info(fl_ctx, "Training finished event received")

--- a/flip-utils/tests/unit/constants/test_flip_constants.py
+++ b/flip-utils/tests/unit/constants/test_flip_constants.py
@@ -237,7 +237,7 @@ class TestModelStatus:
         assert ModelStatus.PENDING.value == "PENDING"
         assert ModelStatus.INITIATED.value == "INITIATED"
         assert ModelStatus.PREPARED.value == "PREPARED"
-        assert ModelStatus.TRAINING_STARTED.value == "TRAINING_STARTED"
+        assert ModelStatus.RUNNING.value == "RUNNING"
         assert ModelStatus.RESULTS_UPLOADED.value == "RESULTS_UPLOADED"
         assert ModelStatus.ERROR.value == "ERROR"
         assert ModelStatus.STOPPED.value == "STOPPED"

--- a/flip-utils/tests/unit/core/test_standard.py
+++ b/flip-utils/tests/unit/core/test_standard.py
@@ -137,7 +137,7 @@ class TestFLIPStandardDevUpdateStatus:
     def test_update_status_runs_without_error_in_dev_mode(self, flip_dev):
         """update_status should run without error in dev mode (no-op)."""
         # Should not raise any exception - it's a no-op in dev mode
-        flip_dev.update_status(model_id="model-123", new_model_status=ModelStatus.TRAINING_STARTED)
+        flip_dev.update_status(model_id="model-123", new_model_status=ModelStatus.RUNNING)
 
 
 class TestFLIPStandardDevSendHandledException:
@@ -363,7 +363,7 @@ class TestFLIPStandardProdUpdateStatus:
             mock_constants.INTERNAL_SERVICE_KEY_HEADER = "x-internal-service-key"
             mock_constants.INTERNAL_SERVICE_KEY = "test-internal-key"
 
-            flip_prod.update_status(valid_model_id, ModelStatus.TRAINING_STARTED)
+            flip_prod.update_status(valid_model_id, ModelStatus.RUNNING)
 
             # Verify API was called
             mock_put.assert_called_once()
@@ -374,7 +374,7 @@ class TestFLIPStandardProdUpdateStatus:
     def test_update_status_rejects_invalid_uuid(self, flip_prod):
         """update_status should reject invalid model IDs."""
         with pytest.raises(ValueError, match="Invalid model ID"):
-            flip_prod.update_status("model-123", ModelStatus.TRAINING_STARTED)
+            flip_prod.update_status("model-123", ModelStatus.RUNNING)
 
 
 class TestFLIPStandardProdSendHandledException:

--- a/flip-utils/tests/unit/nvflare/components/test_flip_server_event_handler.py
+++ b/flip-utils/tests/unit/nvflare/components/test_flip_server_event_handler.py
@@ -143,7 +143,28 @@ class TestServerEventHandler:
 
         handler.handle_event(AppEventType.TRAINING_STARTED, fl_ctx)
 
-        flip.update_status.assert_called_with(model_id, ModelStatus.TRAINING_STARTED)
+        flip.update_status.assert_called_with(model_id, ModelStatus.RUNNING)
+
+    def test_handle_event_task_initiated(self):
+        """Test handle_event with TASK_INITIATED event (evaluation jobs, #782)"""
+        model_id = "123e4567-e89b-12d3-a456-426614174000"
+        flip = MagicMock()
+        handler = ServerEventHandler(model_id=model_id, flip=flip)
+
+        fl_ctx = MagicMock()
+        fl_ctx.get_peer_context.return_value = None
+        engine = MagicMock()
+        fl_ctx.get_engine.return_value = engine
+
+        json_generator = Mock(spec=ValidationJsonGenerator)
+        persist_cleanup = Mock(spec=PersistToS3AndCleanup)
+        engine.get_component.side_effect = lambda comp_id: (
+            json_generator if comp_id == "json_generator" else persist_cleanup
+        )
+
+        handler.handle_event(FlipEvents.TASK_INITIATED, fl_ctx)
+
+        flip.update_status.assert_called_with(model_id, ModelStatus.RUNNING)
 
     def test_handle_event_fatal_system_error(self):
         """Test handle_event with FATAL_SYSTEM_ERROR event"""


### PR DESCRIPTION
Closes #782

> **Depends on PR #772** (the #767 Flower flip-utils source pin — still open): without it, Flower's per-run installs resolve `flip-utils` from PyPI (0.1.8, pre-rename) and the ServerApp crashes on `ModelStatus.RUNNING`. Merge #767 first. NVFLARE unaffected. Details in the PR comments.

## What

Renames model status `TRAINING_STARTED` → `RUNNING` (job-type-neutral) and gives evaluation jobs an emission point so they actually reach it. Evaluation jobs previously sat at `INITIATED` for their entire run and jumped straight to `RESULTS_UPLOADED` — misleading in the UI and a false alarm in `e2e_smoke` (observed on prod 2026-07-14, model `c4c80d62`, ~40 min at `INITIATED` while both clients were actively scoring).

## How

- **flip-api**
  - `ModelStatus` / `ModelAuditAction` rename, keeping the member's slot in both native PG enums; Alembic revision `8c41d0f2ab5e` (`ALTER TYPE ... RENAME VALUE` — existing rows follow automatically, transactional).
  - **Back-compat shim**: `ModelStatus._missing_` accepts legacy `"TRAINING_STARTED"` as `RUNNING`. FL images deploy separately from the hub (surgical per-service task-def deploys in prod), so a pre-rename fl-server must not 4xx against the upgraded hub. Covers the private status endpoint and the `/models?status=` filter (both construct `ModelStatus(value)`). Removal once every deployed FL image emits `RUNNING` is tracked in #803 (review).
  - Wire field `trainingStartedAt` → `runningAt` on the model response (audit-action-derived lifecycle date).
- **flip-utils** (ships in FL images on both backends)
  - `ServerEventHandler`: `AppEventType.TRAINING_STARTED → RUNNING`, and restores the lost `FlipEvents.TASK_INITIATED → RUNNING` branch. `InitEvaluation` fires `TASK_INITIATED` in both `evaluation` and `evaluation_client_api`; the legacy per-app eval handler handled it and the branch was dropped in the handler unification (see the archaeology comment on #782). Training templates never run `InitEvaluation`, so no `RUNNING → PREPARED` zigzag.
  - **No NVFLARE template changes needed** — both eval templates already register `InitEvaluation` + `ServerEventHandler`.
  - `__version__` 0.3.0 → 0.4.0 (review): dropping `ModelStatus.TRAINING_STARTED` from the `StrEnum` is a breaking change to the published package, and `v0.3.0` is already tagged.
- **Flower templates/tutorials**: `standard` strategies emit `RUNNING` at rounds start; the `evaluation` template (and spleen eval tutorial) keep `PREPARED` at checkpoint load and emit `RUNNING` when the eval rounds start, so Flower evals get the full `INITIATED → PREPARED → RUNNING → RESULTS_UPLOADED` ladder.
- **flip-ui**: status label/chip/tile "Training Started" / "In training" → "Running" (tile key + `data-test` ids follow), lifecycle step 03 "Training" → "Running", `runningAt` date, spec updates. The Running step's description now distinguishes the sub-states: "Starting" while `PREPARED`, "In Progress" only once genuinely `RUNNING` (Copilot review).
- **e2e_smoke**: status references follow the rename; the existing past-INITIATED gate now also passes for evaluation jobs once they emit `RUNNING`. Helper names follow too (review): `wait_for_training_started` → `wait_for_model_advanced` (it gates on the first status past `INITIATED`, not any "started" status) and `wait_for_training_running` → `wait_for_model_running`.
- **Model log messages** (Copilot review): the remaining training-specific per-model log lines in the private status-update endpoint (`ERROR`/`STOPPED`/`INITIATED`/`PREPARED`/`RESULTS_UPLOAD_FAILED`) reworded to job-neutral phrasing, consistent with the `RUNNING` message, since evaluation jobs share the lifecycle.
- **Docs**: `create-flip-app-from-flower.rst` lifecycle snippets (the `RUNNING` call now sits before `strategy.start`, matching the real templates).

## Rollout order (prod)

1. **flip-api** (migration + alias shim) — accepts both old and new values.
   - *Operator note (review):* the new task's boot migration renames the stored enum value while old replicas are still draining, and old code has neither a `RUNNING` member nor the shim — so model endpoints can briefly 500 (`LookupError`) on old replicas for rows in this status, i.e. exactly the in-flight jobs people are watching. Minutes-long, self-healing; not a failed deploy.
2. **flip-ui** — follows the hub immediately: nothing in the new UI depends on the FL images (the hub normalises legacy inbound values at the API boundary), while the pre-rename bundle misrenders every `RUNNING` model for as long as it lags (unknown status falls back to the `ERROR` ordinal: error-flagged lifecycle step, "—" status label, "In training" tile count 0). The hard constraint is hub-before-UI: the new UI's default `status=RUNNING,INITIATED` tile filter gets a 400 from a pre-rename hub. Stale browser sessions during the hub→UI gap show the same "—"/error affordances for `RUNNING` models until refreshed onto the new bundle.
3. **FL images** (fl-server / Flower server) — start emitting `RUNNING`; until then the hub shim keeps normalising their legacy `TRAINING_STARTED` reports. Once all deployed FL images are post-rename, retire the shim (#803).

## Verification

- flip-utils: ruff + 505 unit tests passed (incl. new `TASK_INITIATED → RUNNING` handler test).
- flip-api: ruff + mypy + 1201 unit tests passed (incl. new legacy-alias endpoint test) + 91 integration tests passed — the migration drift guard ran revision `8c41d0f2ab5e` against a real Postgres.
- flip-ui: eslint clean (3 pre-existing max-len warnings in untouched `EditProjectDrawer.vue`) + 983 unit tests passed (incl. new Running-step sub-state specs).


## Acceptance Criteria

*Imported from issue #782*

- An NVFLARE evaluation job shows `RUNNING` shortly after job start and `RESULTS_UPLOADED` on completion.
- A training job progresses `INITIATED → PREPARED → RUNNING → RESULTS_UPLOADED` on both backends.
- `make e2e_smoke` passes for an evaluation app whose run outlasts `--training-start-timeout`.
- An fl-server on a pre-rename image can still report status against the upgraded hub.

