### PR TITLE
[Feature]: Show a model's position in the FL scheduler queue (Live activity + Models page)

### DIFF
--- a/docs/source/user-guides/user-common.rst
+++ b/docs/source/user-guides/user-common.rst
@@ -488,6 +488,8 @@ FLIP uses the concept of *nets* that are deployed on the Central Hub and remote 
 
 This scheduling capability means model developers can submit their model for training via the UI and need not be concerned with matters such as GPU capacity or existing jobs that are running/queued. When initiating training the platform will check for available nets and assign the model training to an available net.
 
+While a model is waiting for a net, its place in the queue is shown alongside its status — e.g. ``Model Queued (2)``, where position 1 is the next model to start — both on the Models page and on the model's page, and the model's Live activity feed logs a new line each time the model moves up the queue.
+
 Initiate Training
 -----------------
 

--- a/flip-api/src/flip_api/db/models/main_models.py
+++ b/flip-api/src/flip_api/db/models/main_models.py
@@ -120,7 +120,8 @@ class FLLogs(SQLModel, table=True):
     # and deliberately deferred — so internal add_log callers must supply
     # exactly one of log/event_type (an all-NULL row renders as an empty line).
     log: str | None = Field(default=None)
-    # Typed round events (FLLogEvent values). Stored as plain text — not a native
+    # Typed events (FLLogEvent values): round progress reported by the FL layer,
+    # plus hub-emitted rows (QUEUE_POSITION). Stored as plain text — not a native
     # PG enum — so extending the vocabulary never needs an ALTER TYPE migration.
     # Event-specific facts (total_rounds, size_bytes, returned/expected) live in
     # the JSONB details column; global_round is first-class so round-scoped

--- a/flip-api/src/flip_api/domain/interfaces/model.py
+++ b/flip-api/src/flip_api/domain/interfaces/model.py
@@ -170,6 +170,9 @@ class IModelResponse(BaseModel):
     # The trusts the run was dispatched to — the latest FL job's fl_job_trust
     # roster. Empty before dispatch, when the model has no job yet.
     trusts: list[ITrustSummary] = Field(default_factory=list)
+    # The model's 1-based place in the FL training queue (position 1 = next to
+    # be picked up); None unless the model has a QUEUED job waiting for a net.
+    queue_position: int | None = Field(default=None, alias="queuePosition")
 
     model_config = ConfigDict(
         populate_by_name=True,

--- a/flip-api/src/flip_api/domain/interfaces/model.py
+++ b/flip-api/src/flip_api/domain/interfaces/model.py
@@ -62,6 +62,9 @@ class IAllModelsResponse(BaseModel):
     owner_id: UUID = Field(..., alias="ownerId")
     owner_name: str | None = Field(default=None, alias="ownerName")
     trusts: list[ITrustSummary] = Field(default_factory=list)
+    # The model's 1-based place in the FL training queue (position 1 = next to
+    # be picked up); None unless the model has a QUEUED job waiting for a net.
+    queue_position: int | None = Field(default=None, alias="queuePosition")
 
     model_config = ConfigDict(populate_by_name=True, arbitrary_types_allowed=True)
 

--- a/flip-api/src/flip_api/domain/schemas/private.py
+++ b/flip-api/src/flip_api/domain/schemas/private.py
@@ -18,6 +18,7 @@ from pydantic import BaseModel, Field, model_validator, validator
 
 from flip_api.config import get_settings
 from flip_api.domain.schemas.status import TaskType
+from flip_api.domain.schemas.types import FLLogEvent
 
 
 class Results(BaseModel):
@@ -82,10 +83,14 @@ class TrainingLog(BaseModel):
     log: str | None = None
     # Senders use the FLLogEvent vocabulary, but the field is plain validated text
     # end-to-end (like the fl_logs column): a newer FL image's event is stored and
-    # served via the unknown-event render fallback, never rejected at ingest.
+    # served via the unknown-event render fallback, never rejected at ingest. The
+    # one exception is the hub-reserved QUEUE_POSITION, refused below: a spoofed
+    # row would render in the feed and could perturb the FL scheduler's
+    # emit-on-change dedup (which compares against any stored row).
     event_type: str | None = Field(default=None, max_length=64)
     # 1-based on both backends; every event this endpoint accepts is round-scoped
-    # (the hub-emitted, round-less QUEUE_POSITION is written directly, never ingested here).
+    # (the hub-emitted, round-less QUEUE_POSITION is written directly by the FL
+    # scheduler and rejected at this boundary).
     global_round: int | None = Field(default=None, ge=1)
     details: dict[str, Any] | None = None
     success: bool = True
@@ -96,6 +101,8 @@ class TrainingLog(BaseModel):
             raise ValueError("Exactly one of 'log' and 'event_type' must be set")
         if self.event_type is not None and not self.event_type.strip():
             raise ValueError("'event_type' must be non-blank when set")
+        if self.event_type == FLLogEvent.QUEUE_POSITION:
+            raise ValueError("'QUEUE_POSITION' is emitted by the hub's FL scheduler and cannot be ingested")
         if self.event_type is not None and self.global_round is None:
             raise ValueError("'global_round' is required when 'event_type' is set")
         return self

--- a/flip-api/src/flip_api/domain/schemas/private.py
+++ b/flip-api/src/flip_api/domain/schemas/private.py
@@ -84,7 +84,8 @@ class TrainingLog(BaseModel):
     # end-to-end (like the fl_logs column): a newer FL image's event is stored and
     # served via the unknown-event render fallback, never rejected at ingest.
     event_type: str | None = Field(default=None, max_length=64)
-    # 1-based on both backends; every event in the vocabulary is round-scoped.
+    # 1-based on both backends; every event this endpoint accepts is round-scoped
+    # (the hub-emitted, round-less QUEUE_POSITION is written directly, never ingested here).
     global_round: int | None = Field(default=None, ge=1)
     details: dict[str, Any] | None = None
     success: bool = True

--- a/flip-api/src/flip_api/domain/schemas/types.py
+++ b/flip-api/src/flip_api/domain/schemas/types.py
@@ -22,16 +22,21 @@ NonEmptyUUIDList = Annotated[list[UUID], Field(min_length=1)]
 
 
 class FLLogEvent(StrEnum):
-    """Typed FL progress events accepted by ``POST /model/{id}/logs``.
+    """Typed activity-feed events stored in ``fl_logs.event_type``.
 
-    The FL layer reports **facts** (event type + structured fields); the display
-    text is composed hub-side at serve time (``log_rendering.py``), so wording
-    changes are a flip-api redeploy and never an FL-image rebuild. Stored in the
-    plain-text ``fl_logs.event_type`` column — deliberately NOT a native PG enum,
-    so extending this vocabulary never needs an ``ALTER TYPE`` migration.
+    The reporting layer sends **facts** (event type + structured fields); the
+    display text is composed hub-side at serve time (``log_rendering.py``), so
+    wording changes are a flip-api redeploy and never an FL-image rebuild.
+    Stored in the plain-text ``fl_logs.event_type`` column — deliberately NOT a
+    native PG enum, so extending this vocabulary never needs an ``ALTER TYPE``
+    migration.
 
-    Rounds are 1-based on every event, on both backends (NVFLARE's internal
-    ``_current_round`` is 0-based and is normalised at the emission boundary).
+    The round events arrive from the FL layer via ``POST /model/{id}/logs`` and
+    are 1-based on both backends (NVFLARE's internal ``_current_round`` is
+    0-based and is normalised at the emission boundary). ``QUEUE_POSITION`` is
+    the exception: hub-emitted and round-less, it is written directly by the FL
+    scheduler and never arrives through the ingest endpoint (whose validator
+    requires ``global_round`` on typed events).
     """
 
     ROUND_STARTED = "ROUND_STARTED"

--- a/flip-api/src/flip_api/domain/schemas/types.py
+++ b/flip-api/src/flip_api/domain/schemas/types.py
@@ -37,6 +37,11 @@ class FLLogEvent(StrEnum):
     ROUND_STARTED = "ROUND_STARTED"
     CLIENT_RESULT_RECEIVED = "CLIENT_RESULT_RECEIVED"
     ROUND_AGGREGATED = "ROUND_AGGREGATED"
+    # Hub-emitted (by the FL scheduler at queue mutations), never sent by FL
+    # images: the model's 1-based place in the FL training queue, re-logged on
+    # every movement. Carries no global_round; details = {"position": n,
+    # "job_id": str(FLJob.id)} — job_id keys emit-on-change per training run.
+    QUEUE_POSITION = "QUEUE_POSITION"
 
 
 class FLBackend(StrEnum):

--- a/flip-api/src/flip_api/domain/schemas/types.py
+++ b/flip-api/src/flip_api/domain/schemas/types.py
@@ -35,8 +35,9 @@ class FLLogEvent(StrEnum):
     are 1-based on both backends (NVFLARE's internal ``_current_round`` is
     0-based and is normalised at the emission boundary). ``QUEUE_POSITION`` is
     the exception: hub-emitted and round-less, it is written directly by the FL
-    scheduler and never arrives through the ingest endpoint (whose validator
-    requires ``global_round`` on typed events).
+    scheduler, and the ingest endpoint's validator (``TrainingLog``) rejects it
+    outright — a spoofed row could otherwise perturb the scheduler's
+    emit-on-change dedup, which compares against any stored row.
     """
 
     ROUND_STARTED = "ROUND_STARTED"

--- a/flip-api/src/flip_api/fl_services/initiate_training.py
+++ b/flip-api/src/flip_api/fl_services/initiate_training.py
@@ -87,7 +87,7 @@ def initiate_training(
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"Model ID: {model_id} does not exist")
 
         # One typed row per queue movement: this emits the new job's initial
-        # position ("Model Queued (n)"), replacing the old free-text enqueue line.
+        # position ("Model Queued (n)").
         log_queue_positions(db)
         add_log(model_id, f"Selected trusts for training: {', '.join(t.name for t in trusts)}", db)
 

--- a/flip-api/src/flip_api/fl_services/initiate_training.py
+++ b/flip-api/src/flip_api/fl_services/initiate_training.py
@@ -21,6 +21,7 @@ from flip_api.db.database import get_session
 from flip_api.db.models.main_models import Trust
 from flip_api.domain.interfaces.fl import IInitiateTrainingInputPayload
 from flip_api.domain.schemas.status import ModelStatus
+from flip_api.fl_services.services.fl_scheduler_service import log_queue_positions
 from flip_api.fl_services.services.fl_service import add_fl_job
 from flip_api.model_services.services.model_service import add_log, update_model_status
 from flip_api.utils.constants import SERVICE_UNAVAILABLE_MESSAGE
@@ -85,7 +86,9 @@ def initiate_training(
         if not updated:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"Model ID: {model_id} does not exist")
 
-        add_log(model_id, "This model has been added to the queue.", db)
+        # One typed row per queue movement: this emits the new job's initial
+        # position ("Model Queued (n)"), replacing the old free-text enqueue line.
+        log_queue_positions(db)
         add_log(model_id, f"Selected trusts for training: {', '.join(t.name for t in trusts)}", db)
 
     except HTTPException:

--- a/flip-api/src/flip_api/fl_services/run_jobs.py
+++ b/flip-api/src/flip_api/fl_services/run_jobs.py
@@ -19,6 +19,7 @@ from flip_api.domain.schemas.status import NetStatus
 from flip_api.fl_services.services.fl_scheduler_service import (
     check_for_available_net,
     check_for_queued_jobs,
+    log_queue_positions,
     prepare_and_start_training,
 )
 from flip_api.utils.logger import logger
@@ -96,6 +97,9 @@ def run_jobs_core(db: Session) -> None:
                 "net": scheduler.netId,
             })
             return
+
+        # The pickup just advanced every remaining queued model one place.
+        log_queue_positions(db)
 
         # Step 3: Prepare and start training
         logger.info({

--- a/flip-api/src/flip_api/fl_services/services/fl_scheduler_service.py
+++ b/flip-api/src/flip_api/fl_services/services/fl_scheduler_service.py
@@ -164,15 +164,19 @@ def log_queue_positions(session: Session) -> None:
             )
             .order_by(cast(Column, FLLogs.log_date).desc())
         ).all()
-        last_by_model: dict[UUID, FLLogs] = {}
+        # Keyed by job id (not model id): a model can hold two QUEUED jobs (no
+        # uniqueness on FLJob.model_id), and a model-keyed lookup would let the
+        # newest row suppress one job while forcing the other to re-emit forever.
+        last_details_by_job: dict[str, dict] = {}
         for row in prior_rows:
-            last_by_model.setdefault(row.model_id, row)
+            row_details = row.details or {}
+            row_job_id = row_details.get("job_id")
+            if isinstance(row_job_id, str):
+                last_details_by_job.setdefault(row_job_id, row_details)
 
         emitted = False
         for position, job in enumerate(queued_jobs, start=1):
-            last = last_by_model.get(job.model_id)
-            last_details = (last.details or {}) if last is not None else {}
-            if last_details.get("job_id") == str(job.id) and last_details.get("position") == position:
+            if last_details_by_job.get(str(job.id), {}).get("position") == position:
                 continue
             # A non-None transaction makes add_log skip its per-row commit; the
             # whole batch lands in the single commit below.

--- a/flip-api/src/flip_api/fl_services/services/fl_scheduler_service.py
+++ b/flip-api/src/flip_api/fl_services/services/fl_scheduler_service.py
@@ -135,10 +135,13 @@ def log_queue_positions(session: Session) -> None:
     a re-initiated model always re-logs its first position); a row is written
     only when the position is new or changed, making the function idempotent —
     callers invoke it after any queue mutation without worrying about noise.
+    Rows are batched into a single commit so a deep queue never costs O(N)
+    commits per mutation.
 
-    Positions are a display nicety: any failure is logged and swallowed so an
-    emission problem can never wedge the scheduler tick or the caller's queue
-    mutation.
+    Positions are a display nicety: any failure is logged, the batch is rolled
+    back, and nothing is raised — an emission problem can never wedge the
+    scheduler tick or the caller's queue mutation. Callers invoke this after
+    their own commit, so the rollback cannot discard caller state.
 
     Args:
         session (Session): The database session.
@@ -165,20 +168,31 @@ def log_queue_positions(session: Session) -> None:
         for row in prior_rows:
             last_by_model.setdefault(row.model_id, row)
 
+        emitted = False
         for position, job in enumerate(queued_jobs, start=1):
             last = last_by_model.get(job.model_id)
             last_details = (last.details or {}) if last is not None else {}
             if last_details.get("job_id") == str(job.id) and last_details.get("position") == position:
                 continue
+            # A non-None transaction makes add_log skip its per-row commit; the
+            # whole batch lands in the single commit below.
             add_log(
                 job.model_id,
                 None,
                 session,
                 event_type=FLLogEvent.QUEUE_POSITION.value,
                 details={"position": position, "job_id": str(job.id)},
+                transaction=session,
             )
+            emitted = True
+        if emitted:
+            session.commit()
     except Exception:
         logger.exception("Failed to emit queue-position logs")
+        try:
+            session.rollback()
+        except Exception:
+            logger.exception("Failed to roll back queue-position emission")
 
 
 def revert_scheduler_pickup(scheduler_id: UUID, session: Session) -> None:

--- a/flip-api/src/flip_api/fl_services/services/fl_scheduler_service.py
+++ b/flip-api/src/flip_api/fl_services/services/fl_scheduler_service.py
@@ -116,6 +116,9 @@ def remove_job_from_queue(model_id: UUID, session: Session) -> None:
         session.commit()
         logger.info("Set job(s) as deleted")
 
+        # Deleting a queued job re-ranks everything behind it.
+        log_queue_positions(session)
+
     except SQLAlchemyError as e:
         session.rollback()
         logger.error(f"Error removing job from queue: {e}")
@@ -652,6 +655,13 @@ def update_fl_scheduler(model_id: UUID, session: Session) -> None:
                 session.add(scheduler)
 
         session.commit()
+
+        if job:
+            # Completing a still-QUEUED job (e.g. a queued model stopped or
+            # errored) re-ranks everything behind it; for a job already picked
+            # up this no-ops (emit-on-change).
+            log_queue_positions(session)
+
         if job and scheduler:
             logger.info(
                 "FL job %s set to COMPLETED, scheduler %s released to AVAILABLE.",

--- a/flip-api/src/flip_api/fl_services/services/fl_scheduler_service.py
+++ b/flip-api/src/flip_api/fl_services/services/fl_scheduler_service.py
@@ -138,6 +138,19 @@ def log_queue_positions(session: Session) -> None:
     Rows are batched into a single commit so a deep queue never costs O(N)
     commits per mutation.
 
+    Idempotence holds for serialized callers only: emit-on-change is a
+    read-then-write with nothing locked, so concurrent calls (the scheduler
+    tick on its ``BackgroundScheduler`` thread vs a request thread, or a
+    second flip-api replica) can both read the same prior rows and both
+    write, leaving duplicate — or transiently contradictory — feed rows.
+    That is tolerated: positions are a display nicety and the next mutation
+    self-heals. The hub currently runs one flip-api replica with a single
+    Uvicorn worker (ECS ``desired_count = 1``, no autoscaling; ``fastapi
+    run`` without ``--workers``), so only in-process thread interleaving can
+    race. Scaling flip-api out multiplies the emission sites per tick — close
+    the race then with ``SELECT ... FOR UPDATE`` on the queued jobs or a
+    partial unique index over the ``details`` (job_id, position) pair.
+
     Positions are a display nicety: any failure is logged, the batch is rolled
     back, and nothing is raised — an emission problem can never wedge the
     scheduler tick or the caller's queue mutation. **Precondition:** call this
@@ -161,23 +174,34 @@ def log_queue_positions(session: Session) -> None:
         if not queued_jobs:
             return
 
-        prior_rows = session.exec(
-            select(FLLogs)
+        # DISTINCT ON collapses each job's history to its newest row inside
+        # Postgres, and only the compared details payload is fetched — a
+        # model's QUEUE_POSITION rows accumulate for life (each drain of a
+        # depth-N queue writes O(N^2) rows in total), so materialising every
+        # historical row as a full ORM object would grow monotonically with
+        # usage. If this scan ever shows up in slow-query logs regardless, the
+        # next lever is an index on (model_id, event_type) in a future
+        # Alembic revision.
+        prior_job_id = col(FLLogs.details)["job_id"].astext
+        prior_details = session.exec(
+            select(cast(Column, FLLogs.details))
             .where(
                 col(FLLogs.model_id).in_([job.model_id for job in queued_jobs]),
                 FLLogs.event_type == FLLogEvent.QUEUE_POSITION.value,
             )
-            .order_by(cast(Column, FLLogs.log_date).desc())
+            .distinct(prior_job_id)
+            .order_by(prior_job_id, cast(Column, FLLogs.log_date).desc())
         ).all()
         # Keyed by job id (not model id): a model can hold two QUEUED jobs (no
         # uniqueness on FLJob.model_id), and a model-keyed lookup would let the
         # newest row suppress one job while forcing the other to re-emit forever.
+        # setdefault keeps first-seen-newest as defense in depth should the
+        # query ever hand back more than one row per job.
         last_details_by_job: dict[str, dict] = {}
-        for row in prior_rows:
-            row_details = row.details or {}
-            row_job_id = row_details.get("job_id")
+        for row_details in prior_details:
+            row_job_id = (row_details or {}).get("job_id")
             if isinstance(row_job_id, str):
-                last_details_by_job.setdefault(row_job_id, row_details)
+                last_details_by_job.setdefault(row_job_id, row_details or {})
 
         emitted = False
         for position, job in enumerate(queued_jobs, start=1):

--- a/flip-api/src/flip_api/fl_services/services/fl_scheduler_service.py
+++ b/flip-api/src/flip_api/fl_services/services/fl_scheduler_service.py
@@ -21,6 +21,7 @@ from sqlmodel import Session, col, select
 from flip_api.db.models.main_models import (
     FLJob,
     FLKitSlot,
+    FLLogs,
     FLNets,
     FLScheduler,
     Model,
@@ -37,7 +38,7 @@ from flip_api.domain.schemas.status import (
     ModelStatus,
     NetStatus,
 )
-from flip_api.domain.schemas.types import FLBackend
+from flip_api.domain.schemas.types import FLBackend, FLLogEvent
 from flip_api.fl_services.services.fl_service import (
     bundle_flower_application,
     bundle_nvflare_application,
@@ -119,6 +120,62 @@ def remove_job_from_queue(model_id: UUID, session: Session) -> None:
         session.rollback()
         logger.error(f"Error removing job from queue: {e}")
         raise DatabaseError("Error removing job from queue") from e
+
+
+def log_queue_positions(session: Session) -> None:
+    """Emit one typed activity row per queued model whose queue position changed.
+
+    The FL queue is ``FLJob`` rows in ``QUEUED`` status, ordered by ``created``
+    ascending — exactly the order ``check_for_queued_jobs`` picks from, so
+    position 1 is the next model to start when a net frees up. For each queued
+    job the last logged ``QUEUE_POSITION`` row is compared (keyed by job id, so
+    a re-initiated model always re-logs its first position); a row is written
+    only when the position is new or changed, making the function idempotent —
+    callers invoke it after any queue mutation without worrying about noise.
+
+    Positions are a display nicety: any failure is logged and swallowed so an
+    emission problem can never wedge the scheduler tick or the caller's queue
+    mutation.
+
+    Args:
+        session (Session): The database session.
+
+    Returns:
+        None
+    """
+    try:
+        queued_jobs = session.exec(
+            select(FLJob).where(FLJob.status == JobStatus.QUEUED).order_by(cast(Column, FLJob.created).asc())
+        ).all()
+        if not queued_jobs:
+            return
+
+        prior_rows = session.exec(
+            select(FLLogs)
+            .where(
+                col(FLLogs.model_id).in_([job.model_id for job in queued_jobs]),
+                FLLogs.event_type == FLLogEvent.QUEUE_POSITION.value,
+            )
+            .order_by(cast(Column, FLLogs.log_date).desc())
+        ).all()
+        last_by_model: dict[UUID, FLLogs] = {}
+        for row in prior_rows:
+            last_by_model.setdefault(row.model_id, row)
+
+        for position, job in enumerate(queued_jobs, start=1):
+            last = last_by_model.get(job.model_id)
+            last_details = (last.details or {}) if last is not None else {}
+            if last_details.get("job_id") == str(job.id) and last_details.get("position") == position:
+                continue
+            add_log(
+                job.model_id,
+                None,
+                session,
+                event_type=FLLogEvent.QUEUE_POSITION.value,
+                details={"position": position, "job_id": str(job.id)},
+            )
+    except Exception:
+        logger.exception("Failed to emit queue-position logs")
 
 
 def revert_scheduler_pickup(scheduler_id: UUID, session: Session) -> None:

--- a/flip-api/src/flip_api/fl_services/services/fl_scheduler_service.py
+++ b/flip-api/src/flip_api/fl_services/services/fl_scheduler_service.py
@@ -126,7 +126,7 @@ def remove_job_from_queue(model_id: UUID, session: Session) -> None:
 
 
 def log_queue_positions(session: Session) -> None:
-    """Emit one typed activity row per queued model whose queue position changed.
+    """Emit one typed activity row per queued job whose queue position changed.
 
     The FL queue is ``FLJob`` rows in ``QUEUED`` status, ordered by ``created``
     ascending — exactly the order ``check_for_queued_jobs`` picks from, so
@@ -140,8 +140,9 @@ def log_queue_positions(session: Session) -> None:
 
     Positions are a display nicety: any failure is logged, the batch is rolled
     back, and nothing is raised — an emission problem can never wedge the
-    scheduler tick or the caller's queue mutation. Callers invoke this after
-    their own commit, so the rollback cannot discard caller state.
+    scheduler tick or the caller's queue mutation. **Precondition:** call this
+    only after the caller has committed its own mutation; the failure-path
+    rollback would otherwise discard the caller's uncommitted state.
 
     Args:
         session (Session): The database session.
@@ -150,8 +151,12 @@ def log_queue_positions(session: Session) -> None:
         None
     """
     try:
+        # id is the tiebreak on identical created timestamps so this ranking,
+        # queued_positions_by_model and check_for_queued_jobs can never disagree.
         queued_jobs = session.exec(
-            select(FLJob).where(FLJob.status == JobStatus.QUEUED).order_by(cast(Column, FLJob.created).asc())
+            select(FLJob)
+            .where(FLJob.status == JobStatus.QUEUED)
+            .order_by(cast(Column, FLJob.created).asc(), cast(Column, FLJob.id).asc())
         ).all()
         if not queued_jobs:
             return
@@ -196,7 +201,13 @@ def log_queue_positions(session: Session) -> None:
         try:
             session.rollback()
         except Exception:
-            logger.exception("Failed to roll back queue-position emission")
+            # A session whose rollback failed raises PendingRollbackError on
+            # every subsequent use — handed back to run_jobs_core it would fail
+            # the training start and wedge the net. invalidate() discards the
+            # broken connection without running ROLLBACK on it, leaving the
+            # session reusable on a fresh connection.
+            logger.exception("Failed to roll back queue-position emission; invalidating session")
+            session.invalidate()
 
 
 def revert_scheduler_pickup(scheduler_id: UUID, session: Session) -> None:
@@ -460,11 +471,13 @@ def check_for_queued_jobs(scheduler_id: UUID, session: Session) -> IJobResponse 
     logger.info("Checking for any queued jobs...")
 
     try:
-        # Find the earliest queued job
+        # Find the earliest queued job. The id tiebreak on identical created
+        # timestamps keeps the pickup order in exact agreement with the ranks
+        # shown by log_queue_positions / queued_positions_by_model.
         job_stmt = (
             select(FLJob)
             .where(FLJob.status == JobStatus.QUEUED)
-            .order_by(cast(Column, FLJob.created).asc())
+            .order_by(cast(Column, FLJob.created).asc(), cast(Column, FLJob.id).asc())
             .limit(1)
             .with_for_update(skip_locked=True)
         )
@@ -677,7 +690,8 @@ def update_fl_scheduler(model_id: UUID, session: Session) -> None:
         if job:
             # Completing a still-QUEUED job (e.g. a queued model stopped or
             # errored) re-ranks everything behind it; for a job already picked
-            # up this no-ops (emit-on-change).
+            # up this normally emits nothing (emit-on-change), though it also
+            # self-heals rows a previously failed emission rolled back.
             log_queue_positions(session)
 
         if job and scheduler:

--- a/flip-api/src/flip_api/model_services/retrieve_model.py
+++ b/flip-api/src/flip_api/model_services/retrieve_model.py
@@ -26,6 +26,7 @@ from flip_api.db.models.main_models import FLJob, FLJobTrust, Model, ModelsAudit
 from flip_api.domain.interfaces.model import IModelResponse, IQuery, ITrustSummary
 from flip_api.domain.schemas.actions import ModelAuditAction
 from flip_api.domain.schemas.status import FileUploadStatus, ModelStatus
+from flip_api.model_services.services.model_service import queued_positions_by_model
 from flip_api.utils.logger import logger
 
 RETRIEVE_MODEL_QUERY_FILE = f"{os.path.dirname(os.path.abspath(__file__))}/retrieve_model_query.sql"
@@ -203,6 +204,10 @@ def retrieve_model(
         ).all()
         trusts = [ITrustSummary(id=trust_id, name=name, code=code) for trust_id, name, code in trust_rows]
 
+        # Where this model stands in the FL training queue (1-based; None once
+        # its job is picked up or it has none) — same source as the estate list.
+        queue_position = queued_positions_by_model(db).get(model_id)
+
         return IModelResponse(
             model_id=result["model_id"],
             model_name=result["model_name"],
@@ -216,6 +221,7 @@ def retrieve_model(
             training_started_at=latest_per_action.get(ModelAuditAction.TRAINING_STARTED),
             results_uploaded_at=latest_per_action.get(ModelAuditAction.RESULTS_UPLOADED),
             trusts=trusts,
+            queue_position=queue_position,
         )  # type: ignore[call-arg]
 
     except SQLAlchemyError:

--- a/flip-api/src/flip_api/model_services/services/log_rendering.py
+++ b/flip-api/src/flip_api/model_services/services/log_rendering.py
@@ -20,7 +20,7 @@ are baked and deployed to every trust.
 """
 
 import math
-from typing import Any
+from typing import Any, TypeGuard
 
 from flip_api.db.models.main_models import FLLogs
 from flip_api.domain.schemas.types import FLLogEvent
@@ -58,7 +58,7 @@ def _format_bytes(size_bytes: Any) -> str | None:
     return f"{int(raw)} B"  # pragma: no cover - unreachable, satisfies mypy
 
 
-def _is_count(value: Any) -> bool:
+def _is_count(value: Any) -> TypeGuard[int]:
     """True when a ``details`` value is a genuine integer count (bools excluded)."""
     return isinstance(value, int) and not isinstance(value, bool)
 
@@ -99,6 +99,13 @@ def render_log(row: FLLogs) -> str:
         if _is_count(returned) and _is_count(expected):
             return f"Round {row.global_round} aggregated · {returned} of {expected} trusts returned"
         return f"Round {row.global_round} aggregated"
+
+    if row.event_type == FLLogEvent.QUEUE_POSITION:
+        position = details.get("position")
+        if _is_count(position) and position >= 1:
+            return f"Model Queued ({position})"
+        # A row with an unusable stored position must not invent one.
+        return "Model Queued"
 
     if row.event_type is not None:
         return f"Round {row.global_round} · {row.event_type}"

--- a/flip-api/src/flip_api/model_services/services/log_rendering.py
+++ b/flip-api/src/flip_api/model_services/services/log_rendering.py
@@ -12,11 +12,12 @@
 
 """Display-text composition for the model activity feed.
 
-The FL layer reports **facts** — typed events with structured details
-(``FLLogEvent`` rows in ``fl_logs``) — and this module is the single place
-those facts become English. Keeping the wording hub-side means copy changes
-ship with a flip-api redeploy and never require rebuilding the FL images that
-are baked and deployed to every trust.
+The reporting layer — the FL images for round events, the hub's FL scheduler
+for queue positions — records **facts**: typed events with structured details
+(``FLLogEvent`` rows in ``fl_logs``). This module is the single place those
+facts become English. Keeping the wording hub-side means copy changes ship
+with a flip-api redeploy and never require rebuilding the FL images that are
+baked and deployed to every trust.
 """
 
 import math

--- a/flip-api/src/flip_api/model_services/services/model_service.py
+++ b/flip-api/src/flip_api/model_services/services/model_service.py
@@ -167,9 +167,10 @@ def add_log(
             reported by an FL client. None for model-level (hub) logs.
         fl_client_name (str | None): The FL client name as reported by the FL server.
             None for model-level logs.
-        event_type (str | None): The typed round event this row records, when the FL
-            server reported a structured fact rather than free text. Senders use the
-            FLLogEvent vocabulary but the value is stored as plain text.
+        event_type (str | None): The typed event this row records, when a structured
+            fact rather than free text was reported — round events from the FL server,
+            QUEUE_POSITION from the hub's own FL scheduler. Senders use the FLLogEvent
+            vocabulary but the value is stored as plain text.
         global_round (int | None): 1-based federated round the event belongs to.
         details (dict[str, Any] | None): Event-specific facts (e.g. total_rounds,
             size_bytes, returned/expected counts).
@@ -464,9 +465,12 @@ def queued_positions_by_model(session: Session) -> dict[UUID, int]:
     """Map each queued model to its 1-based place in the FL training queue.
 
     The rank mirrors the scheduler's pickup order exactly — QUEUED ``FLJob``
-    rows by ``created`` ascending (``check_for_queued_jobs``) — so position 1
-    is the next model to start when a net frees up. Models with no queued job
-    are simply absent.
+    rows by ``created`` ascending, ``id`` as tiebreak (``check_for_queued_jobs``)
+    — so position 1 is the next model to start when a net frees up. Models with
+    no queued job are simply absent. A model queued twice (``FLJob`` has no
+    uniqueness on ``model_id``) maps to its earliest position, so the status
+    pill shows the position the model will actually be picked at, while the
+    activity feed logs each job's own position.
 
     Args:
         session (Session): The database session.
@@ -475,7 +479,9 @@ def queued_positions_by_model(session: Session) -> dict[UUID, int]:
         dict[UUID, int]: Model id to 1-based queue position.
     """
     queued_model_ids = session.exec(
-        select(FLJob.model_id).where(FLJob.status == JobStatus.QUEUED).order_by(col(FLJob.created).asc())
+        select(FLJob.model_id)
+        .where(FLJob.status == JobStatus.QUEUED)
+        .order_by(col(FLJob.created).asc(), col(FLJob.id).asc())
     ).all()
     positions: dict[UUID, int] = {}
     for position, queued_model_id in enumerate(queued_model_ids, start=1):

--- a/flip-api/src/flip_api/model_services/services/model_service.py
+++ b/flip-api/src/flip_api/model_services/services/model_service.py
@@ -41,7 +41,7 @@ from flip_api.domain.interfaces.model import (
     ITrustSummary,
 )
 from flip_api.domain.schemas.actions import ModelAuditAction
-from flip_api.domain.schemas.status import ModelStatus
+from flip_api.domain.schemas.status import JobStatus, ModelStatus
 from flip_api.fl_services.services import fl_scheduler_service
 from flip_api.model_services.utils.audit_helper import audit_model_action, audit_model_actions
 from flip_api.utils.logger import logger
@@ -460,6 +460,29 @@ def _run_trusts_by_model(model_ids: list[UUID], session: Session) -> dict[UUID, 
     return trusts_by_model
 
 
+def queued_positions_by_model(session: Session) -> dict[UUID, int]:
+    """Map each queued model to its 1-based place in the FL training queue.
+
+    The rank mirrors the scheduler's pickup order exactly — QUEUED ``FLJob``
+    rows by ``created`` ascending (``check_for_queued_jobs``) — so position 1
+    is the next model to start when a net frees up. Models with no queued job
+    are simply absent.
+
+    Args:
+        session (Session): The database session.
+
+    Returns:
+        dict[UUID, int]: Model id to 1-based queue position.
+    """
+    queued_model_ids = session.exec(
+        select(FLJob.model_id).where(FLJob.status == JobStatus.QUEUED).order_by(col(FLJob.created).asc())
+    ).all()
+    positions: dict[UUID, int] = {}
+    for position, queued_model_id in enumerate(queued_model_ids, start=1):
+        positions.setdefault(queued_model_id, position)
+    return positions
+
+
 def get_all_models_service(
     session: Session,
     user_id: UUID | None,
@@ -541,6 +564,7 @@ def get_all_models_service(
     }
 
     trusts_by_model = _run_trusts_by_model([model.id for model, _, _ in rows], session)
+    queue_positions = queued_positions_by_model(session)
 
     data = [
         IAllModelsResponse(
@@ -553,6 +577,7 @@ def get_all_models_service(
             owner_id=model.owner_id,
             owner_name=owner_name,
             trusts=trusts_by_model.get(model.id, []),
+            queue_position=queue_positions.get(model.id),
         )  # type: ignore[call-arg]
         for model, project_name, owner_name in rows
     ]

--- a/flip-api/tests/integration/test_all_models_endpoint.py
+++ b/flip-api/tests/integration/test_all_models_endpoint.py
@@ -21,6 +21,7 @@ model. These are SQL-shaped joins + access filters that pass silently under a
 mocked session, so they are exercised against the throwaway Postgres.
 """
 
+from datetime import datetime
 from uuid import UUID, uuid4
 
 from fastapi.testclient import TestClient
@@ -34,7 +35,7 @@ from flip_api.db.models.main_models import (
     Trust,
 )
 from flip_api.db.models.user_models import UserProfile
-from flip_api.domain.schemas.status import ModelStatus, ProjectStatus, TrustIntersectStatus
+from flip_api.domain.schemas.status import JobStatus, ModelStatus, ProjectStatus, TrustIntersectStatus
 from tests.integration.conftest import admin_user, override_verify_token_as
 
 MODELS_URL = "/api/models"
@@ -379,3 +380,36 @@ def test_status_counts_exclude_inaccessible_projects(
     counts = client.get(MODELS_URL).json()["statusCounts"]
 
     assert counts.get("PENDING") == 1
+
+
+def test_queued_models_carry_their_queue_position(client: TestClient, session, project_factory, model_factory):
+    """Queued rows expose their 1-based FIFO rank (issue #788); picked-up rows expose null."""
+    admin_id = admin_user(session)
+    project = _add_project(session, project_factory, owner_id=admin_id, name="Queue")
+    first = _add_model(
+        session, model_factory, project_id=project.id, owner_id=admin_id,
+        name="first-queued", status=ModelStatus.INITIATED,
+    )
+    second = _add_model(
+        session, model_factory, project_id=project.id, owner_id=admin_id,
+        name="second-queued", status=ModelStatus.INITIATED,
+    )
+    picked = _add_model(
+        session, model_factory, project_id=project.id, owner_id=admin_id,
+        name="picked-up", status=ModelStatus.INITIATED,
+    )
+    # The queue is QUEUED jobs by created ascending; the picked job left it despite
+    # being the oldest, so it must not occupy a position.
+    session.add(FLJob(model_id=first.id, created=datetime(2026, 1, 1, 10, 0, 0)))
+    session.add(FLJob(model_id=second.id, created=datetime(2026, 1, 1, 10, 5, 0)))
+    session.add(FLJob(model_id=picked.id, status=JobStatus.IN_PROGRESS, created=datetime(2026, 1, 1, 9, 0, 0)))
+    session.commit()
+
+    override_verify_token_as(admin_id)
+    response = client.get(MODELS_URL)
+
+    assert response.status_code == 200
+    by_name = {row["name"]: row for row in response.json()["data"]}
+    assert by_name["first-queued"]["queuePosition"] == 1
+    assert by_name["second-queued"]["queuePosition"] == 2
+    assert by_name["picked-up"]["queuePosition"] is None

--- a/flip-api/tests/integration/test_queue_position_emission.py
+++ b/flip-api/tests/integration/test_queue_position_emission.py
@@ -1,0 +1,128 @@
+# Copyright (c) Guy's and St Thomas' NHS Foundation Trust & King's College London
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Integration coverage of the queue-position emission (issue #788).
+
+``log_queue_positions`` is SQL-shaped end to end: the ranks come from the
+``created``-ascending (``id``-tiebroken) queue query, the emit-on-change dedup
+reads prior rows ``log_date``-descending, the compared payload round-trips
+through the JSONB ``details`` column, and the batch relies on ``add_log``
+deferring its per-row commit under ``transaction=``. All of that passes
+silently under a mocked session — the unit tests fabricate both result sets —
+so the invariants are exercised here against the throwaway Postgres, ending
+with the rendered feed a researcher actually sees.
+"""
+
+from datetime import datetime
+from uuid import UUID
+
+from fastapi.testclient import TestClient
+from sqlmodel import col, select
+
+from flip_api.db.models.main_models import FLJob, FLLogs
+from flip_api.domain.schemas.status import JobStatus, ModelStatus
+from flip_api.domain.schemas.types import FLLogEvent
+from flip_api.fl_services.services.fl_scheduler_service import log_queue_positions
+from tests.integration.conftest import admin_user, override_verify_token_as
+from tests.integration.test_all_models_endpoint import _add_model, _add_project
+
+
+def _positions_by_job(session) -> dict[str, list[int]]:
+    """All persisted QUEUE_POSITION rows oldest-first, keyed by the job id in ``details``."""
+    rows = session.exec(
+        select(FLLogs)
+        .where(FLLogs.event_type == FLLogEvent.QUEUE_POSITION.value)
+        .order_by(col(FLLogs.log_date).asc())
+    ).all()
+    by_job: dict[str, list[int]] = {}
+    for row in rows:
+        details = row.details or {}
+        by_job.setdefault(details["job_id"], []).append(details["position"])
+    return by_job
+
+
+def test_queue_position_emission_ranks_dedups_and_renders(
+    client: TestClient, session, project_factory, model_factory
+):
+    """One pass over the write path: rank → idempotence → re-rank → served feed."""
+    admin_id = admin_user(session)
+    project = _add_project(session, project_factory, owner_id=admin_id, name="Queue emission")
+    head = _add_model(
+        session, model_factory, project_id=project.id, owner_id=admin_id,
+        name="head", status=ModelStatus.INITIATED,
+    )
+    mid = _add_model(
+        session, model_factory, project_id=project.id, owner_id=admin_id,
+        name="mid", status=ModelStatus.INITIATED,
+    )
+    tail = _add_model(
+        session, model_factory, project_id=project.id, owner_id=admin_id,
+        name="tail", status=ModelStatus.INITIATED,
+    )
+
+    head_job = FLJob(model_id=head.id, created=datetime(2026, 1, 1, 10, 0, 0))
+    # mid and tail share a created timestamp: their relative ranks must come
+    # from the id tiebreak, the same secondary key check_for_queued_jobs
+    # picks by, so the emitted positions cannot disagree with pickup order.
+    mid_job = FLJob(
+        id=UUID("00000000-0000-4000-8000-000000000001"),
+        model_id=mid.id,
+        created=datetime(2026, 1, 1, 10, 5, 0),
+    )
+    tail_job = FLJob(
+        id=UUID("ffffffff-ffff-4fff-bfff-fffffffffffe"),
+        model_id=tail.id,
+        created=datetime(2026, 1, 1, 10, 5, 0),
+    )
+    session.add(head_job)
+    session.add(mid_job)
+    session.add(tail_job)
+    session.commit()
+
+    # First emission ranks the whole queue (created asc, id tiebreak) and the
+    # {"position", "job_id"} payload survives the JSONB round-trip. The rows
+    # are readable through the API's own session, so the batch committed.
+    log_queue_positions(session)
+    assert _positions_by_job(session) == {
+        str(head_job.id): [1],
+        str(mid_job.id): [2],
+        str(tail_job.id): [3],
+    }
+
+    # Emit-on-change against real SQL: a second pass reads back the rows it
+    # just wrote and emits nothing.
+    log_queue_positions(session)
+    assert sum(len(positions) for positions in _positions_by_job(session).values()) == 3
+
+    # The head job leaves the queue: everything behind it re-ranks...
+    head_job.status = JobStatus.DELETED
+    session.add(head_job)
+    session.commit()
+    log_queue_positions(session)
+    assert _positions_by_job(session) == {
+        str(head_job.id): [1],
+        str(mid_job.id): [2, 1],
+        str(tail_job.id): [3, 2],
+    }
+
+    # ...and the dedup compares each job against its *newest* row (log_date
+    # descending), so a further pass over the re-ranked queue emits nothing.
+    log_queue_positions(session)
+    assert sum(len(positions) for positions in _positions_by_job(session).values()) == 5
+
+    # The rows land in the activity feed, rendered at serve time.
+    override_verify_token_as(admin_id)
+    response = client.get(f"/api/model/{mid.id}/logs")
+    assert response.status_code == 200
+    body = response.json()
+    assert {row["log"] for row in body} == {"Model Queued (2)", "Model Queued (1)"}
+    assert all(row["globalRound"] is None for row in body)

--- a/flip-api/tests/integration/test_queue_position_emission.py
+++ b/flip-api/tests/integration/test_queue_position_emission.py
@@ -14,12 +14,13 @@
 
 ``log_queue_positions`` is SQL-shaped end to end: the ranks come from the
 ``created``-ascending (``id``-tiebroken) queue query, the emit-on-change dedup
-reads prior rows ``log_date``-descending, the compared payload round-trips
-through the JSONB ``details`` column, and the batch relies on ``add_log``
-deferring its per-row commit under ``transaction=``. All of that passes
-silently under a mocked session — the unit tests fabricate both result sets —
-so the invariants are exercised here against the throwaway Postgres, ending
-with the rendered feed a researcher actually sees.
+collapses each job's history to its newest row inside Postgres (``DISTINCT ON``
+over the JSONB job id, ``log_date``-descending), the compared payload
+round-trips through the JSONB ``details`` column, and the batch relies on
+``add_log`` deferring its per-row commit under ``transaction=``. All of that
+passes silently under a mocked session — the unit tests fabricate both result
+sets — so the invariants are exercised here against the throwaway Postgres,
+ending with the rendered feed a researcher actually sees.
 """
 
 from datetime import datetime

--- a/flip-api/tests/unit/domain/schemas/test_private_schemas.py
+++ b/flip-api/tests/unit/domain/schemas/test_private_schemas.py
@@ -78,6 +78,18 @@ class TestTrainingLog:
         payload = TrainingLog(event_type="SOMETHING_NEW", global_round=3)
         assert payload.event_type == "SOMETHING_NEW"
 
+    def test_queue_position_is_rejected_even_with_a_global_round(self):
+        """QUEUE_POSITION is hub-emitted by definition. Requiring global_round does
+        not keep it out (a spoofed payload can just carry one), so the validator
+        refuses the event_type itself — otherwise the row would render in the feed
+        and could perturb the scheduler's emit-on-change dedup."""
+        with pytest.raises(ValidationError, match="QUEUE_POSITION"):
+            TrainingLog(
+                event_type=FLLogEvent.QUEUE_POSITION,
+                global_round=1,
+                details={"position": 1, "job_id": "some-job"},
+            )
+
     @pytest.mark.parametrize("event_type", ["", "   "])
     def test_blank_event_type_is_rejected(self, event_type):
         with pytest.raises(ValidationError):

--- a/flip-api/tests/unit/fl_services/services/test_fl_scheduler_service.py
+++ b/flip-api/tests/unit/fl_services/services/test_fl_scheduler_service.py
@@ -448,6 +448,21 @@ class TestLogQueuePositions:
             transaction=fake_session,
         )
 
+    def test_two_queued_jobs_of_the_same_model_do_not_oscillate(self, fake_session):
+        # FLJob has no uniqueness on model_id, so a double initiate can queue the
+        # same model twice. The last-row lookup is keyed by job id, so each job
+        # compares against its own latest row — a model-keyed lookup would let the
+        # newest row suppress one job and re-emit the other forever (oscillation).
+        model_id = uuid4()
+        job_a, job_b = _queued_job(model_id), _queued_job(model_id)
+        newer = _position_row(model_id, job_b.id, 2)
+        older = _position_row(model_id, job_a.id, 1)
+        fake_session.exec.side_effect = _exec_returning([job_a, job_b], [newer, older])
+        with patch.object(fl_scheduler_service, "add_log") as mock_add_log:
+            fl_scheduler_service.log_queue_positions(fake_session)
+        mock_add_log.assert_not_called()
+        fake_session.commit.assert_not_called()
+
     def test_reinitiated_model_relogs_even_at_the_same_position(self, fake_session):
         # Same model, new job: the prior row belongs to the model's previous run,
         # so its matching position must not suppress the new run's first row.

--- a/flip-api/tests/unit/fl_services/services/test_fl_scheduler_service.py
+++ b/flip-api/tests/unit/fl_services/services/test_fl_scheduler_service.py
@@ -392,6 +392,7 @@ class TestLogQueuePositions:
         with patch.object(fl_scheduler_service, "add_log") as mock_add_log:
             fl_scheduler_service.log_queue_positions(fake_session)
         mock_add_log.assert_not_called()
+        fake_session.commit.assert_not_called()
 
     def test_new_job_gets_its_position_logged(self, fake_session):
         job = _queued_job()
@@ -404,7 +405,10 @@ class TestLogQueuePositions:
             fake_session,
             event_type=FLLogEvent.QUEUE_POSITION.value,
             details={"position": 1, "job_id": str(job.id)},
+            transaction=fake_session,
         )
+        # The rows are batched: one commit for the whole emission, not one per row.
+        fake_session.commit.assert_called_once()
 
     def test_unchanged_position_is_not_relogged(self, fake_session):
         job = _queued_job()
@@ -412,6 +416,7 @@ class TestLogQueuePositions:
         with patch.object(fl_scheduler_service, "add_log") as mock_add_log:
             fl_scheduler_service.log_queue_positions(fake_session)
         mock_add_log.assert_not_called()
+        fake_session.commit.assert_not_called()
 
     def test_moved_job_logs_its_new_position(self, fake_session):
         job = _queued_job()
@@ -424,6 +429,7 @@ class TestLogQueuePositions:
             fake_session,
             event_type=FLLogEvent.QUEUE_POSITION.value,
             details={"position": 1, "job_id": str(job.id)},
+            transaction=fake_session,
         )
 
     def test_second_of_two_queued_jobs_gets_position_two(self, fake_session):
@@ -439,6 +445,7 @@ class TestLogQueuePositions:
             fake_session,
             event_type=FLLogEvent.QUEUE_POSITION.value,
             details={"position": 2, "job_id": str(second.id)},
+            transaction=fake_session,
         )
 
     def test_reinitiated_model_relogs_even_at_the_same_position(self, fake_session):
@@ -461,9 +468,18 @@ class TestLogQueuePositions:
             fl_scheduler_service.log_queue_positions(fake_session)
         mock_add_log.assert_called_once()
 
-    def test_emission_failure_never_raises(self, fake_session):
+    def test_emission_failure_never_raises_and_rolls_back(self, fake_session):
         job = _queued_job()
         fake_session.exec.side_effect = _exec_returning([job], [])
+        with patch.object(fl_scheduler_service, "add_log", side_effect=Exception("db down")):
+            fl_scheduler_service.log_queue_positions(fake_session)  # must not raise
+        fake_session.rollback.assert_called_once()
+        fake_session.commit.assert_not_called()
+
+    def test_emission_failure_with_failing_rollback_still_never_raises(self, fake_session):
+        job = _queued_job()
+        fake_session.exec.side_effect = _exec_returning([job], [])
+        fake_session.rollback.side_effect = Exception("rollback failed")
         with patch.object(fl_scheduler_service, "add_log", side_effect=Exception("db down")):
             fl_scheduler_service.log_queue_positions(fake_session)  # must not raise
 

--- a/flip-api/tests/unit/fl_services/services/test_fl_scheduler_service.py
+++ b/flip-api/tests/unit/fl_services/services/test_fl_scheduler_service.py
@@ -151,7 +151,10 @@ def test_remove_job_from_queue(fake_session, model_id):
     job = MagicMock()
     fake_session.exec.return_value.all.return_value = [job]
 
-    fl_scheduler_service.remove_job_from_queue(model_id, fake_session)
+    # Patched so its own add_log commit doesn't skew the count asserted below;
+    # the re-emission behaviour has its own tests in TestLogQueuePositions.
+    with patch.object(fl_scheduler_service, "log_queue_positions"):
+        fl_scheduler_service.remove_job_from_queue(model_id, fake_session)
 
     assert job.status == JobStatus.DELETED
     assert job.completed is not None
@@ -463,3 +466,34 @@ class TestLogQueuePositions:
         fake_session.exec.side_effect = _exec_returning([job], [])
         with patch.object(fl_scheduler_service, "add_log", side_effect=Exception("db down")):
             fl_scheduler_service.log_queue_positions(fake_session)  # must not raise
+
+    def test_update_fl_scheduler_reemits_queue_positions(self, fake_session, model_id, fl_job_id):
+        """Completing a still-QUEUED job (stopped/errored queued model) re-ranks the tail."""
+        job = MagicMock()
+        job.id = fl_job_id
+        fake_session.exec.side_effect = [
+            MagicMock(first=MagicMock(return_value=job)),
+            MagicMock(first=MagicMock(return_value=MagicMock())),
+        ]
+        with patch.object(fl_scheduler_service, "log_queue_positions") as mock_positions:
+            fl_scheduler_service.update_fl_scheduler(model_id, fake_session)
+        mock_positions.assert_called_once_with(fake_session)
+
+    def test_update_fl_scheduler_without_a_job_does_not_reemit(self, fake_session, model_id):
+        fake_session.exec.return_value.first.return_value = None
+        with patch.object(fl_scheduler_service, "log_queue_positions") as mock_positions:
+            fl_scheduler_service.update_fl_scheduler(model_id, fake_session)
+        mock_positions.assert_not_called()
+
+    def test_remove_job_from_queue_reemits_queue_positions(self, fake_session, model_id):
+        """Deleting a queued job (stop/abort of a queued model) re-ranks everything behind it."""
+        fake_session.exec.return_value.all.return_value = [MagicMock()]
+        with patch.object(fl_scheduler_service, "log_queue_positions") as mock_positions:
+            fl_scheduler_service.remove_job_from_queue(model_id, fake_session)
+        mock_positions.assert_called_once_with(fake_session)
+
+    def test_remove_job_from_queue_without_jobs_does_not_reemit(self, fake_session, model_id):
+        fake_session.exec.return_value.all.return_value = []
+        with patch.object(fl_scheduler_service, "log_queue_positions") as mock_positions:
+            fl_scheduler_service.remove_job_from_queue(model_id, fake_session)
+        mock_positions.assert_not_called()

--- a/flip-api/tests/unit/fl_services/services/test_fl_scheduler_service.py
+++ b/flip-api/tests/unit/fl_services/services/test_fl_scheduler_service.py
@@ -15,7 +15,7 @@ from uuid import uuid4
 
 import pytest
 
-from flip_api.db.models.main_models import FLJob, FLLogs
+from flip_api.db.models.main_models import FLJob
 from flip_api.domain.interfaces.fl import (
     IJobResponse,
     INetDetails,
@@ -366,13 +366,9 @@ def _queued_job(model_id=None):
     return FLJob(id=uuid4(), model_id=model_id or uuid4())
 
 
-def _position_row(model_id, job_id, position):
-    return FLLogs(
-        model_id=model_id,
-        success=True,
-        event_type=FLLogEvent.QUEUE_POSITION.value,
-        details={"position": position, "job_id": str(job_id)},
-    )
+def _position_details(job_id, position):
+    """One details payload, as the DISTINCT ON dedup query returns them (JSONB dicts, not rows)."""
+    return {"position": position, "job_id": str(job_id)}
 
 
 def _exec_returning(*result_lists):
@@ -412,7 +408,7 @@ class TestLogQueuePositions:
 
     def test_unchanged_position_is_not_relogged(self, fake_session):
         job = _queued_job()
-        fake_session.exec.side_effect = _exec_returning([job], [_position_row(job.model_id, job.id, 1)])
+        fake_session.exec.side_effect = _exec_returning([job], [_position_details(job.id, 1)])
         with patch.object(fl_scheduler_service, "add_log") as mock_add_log:
             fl_scheduler_service.log_queue_positions(fake_session)
         mock_add_log.assert_not_called()
@@ -420,7 +416,7 @@ class TestLogQueuePositions:
 
     def test_moved_job_logs_its_new_position(self, fake_session):
         job = _queued_job()
-        fake_session.exec.side_effect = _exec_returning([job], [_position_row(job.model_id, job.id, 2)])
+        fake_session.exec.side_effect = _exec_returning([job], [_position_details(job.id, 2)])
         with patch.object(fl_scheduler_service, "add_log") as mock_add_log:
             fl_scheduler_service.log_queue_positions(fake_session)
         mock_add_log.assert_called_once_with(
@@ -435,7 +431,7 @@ class TestLogQueuePositions:
     def test_second_of_two_queued_jobs_gets_position_two(self, fake_session):
         first, second = _queued_job(), _queued_job()
         fake_session.exec.side_effect = _exec_returning(
-            [first, second], [_position_row(first.model_id, first.id, 1)]
+            [first, second], [_position_details(first.id, 1)]
         )
         with patch.object(fl_scheduler_service, "add_log") as mock_add_log:
             fl_scheduler_service.log_queue_positions(fake_session)
@@ -455,8 +451,8 @@ class TestLogQueuePositions:
         # newest row suppress one job and re-emit the other forever (oscillation).
         model_id = uuid4()
         job_a, job_b = _queued_job(model_id), _queued_job(model_id)
-        newer = _position_row(model_id, job_b.id, 2)
-        older = _position_row(model_id, job_a.id, 1)
+        newer = _position_details(job_b.id, 2)
+        older = _position_details(job_a.id, 1)
         fake_session.exec.side_effect = _exec_returning([job_a, job_b], [newer, older])
         with patch.object(fl_scheduler_service, "add_log") as mock_add_log:
             fl_scheduler_service.log_queue_positions(fake_session)
@@ -467,17 +463,18 @@ class TestLogQueuePositions:
         # Same model, new job: the prior row belongs to the model's previous run,
         # so its matching position must not suppress the new run's first row.
         job = _queued_job()
-        fake_session.exec.side_effect = _exec_returning([job], [_position_row(job.model_id, uuid4(), 1)])
+        fake_session.exec.side_effect = _exec_returning([job], [_position_details(uuid4(), 1)])
         with patch.object(fl_scheduler_service, "add_log") as mock_add_log:
             fl_scheduler_service.log_queue_positions(fake_session)
         mock_add_log.assert_called_once()
 
     def test_only_the_latest_prior_row_counts(self, fake_session):
-        # Rows arrive newest-first; an older matching row behind a newer different
-        # one must not suppress emission.
+        # DISTINCT ON should hand back one row per job, but the Python fold keeps
+        # first-seen (newest, per the query's ordering) as defense in depth: an
+        # older matching row behind a newer different one must not suppress emission.
         job = _queued_job()
-        newer = _position_row(job.model_id, job.id, 2)
-        older = _position_row(job.model_id, job.id, 1)
+        newer = _position_details(job.id, 2)
+        older = _position_details(job.id, 1)
         fake_session.exec.side_effect = _exec_returning([job], [newer, older])
         with patch.object(fl_scheduler_service, "add_log") as mock_add_log:
             fl_scheduler_service.log_queue_positions(fake_session)

--- a/flip-api/tests/unit/fl_services/services/test_fl_scheduler_service.py
+++ b/flip-api/tests/unit/fl_services/services/test_fl_scheduler_service.py
@@ -15,6 +15,7 @@ from uuid import uuid4
 
 import pytest
 
+from flip_api.db.models.main_models import FLJob, FLLogs
 from flip_api.domain.interfaces.fl import (
     IJobResponse,
     INetDetails,
@@ -22,7 +23,7 @@ from flip_api.domain.interfaces.fl import (
     ISchedulerResponse,
 )
 from flip_api.domain.schemas.status import JobStatus, ModelStatus, NetStatus
-from flip_api.domain.schemas.types import FLBackend
+from flip_api.domain.schemas.types import FLBackend, FLLogEvent
 from flip_api.fl_services.services import fl_scheduler_service
 from flip_api.utils.exceptions import NotFoundError
 
@@ -356,3 +357,109 @@ def test_get_slot_names_by_trust_ids_maps_assigned_slots(fake_session):
     result = fl_scheduler_service.get_slot_names_by_trust_ids([trust_a, trust_b], fake_session)
 
     assert result == {trust_a: "Trust_1", trust_b: "Trust_2"}
+
+
+def _queued_job(model_id=None):
+    return FLJob(id=uuid4(), model_id=model_id or uuid4())
+
+
+def _position_row(model_id, job_id, position):
+    return FLLogs(
+        model_id=model_id,
+        success=True,
+        event_type=FLLogEvent.QUEUE_POSITION.value,
+        details={"position": position, "job_id": str(job_id)},
+    )
+
+
+def _exec_returning(*result_lists):
+    """One MagicMock per session.exec(...) call, whose .all() yields the given list."""
+    return [MagicMock(all=MagicMock(return_value=list(results))) for results in result_lists]
+
+
+class TestLogQueuePositions:
+    """log_queue_positions writes one typed row per queued model whose position changed.
+
+    Emit-on-change keyed by job id makes the helper idempotent, so every queue
+    mutation site can call it unconditionally without spamming the feed.
+    """
+
+    def test_empty_queue_emits_nothing(self, fake_session):
+        fake_session.exec.side_effect = _exec_returning([])
+        with patch.object(fl_scheduler_service, "add_log") as mock_add_log:
+            fl_scheduler_service.log_queue_positions(fake_session)
+        mock_add_log.assert_not_called()
+
+    def test_new_job_gets_its_position_logged(self, fake_session):
+        job = _queued_job()
+        fake_session.exec.side_effect = _exec_returning([job], [])
+        with patch.object(fl_scheduler_service, "add_log") as mock_add_log:
+            fl_scheduler_service.log_queue_positions(fake_session)
+        mock_add_log.assert_called_once_with(
+            job.model_id,
+            None,
+            fake_session,
+            event_type=FLLogEvent.QUEUE_POSITION.value,
+            details={"position": 1, "job_id": str(job.id)},
+        )
+
+    def test_unchanged_position_is_not_relogged(self, fake_session):
+        job = _queued_job()
+        fake_session.exec.side_effect = _exec_returning([job], [_position_row(job.model_id, job.id, 1)])
+        with patch.object(fl_scheduler_service, "add_log") as mock_add_log:
+            fl_scheduler_service.log_queue_positions(fake_session)
+        mock_add_log.assert_not_called()
+
+    def test_moved_job_logs_its_new_position(self, fake_session):
+        job = _queued_job()
+        fake_session.exec.side_effect = _exec_returning([job], [_position_row(job.model_id, job.id, 2)])
+        with patch.object(fl_scheduler_service, "add_log") as mock_add_log:
+            fl_scheduler_service.log_queue_positions(fake_session)
+        mock_add_log.assert_called_once_with(
+            job.model_id,
+            None,
+            fake_session,
+            event_type=FLLogEvent.QUEUE_POSITION.value,
+            details={"position": 1, "job_id": str(job.id)},
+        )
+
+    def test_second_of_two_queued_jobs_gets_position_two(self, fake_session):
+        first, second = _queued_job(), _queued_job()
+        fake_session.exec.side_effect = _exec_returning(
+            [first, second], [_position_row(first.model_id, first.id, 1)]
+        )
+        with patch.object(fl_scheduler_service, "add_log") as mock_add_log:
+            fl_scheduler_service.log_queue_positions(fake_session)
+        mock_add_log.assert_called_once_with(
+            second.model_id,
+            None,
+            fake_session,
+            event_type=FLLogEvent.QUEUE_POSITION.value,
+            details={"position": 2, "job_id": str(second.id)},
+        )
+
+    def test_reinitiated_model_relogs_even_at_the_same_position(self, fake_session):
+        # Same model, new job: the prior row belongs to the model's previous run,
+        # so its matching position must not suppress the new run's first row.
+        job = _queued_job()
+        fake_session.exec.side_effect = _exec_returning([job], [_position_row(job.model_id, uuid4(), 1)])
+        with patch.object(fl_scheduler_service, "add_log") as mock_add_log:
+            fl_scheduler_service.log_queue_positions(fake_session)
+        mock_add_log.assert_called_once()
+
+    def test_only_the_latest_prior_row_counts(self, fake_session):
+        # Rows arrive newest-first; an older matching row behind a newer different
+        # one must not suppress emission.
+        job = _queued_job()
+        newer = _position_row(job.model_id, job.id, 2)
+        older = _position_row(job.model_id, job.id, 1)
+        fake_session.exec.side_effect = _exec_returning([job], [newer, older])
+        with patch.object(fl_scheduler_service, "add_log") as mock_add_log:
+            fl_scheduler_service.log_queue_positions(fake_session)
+        mock_add_log.assert_called_once()
+
+    def test_emission_failure_never_raises(self, fake_session):
+        job = _queued_job()
+        fake_session.exec.side_effect = _exec_returning([job], [])
+        with patch.object(fl_scheduler_service, "add_log", side_effect=Exception("db down")):
+            fl_scheduler_service.log_queue_positions(fake_session)  # must not raise

--- a/flip-api/tests/unit/fl_services/services/test_fl_scheduler_service.py
+++ b/flip-api/tests/unit/fl_services/services/test_fl_scheduler_service.py
@@ -151,7 +151,7 @@ def test_remove_job_from_queue(fake_session, model_id):
     job = MagicMock()
     fake_session.exec.return_value.all.return_value = [job]
 
-    # Patched so its own add_log commit doesn't skew the count asserted below;
+    # Patched so its batch commit doesn't skew the count asserted below;
     # the re-emission behaviour has its own tests in TestLogQueuePositions.
     with patch.object(fl_scheduler_service, "log_queue_positions"):
         fl_scheduler_service.remove_job_from_queue(model_id, fake_session)
@@ -381,7 +381,7 @@ def _exec_returning(*result_lists):
 
 
 class TestLogQueuePositions:
-    """log_queue_positions writes one typed row per queued model whose position changed.
+    """log_queue_positions writes one typed row per queued job whose position changed.
 
     Emit-on-change keyed by job id makes the helper idempotent, so every queue
     mutation site can call it unconditionally without spamming the feed.
@@ -483,6 +483,15 @@ class TestLogQueuePositions:
             fl_scheduler_service.log_queue_positions(fake_session)
         mock_add_log.assert_called_once()
 
+    def test_batched_rows_land_in_a_single_commit(self, fake_session):
+        # add_log deliberately unpatched: transaction= must make it defer its
+        # per-row commit so the whole emission lands in the one batch commit.
+        first, second = _queued_job(), _queued_job()
+        fake_session.exec.side_effect = _exec_returning([first, second], [])
+        fl_scheduler_service.log_queue_positions(fake_session)
+        assert fake_session.add.call_count == 2
+        fake_session.commit.assert_called_once()
+
     def test_emission_failure_never_raises_and_rolls_back(self, fake_session):
         job = _queued_job()
         fake_session.exec.side_effect = _exec_returning([job], [])
@@ -490,6 +499,7 @@ class TestLogQueuePositions:
             fl_scheduler_service.log_queue_positions(fake_session)  # must not raise
         fake_session.rollback.assert_called_once()
         fake_session.commit.assert_not_called()
+        fake_session.invalidate.assert_not_called()
 
     def test_emission_failure_with_failing_rollback_still_never_raises(self, fake_session):
         job = _queued_job()
@@ -497,6 +507,10 @@ class TestLogQueuePositions:
         fake_session.rollback.side_effect = Exception("rollback failed")
         with patch.object(fl_scheduler_service, "add_log", side_effect=Exception("db down")):
             fl_scheduler_service.log_queue_positions(fake_session)  # must not raise
+        # A failed rollback leaves the session raising PendingRollbackError on
+        # every subsequent use; invalidate() is what hands the caller back a
+        # session that works on a fresh connection.
+        fake_session.invalidate.assert_called_once()
 
     def test_update_fl_scheduler_reemits_queue_positions(self, fake_session, model_id, fl_job_id):
         """Completing a still-QUEUED job (stopped/errored queued model) re-ranks the tail."""

--- a/flip-api/tests/unit/fl_services/test_initiate_training.py
+++ b/flip-api/tests/unit/fl_services/test_initiate_training.py
@@ -91,9 +91,15 @@ def mock_add_log():
         yield mock
 
 
+@pytest.fixture
+def mock_log_queue_positions():
+    with patch("flip_api.fl_services.initiate_training.log_queue_positions") as mock:
+        yield mock
+
+
 def test_initiate_training_success(
     model_id, fake_request, mock_db, client1, mock_can_modify_model, mock_add_fl_job, mock_update_model_status,
-    mock_add_log
+    mock_add_log, mock_log_queue_positions
 ):
     payload = IInitiateTrainingInputPayload(trust_ids=[client1.id])
     response = initiate_training(model_id, payload, fake_request, mock_db, user_id="user123")
@@ -106,10 +112,13 @@ def test_initiate_training_success(
     assert [t.name for t in called_trusts] == ["client1"]
 
     mock_update_model_status.assert_called_once()
-    assert mock_add_log.call_count == 2
+    # The enqueue announcement is a typed queue-position row ("Model Queued (n)"),
+    # emitted via log_queue_positions; add_log carries only the trusts audit line.
+    mock_log_queue_positions.assert_called_once_with(mock_db)
+    assert mock_add_log.call_count == 1
     # Audit log uses names extracted from the resolved Trust rows, not the raw payload ids.
-    second_log_msg = mock_add_log.call_args_list[1].args[1]
-    assert "client1" in second_log_msg
+    trusts_log_msg = mock_add_log.call_args_list[0].args[1]
+    assert "client1" in trusts_log_msg
 
 
 def test_initiate_training_passes_full_trust_rows_to_add_fl_job(

--- a/flip-api/tests/unit/fl_services/test_run_jobs.py
+++ b/flip-api/tests/unit/fl_services/test_run_jobs.py
@@ -180,3 +180,30 @@ def test_recover_stale_busy_deleted_job(caplog):
     assert result == 2
     session.commit.assert_called_once()
     assert "Recovered 2 stale BUSY scheduler(s)" in caplog.text
+
+
+# ── queue-position re-emission ───────────────────────────────────────────────
+
+
+def test_run_jobs_reemits_queue_positions_after_pickup(
+    mock_db, mock_check_for_available_net, mock_check_for_queued_jobs
+):
+    """A pickup advances every remaining queued model, so positions are re-logged."""
+    with (
+        patch("flip_api.fl_services.run_jobs.prepare_and_start_training"),
+        patch("flip_api.fl_services.run_jobs.log_queue_positions") as mock_positions,
+    ):
+        run_jobs_core(mock_db)
+
+    mock_positions.assert_called_once_with(mock_db)
+
+
+def test_run_jobs_does_not_reemit_when_no_job_was_picked(
+    mock_db, mock_check_for_available_net, mock_check_for_queued_jobs
+):
+    mock_check_for_queued_jobs.return_value = None
+
+    with patch("flip_api.fl_services.run_jobs.log_queue_positions") as mock_positions:
+        run_jobs_core(mock_db)
+
+    mock_positions.assert_not_called()

--- a/flip-api/tests/unit/model_services/services/test_log_rendering.py
+++ b/flip-api/tests/unit/model_services/services/test_log_rendering.py
@@ -114,3 +114,16 @@ class TestRenderLog:
             details={"returned": returned, "expected": expected},
         )
         assert render_log(row) == "Round 6 aggregated"
+
+    def test_queue_position(self):
+        row = _row(event_type=FLLogEvent.QUEUE_POSITION.value, details={"position": 3, "job_id": str(uuid4())})
+        assert render_log(row) == "Model Queued (3)"
+
+    @pytest.mark.parametrize(
+        "details",
+        [None, {}, {"position": "3"}, {"position": True}, {"position": 0}, {"position": -1}, {"position": 2.5}],
+    )
+    def test_queue_position_with_unusable_position_degrades_positionless(self, details):
+        """A row with an unusable stored position must not invent one."""
+        row = _row(event_type=FLLogEvent.QUEUE_POSITION.value, details=details)
+        assert render_log(row) == "Model Queued"

--- a/flip-api/tests/unit/model_services/services/test_model_service.py
+++ b/flip-api/tests/unit/model_services/services/test_model_service.py
@@ -28,6 +28,7 @@ from flip_api.model_services.services.model_service import (
     edit_model,
     get_metrics,
     get_model_status,
+    queued_positions_by_model,
     resolve_trust_from_fl_client_name,
     update_model_status,
     validate_trust_ids,
@@ -505,3 +506,27 @@ def test_run_trusts_by_model_empty_input_short_circuits():
 
     assert result == {}
     session.exec.assert_not_called()
+
+
+def test_queued_positions_by_model_ranks_by_scheduler_pickup_order():
+    """Positions are the 1-based rank over QUEUED jobs in created order (FIFO)."""
+    session = MagicMock()
+    first, second = uuid4(), uuid4()
+    session.exec.return_value.all.return_value = [first, second]
+
+    assert queued_positions_by_model(session) == {first: 1, second: 2}
+
+
+def test_queued_positions_by_model_keeps_the_earliest_position_per_model():
+    session = MagicMock()
+    model_id = uuid4()
+    session.exec.return_value.all.return_value = [model_id, model_id]
+
+    assert queued_positions_by_model(session) == {model_id: 1}
+
+
+def test_queued_positions_by_model_empty_queue():
+    session = MagicMock()
+    session.exec.return_value.all.return_value = []
+
+    assert queued_positions_by_model(session) == {}

--- a/flip-api/tests/unit/model_services/test_retrieve_model.py
+++ b/flip-api/tests/unit/model_services/test_retrieve_model.py
@@ -114,16 +114,19 @@ def test_retrieve_model_success(
     mock_result.mappings.return_value.first.return_value = mock_raw_sql_result
     override_dependencies.execute.return_value = mock_result
 
-    # Three follow-up SQLModel queries after the raw SQL: Model.creation_timestamp,
-    # ModelsAudit rows, then the participating trusts. All empty so the lifecycle
-    # fields stay None and `trusts` stays empty.
+    # Four follow-up SQLModel queries after the raw SQL: Model.creation_timestamp,
+    # ModelsAudit rows, the participating trusts, then the FL queue. All empty so
+    # the lifecycle fields stay None, `trusts` stays empty and there is no queue
+    # position.
     creation_call = MagicMock()
     creation_call.first.return_value = None
     audit_call = MagicMock()
     audit_call.all.return_value = []
     trusts_call = MagicMock()
     trusts_call.all.return_value = []
-    override_dependencies.exec.side_effect = [creation_call, audit_call, trusts_call]
+    queue_call = MagicMock()
+    queue_call.all.return_value = []
+    override_dependencies.exec.side_effect = [creation_call, audit_call, trusts_call, queue_call]
 
     # response = client.get(f"/model/{test_model_id}")
     result = retrieve_model(model_id=test_model_id, db=override_dependencies, user_id=test_user_id)
@@ -135,6 +138,7 @@ def test_retrieve_model_success(
     assert len(result.files) == 1
     assert result.files[0].id == file_id
     assert result.files[0].status == FileUploadStatus.COMPLETED
+    assert result.queue_position is None
 
 
 def test_retrieve_model_forbidden(override_dependencies, mock_can_access_false):
@@ -223,7 +227,9 @@ def test_retrieve_model_reports_the_trusts_that_took_part(
         (gstt_id, "Guy's and St Thomas'", "GSTT"),
         (kch_id, "King's College Hospital", None),
     ]
-    override_dependencies.exec.side_effect = [creation_call, audit_call, trusts_call]
+    queue_call = MagicMock()
+    queue_call.all.return_value = []
+    override_dependencies.exec.side_effect = [creation_call, audit_call, trusts_call, queue_call]
 
     result = retrieve_model(model_id=test_model_id, db=override_dependencies, user_id=test_user_id)
 
@@ -238,3 +244,37 @@ def test_retrieve_model_reports_the_trusts_that_took_part(
     trusts_stmt = str(override_dependencies.exec.call_args_list[2].args[0])
     assert "fl_job_trust" in trusts_stmt
     assert "model_trust_intersect" not in trusts_stmt
+
+
+def test_retrieve_model_reports_the_queue_position(
+    override_dependencies,
+    mock_can_access_true,
+    mock_load_sql,
+):
+    """A queued model carries its 1-based place in the FL training queue (issue #788)."""
+    mock_result = MagicMock()
+    mock_result.mappings.return_value.first.return_value = {
+        "model_id": str(test_model_id),
+        "model_name": "Test Model",
+        "model_description": "Desc",
+        "project_id": str(uuid4()),
+        "status": ModelStatus.INITIATED.value,
+        "files": [],
+        "query": None,
+    }
+    override_dependencies.execute.return_value = mock_result
+
+    creation_call = MagicMock()
+    creation_call.first.return_value = None
+    audit_call = MagicMock()
+    audit_call.all.return_value = []
+    trusts_call = MagicMock()
+    trusts_call.all.return_value = []
+    queue_call = MagicMock()
+    # One queued job ahead of this model's, so it sits at position 2.
+    queue_call.all.return_value = [uuid4(), test_model_id]
+    override_dependencies.exec.side_effect = [creation_call, audit_call, trusts_call, queue_call]
+
+    result = retrieve_model(model_id=test_model_id, db=override_dependencies, user_id=test_user_id)
+
+    assert result.queue_position == 2

--- a/flip-ui/src/pages/__tests__/models.spec.ts
+++ b/flip-ui/src/pages/__tests__/models.spec.ts
@@ -177,6 +177,26 @@ describe("Models Page", () => {
         expect(wrapper.find("[data-test='model-status-indicator']").text()).toBe("Training Started");
     });
 
+    test("a queued model's status pill carries its queue position", async () => {
+        setModels([makeModel({
+            status: "INITIATED",
+            queuePosition: 2
+        })]);
+        const wrapper = mountPage();
+        await wrapper.vm.$nextTick();
+
+        expect(wrapper.find("[data-test='model-status-indicator']").text()).toBe("Model Queued (2)");
+        expect(wrapper.find("[data-test='model-status-indicator-mobile']").text()).toBe("Model Queued (2)");
+    });
+
+    test("a queued model without a position keeps the plain label", async () => {
+        setModels([makeModel({ status: "INITIATED" })]);
+        const wrapper = mountPage();
+        await wrapper.vm.$nextTick();
+
+        expect(wrapper.find("[data-test='model-status-indicator']").text()).toBe("Model Queued");
+    });
+
     test("stacks mobile rows with the status pill and green-dot trust chips below sm", async () => {
         setModels([makeModel({
             trusts: [trust("GSTT"), trust("KCH")],

--- a/flip-ui/src/pages/models.vue
+++ b/flip-ui/src/pages/models.vue
@@ -176,7 +176,7 @@
                                         :class="statusPillClass(model.status)"
                                     >
                                         <span class="inline-block w-1.5 h-1.5 rounded-full" :class="statusDotClass(model.status)" />
-                                        {{ modelStatusLabel(model.status) }}
+                                        {{ modelStatusLabelWithQueue(model.status, model.queuePosition) }}
                                     </span>
                                 </div>
                             </div>
@@ -225,7 +225,7 @@
                                         :class="statusPillClass(model.status)"
                                     >
                                         <span class="inline-block w-1.5 h-1.5 rounded-full" :class="statusDotClass(model.status)" />
-                                        {{ modelStatusLabel(model.status) }}
+                                        {{ modelStatusLabelWithQueue(model.status, model.queuePosition) }}
                                     </span>
                                 </div>
                                 <div v-if="model.trusts.length" class="flex flex-wrap items-center gap-1.5 mt-2">
@@ -287,7 +287,7 @@ import { getAllModels,
     isModelStatusError,
     ModelStatus,
     modelStatusDotClass as statusDotClass,
-    modelStatusLabel,
+    modelStatusLabelWithQueue,
     modelStatusPillClass as statusPillClass } from "@/services/model-service";
 
 const pageSize = 20;

--- a/flip-ui/src/pages/project/[projectId]/model/[modelId]/index.vue
+++ b/flip-ui/src/pages/project/[projectId]/model/[modelId]/index.vue
@@ -296,7 +296,7 @@ const steps = computed((): IStep[] => {
         modelData.value?.resultsUploadedAt
     ];
 
-    return buildModelSteps(modelData.value?.status).map((step, i) => ({
+    return buildModelSteps(modelData.value?.status, modelData.value?.queuePosition).map((step, i) => ({
         ...step,
         date: dates[i] ?? null
     }));

--- a/flip-ui/src/services/__tests__/model-service.spec.ts
+++ b/flip-ui/src/services/__tests__/model-service.spec.ts
@@ -14,7 +14,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { _http } from "@/services/api";
-import { buildModelSteps, clearJobTypesCache, createModel, DEFAULT_JOB_TYPE, deleteModel, editModel, fetchJobTypes, getAllModels, getDownloadUrlForResults, getLogsForModel, getModel, getModelFileStatus, getModelMetrics, getModels, getPreSignedUrl, getRequiredFilesForJobType, getStatusEnumValue, initialiseTraining, isValidJobType, type ModelStatus, ModelStatusEnum, stopTraining, uploadModelFile } from "@/services/model-service";
+import { buildModelSteps, clearJobTypesCache, createModel, DEFAULT_JOB_TYPE, deleteModel, editModel, fetchJobTypes, getAllModels, getDownloadUrlForResults, getLogsForModel, getModel, getModelFileStatus, getModelMetrics, getModels, getPreSignedUrl, getRequiredFilesForJobType, getStatusEnumValue, initialiseTraining, isValidJobType, type ModelStatus, ModelStatusEnum, modelStatusLabelWithQueue, stopTraining, uploadModelFile } from "@/services/model-service";
 
 vi.mock("@/services/api", () => ({
     _http: {
@@ -498,6 +498,29 @@ describe("model-service", () => {
             // receiving a newer status degrades gracefully rather than crashing.
             expect(() => buildModelSteps("NONSENSE" as ModelStatus)).not.toThrow();
             expect(stepByName("NONSENSE" as ModelStatus, "Training").error).toBe(true);
+        });
+
+        it("INITIATED with a queue position describes step 02 as Model Queued (n)", () => {
+            const step = buildModelSteps("INITIATED", 2).find(s => s.name === "Model Prepared");
+            expect(step?.description).toBe("Model Queued (2)");
+        });
+
+        it("INITIATED without a queue position keeps the plain Model Queued description", () => {
+            expect(stepByName("INITIATED", "Model Prepared").description).toBe("Model Queued");
+        });
+    });
+
+    describe("modelStatusLabelWithQueue", () => {
+        it("appends the queue position when present", () => {
+            expect(modelStatusLabelWithQueue("INITIATED", 2)).toBe("Model Queued (2)");
+        });
+
+        it.each([[undefined], [null], [0], [-1]])("omits the suffix for %s", (position) => {
+            expect(modelStatusLabelWithQueue("INITIATED", position as number | null | undefined)).toBe("Model Queued");
+        });
+
+        it("appends to whatever label the status maps to", () => {
+            expect(modelStatusLabelWithQueue("PENDING", 3)).toBe("Model Created (3)");
         });
     });
 

--- a/flip-ui/src/services/model-service.ts
+++ b/flip-ui/src/services/model-service.ts
@@ -165,10 +165,12 @@ export function modelStatusLabel(status: ModelStatus | undefined): string {
 }
 
 /**
- * Label for a model status with the model's FL queue position appended when it
- * is waiting in the training queue, e.g. "Model Queued (2)". Position 1 is the
- * next model to start when a net frees up; absent or unusable positions render
- * the plain label.
+ * Label for a model status with the FL queue position appended whenever a usable
+ * (>= 1) position is supplied, e.g. "Model Queued (2)" — position 1 is the next
+ * model to start when a net frees up. The helper itself is status-agnostic; the
+ * backend only supplies a position while the model has a queued job waiting for
+ * a net, so in practice the suffix appears on queued models. Absent or unusable
+ * positions render the plain label.
  */
 export function modelStatusLabelWithQueue(status: ModelStatus | undefined, queuePosition?: number | null): string {
     const label = modelStatusLabel(status);

--- a/flip-ui/src/services/model-service.ts
+++ b/flip-ui/src/services/model-service.ts
@@ -84,6 +84,9 @@ export interface IModelDashboard {
     resultsUploadedAt?: string | null;
     // The trusts the run was dispatched to. Empty before dispatch.
     trusts?: IModelSummaryTrust[];
+    // The model's 1-based place in the FL training queue (1 = next to be picked
+    // up); null/absent unless the model has a queued job waiting for a net.
+    queuePosition?: number | null;
 }
 
 export interface IModelCreate {
@@ -161,6 +164,18 @@ export function modelStatusLabel(status: ModelStatus | undefined): string {
     return status ? MODEL_STATUS_LABELS[status] ?? "—" : "—";
 }
 
+/**
+ * Label for a model status with the model's FL queue position appended when it
+ * is waiting in the training queue, e.g. "Model Queued (2)". Position 1 is the
+ * next model to start when a net frees up; absent or unusable positions render
+ * the plain label.
+ */
+export function modelStatusLabelWithQueue(status: ModelStatus | undefined, queuePosition?: number | null): string {
+    const label = modelStatusLabel(status);
+
+    return queuePosition != null && queuePosition >= 1 ? `${label} (${queuePosition})` : label;
+}
+
 /** True for terminal failure / cancellation states (drives the red-cross icon). */
 export function isModelStatusError(status: ModelStatus | undefined): boolean {
     return status === "ERROR" || status === "STOPPED" || status === "RESULTS_UPLOAD_FAILED";
@@ -229,7 +244,7 @@ export function getStatusEnumValue(status: string | undefined): number {
  * Per-step dates (creation/prepared/training/results timestamps) are layered on
  * by the caller, which holds the model record; this helper is purely status-driven.
  */
-export function buildModelSteps(status: ModelStatus | undefined): IStep[] {
+export function buildModelSteps(status: ModelStatus | undefined, queuePosition?: number | null): IStep[] {
     const statusValue = getStatusEnumValue(status);
     const isStopped = statusValue === ModelStatusEnum.STOPPED;
     const isError = statusValue === ModelStatusEnum.ERROR;
@@ -248,7 +263,9 @@ export function buildModelSteps(status: ModelStatus | undefined): IStep[] {
         {
             id: "02",
             name: "Model Prepared",
-            description: statusValue === ModelStatusEnum.INITIATED ? "Model Queued" : undefined,
+            description: statusValue === ModelStatusEnum.INITIATED
+                ? modelStatusLabelWithQueue("INITIATED", queuePosition)
+                : undefined,
             inProgress: statusValue === ModelStatusEnum.INITIATED,
             completed: statusValue >= ModelStatusEnum.PREPARED || isStopped || isError || isUploadFailed
         },
@@ -379,6 +396,9 @@ export interface IModelSummary {
     ownerId: string;
     ownerName?: string | null;
     trusts: IModelSummaryTrust[];
+    // The model's 1-based place in the FL training queue (1 = next to be picked
+    // up); null/absent unless the model has a queued job waiting for a net.
+    queuePosition?: number | null;
 }
 
 /**

--- a/flip-ui/src/services/model-service.ts
+++ b/flip-ui/src/services/model-service.ts
@@ -236,7 +236,8 @@ export function getStatusEnumValue(status: string | undefined): number {
 
 /**
  * Builds the four-step lifecycle tracker (Created → Prepared → Training → Uploaded)
- * shown on the model page, derived from the model's single status value.
+ * shown on the model page, derived from the model's status plus the optional queue
+ * position, which only feeds step 02's description while the model is INITIATED.
  *
  * When training is stopped or errors, prior completed steps stay completed (✅)
  * rather than showing 🚫. RESULTS_UPLOAD_FAILED means training finished but the
@@ -244,7 +245,7 @@ export function getStatusEnumValue(status: string | undefined): number {
  * "Results Uploaded" shows the error. See issue #29.
  *
  * Per-step dates (creation/prepared/training/results timestamps) are layered on
- * by the caller, which holds the model record; this helper is purely status-driven.
+ * by the caller, which holds the model record.
  */
 export function buildModelSteps(status: ModelStatus | undefined, queuePosition?: number | null): IStep[] {
     const statusValue = getStatusEnumValue(status);

--- a/flip-utils/flip/schemas.py
+++ b/flip-utils/flip/schemas.py
@@ -70,7 +70,10 @@ class TrainingLog(BaseModel):
     log: str | None = None
     # Senders use the FLLogEvent vocabulary, but the field is plain validated text
     # end-to-end (like the fl_logs column): a newer FL image's event is stored and
-    # served via the unknown-event render fallback, never rejected at ingest.
+    # served via the unknown-event render fallback, never rejected at ingest. The
+    # one exception is QUEUE_POSITION (absent from the enum above on purpose):
+    # it is reserved for the hub's own FL scheduler and the hub 422-rejects it,
+    # so refusing it here fails fast FL-side instead.
     event_type: str | None = Field(default=None, max_length=64)
     # 1-based on both backends; every event in the vocabulary is round-scoped.
     global_round: int | None = Field(default=None, ge=1)
@@ -83,6 +86,8 @@ class TrainingLog(BaseModel):
             raise ValueError("Exactly one of 'log' and 'event_type' must be set")
         if self.event_type is not None and not self.event_type.strip():
             raise ValueError("'event_type' must be non-blank when set")
+        if self.event_type == "QUEUE_POSITION":
+            raise ValueError("'QUEUE_POSITION' is emitted by the hub's FL scheduler and cannot be sent")
         if self.event_type is not None and self.global_round is None:
             raise ValueError("'global_round' is required when 'event_type' is set")
         return self

--- a/flip-utils/tests/unit/test_schemas.py
+++ b/flip-utils/tests/unit/test_schemas.py
@@ -113,6 +113,13 @@ class TestTrainingLog:
         with pytest.raises(ValidationError):
             TrainingLog(event_type=event_type, global_round=3)
 
+    def test_queue_position_is_rejected(self):
+        """QUEUE_POSITION is reserved for the hub's own FL scheduler (mirrors
+        flip-api, which 422-rejects it at ingest) — refusing it here fails fast
+        FL-side instead of after the POST."""
+        with pytest.raises(ValidationError, match="QUEUE_POSITION"):
+            TrainingLog(event_type="QUEUE_POSITION", global_round=1)
+
     def test_missing_field_raises(self):
         """Omitting a required field should raise a ValidationError."""
         with pytest.raises(ValidationError):


### PR DESCRIPTION
Closes #788

## What

Shows a queued model's **1-based position in the FL scheduler queue** on both user-facing surfaces:

- **Live activity** (model detail page): one typed log row per queue movement, rendered hub-side as
  `Model Queued (3)` → `Model Queued (2)` → `Model Queued (1)`.
- **Models page** (estate-wide) + the model page's lifecycle tracker: the status carries the current
  position, e.g. `Model Queued (2)`; position `1` = next to be picked up. Models whose job has been picked
  up (or that have no job) show no position.

## How

Stacked on #757 and built on its facts-vs-rendering machinery — **no DB migration** anywhere:

- New `FLLogEvent.QUEUE_POSITION` value (plain-text `event_type` column) with `details = {"position": n,
  "job_id": ...}`; `render_log()` composes the English at serve time and degrades to a bare `Model Queued`
  on an unusable stored position.
- New `log_queue_positions(session)` in `fl_scheduler_service`: ranks `FLJob.status == QUEUED` by `created`
  ascending with `id` as tiebreak — the identical ordering `check_for_queued_jobs` now picks by, so the
  displayed rank can never disagree with pickup order — and writes a row **only when a job's position
  changed** (keyed by job id, so re-initiated models re-log correctly). The dedup reads each job's newest
  prior row via `DISTINCT ON` over the JSONB job id, fetching only the compared `details` payload, so the
  scan stays bounded as a model's row history accumulates. Never raises — a failed emission can't wedge
  the scheduler tick, and if the failure-path rollback itself fails the session is invalidated so callers
  get a working session back on a fresh connection. Idempotence assumes serialized callers — documented
  along with the hub's single-replica/single-worker deployment invariant it leans on. Called at every
  queue mutation: enqueue (`initiate_training`, replacing the old free-text "added to the queue" line),
  pickup (`run_jobs_core`), queued-job deletion (`remove_job_from_queue` — stop/abort) and queued-job
  completion (`update_fl_scheduler`).
- `QUEUE_POSITION` is reserved for the hub: the `POST /model/{id}/logs` ingest validator (`TrainingLog`)
  rejects it outright — a spoofed row would render in the feed and could perturb the emit-on-change dedup —
  and the flip-utils mirror schema refuses it sender-side too (unknown event types from newer FL images
  remain accepted for forward compat).
- Current position is computed on read (same rank) and stamped as `queuePosition` on the estate list
  (`GET /models`) and the model detail response; the UI appends it via a single
  `modelStatusLabelWithQueue()` helper (Models-page pills, lifecycle-tracker step description).
- While deployment mode (#770) has pickup paused, no mutations occur, so positions simply hold.

## Testing

- flip-api: 1282 unit + 97 integration green (ruff + mypy clean). New coverage: rendering happy/degraded
  paths, emit-on-change semantics (initial emit, movement, no-change, re-initiation, latest-row-wins,
  single batch commit, swallow-on-failure incl. session invalidation), all four call sites, rank
  computation, endpoint stamping (integration, real Postgres), detail-response position, ingest rejection
  of a spoofed `QUEUE_POSITION`, and a write-path integration test driving `log_queue_positions` against
  real Postgres (created-asc/id-tiebreak ranking, `DISTINCT ON` newest-per-job dedup, JSONB round-trip,
  re-rank after the head job leaves, rendered feed).
- flip-utils: 573 unit green (mirror-schema rejection covered).
- flip-ui: 1053 unit green, lint clean. New coverage: label helper, queued-pill rendering (desktop +
  mobile), lifecycle-tracker description with/without position.
- Note: the `test_*.yml` suites trigger only on PRs targeting `develop`/`main`, so they don't run on this
  stacked PR — they will fire on the retarget to `develop`. The runs above were the local gate.

> **Stacked PR** — base is `feat/round-progress-card` (#757). After #757 merges, retarget to `develop`
> before the base branch is deleted.

## Documentation

`docs/source/user-guides/user-common.rst` (training scheduler section) now mentions the visible queue
position.

## Acceptance Criteria

*Imported from issue #788*

- [x] A queued model's position is its **1-based FIFO rank among jobs waiting for a net** — `FLJob.status == QUEUED`
  ordered by `created` ascending (`position = count(QUEUED jobs created before this one) + 1`). It is **not**
  derived from `Model.status`, which cannot distinguish "waiting for a net" from "picked and preparing".
- [x] On the model detail page's **Live activity** feed, the model's queue position is visible and a **new log line
  is emitted each time the position changes** (as jobs ahead are picked up), rendered newest-first in the
  existing timeline.
- [x] On the estate-wide **Models page**, each model under the `Queued` tile shows its position appended to the
  status label (e.g. `Model Queued (2)`); position `1` = next to be picked up.
- [x] Position updates as the queue drains: a model at `(3)` becomes `(2)`, then `(1)`, then loses the indicator
  once it is assigned to a net.
- [x] No position is shown for models that are not waiting in the queue (`PENDING`, `PREPARED`,
  `TRAINING_STARTED`, and terminal states).

