### PR TITLE
feat: add FL run metrics extraction tooling and Ark+ finetuning tutorial

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -456,3 +456,8 @@ fl-tutorials/nvflare/image_segmentation/3d_spleen_segmentation/uv.lock
 fl-services/flower/provision/creds/
 fl-services/flower/runs/
 fl-tutorials/flower/data/
+
+# Default output dir for scripts/extract_model_metrics.sh and
+# scripts/extract_simulator_metrics.sh (per-model round timings, logs, boxplots) —
+# local analysis scratch, not repo content.
+/model_metrics/

--- a/fl-tutorials/nvflare/image_classification/finetuning/.env.app
+++ b/fl-tutorials/nvflare/image_classification/finetuning/.env.app
@@ -1,0 +1,13 @@
+JOB_TYPE=standard_client_api
+# Fallback dataset used for BOTH sites when the per-site vars below are unset —
+# points at the small smoke-test set (make -C fl-tutorials download-xray-data).
+DEV_IMAGES_DIR=../../data/xrays_mini_300/accession-resources/
+DEV_DATAFRAME=../../data/xrays_mini_300/dataframe.csv
+# Paper-replication baseline: give each simulated site its own cohort
+# (site-1 = UK, site-2 = Thailand). Uncomment and point at the synthetic data.
+#SITE1_IMAGES_DIR=/path/to/uk/accession-resources
+#SITE1_DATAFRAME=/path/to/uk/dataframe.csv
+#SITE2_IMAGES_DIR=/path/to/thai/accession-resources
+#SITE2_DATAFRAME=/path/to/thai/dataframe.csv
+FLIP_PROJECT_ID=
+FLIP_QUERY=

--- a/fl-tutorials/nvflare/image_classification/finetuning/Makefile
+++ b/fl-tutorials/nvflare/image_classification/finetuning/Makefile
@@ -1,0 +1,73 @@
+# Copyright (c) 2026 Guy's and St Thomas' NHS Foundation Trust & King's College London
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+APP_DIR := $(CURDIR)
+REPO_ROOT := $(abspath $(APP_DIR)/../../../..)
+
+# Run job.py in the flip-utils environment with the `full` ML extra — the same package set the
+# flare-fl-base FL image installs, so a local SimEnv run matches the deployed image.
+FLIP_UTILS := $(REPO_ROOT)/flip-utils
+UV_RUN := uv run --project $(FLIP_UTILS) --extra full
+
+# --- Load app-specific env ---
+ifneq ("$(wildcard .env.app)","")
+include ./.env.app
+export $(shell sed 's/=.*//' ./.env.app)
+endif
+
+# Paper-replication defaults: 2 clients, 50 global rounds (local epochs / batch size /
+# LR come from app_files/config.json, exactly as in the production run).
+N_CLIENTS ?= 2
+ROUNDS ?= 50
+WORKSPACE ?= /tmp/nvflare/finetuning
+METRICS_OUT ?= $(REPO_ROOT)/model_metrics
+
+# Per-site cohort env (SITE1_*/SITE2_*) is forwarded only when set; data_utils gives it
+# precedence over config.json SITE_DATA and the single-source DEV_* fallback.
+SIM_ENV := DEV_IMAGES_DIR="$(abspath $(DEV_IMAGES_DIR))" DEV_DATAFRAME="$(abspath $(DEV_DATAFRAME))"
+ifneq ($(strip $(SITE1_IMAGES_DIR)),)
+SIM_ENV += SITE1_IMAGES_DIR="$(abspath $(SITE1_IMAGES_DIR))" SITE1_DATAFRAME="$(abspath $(SITE1_DATAFRAME))"
+endif
+ifneq ($(strip $(SITE2_IMAGES_DIR)),)
+SIM_ENV += SITE2_IMAGES_DIR="$(abspath $(SITE2_IMAGES_DIR))" SITE2_DATAFRAME="$(abspath $(SITE2_DATAFRAME))"
+endif
+
+.PHONY: run export sim metrics clean
+
+# --- Tutorial-harness entrypoint ---
+# The shared harness (fl-tutorials/nvflare/Makefile) auto-discovers any dir with a .env.app
+# and invokes `make run`. The Client API variant runs via the recipe/simulator path (job.py).
+run: sim
+
+# --- Export job config (no GPU needed) ---
+export:
+	$(UV_RUN) python job.py \
+		--export \
+		--export-dir ./fl_job \
+		--n_clients $(N_CLIENTS) \
+		--num_rounds $(ROUNDS)
+
+# --- SimEnv local simulation (requires GPU + data; see .env.app) ---
+sim:
+	$(SIM_ENV) $(UV_RUN) python job.py \
+		--n_clients $(N_CLIENTS) \
+		--num_rounds $(ROUNDS) \
+		--workspace $(WORKSPACE)
+
+# --- Extract the production-equivalent round metrics from the simulator logs ---
+# Same rounds.tsv/summary.md/boxplot outputs as scripts/extract_model_metrics.sh.
+# Optional: COMPARE=/path/to/platform/rounds.tsv adds a side-by-side overhead table.
+metrics:
+	bash $(REPO_ROOT)/scripts/extract_simulator_metrics.sh "$(WORKSPACE)" \
+		-o "$(METRICS_OUT)" $(if $(COMPARE),--compare "$(COMPARE)")
+
+clean:
+	rm -rf ./fl_job

--- a/fl-tutorials/nvflare/image_classification/finetuning/README.md
+++ b/fl-tutorials/nvflare/image_classification/finetuning/README.md
@@ -1,0 +1,64 @@
+<!--
+    Copyright (c) 2026 Guy's and St Thomas' NHS Foundation Trust & King's College London
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+        http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+
+# Ark+ fine-tuning — local-simulator replica of the UK–Thailand production run
+
+This tutorial holds the **exact app files used in the cross-continental FLIP
+experiment** (`app_files/`: `trainer.py`, Ark+ modules, `config.json`,
+`pretrained_weights.pt`) wired to run on the local NVFLARE simulator via
+`FlipFedAvgRecipe` — the same `standard_client_api` job type, the same FLIP
+`ScatterAndGather` controller, and the same `PercentilePrivacy` filter
+configuration (percentile 95, gamma 2.0) as the production deployment.
+
+Because the controller is identical, the simulator log carries the same
+`Round N started./finished.`, `Start/End aggregation.` and
+`Contribution … ACCEPTED` events that `scripts/extract_model_metrics.sh`
+extracts from production CloudWatch. `scripts/extract_simulator_metrics.sh`
+extracts them locally into the **same `rounds.tsv`/`summary.md`/boxplot
+artefacts**, enabling a platform-overhead baseline comparison.
+
+## Run
+
+```bash
+# 1. Point the simulator at the data (defaults to the mini smoke set; for the
+#    paper replication uncomment SITE1_*/SITE2_* in .env.app and point them at
+#    the UK and Thai synthetic cohorts respectively).
+$EDITOR .env.app
+
+# 2. Run the simulation (GPU required; defaults: 2 clients, 50 rounds — the
+#    paper's configuration; local epochs/batch/LR come from app_files/config.json)
+make sim                       # or: make sim ROUNDS=3 for a quick smoke run
+
+# 3. Extract the production-equivalent metrics from the simulator logs
+make metrics
+# ... or with a side-by-side platform comparison:
+make metrics COMPARE=model_metrics/<model_id>/rounds.tsv
+```
+
+Outputs land under `model_metrics/simulator-finetuning-<timestamp>/`.
+
+## Interpretation caveats
+
+- Both simulated clients share **one host and one GPU** (`num_threads = 2`), so
+  round durations reflect GPU contention, not two independent sites.
+- No WAN, TLS, task encryption, or trust-side services are involved: the
+  platform-minus-simulator round-duration delta bundles network transfer,
+  platform overhead, and hardware differences. The aggregation and
+  inter-round-gap rows are the directly comparable (host-light) quantities.
+
+## Notes
+
+- `pretrained_weights.pt` (~759 MiB) is staged into every site's `app/custom/`
+  by `job.py`; first simulator start-up is correspondingly slow.
+- `pretrained_weights/` (the unpacked copy of the checkpoint) is not used by
+  the tutorial and can be deleted.

--- a/fl-tutorials/nvflare/image_classification/finetuning/app_files/arkplus_flat_models.py
+++ b/fl-tutorials/nvflare/image_classification/finetuning/app_files/arkplus_flat_models.py
@@ -1,0 +1,238 @@
+# Copyright (c) 2026 Guy's and St Thomas' NHS Foundation Trust & King's College London
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+
+import timm.models.swin_transformer as swin
+import torch
+import torch.nn as nn
+
+
+def _normalise_checkpoint_state_dict(checkpoint, pretrained_key=None):
+    if pretrained_key:
+        if pretrained_key not in checkpoint:
+            raise KeyError(
+                f"PRETRAINED_KEY={pretrained_key!r} not found in checkpoint. "
+                f"Available keys: {list(checkpoint.keys())[:20]}"
+            )
+        state_dict = checkpoint[pretrained_key]
+    elif isinstance(checkpoint, dict) and "state_dict" in checkpoint:
+        state_dict = checkpoint["state_dict"]
+    elif isinstance(checkpoint, dict) and "model" in checkpoint:
+        state_dict = checkpoint["model"]
+    else:
+        state_dict = checkpoint
+
+    if any("module." in k for k in state_dict.keys()):
+        state_dict = {k.replace("module.", "", 1): v for k, v in state_dict.items() if k.startswith("module.")}
+    return state_dict
+
+
+# def _remap_scale_up_downsample_keys_for_timm(state_dict, model):
+#     """Map Ark+ scale_up checkpoint downsample keys to installed timm Swin keys.
+#
+#     The Ark+ checkpoint stores downsample modules on layers.0/1/2, while the
+#     timm SwinTransformer available in this environment stores the same tensors
+#     on layers.1/2/3. Shapes verify the one-stage shift.
+#     """
+#     model_state = model.state_dict()
+#     remapped = {}
+#     used_sources = set()
+#     for key, value in state_dict.items():
+#         new_key = key
+#         for src, dst in (
+#             ("layers.0.downsample.", "layers.1.downsample."),
+#             ("layers.1.downsample.", "layers.2.downsample."),
+#             ("layers.2.downsample.", "layers.3.downsample."),
+#         ):
+#             if key.startswith(src):
+#                 candidate = dst + key[len(src) :]
+#                 if candidate in model_state and tuple(value.shape) == tuple(model_state[candidate].shape):
+#                     new_key = candidate
+#                     used_sources.add(key)
+#                 break
+#         remapped[new_key] = value
+#
+#     if used_sources:
+#         print(f"Remapped {len(used_sources)} Ark+ scale_up downsample tensors for installed timm Swin layout.")
+#     return remapped
+
+
+# def _filter_state_dict_for_model(model, state_dict, load_backbone_only=False):
+#     state_dict = _remap_scale_up_downsample_keys_for_timm(state_dict, model)
+#
+#     if load_backbone_only:
+#         state_dict = {k: v for k, v in state_dict.items() if not k.startswith("omni_heads.")}
+#
+#     model_state = model.state_dict()
+#     compatible = {}
+#     skipped = []
+#     for key, value in state_dict.items():
+#         if "attn_mask" in key:
+#             skipped.append(key)
+#             continue
+#         if key not in model_state:
+#             skipped.append(key)
+#             continue
+#         if tuple(value.shape) != tuple(model_state[key].shape):
+#             skipped.append(key)
+#             continue
+#         compatible[key] = value
+#
+#     print(f"Loading {len(compatible)} compatible pretrained tensors; skipped {len(skipped)} tensors.")
+#     if skipped:
+#         print(f"Skipped pretrained keys sample: {skipped[:20]}")
+#     return compatible
+
+
+def _load_pretrained_weights(model, pretrained_weights, pretrained_key=None, load_backbone_only=False):
+    if not pretrained_weights:
+        return model
+
+    checkpoint_path = Path(pretrained_weights)
+    if not checkpoint_path.exists():
+        raise FileNotFoundError(f"Pretrained checkpoint not found: {checkpoint_path}")
+    checkpoint = torch.load(str(checkpoint_path), map_location="cpu", weights_only=True)
+
+    # state_dict = _normalise_checkpoint_state_dict(checkpoint, pretrained_key=pretrained_key)
+    # state_dict = _filter_state_dict_for_model(
+    #     model,
+    #     state_dict,
+    #     load_backbone_only=load_backbone_only,
+    # )
+    msg = model.load_state_dict(checkpoint, strict=False)
+    print(f"Loaded pretrained checkpoint with msg: {msg}")
+    return model
+
+
+class ArkSwinTransformer(swin.SwinTransformer):
+    def __init__(self, num_classes_list, projector_features=None, use_mlp=False, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        assert num_classes_list is not None
+
+        self.projector = None
+        if projector_features:
+            encoder_features = self.num_features
+            self.num_features = projector_features
+            if use_mlp:
+                self.projector = nn.Sequential(
+                    nn.Linear(encoder_features, self.num_features),
+                    nn.ReLU(inplace=True),
+                    nn.Linear(self.num_features, self.num_features),
+                )
+            else:
+                self.projector = nn.Linear(encoder_features, self.num_features)
+
+        self.omni_heads = []
+        for num_classes in num_classes_list:
+            self.omni_heads.append(nn.Linear(self.num_features, num_classes) if num_classes > 0 else nn.Identity())
+        self.omni_heads = nn.ModuleList(self.omni_heads)
+
+    @staticmethod
+    def _global_pool(x):
+        """Global-average-pool over spatial/sequence dims, leaving (B, C).
+
+        timm's ``forward_features`` returns the unpooled feature map
+        (``(B, H, W, C)`` for Swin) — pooling normally happens in
+        ``forward_head``, which this model bypasses in favour of its own
+        omni heads.  Without this, the heads would emit per-location
+        outputs instead of one prediction per image.  Mirrors the head's
+        default ``global_pool='avg'``.  A no-op if already ``(B, C)``.
+        """
+        if x.ndim > 2:
+            x = x.mean(dim=tuple(range(1, x.ndim - 1)))
+        return x
+
+    def forward(self, x, head_n=None):
+        x = self.forward_features(x)
+        x = self._global_pool(x)
+        if self.projector:
+            x = self.projector(x)
+        if head_n is not None:
+            return x, self.omni_heads[head_n](x)
+        else:
+            return [head(x) for head in self.omni_heads]
+
+    def generate_embeddings(self, x, after_proj=True):
+        x = self.forward_features(x)
+        x = self._global_pool(x)
+        if after_proj:
+            x = self.projector(x)
+        return x
+
+
+def build_omni_model(args, num_classes_list):
+    if args.model_name == "swin_base":  # swin_base_patch4_window7_224
+        model = ArkSwinTransformer(
+            num_classes_list,
+            args.projector_features,
+            args.use_mlp,
+            patch_size=4,
+            window_size=7,
+            embed_dim=128,
+            depths=(2, 2, 18, 2),
+            num_heads=(4, 8, 16, 32),
+        )
+    elif args.model_name == "swin_large":  # swin_large_patch4_window7_224
+        model = ArkSwinTransformer(
+            num_classes_list,
+            args.projector_features,
+            args.use_mlp,
+            patch_size=4,
+            window_size=7,
+            embed_dim=192,
+            depths=(2, 2, 18, 2),
+            num_heads=(6, 12, 24, 48),
+        )
+    elif args.model_name == "swin_large_384":  # swin_large_patch4_window12_384
+        model = ArkSwinTransformer(
+            num_classes_list,
+            args.projector_features,
+            args.use_mlp,
+            img_size=getattr(args, "input_size", 384),
+            patch_size=4,
+            window_size=12,
+            embed_dim=192,
+            depths=(2, 2, 18, 2),
+            num_heads=(6, 12, 24, 48),
+        )
+    elif args.model_name == "swin_large_768":  # swin_large_patch4_window12_384
+        model = ArkSwinTransformer(
+            num_classes_list,
+            args.projector_features,
+            args.use_mlp,
+            img_size=768,
+            patch_size=4,
+            window_size=12,
+            embed_dim=192,
+            depths=(2, 2, 18, 2),
+            num_heads=(6, 12, 24, 48),
+        )
+    elif args.model_name == "swin_large_1152":  # swin_large_patch4_window12_384
+        model = ArkSwinTransformer(
+            num_classes_list,
+            args.projector_features,
+            args.use_mlp,
+            img_size=1152,
+            patch_size=4,
+            window_size=12,
+            embed_dim=192,
+            depths=(2, 2, 18, 2),
+            num_heads=(6, 12, 24, 48),
+        )
+    model = _load_pretrained_weights(
+        model,
+        getattr(args, "pretrained_weights", None),
+        pretrained_key=getattr(args, "pretrained_key", None),
+        load_backbone_only=bool(getattr(args, "load_backbone_only", False)),
+    )
+
+    return model

--- a/fl-tutorials/nvflare/image_classification/finetuning/app_files/arkplus_flat_utils.py
+++ b/fl-tutorials/nvflare/image_classification/finetuning/app_files/arkplus_flat_utils.py
@@ -1,0 +1,350 @@
+# Copyright (c) 2026 Guy's and St Thomas' NHS Foundation Trust & King's College London
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import torch
+import yaml
+from PIL import Image
+from scipy import interpolate
+from sklearn.metrics import roc_auc_score
+
+
+def get_config(config):
+    with open(config, "r") as stream:
+        return yaml.safe_load(stream)
+
+
+class MetricLogger(object):
+    """Computes and stores the average and current value"""
+
+    def __init__(self, name, fmt=":f"):
+        self.name = name
+        self.fmt = fmt
+        self.reset()
+
+    def reset(self):
+        self.val = 0
+        self.avg = 0
+        self.sum = 0
+        self.count = 0
+
+    def update(self, val, n=1):
+        self.val = val
+        self.sum += val * n
+        self.count += n
+        self.avg = self.sum / self.count
+
+    def __str__(self):
+        fmtstr = "{name} {val" + self.fmt + "} ({avg" + self.fmt + "})"
+        return fmtstr.format(**self.__dict__)
+
+
+class ProgressLogger(object):
+    def __init__(self, num_batches, meters, prefix=""):
+        self.batch_fmtstr = self._get_batch_fmtstr(num_batches)
+        self.meters = meters
+        self.prefix = prefix
+
+    def display(self, batch):
+        entries = [self.prefix + self.batch_fmtstr.format(batch)]
+        entries += [str(meter) for meter in self.meters]
+        print("\t".join(entries))
+
+    def _get_batch_fmtstr(self, num_batches):
+        num_digits = len(str(num_batches // 1))
+        fmt = "{:" + str(num_digits) + "d}"
+        return "[" + fmt + "/" + fmt.format(num_batches) + "]"
+
+
+def metric_AUROC(target, output, nb_classes=14):
+    outAUROC = []
+
+    target = target.cpu().numpy()
+    output = output.cpu().numpy()
+
+    for i in range(nb_classes):
+        if np.any(target[:, i]):
+            outAUROC.append(roc_auc_score(target[:, i], output[:, i]))
+
+    return outAUROC
+
+
+def vararg_callback_bool(option, opt_str, value, parser):
+    assert value is None
+
+    arg = parser.rargs[0]
+    if arg.lower() in ("yes", "true", "t", "y", "1"):
+        value = True
+    elif arg.lower() in ("no", "false", "f", "n", "0"):
+        value = False
+
+    del parser.rargs[:1]
+    setattr(parser.values, option.dest, value)
+
+
+def vararg_callback_int(option, opt_str, value, parser):
+    assert value is None
+    value = []
+
+    def intable(str):
+        try:
+            int(str)
+            return True
+        except ValueError:
+            return False
+
+    for arg in parser.rargs:
+        # stop on --foo like options
+        if arg[:2] == "--" and len(arg) > 2:
+            break
+        # stop on -a, but not on -3 or -3.0
+        if arg[:1] == "-" and len(arg) > 1 and not intable(arg):
+            break
+        value.append(int(arg))
+
+    del parser.rargs[: len(value)]
+    setattr(parser.values, option.dest, value)
+
+
+class AverageMeter(object):
+    """Computes and stores the average and current value"""
+
+    def __init__(self):
+        self.reset()
+
+    def reset(self):
+        self.val = 0
+        self.avg = 0
+        self.sum = 0
+        self.count = 0
+
+    def update(self, val, n=1):
+        self.val = val
+        self.sum += val * n
+        self.count += n
+        self.avg = self.sum / self.count
+
+
+def torch_dice_coef_loss(y_true, y_pred, smooth=1.0):
+    y_true_f = torch.flatten(y_true)
+    y_pred_f = torch.flatten(y_pred)
+    intersection = torch.sum(y_true_f * y_pred_f)
+    return 1.0 - ((2.0 * intersection + smooth) / (torch.sum(y_true_f) + torch.sum(y_pred_f) + smooth))
+
+
+def cosine_anneal_schedule(t, epochs, learning_rate):
+    T = epochs
+    M = 1
+    alpha_zero = learning_rate
+
+    cos_inner = np.pi * (t % (T // M))  # t - 1 is used when t has 1-based indexing.
+    cos_inner /= T // M
+    cos_out = np.cos(cos_inner) + 1
+    return float(alpha_zero / 2 * cos_out)
+
+
+def dice(im1, im2, empty_score=1.0):
+    im1 = np.asarray(im1 > 0.5).astype(np.bool)
+    im2 = np.asarray(im2 > 0.5).astype(np.bool)
+
+    if im1.shape != im2.shape:
+        raise ValueError("Shape mismatch: im1 and im2 must have the same shape.")
+
+    im_sum = im1.sum() + im2.sum()
+    if im_sum == 0:
+        return empty_score
+
+    intersection = np.logical_and(im1, im2)
+
+    return 2.0 * intersection.sum() / im_sum
+
+
+def mean_dice_coef(y_true, y_pred):
+    sum = 0
+    for i in range(y_true.shape[0]):
+        sum += dice(y_true[i, :, :, :], y_pred[i, :, :, :])
+    return sum / y_true.shape[0]
+
+
+def save_image(input, idx):
+    def disparity_normalization(disp):  # disp is an array in uint8 data type
+        _min = np.amin(disp)
+        _max = np.amax(disp)
+        disp_norm = (disp - _min) * 255.0 / (_max - _min)
+        return np.uint8(disp_norm)
+
+    im = disparity_normalization(input)
+    im = Image.fromarray(im)
+    im.save("{}.jpeg".format(idx))
+
+
+def save_snapshot(samples, masks, outputs, save_snapshot_path):
+    bsz = samples.shape[0]
+
+    snap_shot = torch.cat(
+        (
+            samples[:, 0, :, :],
+            masks[:, 0, :, :],
+            outputs[:, 0, :, :],
+            masks[:, 1, :, :],
+            outputs[:, 1, :, :],
+            masks[:, 2, :, :],
+            outputs[:, 2, :, :],
+        ),
+        dim=2,
+    )
+    frames = []
+    for b in range(bsz):
+        frames.append(snap_shot[b])
+    snap_shot = torch.cat(frames, dim=0)
+    print("Saving snapshot..... Size:", snap_shot.size())
+    save_image(snap_shot.cpu().numpy(), save_snapshot_path)
+
+
+# --------------------------------------------------------
+# Copy from DINO https://github.com/facebookresearch/dino
+# Copyright (c) Facebook, Inc. and its affiliates.
+# --------------------------------------------------------
+def cosine_scheduler(base_value, final_value, epochs, niter_per_ep, warmup_epochs=0, start_warmup_value=0):
+    warmup_schedule = np.array([])
+    warmup_iters = warmup_epochs * niter_per_ep
+    if warmup_epochs > 0:
+        warmup_schedule = np.linspace(start_warmup_value, base_value, warmup_iters)
+
+    iters = np.arange(epochs * niter_per_ep - warmup_iters)
+    schedule = final_value + 0.5 * (base_value - final_value) * (1 + np.cos(np.pi * iters / len(iters)))
+
+    schedule = np.concatenate((warmup_schedule, schedule))
+    assert len(schedule) == epochs * niter_per_ep
+    return schedule
+
+
+# --------------------------------------------------------
+# Copy from SimMIM
+# Copyright (c) 2021 Microsoft
+# Licensed under The MIT License [see LICENSE for details]
+# Written by Ze Liu
+# Modified by Zhenda Xie
+# --------------------------------------------------------
+def load_pretrained_simmim(pretrained_weights, model):
+    print(">>>>>>>>>> Fine-tuned from {pretrained_weights} ..........")
+    checkpoint = torch.load(pretrained_weights, map_location="cpu")
+    checkpoint_model = checkpoint["model"]
+
+    if any([True if "encoder." in k else False for k in checkpoint_model.keys()]):
+        checkpoint_model = {
+            k.replace("encoder.", ""): v for k, v in checkpoint_model.items() if k.startswith("encoder.")
+        }
+        print("Detect pre-trained model, remove [encoder.] prefix.")
+    else:
+        print("Detect non-pre-trained model, pass without doing anything.")
+    print(">>>>>>>>>> Remapping pre-trained keys for SWIN ..........")
+    checkpoint = remap_pretrained_keys_swin(model, checkpoint_model)
+    # if args.model_name.startswith('swin'):
+    #     print(">>>>>>>>>> Remapping pre-trained keys for SWIN ..........")
+    #     checkpoint = remap_pretrained_keys_swin(model, checkpoint_model)
+    # elif args.model_name.startswith('vit'):
+    #     print(">>>>>>>>>> Remapping pre-trained keys for VIT ..........")
+    #     checkpoint = remap_pretrained_keys_vit(model, checkpoint_model)
+    # else:
+    #     raise NotImplementedError
+
+    # msg = model.load_state_dict(checkpoint_model, strict=False)
+    # print(msg)
+
+    # del checkpoint
+    # torch.cuda.empty_cache()
+    # print(">>>>>>>>>> loaded successfully '{}'".format(pretrained_weights))
+
+
+def remap_pretrained_keys_swin(model, checkpoint_model):
+    state_dict = model.state_dict()
+
+    # Geometric interpolation when pre-trained patch size mismatch with fine-tuned patch size
+    all_keys = list(checkpoint_model.keys())
+    for key in all_keys:
+        if "relative_position_bias_table" in key:
+            relative_position_bias_table_pretrained = checkpoint_model[key]
+            relative_position_bias_table_current = state_dict[key]
+            L1, nH1 = relative_position_bias_table_pretrained.size()
+            L2, nH2 = relative_position_bias_table_current.size()
+            if nH1 != nH2:
+                print("Error in loading {key}, passing......")
+            else:
+                if L1 != L2:
+                    print("{key}: Interpolate relative_position_bias_table using geo.")
+                    src_size = int(L1**0.5)
+                    dst_size = int(L2**0.5)
+
+                    def geometric_progression(a, r, n):
+                        return a * (1.0 - r**n) / (1.0 - r)
+
+                    left, right = 1.01, 1.5
+                    while right - left > 1e-6:
+                        q = (left + right) / 2.0
+                        gp = geometric_progression(1, q, src_size // 2)
+                        if gp > dst_size // 2:
+                            right = q
+                        else:
+                            left = q
+
+                    # if q > 1.090307:
+                    #     q = 1.090307
+
+                    dis = []
+                    cur = 1
+                    for i in range(src_size // 2):
+                        dis.append(cur)
+                        cur += q ** (i + 1)
+
+                    r_ids = [-_ for _ in reversed(dis)]
+
+                    x = r_ids + [0] + dis
+                    y = r_ids + [0] + dis
+
+                    t = dst_size // 2.0
+                    dx = np.arange(-t, t + 0.1, 1.0)
+                    dy = np.arange(-t, t + 0.1, 1.0)
+
+                    print("Original positions = %s" % str(x))
+                    print("Target positions = %s" % str(dx))
+
+                    all_rel_pos_bias = []
+
+                    for i in range(nH1):
+                        z = relative_position_bias_table_pretrained[:, i].view(src_size, src_size).float().numpy()
+                        f_cubic = interpolate.interp2d(x, y, z, kind="cubic")
+                        all_rel_pos_bias.append(
+                            torch.Tensor(f_cubic(dx, dy))
+                            .contiguous()
+                            .view(-1, 1)
+                            .to(relative_position_bias_table_pretrained.device)
+                        )
+
+                    new_rel_pos_bias = torch.cat(all_rel_pos_bias, dim=-1)
+                    checkpoint_model[key] = new_rel_pos_bias
+
+    # delete relative_position_index since we always re-init it
+    relative_position_index_keys = [k for k in checkpoint_model.keys() if "relative_position_index" in k]
+    for k in relative_position_index_keys:
+        del checkpoint_model[k]
+
+    # delete relative_coords_table since we always re-init it
+    relative_coords_table_keys = [k for k in checkpoint_model.keys() if "relative_coords_table" in k]
+    for k in relative_coords_table_keys:
+        del checkpoint_model[k]
+
+    # delete attn_mask since we always re-init it
+    attn_mask_keys = [k for k in checkpoint_model.keys() if "attn_mask" in k]
+    for k in attn_mask_keys:
+        del checkpoint_model[k]
+
+    return checkpoint_model

--- a/fl-tutorials/nvflare/image_classification/finetuning/app_files/config.json
+++ b/fl-tutorials/nvflare/image_classification/finetuning/app_files/config.json
@@ -1,0 +1,61 @@
+{
+  "job_type": "standard_client_api",
+  "SERVER_CHECKPOINT": "pretrained_weights.pt",
+  "AGGREGATE_ONLY_REGEX": "omni_heads",
+  "GLOBAL_ROUNDS": 50,
+  "MIN_CLIENTS": 1,
+  "WAIT_TIME_AFTER_MIN_RECEIVED": 0,
+  "LOCAL_ROUNDS": 5,
+  "LR_START": 0.0015,
+  "LR_END": 0.00015,
+  "LR_FLOOR": 0.00015,
+  "VAL_SPLIT": 0.2,
+  "SPLIT_SEED": 42,
+  "BATCH_SIZE": 4,
+  "DATALOADER_WORKERS": 4,
+  "LESIONS": {
+    "0": "Effusion",
+    "1": "Consolidation",
+    "2": "Infiltration",
+    "3": "Lung Nodule or Mass",
+    "4": "Pneumothorax",
+    "-1": "Lungs in normal arrangement"
+  },
+  "value_to_numerical": {
+    "1": "Yes",
+    "0": "No"
+  },
+  "VALIDATE_EVERY": 1,
+  "ARKPLUS": {
+    "MODEL_NAME": "swin_large_384",
+    "PROJECTOR_FEATURES": 1376,
+    "USE_MLP": false,
+    "USE_TEACHER_STUDENT": true,
+    "HEAD_ID": 0,
+    "NUM_CLASSES_LIST": [
+      5
+    ],
+    "EMA_MODE": "epoch",
+    "TEACHER_MOMENTUM": 0.9,
+    "CONSISTENCY_WEIGHT": 0.1,
+    "USE_AMP": true,
+    "AMP_DTYPE": "float16",
+    "REQUIRE_ARKPLUS_IMPORT": true,
+    "INPUT_SIZE": 768,
+    "LOAD_BACKBONE_ONLY": true
+  },
+  "SITE_DATA": {
+    "site-1": {
+      "images_dir": "/site-data/site-1/accession-resources",
+      "dataframe": "/site-data/site-1/sample_get_dataframe_response.csv"
+    },
+    "site-2": {
+      "images_dir": "/site-data/site-2/accession-resources",
+      "dataframe": "/site-data/site-2/sample_get_dataframe_response.csv"
+    },
+    "default": {
+      "images_dir": null,
+      "dataframe": null
+    }
+  }
+}

--- a/fl-tutorials/nvflare/image_classification/finetuning/app_files/data_utils.py
+++ b/fl-tutorials/nvflare/image_classification/finetuning/app_files/data_utils.py
@@ -1,0 +1,461 @@
+# Copyright (c) 2026 Guy's and St Thomas' NHS Foundation Trust & King's College London
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Data utilities for the NVFLARE-style FLIP x-ray tutorial.
+
+This file intentionally keeps the original tutorial data style: a dataframe/CSV
+with accession ids and label columns plus DICOM resources in the FLIP test-data
+layout. It prepares MONAI datasets whose batch dictionaries contain ``image`` and
+one scalar label per lesion.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+import monai.transforms as mt
+import numpy as np
+import pandas as pd
+import pydicom
+import torch
+from flip import FLIP
+from flip.constants import FlipConstants, ResourceType
+from monai.config import KeysCollection
+
+# from monai.data import DataLoader, Dataset
+from monai.transforms.transform import MapTransform
+
+
+def _is_local_dev() -> bool:
+    """Whether to read data from local files (simulator) or the FLIP API (real trust).
+
+    ``True`` in the NVFLARE simulator (``LOCAL_DEV=true``): resolve data from local
+    ``SITE_DATA``/``DEV_*`` paths. ``False`` on a real federated client: ignore
+    ``SITE_DATA`` and fetch the dataframe + DICOMs from the trust APIs via the FLIP
+    package. Mirrors the flip package's own ``LOCAL_DEV`` switch
+    (``flip.core.factory`` → ``FLIPStandardDev`` vs ``FLIPStandardProd``).
+    """
+    return bool(FlipConstants.LOCAL_DEV)
+
+
+# ---------------------------------------------------------------------------
+# Custom MONAI transform: 1→3 channel repeat + ImageNet normalization
+# ---------------------------------------------------------------------------
+class RepeatChannelImageNetNormalized(MapTransform):
+    """Repeat 1-channel to 3-channel RGB and apply ImageNet normalization.
+
+    Expects input shape ``(1, H, W)`` in range ``[0, 1]`` (as produced by
+    ``ScaleIntensityd``).  Outputs ``(3, H, W)`` with ImageNet-standard
+    mean/std per channel.
+    """
+
+    def __init__(self, keys: KeysCollection, allow_missing_keys: bool = False):
+        super().__init__(keys, allow_missing_keys)
+        self.mean = torch.tensor([0.485, 0.456, 0.406]).view(3, 1, 1)
+        self.std = torch.tensor([0.229, 0.224, 0.225]).view(3, 1, 1)
+
+    def __call__(self, data):
+        d = dict(data)
+        for key in self.key_iterator(d):
+            img = d[key]
+            if img.shape[-3] == 1:
+                img = img.repeat_interleave(3, dim=-3)
+            d[key] = (img - self.mean.to(img.device)) / (self.std.to(img.device))
+        return d
+
+
+APP_DIR = Path(__file__).resolve().parent
+CONFIG_PATH = APP_DIR / "config.json"
+
+
+@dataclass
+class Lesion:
+    id: int
+    lesion: str
+
+
+@dataclass
+class SiteDataConfig:
+    site_name: str
+    images_dir: str | None = None
+    dataframe: str | None = None
+
+
+class LesionDict:
+    def __init__(self, items: Sequence[Lesion]):
+        self.items = list(items)
+
+    def contains(self, element_value: str) -> bool:
+        return any(item.lesion == element_value for item in self.items)
+
+    def get_lesion_list(self) -> list[str]:
+        return [item.lesion for item in sorted(self.items, key=lambda x: x.id)]
+
+
+def load_config() -> dict:
+    with open(CONFIG_PATH, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def get_lesions(config: dict | None = None) -> LesionDict:
+    cfg = config or load_config()
+    lesions = []
+    for key, name in cfg["LESIONS"].items():
+        idx = int(key)
+        if idx >= 0:
+            lesions.append(Lesion(id=idx, lesion=name))
+    return LesionDict(sorted(lesions, key=lambda x: x.id))
+
+
+def get_normal_key(config: dict | None = None) -> str:
+    cfg = config or load_config()
+    for key, name in cfg.get("LESIONS", {}).items():
+        if int(key) < 0:
+            return name
+    return "Lungs in normal arrangement"
+
+
+def get_labels_from_radiology_row(radiology_row, lesions: LesionDict, value_to_numerical: dict, normal_label: str):
+    # JSON gives string keys; support both str and int access.
+    yes_str = value_to_numerical.get("1", value_to_numerical.get(1, "Yes"))
+    no_str = value_to_numerical.get("0", value_to_numerical.get(0, "No"))
+    columns = radiology_row.keys()
+    override_negative = normal_label in columns and radiology_row[normal_label] == yes_str
+    binary = {yes_str: 1, no_str: 0, 1: 1, 0: 0, "1": 1, "0": 0}
+
+    out_dict = {}
+    for lesion in lesions.items:
+        if override_negative:
+            out_dict[lesion.lesion] = 0
+        elif lesion.lesion in columns:
+            out_dict[lesion.lesion] = binary.get(radiology_row[lesion.lesion], -1)
+        else:
+            out_dict[lesion.lesion] = -1
+    return out_dict
+
+
+def get_lesion_label(in_batch: dict, lesions: LesionDict) -> torch.Tensor:
+    out_tensor = [in_batch[les.lesion] for les in sorted(lesions.items, key=lambda x: x.id)]
+    return torch.stack(out_tensor, dim=1).float()
+
+
+def _ensure_image_channel_first(image):
+    array = np.asarray(image)
+    if array.ndim == 2:
+        return array[None, ...]
+    if array.ndim == 3:
+        if array.shape[-1] in (1, 3):
+            return np.moveaxis(array, -1, 0)
+        if array.shape[0] in (1, 3):
+            return array
+    return array
+
+
+def get_xray_transforms(is_validation: bool = False):
+    cfg = load_config()
+    input_size = int(cfg.get("ARKPLUS", {}).get("INPUT_SIZE", 224))
+    transforms = [
+        mt.LoadImaged(keys=["image"]),
+        mt.Lambdad(keys=["image"], func=_ensure_image_channel_first),
+        mt.Resized(keys=["image"], spatial_size=[input_size, input_size]),
+        # mt.Rotate90d(keys=["image"], k=-1),
+        mt.Flipd(keys=["image"], spatial_axis=1),
+        mt.ScaleIntensityd(keys=["image"], channel_wise=True),
+        mt.EnsureTyped(keys=["image"]),
+        RepeatChannelImageNetNormalized(keys=["image"]),
+    ]
+    if not is_validation:
+        transforms.append(mt.RandAffined(keys=["image"], rotate_range=[-0.05, 0.05], scale_range=[0.01, 0.05]))
+    return mt.Compose(transforms)
+
+
+def normalize_site_name(site_name: str | None) -> str:
+    name = (site_name or "").strip()
+    if not name:
+        return ""
+    if name.startswith("site") and "-" not in name and len(name) > 4:
+        suffix = name[4:]
+        if suffix.isdigit():
+            return f"site-{suffix}"
+    return name
+
+
+def get_site_data_config(config: dict | None = None, site_name: str | None = None) -> SiteDataConfig:
+    cfg = config or load_config()
+    requested_site = normalize_site_name(site_name)
+    site_data = cfg.get("SITE_DATA", {})
+
+    entry = None
+    for candidate in [requested_site, (site_name or "").strip(), "default"]:
+        if candidate and candidate in site_data:
+            entry = site_data[candidate]
+            break
+
+    if entry is None:
+        entry = {}
+
+    # Per-site data resolution for the in-process Client-API simulator (no Docker mounts). Precedence:
+    #   1. SITE{N}_IMAGES_DIR / SITE{N}_DATAFRAME env (mapped from the NVFLARE site name, "site-1" -> "SITE1")
+    #   2. the config SITE_DATA entry's path
+    #   3. the single-site DEV_* env
+    # Per-site env wins because config SITE_DATA holds the legacy container-mount targets (/site-data/...),
+    # which don't exist in the no-Docker SimEnv; the real per-site host paths live in .env.app as SITE{N}_*.
+    # (In the legacy executor tutorial this per-site wiring was done by the testing harness' Docker mounts.)
+    site_env = requested_site.replace("-", "").upper() if requested_site else ""  # "site-1" -> "SITE1"
+    images_dir = (
+        (os.environ.get(f"{site_env}_IMAGES_DIR") if site_env else None)
+        or entry.get("images_dir")
+        or os.environ.get("DEV_IMAGES_DIR")
+    )
+    dataframe = (
+        (os.environ.get(f"{site_env}_DATAFRAME") if site_env else None)
+        or entry.get("dataframe")
+        or os.environ.get("DEV_DATAFRAME")
+    )
+    resolved_site = requested_site or "default"
+    return SiteDataConfig(site_name=resolved_site, images_dir=images_dir, dataframe=dataframe)
+
+
+def _read_dataframe(dataframe_path: str | None = None) -> pd.DataFrame:
+    path = dataframe_path or os.environ.get("DEV_DATAFRAME")
+    if path and Path(path).exists():
+        return pd.read_csv(path, sep=None, engine="python")
+    raise RuntimeError(f"Dataframe path is not set or does not exist: {path!r}")
+
+
+def _load_dataframe(site_cfg: SiteDataConfig, project_id: str = "", query: str = "") -> pd.DataFrame:
+    """Load the cohort dataframe: local CSV in the simulator, FLIP API on a real trust."""
+    if _is_local_dev():
+        return _read_dataframe(site_cfg.dataframe)
+    return FLIP().get_dataframe(project_id, query)
+
+
+def _find_accession_column(df: pd.DataFrame) -> str:
+    for col in ["accession_id", "accession_number", "accession", "AccessionNumber"]:
+        if col in df.columns:
+            return col
+    raise KeyError(f"Could not find accession column in dataframe columns: {list(df.columns)}")
+
+
+def _label_aware_split(datalist, label_names, val_split: float, seed: int, logger=None):
+    """
+    Guarantee at least one positive sample per label in train and val splits,
+    then fill remaining capacity with unassigned items.
+
+    Processing labels in order of rarity (fewest positives first) ensures rare
+    labels reserve their slot before common labels consume all split capacity.
+    """
+    datalist = list(datalist)
+    rng = np.random.default_rng(seed)
+    rng.shuffle(datalist)
+
+    n_total = len(datalist)
+    n_train = int(n_total * (1 - val_split))
+    n_val = n_total - n_train
+
+    splits = {"train": [], "val": []}
+    limits = {"train": n_train, "val": n_val}
+    assigned = set()
+
+    def can_add(split_name):
+        return len(splits[split_name]) < limits[split_name]
+
+    def add_item(index, split_name):
+        if index in assigned or not can_add(split_name):
+            return False
+        splits[split_name].append(datalist[index])
+        assigned.add(index)
+        return True
+
+    label_positive_indices = {
+        label: [i for i, item in enumerate(datalist) if item.get(label) == 1] for label in label_names
+    }
+    labels_by_rarity = sorted(label_names, key=lambda label: len(label_positive_indices[label]))
+
+    for label in labels_by_rarity:
+        positive_indices = list(label_positive_indices[label])
+        rng.shuffle(positive_indices)
+
+        if not positive_indices:
+            if logger is not None:
+                logger.warning("No positive samples found for label %s before splitting.", label)
+            continue
+
+        target_splits = ["train"]
+        if len(positive_indices) >= 2 and n_val > 0:
+            target_splits.append("val")
+
+        for split_name in target_splits:
+            if any(item.get(label) == 1 for item in splits[split_name]):
+                continue
+            for index in positive_indices:
+                if add_item(index, split_name):
+                    break
+
+    remaining_indices = [i for i in range(n_total) if i not in assigned]
+    rng.shuffle(remaining_indices)
+
+    for split_name in ("train", "val"):
+        for index in remaining_indices:
+            if not can_add(split_name):
+                break
+            add_item(index, split_name)
+
+    if logger is not None:
+        logger.info(
+            "Using label-aware split with seed=%s: train=%s, val=%s",
+            seed,
+            len(splits["train"]),
+            len(splits["val"])
+        )
+        _log_split_balance(splits, label_names, logger)
+
+    return splits["train"], splits["val"]
+
+
+def _log_split_balance(splits, label_names, logger):
+    for split_name, split_rows in splits.items():
+        logger.info("%s split label balance (%s samples):", split_name.upper(), len(split_rows))
+        for label in label_names:
+            num_positive = sum(1 for item in split_rows if item.get(label) == 1)
+            num_negative = sum(1 for item in split_rows if item.get(label) == 0)
+            num_masked = sum(1 for item in split_rows if item.get(label) == -1)
+            if num_positive == 0:
+                logger.warning("%s split has no positive samples for %s.", split_name.upper(), label)
+            logger.info(
+                "  %-20s: %4d positive, %4d negative, %4d masked/unknown",
+                label,
+                num_positive,
+                num_negative,
+                num_masked,
+            )
+
+
+def _dicoms_for_accession(
+    accession_id: str,
+    project_id: str = "",
+    images_dir: str | None = None,
+) -> list[Path]:
+    if _is_local_dev():
+        # Local test-data path used by make test-xrays-standard and SITE_DATA (simulator only).
+        root_path = images_dir or os.environ.get("DEV_IMAGES_DIR")
+        if root_path:
+            root = Path(root_path)
+            candidates = []
+            # Try accession subfolder first, then recursive match. This is flexible for mini test data.
+            for p in [root / str(accession_id), root / f"{accession_id}"]:
+                if p.exists():
+                    candidates.extend(p.rglob("*.dcm"))
+            if not candidates and root.exists():
+                candidates.extend(root.rglob(f"*{accession_id}*.dcm"))
+            if not candidates and root.exists():
+                # Fall back to all DICOMs only if there are very few. This avoids total failure on
+                # slightly different mini-data layouts.
+                all_dicoms = list(root.rglob("*.dcm"))
+                if len(all_dicoms) <= 500:
+                    candidates = all_dicoms
+            return sorted(set(candidates))
+        return []
+
+    # Real FLIP client path (LOCAL_DEV=false): fetch DICOMs from the trust imaging-api.
+    if project_id:
+        flip = FLIP()
+        # ResourceType.ALL: XNAT labels Secondary Capture DICOM resources "secondary", not "DICOM" —
+        # the synthetic chest radiographs are SC, so a DICOM-labelled fetch 404s on every study.
+        # ALL downloads every resource on the scan; the rglob("*.dcm") below picks out the DICOMs.
+        folder = flip.get_by_accession_number(project_id, accession_id, resource_type=[ResourceType.ALL])
+        return sorted(Path(folder).rglob("*.dcm"))
+
+    return []
+
+
+def build_datalist(
+    config: dict | None = None,
+    site_name: str | None = None,
+    project_id: str | None = None,
+    query: str | None = None,
+    logger=None,
+):
+    cfg = config or load_config()
+    site_cfg = get_site_data_config(cfg, site_name)
+    lesions = get_lesions(cfg)
+    normal_key = get_normal_key(cfg)
+    value_to_numerical = cfg.get("value_to_numerical", {"1": "Yes", "0": "No"})
+    project_id = project_id if project_id is not None else os.environ.get("PROJECT_ID", "")
+    query = query if query is not None else os.environ.get("QUERY", "")
+    df = _load_dataframe(site_cfg, project_id=project_id, query=query)
+    accession_col = _find_accession_column(df)
+
+    if logger is not None:
+        logger.info(
+            "Loading xray data for site=%s dataframe=%s images_dir=%s",
+            site_cfg.site_name,
+            site_cfg.dataframe,
+            site_cfg.images_dir,
+        )
+
+    datalist = []
+    seen_paths = set()
+    skipped_accessions = 0
+    for _, row in df.iterrows():
+        accession_id = str(row[accession_col])
+        labels = get_labels_from_radiology_row(row, lesions, value_to_numerical, normal_key)
+        try:
+            dicom_paths = _dicoms_for_accession(accession_id, project_id=project_id, images_dir=site_cfg.images_dir)
+        except Exception as exc:
+            # A single accession failing to fetch (e.g. a missing/broken DICOM resource in the
+            # trust imaging backend) must not abort the whole federated run — one bad study on one
+            # site would otherwise kill training for every site. Skip it and carry on; the run
+            # trains on the accessions that ARE retrievable. (See FLIP#677.)
+            skipped_accessions += 1
+            if logger is not None:
+                logger.warning("Skipping accession %s: failed to fetch DICOMs (%s)", accession_id, exc)
+            continue
+        for img in dicom_paths:
+            if img in seen_paths:
+                continue
+            try:
+                _ = pydicom.dcmread(str(img), stop_before_pixels=True)
+            except Exception:
+                continue
+            item = {"image": str(img)}
+            item.update(labels)
+            datalist.append(item)
+            seen_paths.add(img)
+
+    if skipped_accessions and logger is not None:
+        logger.warning(
+            "Skipped %d accession(s) whose DICOMs could not be fetched; training on the remaining %d sample(s).",
+            skipped_accessions,
+            len(datalist),
+        )
+
+    if not datalist:
+        raise RuntimeError(
+            "No DICOM image/label pairs found for "
+            f"site={site_cfg.site_name!r}. Check images_dir={site_cfg.images_dir!r}, "
+            f"dataframe={site_cfg.dataframe!r}, and accession ids."
+        )
+
+    val_split = float(cfg.get("VAL_SPLIT", 0.2))
+    split_seed = int(cfg.get("SPLIT_SEED", 42))
+    train_items, val_items = _label_aware_split(
+        datalist=datalist,
+        label_names=lesions.get_lesion_list(),
+        val_split=val_split,
+        seed=split_seed,
+        logger=logger,
+    )
+    return train_items, val_items

--- a/fl-tutorials/nvflare/image_classification/finetuning/app_files/loss_and_metrics.py
+++ b/fl-tutorials/nvflare/image_classification/finetuning/app_files/loss_and_metrics.py
@@ -1,0 +1,59 @@
+# Copyright (c) 2026 Guy's and St Thomas' NHS Foundation Trust & King's College London
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import torch
+from data_utils import LesionDict
+
+
+def get_bce_loss(outputs: torch.Tensor, targets: torch.Tensor) -> torch.Tensor:
+    """
+    Computes the Binary Cross-Entropy loss, not taking into account elements where the ground truths are -1.
+    """
+
+    loss_function = torch.nn.BCEWithLogitsLoss(reduction="none")
+    mask = (targets != -1).to(dtype=targets.dtype, device=targets.device)
+    loss = loss_function(outputs, targets) * mask
+    loss = loss.sum() / mask.sum()
+    return loss
+
+
+def compute_precision_recall_f1(
+    prediction: torch.Tensor, ground_truth: torch.Tensor, pathology: str, lesions: LesionDict
+):
+    prediction = prediction.detach().cpu().numpy().round()
+    ground_truth = ground_truth.detach().cpu().numpy()
+
+    prediction_new = []
+    ground_truth_new = []
+    for b in range(prediction.shape[0]):
+        for lesion in lesions.items:
+            if lesion.lesion == pathology:
+                prediction_new.append(prediction[b, int(lesion.id)])
+                ground_truth_new.append(ground_truth[b, int(lesion.id)])
+                break
+
+    prediction_new = np.array(prediction_new)
+    ground_truth_new = np.array(ground_truth_new)
+
+    # Calculate metrics using the pathology-specific predictions and ground truth
+    tp = np.sum((prediction_new == 1) & (ground_truth_new == 1))
+    fp = np.sum((prediction_new == 1) & (ground_truth_new == 0))
+    fn = np.sum((prediction_new == 0) & (ground_truth_new == 1))
+
+    # Gracefully handle division by zero cases by returning NaN
+    # The trainer will use np.nanmean() to ignore these when computing epoch averages
+    # This ensures only valid batches contribute to the metric, not artificially lowering it with 0.0
+    precision = tp / (tp + fp) if (tp + fp) > 0 else np.nan
+    recall = tp / (tp + fn) if (tp + fn) > 0 else np.nan
+    f1 = 2 * (precision * recall) / (precision + recall) if (precision + recall) > 0 else np.nan
+
+    return precision, recall, f1

--- a/fl-tutorials/nvflare/image_classification/finetuning/app_files/models.py
+++ b/fl-tutorials/nvflare/image_classification/finetuning/app_files/models.py
@@ -1,0 +1,173 @@
+# Copyright (c) 2026 Guy's and St Thomas' NHS Foundation Trust & King's College London
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""NVFLARE entry model for Ark+ inside the FLIP x-ray tutorial.
+
+NVFLARE's PTFileModelPersistor loads ``models.get_model`` from this file.
+This adapter constructs the Ark+ FedArk chest-xray model from flat files in this
+directory so it can be uploaded through FLIP interfaces that do not support
+nested folders.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import arkplus_flat_models
+import torch
+from torch import nn
+
+APP_DIR = Path(__file__).resolve().parent
+CONFIG_PATH = APP_DIR / "config.json"
+
+
+def _load_config() -> dict:
+    with open(CONFIG_PATH, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+# Model construction only — no pretrained weights are loaded here.
+# This is the construction half of arkplus_flat_models.build_omni_model,
+# used by preprocess_checkpoints.py to create a bare ArkSwinTransformer
+# for checkpoint validation and cleaning.
+def _build_arkplus_raw(arkplus_config: dict) -> nn.Module:
+    """Return a raw ArkSwinTransformer matching *arkplus_config*."""
+    model_name = str(arkplus_config.get("MODEL_NAME", "swin_large_768"))
+    input_size = int(arkplus_config.get("INPUT_SIZE", 768))
+    projector_features = arkplus_config.get("PROJECTOR_FEATURES", 1376)
+    use_mlp = bool(arkplus_config.get("USE_MLP", False))
+    num_classes_list = list(arkplus_config.get("NUM_CLASSES_LIST", [5]))
+
+    if model_name in ("swin_large_768", "swin_large_384"):
+        return arkplus_flat_models.ArkSwinTransformer(
+            num_classes_list,
+            projector_features,
+            use_mlp,
+            img_size=input_size,
+            patch_size=4,
+            window_size=12,
+            embed_dim=192,
+            depths=(2, 2, 18, 2),
+            num_heads=(6, 12, 24, 48),
+        )
+    if model_name == "swin_base":
+        return arkplus_flat_models.ArkSwinTransformer(
+            num_classes_list,
+            projector_features,
+            use_mlp,
+            patch_size=4,
+            window_size=7,
+            embed_dim=128,
+            depths=(2, 2, 18, 2),
+            num_heads=(4, 8, 16, 32),
+        )
+    raise ValueError(f"Unknown ARKPLUS model_name: {model_name!r}")
+
+
+class ArkPlusNVFlareWrapper(nn.Module):
+    """Wrap Ark+'s multi-head output into the simple classifier shape FLIP expects.
+
+    The real Ark+ model returns ``(features, logits)`` when called with a head id.
+    The existing FLIP x-ray trainer/validator expects ``model(images) -> logits``.
+    This wrapper keeps the real Ark+ model as ``self.ark_model`` while exposing a
+    normal classifier forward for the NVFLARE tutorial.
+    """
+
+    def __init__(self, ark_model: nn.Module, head_id: int = 0, num_classes: int = 2):
+        super().__init__()
+        self.ark_model = ark_model
+        self.head_id = int(head_id)
+        self.num_classes = int(num_classes)
+
+    def _pool_logits(self, logits: torch.Tensor) -> torch.Tensor:
+        """Convert Ark+ spatial logits to the [batch, classes] shape FLIP expects."""
+        if logits.ndim == 4:
+            # Ark+ may return [B, H, W, C] or [B, C, H, W].
+            num_classes = int(self.num_classes)
+            if logits.shape[-1] == num_classes:
+                logits = logits.mean(dim=(1, 2))
+            elif logits.shape[1] == num_classes:
+                logits = logits.mean(dim=(2, 3))
+            else:
+                logits = logits.flatten(start_dim=1)
+        return logits
+
+    def state_dict(self, *args, **kwargs):
+        return self.ark_model.state_dict(*args, **kwargs)
+
+    def load_state_dict(self, state_dict, strict=True):
+        keys = list(state_dict.keys())
+        if keys and keys[0].startswith("ark_model."):
+            return super().load_state_dict(state_dict, strict=strict)
+        wrapped = {f"ark_model.{k}": v for k, v in state_dict.items()}
+        return super().load_state_dict(wrapped, strict=strict)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        _features, logits = self.ark_model(x, self.head_id)
+        return self._pool_logits(logits)
+
+    def forward_with_features(self, x: torch.Tensor):
+        features, logits = self.ark_model(x, self.head_id)
+        return features, self._pool_logits(logits)
+
+
+def get_model() -> nn.Module:
+    """Return a fresh Ark+ model for NVFLARE.
+
+    This zero-argument function is required by the FLIP/NVFLARE standard job
+    config: ``models.get_model``.
+
+    The ~759 MiB backbone (``pretrained_weights.pt``) is NOT a hard requirement here.
+    It is loaded into the initial global model **server-side** by
+    ``flip.nvflare.components.InitialCheckpointPTModelPersistor`` (from the app's ``custom/``
+    in the simulator, or the hub shared volume in a real deployment) and delivered to every
+    client as the round-0 global model. So:
+
+    - if ``pretrained_weights.pt`` is present next to this file, load it (convenient for a
+      standalone/simulator run where the backbone is already staged locally);
+    - otherwise build a **bare** architecture — the real weights arrive at round 0.
+
+    Clients therefore never need the checkpoint file; the server (persistor) supplies it.
+    """
+    cfg = _load_config()
+    ark_cfg = cfg.get("ARKPLUS", {})
+    num_classes_list = ark_cfg.get("NUM_CLASSES_LIST", [2])
+    head_id = int(ark_cfg.get("HEAD_ID", 0))
+
+    PRETRAINED_PATH = APP_DIR / "pretrained_weights.pt"
+    pretrained_weights = str(PRETRAINED_PATH) if PRETRAINED_PATH.is_file() else None
+
+    try:
+        args = SimpleNamespace(
+            model_name=ark_cfg.get("MODEL_NAME", "swin_base"),
+            input_size=int(ark_cfg.get("INPUT_SIZE", 224)),
+            projector_features=ark_cfg.get("PROJECTOR_FEATURES", 1376),
+            use_mlp=bool(ark_cfg.get("USE_MLP", False)),
+            pretrained_weights=pretrained_weights,
+            pretrained_key=None,
+            load_backbone_only=bool(ark_cfg.get("LOAD_BACKBONE_ONLY", False)),
+        )
+        ark_model = arkplus_flat_models.build_omni_model(args, num_classes_list=num_classes_list)
+        return ArkPlusNVFlareWrapper(
+            ark_model=ark_model,
+            head_id=head_id,
+            num_classes=num_classes_list[head_id],
+        )
+    except Exception as exc:
+        raise RuntimeError(
+            "Failed to build the real Ark+ FedArk model. This commonly means the "
+            "runtime is missing Ark+ dependencies such as `timm`. Add them to the "
+            "root flip-fl-base pyproject/uv environment or set "
+            "ARKPLUS.REQUIRE_ARKPLUS_IMPORT=false only for a non-Ark smoke test. "
+            f"Original error: {exc!r}"
+        ) from exc

--- a/fl-tutorials/nvflare/image_classification/finetuning/app_files/trainer.py
+++ b/fl-tutorials/nvflare/image_classification/finetuning/app_files/trainer.py
@@ -1,0 +1,533 @@
+# Copyright (c) 2026 Guy's and St Thomas' NHS Foundation Trust & King's College London
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Client-API trainer for the Ark+ fine-tuning chest X-ray tutorial.
+
+This is the NVFLARE Client-API counterpart of the legacy ``FLIP_TRAINER(Executor)``. The FL transport
+is restructured onto the canonical ``flare.init()`` / ``flare.is_running()`` round loop (receive the
+global model, train locally, send back a ``DIFF``), while the Ark+ fine-tuning compute — head-only
+fine-tuning with a frozen backbone, an EMA teacher/student consistency loss, AMP, and per-lesion
+precision/recall/F1 — is preserved verbatim from the executor tutorial. Metrics stream through
+``SummaryWriter`` (one series per lesion) instead of the legacy ``send_metrics_value``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import gc
+import json
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+import nvflare.client as flare
+import torch
+from data_utils import (
+    Lesion,
+    LesionDict,
+    build_datalist,
+    get_lesion_label,
+    get_xray_transforms,
+)
+from loss_and_metrics import compute_precision_recall_f1, get_bce_loss
+from models import get_model
+from monai.data import DataLoader, Dataset
+from nvflare.client.tracking import SummaryWriter
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ArkTrainState:
+    """Persistent per-client training state + Ark+ hyperparameters, created once and reused every round."""
+
+    model: torch.nn.Module
+    teacher_model: torch.nn.Module | None
+    optimizer: torch.optim.Optimizer
+    scheduler: torch.optim.lr_scheduler.LRScheduler
+    amp_scaler: torch.amp.GradScaler
+    consistency_loss: torch.nn.Module
+    lesions: LesionDict
+    device: torch.device
+    use_teacher_student: bool
+    ema_mode: str
+    teacher_momentum: float
+    consistency_weight: float
+    amp_enabled: bool
+    amp_dtype: torch.dtype
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--project_id", type=str, default="")
+    return parser.parse_args()
+
+
+def load_query() -> str:
+    """Read the cohort query from the client app config.
+
+    NVFlare's TaskScriptRunner does a naive whitespace split on task_script_args,
+    so the SQL query (which can contain spaces) is plumbed via the top-level
+    ``query`` key in ``config/config_fed_client.json`` rather than as a CLI flag.
+    In dev/simulator mode this is ignored by ``flip.get_dataframe``.
+    """
+    client_cfg = Path(__file__).parent.parent / "config" / "config_fed_client.json"
+    if client_cfg.exists():
+        try:
+            return json.loads(client_cfg.read_text()).get("query", "")
+        except Exception:
+            return ""
+    return ""
+
+
+def load_config() -> dict:
+    """Load the user-supplied config.json that sits next to this script (kept unmutated for build_datalist)."""
+    config_path = Path(__file__).parent.resolve() / "config.json"
+    with open(config_path) as f:
+        return json.load(f)
+
+
+def build_lesion_dict(config: dict) -> LesionDict:
+    """Build the trainable LesionDict from config, dropping the reserved ``-1`` normality key."""
+    lesions = dict(config["LESIONS"])
+    lesions.pop("-1", None)
+    return LesionDict(items=[Lesion(id=int(k), lesion=v) for k, v in lesions.items()])
+
+
+def _autocast(state: ArkTrainState):
+    """AMP autocast context — mirrors the legacy trainer so training/validation math is identical."""
+    if hasattr(torch, "amp"):
+        return torch.amp.autocast(device_type="cuda", dtype=state.amp_dtype, enabled=state.amp_enabled)
+    return torch.cuda.amp.autocast(dtype=state.amp_dtype, enabled=state.amp_enabled)
+
+
+def _setup_teacher_model(
+    model: torch.nn.Module,
+    device: torch.device,
+    use_teacher_student: bool,
+    ema_mode: str,
+    teacher_momentum: float,
+    consistency_weight: float,
+) -> tuple[torch.nn.Module | None, bool, str]:
+    """Create the local EMA teacher used by Ark+ client training (verbatim from legacy _setup_teacher_model)."""
+    if not use_teacher_student:
+        return None, False, ema_mode
+
+    if not hasattr(model, "forward_with_features"):
+        logger.warning(
+            "ARKPLUS.USE_TEACHER_STUDENT=true, but the model does not expose "
+            "forward_with_features(); falling back to standard training."
+        )
+        return None, False, ema_mode
+
+    if ema_mode not in {"epoch", "iteration"}:
+        logger.warning("Unsupported ARKPLUS.EMA_MODE=%r; using 'epoch' instead.", ema_mode)
+        ema_mode = "epoch"
+
+    if not 0.0 <= consistency_weight <= 1.0:
+        raise ValueError("ARKPLUS.CONSISTENCY_WEIGHT must be between 0 and 1.")
+
+    teacher_model = copy.deepcopy(model).to(device)
+    teacher_model.eval()
+    for param in teacher_model.parameters():
+        param.requires_grad_(False)
+
+    logger.info(
+        "Ark+ teacher/student training enabled: EMA_MODE=%s, TEACHER_MOMENTUM=%s, CONSISTENCY_WEIGHT=%s",
+        ema_mode,
+        teacher_momentum,
+        consistency_weight,
+    )
+    return teacher_model, True, ema_mode
+
+
+def _sync_teacher_from_student_once(state: ArkTrainState, already_synced: bool) -> bool:
+    """Initialize the local teacher from the first server-provided student weights (legacy semantics)."""
+    if not state.use_teacher_student or state.teacher_model is None or already_synced:
+        return already_synced
+    state.teacher_model.load_state_dict(state.model.state_dict())
+    state.teacher_model.eval()
+    return True
+
+
+def _ema_update_teacher(state: ArkTrainState) -> None:
+    """Update the local teacher as an EMA of the student model (verbatim from legacy _ema_update_teacher)."""
+    if not state.use_teacher_student or state.teacher_model is None:
+        return
+    momentum = state.teacher_momentum
+    with torch.no_grad():
+        student_state = state.model.state_dict()
+        teacher_state = state.teacher_model.state_dict()
+        for name, teacher_value in teacher_state.items():
+            student_value = student_state[name].detach()
+            if torch.is_floating_point(teacher_value):
+                teacher_value.mul_(momentum).add_(student_value.to(teacher_value.device), alpha=1.0 - momentum)
+            else:
+                teacher_value.copy_(student_value.to(teacher_value.device))
+
+
+def _log_batch_distribution(
+    labels: torch.Tensor,
+    lesions: LesionDict,
+    epoch: int,
+    phase: str,
+    batch_idx: int,
+    n_batches: int,
+) -> None:
+    """Log the per-lesion positive/negative/masked class counts for one batch (preserved from legacy)."""
+    labels_np = labels.detach().cpu().numpy()
+    batch_info = f"Epoch {epoch + 1}, {phase} Batch {batch_idx + 1}/{n_batches}, Batch size: {labels.shape[0]} - "
+    for lesion_idx, lesion in enumerate(lesions.items):
+        lesion_labels = labels_np[:, lesion_idx]
+        valid_labels = lesion_labels[lesion_labels != -1]
+        if len(valid_labels) > 0:
+            num_positive = int(np.sum(valid_labels == 1))
+            num_negative = int(np.sum(valid_labels == 0))
+            batch_info += f"{lesion.lesion}: {num_positive} pos / {num_negative} neg; "
+        else:
+            batch_info += f"{lesion.lesion}: all masked; "
+    logger.info(batch_info)
+
+
+def log_dataset_class_distribution(train_dict: list, val_dict: list, lesions: LesionDict) -> None:
+    """Log the overall class distribution in the train/val datasets (preserved from legacy)."""
+    logger.info("\n" + "=" * 80)
+    logger.info("OVERALL CLASS DISTRIBUTION IN DATASETS")
+    logger.info("=" * 80)
+    for dataset_name, datalist in [("TRAINING", train_dict), ("VALIDATION", val_dict)]:
+        logger.info(f"\n{dataset_name} Dataset ({len(datalist)} samples):")
+        for lesion in lesions.items:
+            lesion_name = lesion.lesion
+            all_labels = [item[lesion_name] for item in datalist]
+            num_positive = sum(1 for label in all_labels if label == 1)
+            num_negative = sum(1 for label in all_labels if label == 0)
+            num_masked = sum(1 for label in all_labels if label == -1)
+            if num_positive + num_negative > 0:
+                positive_ratio = num_positive / (num_positive + num_negative) * 100
+            else:
+                positive_ratio = 0.0
+            logger.info(
+                f"  {lesion_name:20s}: {num_positive:4d} positive, {num_negative:4d} negative, "
+                f"{num_masked:4d} masked/unknown"
+            )
+            logger.info(f"                        Positive ratio: {positive_ratio:.2f}% (excluding masked)")
+    logger.info("=" * 80 + "\n")
+
+
+def _safe_mean(values: list) -> float:
+    if not values:
+        return float("nan")
+    return float(np.nanmean(values))
+
+
+def _publish(writer: SummaryWriter, label: str, value: float, step: int) -> None:
+    """Push a scalar through SummaryWriter, swapping NaN for 0.0 like the legacy code did."""
+    if np.isnan(value):
+        logger.warning(f"{label} is NaN — sending 0.0")
+        value = 0.0
+    writer.add_scalar(label, value, global_step=step)
+
+
+def aggregate_and_publish(
+    train_metrics: dict,
+    val_metrics: dict | None,
+    writer: SummaryWriter,
+    lesions: LesionDict,
+    step: int,
+) -> None:
+    """Aggregate per-batch metrics with np.nanmean and stream them, one SummaryWriter series per lesion."""
+    _publish(writer, "TRAIN_LOSS", _safe_mean(train_metrics["loss"]), step)
+    # Only publish VAL_* scalars when validation actually ran this epoch (per VALIDATE_EVERY) — emitting a
+    # 0.0 placeholder would inject spurious zeros into the validation series.
+    if val_metrics is not None:
+        _publish(writer, "VAL_LOSS", _safe_mean(val_metrics["loss"]), step)
+    for metric in ["f1-score", "precision", "recall"]:
+        for name in lesions.get_lesion_list():
+            # Include the lesion name in the tag so each lesion writes to a distinct series.
+            _publish(writer, f"TRAIN-{metric.upper()}-{name}", _safe_mean(train_metrics[metric][name]), step)
+            if val_metrics is not None:
+                _publish(writer, f"VAL-{metric.upper()}-{name}", _safe_mean(val_metrics[metric][name]), step)
+
+
+def _empty_metrics(lesions: LesionDict) -> dict:
+    metrics: dict = {"loss": [], "precision": {}, "recall": {}, "f1-score": {}}
+    for name in lesions.get_lesion_list():
+        metrics["precision"][name] = []
+        metrics["recall"][name] = []
+        metrics["f1-score"][name] = []
+    return metrics
+
+
+def train_one_epoch(state: ArkTrainState, loader: DataLoader, epoch: int) -> dict:
+    """One training pass. Ark+ teacher/student + AMP compute preserved verbatim from legacy local_train."""
+    state.model.train()
+    if state.teacher_model is not None:
+        state.teacher_model.eval()
+
+    metrics = _empty_metrics(state.lesions)
+    for i, batch in enumerate(loader):
+        images = batch["image"].to(state.device)
+        labels = get_lesion_label(batch, state.lesions).to(state.device)
+        _log_batch_distribution(labels, state.lesions, epoch, "Train", i, len(loader))
+
+        state.optimizer.zero_grad()
+        with _autocast(state):
+            if state.use_teacher_student and state.teacher_model is not None:
+                student_features, output = state.model.forward_with_features(images)
+                with torch.no_grad():
+                    teacher_features, _ = state.teacher_model.forward_with_features(images)
+                classification_loss = get_bce_loss(output, labels)
+                consistency_loss = state.consistency_loss(student_features, teacher_features.detach())
+                loss = (
+                    1.0 - state.consistency_weight
+                ) * classification_loss + state.consistency_weight * consistency_loss
+            else:
+                output = state.model(images)
+                loss = get_bce_loss(output, labels)
+        state.amp_scaler.scale(loss).backward()
+        state.amp_scaler.step(state.optimizer)
+        state.amp_scaler.update()
+        if state.ema_mode == "iteration":
+            _ema_update_teacher(state)
+
+        metrics["loss"].append(loss.item())
+        output = torch.sigmoid(output)
+        for pathology in state.lesions.get_lesion_list():
+            precision, recall, f1_score = compute_precision_recall_f1(output, labels, pathology, lesions=state.lesions)
+            metrics["precision"][pathology].append(precision)
+            metrics["recall"][pathology].append(recall)
+            metrics["f1-score"][pathology].append(f1_score)
+
+    return metrics
+
+
+def run_eval_pass(state: ArkTrainState, loader: DataLoader, epoch: int, phase: str, log_batches: bool) -> dict:
+    """A no-grad evaluation pass over ``loader``. Shared by in-training validation and is_evaluate scoring."""
+    state.model.eval()
+    metrics = _empty_metrics(state.lesions)
+    with torch.no_grad():
+        for i, batch in enumerate(loader):
+            images = batch["image"].to(state.device)
+            labels = get_lesion_label(batch, state.lesions).to(state.device)
+            if log_batches:
+                _log_batch_distribution(labels, state.lesions, epoch, phase, i, len(loader))
+            with _autocast(state):
+                output = state.model(images)
+                loss = get_bce_loss(output, labels).item()
+            metrics["loss"].append(loss)
+            output = torch.sigmoid(output)
+            for pathology in state.lesions.get_lesion_list():
+                precision, recall, f1_score = compute_precision_recall_f1(
+                    output, labels, pathology, lesions=state.lesions
+                )
+                metrics["precision"][pathology].append(precision)
+                metrics["recall"][pathology].append(recall)
+                metrics["f1-score"][pathology].append(f1_score)
+    return metrics
+
+
+def local_train(
+    state: ArkTrainState,
+    train_loader: DataLoader,
+    val_loader: DataLoader,
+    epochs: int,
+    validate_every: int,
+    writer: SummaryWriter,
+    global_round: int,
+) -> int:
+    """Run ``epochs`` local epochs and stream metrics. Returns total iteration count (legacy _n_iterations)."""
+    n_iterations = 0
+    for epoch in range(epochs):
+        train_metrics = train_one_epoch(state, train_loader, epoch)
+        n_iterations += len(train_metrics["loss"])
+
+        if state.ema_mode == "epoch":
+            _ema_update_teacher(state)
+
+        val_metrics = None
+        if epoch % validate_every == 0:
+            val_metrics = run_eval_pass(state, val_loader, epoch, "Val", log_batches=True)
+            state.model.train()
+
+        state.scheduler.step()
+
+        step = global_round * epochs + epoch + 1
+        aggregate_and_publish(train_metrics, val_metrics, writer, state.lesions, step)
+
+    return n_iterations
+
+
+def cross_site_validate(state: ArkTrainState, loader: DataLoader, writer: SummaryWriter) -> dict:
+    """Score the global model on the local val split and publish TEST_* metrics (folds in validator.py)."""
+    metrics = run_eval_pass(state, loader, epoch=0, phase="Test", log_batches=False)
+    writer.add_scalar("TEST_LOSS", _safe_mean(metrics["loss"]), global_step=0)
+    for metric in ["f1-score", "precision", "recall"]:
+        for name in state.lesions.get_lesion_list():
+            # Include the lesion name in the tag so each lesion writes to a distinct series.
+            writer.add_scalar(f"TEST-{metric.upper()}-{name}", _safe_mean(metrics[metric][name]), global_step=0)
+    return metrics
+
+
+def main() -> None:
+    args = parse_args()
+    config = load_config()
+
+    epochs = config["LOCAL_ROUNDS"]
+    lr_start = config["LR_START"]
+    lr_end = config["LR_END"]
+    lr_floor = config.get("LR_FLOOR", 0.0001)
+    batch_size = config["BATCH_SIZE"]
+    num_workers = int(config.get("DATALOADER_WORKERS", 4))
+    validate_every = config["VALIDATE_EVERY"] if "VALIDATE_EVERY" in config else 1
+
+    _value_to_numerical = {int(k): v for k, v in config["value_to_numerical"].items()}
+    if 0 not in _value_to_numerical and 1 not in _value_to_numerical:
+        raise ValueError("value_to_numerical must contain mappings for 0 and 1.")
+
+    ark_cfg = config.get("ARKPLUS", {})
+    use_teacher_student = bool(ark_cfg.get("USE_TEACHER_STUDENT", False))
+    ema_mode = str(ark_cfg.get("EMA_MODE", "epoch")).lower()
+    teacher_momentum = float(ark_cfg.get("TEACHER_MOMENTUM", 0.9))
+    consistency_weight = float(ark_cfg.get("CONSISTENCY_WEIGHT", 0.1))
+    amp_enabled = bool(ark_cfg.get("USE_AMP", False)) and torch.cuda.is_available()
+    amp_dtype_name = str(ark_cfg.get("AMP_DTYPE", "float16")).lower()
+    amp_dtype = torch.bfloat16 if amp_dtype_name == "bfloat16" else torch.float16
+
+    lesions = build_lesion_dict(config)
+    device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+
+    model = get_model().to(device)
+    # Freeze backbone + projector, only train the classifier head (verbatim from legacy).
+    for name, param in model.named_parameters():
+        if not name.startswith("ark_model.omni_heads"):
+            param.requires_grad = False
+    trainable = sum(p.numel() for p in model.parameters() if p.requires_grad)
+    total = sum(p.numel() for p in model.parameters())
+    logger.info(f"Trainable params: {trainable:,} / {total:,} (backbone frozen)")
+
+    consistency_loss = torch.nn.MSELoss()
+    try:
+        amp_scaler = torch.amp.GradScaler("cuda", enabled=amp_enabled)
+    except TypeError:
+        amp_scaler = torch.cuda.amp.GradScaler(enabled=amp_enabled)
+    teacher_model, use_teacher_student, ema_mode = _setup_teacher_model(
+        model, device, use_teacher_student, ema_mode, teacher_momentum, consistency_weight
+    )
+
+    optimizer = torch.optim.Adam([p for p in model.parameters() if p.requires_grad], lr=lr_start)
+    gamma_lr = (lr_end / lr_start) ** (1 / epochs)
+    scheduler = torch.optim.lr_scheduler.LambdaLR(
+        optimizer,
+        lr_lambda=lambda epoch: max(gamma_lr ** epoch, lr_floor / lr_start),
+    )
+
+    if amp_enabled:
+        logger.info(f"Mixed precision enabled for training with dtype={amp_dtype}.")
+
+    state = ArkTrainState(
+        model=model,
+        teacher_model=teacher_model,
+        optimizer=optimizer,
+        scheduler=scheduler,
+        amp_scaler=amp_scaler,
+        consistency_loss=consistency_loss,
+        lesions=lesions,
+        device=device,
+        use_teacher_student=use_teacher_student,
+        ema_mode=ema_mode,
+        teacher_momentum=teacher_momentum,
+        consistency_weight=consistency_weight,
+        amp_enabled=amp_enabled,
+        amp_dtype=amp_dtype,
+    )
+
+    # flare.init() must precede any other flare.* call (e.g. get_site_name()); data loads once, after init.
+    flare.init()
+    site_name = flare.get_site_name()
+    train_dict, val_dict = build_datalist(
+        config=config,
+        site_name=site_name,
+        project_id=args.project_id,
+        query=load_query(),
+        logger=logger,
+    )
+    train_loader = DataLoader(
+        Dataset(train_dict, transform=get_xray_transforms()),
+        batch_size=batch_size,
+        shuffle=True,
+        num_workers=num_workers,
+        pin_memory=torch.cuda.is_available(),
+    )
+    val_loader = DataLoader(
+        Dataset(val_dict, transform=get_xray_transforms(is_validation=True)),
+        batch_size=batch_size,
+        shuffle=False,
+        num_workers=num_workers,
+        pin_memory=torch.cuda.is_available(),
+    )
+    logger.info(
+        "DataLoader created for site=%s: training batches=%d, validation batches=%d",
+        site_name,
+        len(train_loader),
+        len(val_loader),
+    )
+    log_dataset_class_distribution(train_dict, val_dict, lesions)
+
+    writer = SummaryWriter()
+    teacher_synced = False
+
+    while flare.is_running():
+        input_model = flare.receive()
+        if input_model is None:
+            break
+
+        if flare.is_train():
+            original = {k: torch.as_tensor(v) for k, v in input_model.params.items()}
+            model.load_state_dict(original)
+            teacher_synced = _sync_teacher_from_student_once(state, teacher_synced)
+            global_round = input_model.current_round or 0
+
+            n_iterations = local_train(state, train_loader, val_loader, epochs, validate_every, writer, global_round)
+
+            # Send back DIFF (matches the legacy get_model_weights_diff behaviour used with the
+            # FullModelShareableGenerator).
+            new_state = {k: v.detach().cpu().numpy() for k, v in model.state_dict().items()}
+            diff = {k: new_state[k] - original[k].detach().cpu().numpy() for k in new_state}
+            flare.send(
+                flare.FLModel(
+                    params=diff,
+                    params_type="DIFF",
+                    meta={"NUM_STEPS_CURRENT_ROUND": n_iterations},
+                )
+            )
+
+            # Free transient buffers between rounds — the Ark+ backbone + EMA teacher are large.
+            gc.collect()
+            if torch.cuda.is_available():
+                torch.cuda.empty_cache()
+
+        elif flare.is_evaluate():
+            model.load_state_dict({k: torch.as_tensor(v) for k, v in input_model.params.items()})
+            metrics = cross_site_validate(state, val_loader, writer)
+            flare.send(flare.FLModel(metrics={"loss": _safe_mean(metrics["loss"])}))
+
+        elif flare.is_submit_model():
+            params = {k: v.detach().cpu().numpy() for k, v in model.state_dict().items()}
+            flare.send(flare.FLModel(params=params, params_type="FULL"))
+
+        else:
+            logger.warning("Received unknown task; ignoring.")
+
+
+if __name__ == "__main__":
+    main()

--- a/fl-tutorials/nvflare/image_classification/finetuning/job.py
+++ b/fl-tutorials/nvflare/image_classification/finetuning/job.py
@@ -1,0 +1,111 @@
+# Copyright (c) 2026 Guy's and St Thomas' NHS Foundation Trust & King's College London
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""FedAvg Client API job definition for the Ark+ fine-tuning experiment.
+
+Local-simulator replica of the UK--Thailand production run: same job type
+(``standard_client_api``), same FLIP ScatterAndGather controller and
+PercentilePrivacy filter (via :class:`FlipFedAvgRecipe`), same app files.
+Because the controller is identical, the simulator log carries the same
+``Round N started./finished.``, ``Start/End aggregation.``, and
+``Contribution ... ACCEPTED`` lines that ``scripts/extract_model_metrics.sh``
+parses from CloudWatch in production — extract them locally with
+``scripts/extract_simulator_metrics.sh`` for a platform-overhead baseline.
+
+Defaults mirror the paper's run: 2 clients, 50 rounds (local epochs, batch
+size, LR schedule etc. come from ``app_files/config.json`` as in production).
+
+Usage:
+    # Export job config for review (no GPU needed)
+    python job.py --export --export-dir ./fl_job --n_clients 2 --num_rounds 50
+
+    # SimEnv local simulation (requires GPU + data; see .env.app)
+    python job.py --n_clients 2 --num_rounds 50
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+# app_files/ must be importable at recipe-construction time so PTFileModelPersistor
+# and PTModelLocator can reference 'models.get_model' correctly.
+_APP_FILES_DIR = Path(__file__).parent / "app_files"
+if str(_APP_FILES_DIR) not in sys.path:
+    sys.path.insert(0, str(_APP_FILES_DIR))
+
+from flip.nvflare.recipes import FlipFedAvgRecipe  # noqa: E402
+from nvflare import FedJob  # noqa: E402
+from nvflare.recipe import SimEnv  # noqa: E402
+
+
+def stage_app_files(job: FedJob) -> None:
+    """Bundle every file in ``app_files/`` into the job's server + client ``custom/`` directories.
+
+    The recipe wires only the NVFLARE components; the user-supplied app files (``trainer.py``,
+    ``models.py``, ``config.json``, the Ark+ modules, and ``pretrained_weights.pt``) must be added
+    to the job explicitly so they land in every site's ``app/custom/`` — exactly the layout the
+    production upload produces.
+
+    Args:
+        job: The recipe's underlying :class:`~nvflare.job_config.api.FedJob` (``recipe.job``).
+    """
+    for src in sorted(_APP_FILES_DIR.iterdir()):
+        if src.is_file():
+            job.add_file_to_server(str(src))
+            job.add_file_to_clients(str(src))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="FLIP Ark+ fine-tuning Client API FedAvg job (simulator replica)")
+    parser.add_argument("--n_clients", type=int, default=2, help="Number of clients")
+    parser.add_argument("--num_rounds", type=int, default=50, help="Number of federated rounds")
+    parser.add_argument(
+        "--workspace",
+        type=str,
+        default="/tmp/nvflare/finetuning",
+        help="SimEnv workspace root (extract_simulator_metrics.sh reads logs from here)",
+    )
+    # NOTE: ``--export``/``--export-dir`` are handled by NVFLARE's ``Recipe.execute`` (it strips them
+    # from ``sys.argv`` before this parser runs), so they are intentionally not declared here.
+    args = parser.parse_args()
+
+    project_id = os.environ.get("FLIP_PROJECT_ID", "")
+    query = os.environ.get("FLIP_QUERY", "SELECT * FROM Table;")
+
+    recipe = FlipFedAvgRecipe(
+        num_rounds=args.num_rounds,
+        min_clients=args.n_clients,
+        train_script="trainer.py",
+        train_args="--project_id {project_id}",
+        project_id=project_id,
+        query=query,
+    )
+
+    stage_app_files(recipe.job)
+
+    env = SimEnv(
+        num_clients=args.n_clients,
+        num_threads=args.n_clients,
+        workspace_root=args.workspace,
+    )
+    run = recipe.execute(env)
+
+    print()
+    print(f"Job status:  {run.get_status()}")
+    print(f"Job results: {run.get_result()}")
+    print()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/extract_model_metrics.sh
+++ b/scripts/extract_model_metrics.sh
@@ -1,0 +1,1041 @@
+#!/bin/bash
+#
+# Copyright (c) 2026 Guy's and St Thomas' NHS Foundation Trust & King's College London
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+# extract_model_metrics.sh — pull FL-run metrics for one model out of the Central Hub's
+# production CloudWatch logs (flip-api, fl-api-net-*, fl-server-net-*). Trust-side logs
+# (EC2, not CloudWatch) are out of scope — see the "NOT AVAILABLE" notes this script writes
+# into summary.md for anything that can only be observed there.
+#
+# ---------------------------------------------------------------------------------------
+# WHY THIS SCRIPT LOOKS THE WAY IT DOES (read this before extending it)
+# ---------------------------------------------------------------------------------------
+#
+# 1. Log group names are static Terraform literals, not derivable from model/project IDs:
+#      /ecs/flip-api          (deploy/providers/AWS/ecs.tf)
+#      /ecs/fl-api-net-1      (one per FL network; today only net-1 exists)
+#      /ecs/fl-server-net-1   (one per FL network; today only net-1 exists)
+#    A future second network would add /ecs/fl-api-net-2 / /ecs/fl-server-net-2 by the same
+#    literal-string convention (there is no Terraform for_each to generalise from yet — see
+#    deploy/providers/AWS/ecs.tf). This script auto-discovers whatever exists via
+#    `describe-log-groups --log-group-name-prefix`, so it does not need updating when a
+#    second net is added.
+#
+# 2. flip-api's own log lines carry the model_id (it's an internal-service-authenticated
+#    endpoint per model — see flip-api/src/flip_api/private_services/), so we can filter
+#    flip-api logs directly by the model_id substring. fl-api-net-*/fl-server-net-* logs do
+#    NOT mention model_id or project_id anywhere (confirmed by reading
+#    flip-utils/flip/nvflare/controllers/scatter_and_gather.py and the fl-api app.py files in
+#    both backends) — a net trains one job at a time (the scheduler marks it BUSY), so this
+#    script correlates fl-api/fl-server events to the model purely by TIME WINDOW: it first
+#    finds the model's TRAINING_STARTED -> terminal-status window from flip-api logs, pads
+#    it, and treats everything in that window on the relevant net as belonging to this run.
+#    If two nets are ever trained concurrently for genuinely different jobs, an operator
+#    would need to add a per-net filter here (e.g. restrict to a specific net's log group
+#    once the net used by this model is known some other way) — there is no way to derive
+#    that from the hub logs alone today.
+#
+# 3. IMPORTANT / non-obvious: flip-api's uvicorn-formatted log lines get hard-wrapped at
+#    ~80 columns by whatever writes flip-api's stdout, and each wrapped fragment lands as
+#    its OWN CloudWatch log event (same timestamp, same log stream, no level prefix on the
+#    continuation fragments). fl-api-net-*/fl-server-net-* logs do NOT exhibit this — they
+#    come through as single, unwrapped events. Verified live against prod on 2026-07-06,
+#    e.g. a single logical line arrived as three raw events:
+#        "      INFO   Attempting to set the model's status... ID:"
+#        "             846f2bc8-fc82-472a-a453-f6851d5299b3, Status: ModelStatus.INITIATED"
+#    Any pattern match against a single raw flip-api event will miss content that landed on
+#    a wrapped continuation. This script re-joins wrapped fragments back into logical lines
+#    before doing any parsing (see reconstruct_flip_api_lines()) — do not remove that step,
+#    and do not try to `grep` the raw flip-api.jsonl dump directly for anything that might
+#    span a line wrap (the model_id itself is short enough it is never split, which is what
+#    makes the initial coarse discovery filter safe to run against raw events).
+#
+# 4. Logging is plain Python `logging` via uvicorn's own logger (`logging.getLogger
+#    ("uvicorn")`) — NOT structlog, NOT JSON. A few call sites log a raw Python dict
+#    (e.g. model_service.add_log()), which becomes a Python *repr* string
+#    ({'message': ..., 'modelId': UUID('...'), 'log': '...'}), not JSON — don't try to
+#    `jq`-parse message bodies as JSON; everything here is matched with grep/sed regexes
+#    against plain text.
+#
+# 5. CloudWatch Logs Insights was considered (the task brief suggested it for time-window /
+#    aggregation queries) but was deliberately NOT used here: Insights' @timestamp field is
+#    a formatted string ("YYYY-MM-DD HH:MM:SS.mmm") that has to be re-parsed back into epoch
+#    milliseconds, which is one more fragile step on top of the line-wrap issue above with no
+#    real benefit at this log volume (a single FL run's logs comfortably fit in a handful of
+#    filter-log-events pages). `aws logs filter-log-events` gives native epoch-ms timestamps
+#    and was verified working end-to-end against prod. If log volume grows enough that
+#    filter-log-events pagination becomes slow, switching find_model_window() and the raw
+#    dump loop over to start-query/get-query-results is the natural next step.
+#
+# Metrics coverage (see summary.md's "Data provenance" table for the authoritative version):
+#   1. Communication rounds       — fl-server-net-* logs (NVFLARE: "Round N started/finished";
+#                                    Flower: "(round N)" in forwarded-metric lines). FULL for
+#                                    NVFLARE, PARTIAL for Flower (round numbers only, no
+#                                    explicit round-boundary log line), NONE if backend can't
+#                                    be identified from the logs in-window.
+#   2. Update size (bytes)        — NOT AVAILABLE. No code path logs the byte size of a
+#                                    per-round model-weight update on the hub side (checked
+#                                    fl-api upload.py in both backends and flip-utils). Only
+#                                    the *initial* model-file bundle's S3 ContentLength is
+#                                    logged by flip-api (file_services/uploaded_file.py) —
+#                                    reported separately, clearly marked as NOT the same
+#                                    metric. Per-round weight size would need trust-side or
+#                                    fl-server-side instrumentation that doesn't exist yet.
+#   3. Aggregation time            — fl-server-net-* logs, NVFLARE only ("Start aggregation."/
+#                                    "End aggregation." pairs). NOT AVAILABLE for Flower (no
+#                                    equivalent log line in the platform code).
+#   4. Per-round communication time — derived from the same NVFLARE round/aggregation/
+#                                    contribution log lines; PARTIAL for Flower (only a rough
+#                                    per-round timestamp spread from forwarded metrics).
+#   5. Wall-clock time             — flip-api model-status-transition timeline (FULL).
+#   6. Deployment failures         — flip-api + fl-api-net-* + fl-server-net-* ERROR/WARNING
+#                                    lines and known failure phrases (FULL, best-effort).
+#   7. Infra constraints           — generic OOM/timeout/throttle/connection-refused greps
+#                                    across all three log groups, plus a best-effort (and
+#                                    time-limited — ECS only retains ~1h of stopped-task
+#                                    metadata) ECS stopped-task check.
+#
+# ---------------------------------------------------------------------------------------
+
+set -euo pipefail
+
+# --------------------------------------------------------------------------------------
+# Usage / defaults
+# --------------------------------------------------------------------------------------
+
+SCRIPT_NAME="$(basename "$0")"
+
+usage() {
+    cat <<EOF
+Usage: ${SCRIPT_NAME} <flip-ui-model-url> [options]
+
+Extract FL run metrics for one model from production CloudWatch logs
+(flip-api, fl-api-net-*, fl-server-net-*).
+
+Arguments:
+  <flip-ui-model-url>   e.g. https://app.flip.aicentre.co.uk/project/<project_id>/model/<model_id>
+
+Options:
+  -o, --output-dir DIR      Base output directory (default: ./model_metrics)
+      --profile PROFILE     AWS CLI profile (default: prod)
+      --region REGION       AWS region (default: eu-west-2)
+      --start ISO8601       Start of the search window (skips auto-discovery), e.g. 2026-06-30T09:00:00Z
+      --end ISO8601         End of the search window (requires --start)
+      --search-days N       When --start/--end are not given, how many days back to search
+                             for the model_id in flip-api logs (default: 7, matching the
+                             CloudWatch retention configured in deploy/providers/AWS/ecs.tf)
+      --pad-minutes N        Padding (minutes) applied around the discovered training window
+                             before querying fl-api-net-*/fl-server-net-* (default: 10)
+      --ecs-cluster NAME     ECS cluster name for the best-effort stopped-task check
+                             (default: flip-cluster)
+      --skip-ecs-check       Skip the best-effort ECS stopped-task lookup
+  -h, --help                 Show this help and exit
+
+Examples:
+  ${SCRIPT_NAME} https://app.flip.aicentre.co.uk/project/f48850b7-3101-46d1-8fa7-a00bf01d2597/model/d7d65959-3e40-4744-b853-0ece208df840
+  ${SCRIPT_NAME} <url> -o /tmp/metrics --pad-minutes 20
+  ${SCRIPT_NAME} <url> --start 2026-06-30T09:00:00Z --end 2026-06-30T11:00:00Z
+EOF
+}
+
+OUTPUT_DIR="./model_metrics"
+AWS_PROFILE_ARG="prod"
+AWS_REGION_ARG="eu-west-2"
+USER_START=""
+USER_END=""
+SEARCH_DAYS=7
+PAD_MINUTES=10
+ECS_CLUSTER="flip-cluster"
+SKIP_ECS_CHECK=false
+URL=""
+
+# --------------------------------------------------------------------------------------
+# Argument parsing
+# --------------------------------------------------------------------------------------
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -o|--output-dir)
+            OUTPUT_DIR="$2"; shift 2 ;;
+        --profile)
+            AWS_PROFILE_ARG="$2"; shift 2 ;;
+        --region)
+            AWS_REGION_ARG="$2"; shift 2 ;;
+        --start)
+            USER_START="$2"; shift 2 ;;
+        --end)
+            USER_END="$2"; shift 2 ;;
+        --search-days)
+            SEARCH_DAYS="$2"; shift 2 ;;
+        --pad-minutes)
+            PAD_MINUTES="$2"; shift 2 ;;
+        --ecs-cluster)
+            ECS_CLUSTER="$2"; shift 2 ;;
+        --skip-ecs-check)
+            SKIP_ECS_CHECK=true; shift ;;
+        -h|--help)
+            usage; exit 0 ;;
+        -*)
+            echo "Unknown option: $1" >&2; usage >&2; exit 1 ;;
+        *)
+            if [[ -z "$URL" ]]; then
+                URL="$1"; shift
+            else
+                echo "Unexpected extra argument: $1" >&2; usage >&2; exit 1
+            fi
+            ;;
+    esac
+done
+
+if [[ -z "$URL" ]]; then
+    echo "Error: missing <flip-ui-model-url>" >&2
+    usage >&2
+    exit 1
+fi
+
+if [[ -n "$USER_START" && -z "$USER_END" ]] || [[ -z "$USER_START" && -n "$USER_END" ]]; then
+    echo "Error: --start and --end must be given together" >&2
+    exit 1
+fi
+
+# --------------------------------------------------------------------------------------
+# Logging helpers
+# --------------------------------------------------------------------------------------
+
+log()  { echo "[$(date -u '+%Y-%m-%dT%H:%M:%SZ')] $*" >&2; }
+warn() { echo "[$(date -u '+%Y-%m-%dT%H:%M:%SZ')] WARNING: $*" >&2; }
+die()  { echo "[$(date -u '+%Y-%m-%dT%H:%M:%SZ')] ERROR: $*" >&2; exit 1; }
+
+# --------------------------------------------------------------------------------------
+# Dependency checks
+# --------------------------------------------------------------------------------------
+
+for dep in aws jq date grep sed awk; do
+    command -v "$dep" >/dev/null 2>&1 || die "Required dependency '$dep' not found on PATH."
+done
+
+# --------------------------------------------------------------------------------------
+# Parse & validate the FLIP UI URL
+# --------------------------------------------------------------------------------------
+
+UUID_RE='[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}'
+
+if [[ "$URL" =~ /project/(${UUID_RE})/model/(${UUID_RE}) ]]; then
+    PROJECT_ID="${BASH_REMATCH[1],,}"
+    MODEL_ID="${BASH_REMATCH[2],,}"
+else
+    die "Could not parse a /project/<uuid>/model/<uuid> path out of: ${URL}"
+fi
+
+log "Parsed project_id=${PROJECT_ID} model_id=${MODEL_ID}"
+
+# --------------------------------------------------------------------------------------
+# AWS CLI wrapper + auth check
+# --------------------------------------------------------------------------------------
+
+awscli() {
+    aws --profile "$AWS_PROFILE_ARG" --region "$AWS_REGION_ARG" --output json "$@"
+}
+
+if ! awscli sts get-caller-identity >/dev/null 2>&1; then
+    die "Could not authenticate with AWS profile '${AWS_PROFILE_ARG}'. Run 'aws sso login --profile ${AWS_PROFILE_ARG}' and retry. (Per CLAUDE.md, production access uses AWS SSO under profile 'prod'.)"
+fi
+
+log "Authenticated as: $(awscli sts get-caller-identity --query Arn --output text)"
+
+# --------------------------------------------------------------------------------------
+# Output directories
+# --------------------------------------------------------------------------------------
+
+MODEL_OUT_DIR="${OUTPUT_DIR%/}/${MODEL_ID}"
+LOGS_DIR="${MODEL_OUT_DIR}/logs"
+mkdir -p "$LOGS_DIR"
+
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+log "Output directory: ${MODEL_OUT_DIR}"
+
+# --------------------------------------------------------------------------------------
+# Resolve / discover log groups
+# --------------------------------------------------------------------------------------
+
+FLIP_API_LOG_GROUP="/ecs/flip-api"
+
+log_group_exists() {
+    local name="$1"
+    awscli logs describe-log-groups --log-group-name-prefix "$name" \
+        --query "logGroups[?logGroupName=='${name}'] | length(@)" --output text 2>/dev/null | grep -qv '^0$'
+}
+
+log_group_exists "$FLIP_API_LOG_GROUP" || die "Log group ${FLIP_API_LOG_GROUP} not found — check --profile/--region."
+
+discover_log_groups() {
+    # Prints one log group name per line matching the given prefix.
+    local prefix="$1"
+    awscli logs describe-log-groups --log-group-name-prefix "$prefix" \
+        --query 'logGroups[].logGroupName' --output text 2>/dev/null | tr '\t' '\n' | sed '/^$/d'
+}
+
+mapfile -t FL_API_LOG_GROUPS < <(discover_log_groups "/ecs/fl-api-net-")
+mapfile -t FL_SERVER_LOG_GROUPS < <(discover_log_groups "/ecs/fl-server-net-")
+
+if [[ ${#FL_API_LOG_GROUPS[@]} -eq 0 ]]; then
+    warn "No /ecs/fl-api-net-* log groups discovered — fl-api-side metrics will be unavailable."
+fi
+if [[ ${#FL_SERVER_LOG_GROUPS[@]} -eq 0 ]]; then
+    warn "No /ecs/fl-server-net-* log groups discovered — round/aggregation metrics will be unavailable."
+fi
+
+log "Log groups: ${FLIP_API_LOG_GROUP}, fl-api=[${FL_API_LOG_GROUPS[*]:-none}], fl-server=[${FL_SERVER_LOG_GROUPS[*]:-none}]"
+
+# --------------------------------------------------------------------------------------
+# Time helpers
+# --------------------------------------------------------------------------------------
+
+now_ms() { echo $(( $(date -u +%s) * 1000 )); }
+
+iso_to_ms() {
+    local iso="$1"
+    local s
+    s="$(date -u -d "$iso" +%s 2>/dev/null)" || die "Could not parse timestamp: ${iso}"
+    echo $(( s * 1000 ))
+}
+
+ms_to_iso() {
+    local ms="$1"
+    date -u -d "@$(( ms / 1000 ))" '+%Y-%m-%dT%H:%M:%SZ'
+}
+
+# --------------------------------------------------------------------------------------
+# fetch_log_events LOG_GROUP START_MS END_MS FILTER_PATTERN OUT_FILE
+#
+# Paginates `aws logs filter-log-events` across [START_MS, END_MS) and writes one compact
+# JSON object per line ({timestamp, logStreamName, message}) to OUT_FILE, sorted by
+# timestamp. FILTER_PATTERN may be an empty string for "no filter" (dump everything).
+# Capped at MAX_PAGES pages as a safety net against runaway pagination on a mis-set window.
+# --------------------------------------------------------------------------------------
+
+MAX_PAGES=500
+
+fetch_log_events() {
+    local log_group="$1" start_ms="$2" end_ms="$3" filter_pattern="$4" out_file="$5"
+    local raw_file="${WORK_DIR}/$(basename "$out_file").raw"
+    : > "$raw_file"
+
+    local next_token="" page=0
+    while :; do
+        page=$((page + 1))
+        if [[ $page -gt $MAX_PAGES ]]; then
+            warn "fetch_log_events: hit MAX_PAGES=${MAX_PAGES} for ${log_group}; results may be truncated. Narrow the window with --start/--end/--pad-minutes."
+            break
+        fi
+
+        local args=(logs filter-log-events --log-group-name "$log_group" \
+            --start-time "$start_ms" --end-time "$end_ms" --interleaved)
+        [[ -n "$filter_pattern" ]] && args+=(--filter-pattern "$filter_pattern")
+        [[ -n "$next_token" ]] && args+=(--next-token "$next_token")
+
+        local resp
+        if ! resp="$(awscli "${args[@]}" 2>&1)"; then
+            warn "fetch_log_events failed for ${log_group} (page ${page}): ${resp}"
+            break
+        fi
+
+        jq -c '.events[] | {timestamp, logStreamName, message}' <<<"$resp" >> "$raw_file"
+
+        next_token="$(jq -r '.nextToken // empty' <<<"$resp")"
+        [[ -z "$next_token" ]] && break
+    done
+
+    jq -c -s 'sort_by(.timestamp) | .[]' "$raw_file" > "$out_file" 2>/dev/null || : > "$out_file"
+    wc -l < "$out_file" | tr -d ' '
+}
+
+# --------------------------------------------------------------------------------------
+# reconstruct_flip_api_lines IN_FILE OUT_FILE
+#
+# flip-api's stdout is hard-wrapped at ~80 columns before it reaches CloudWatch (see the
+# header comment, point 3). Each wrapped fragment is its own log event with no level
+# prefix. This rejoins fragments into logical lines within each log stream (continuation =
+# any event whose message does NOT start with a log-level keyword), and collapses the
+# incidental double-spacing the wrap leaves behind.
+# --------------------------------------------------------------------------------------
+
+RECONSTRUCT_JQ="${WORK_DIR}/reconstruct.jq"
+cat > "$RECONSTRUCT_JQ" <<'JQ_EOF'
+[inputs]
+| group_by(.logStreamName)
+| map(
+    reduce .[] as $e (
+      {lines: [], cur: null};
+      if ($e.message | test("^[ \t]*(DEBUG|INFO|WARNING|ERROR|CRITICAL)[ \t]")) then
+        {lines: (.lines + (if .cur then [.cur] else [] end)),
+         cur: {timestamp: $e.timestamp, logStreamName: $e.logStreamName,
+               message: ($e.message | sub("^[ \t]+"; ""))}}
+      else
+        (.cur // {timestamp: $e.timestamp, logStreamName: $e.logStreamName, message: ""}) as $base
+        | {lines: .lines,
+           cur: ($base
+                 | .message |= (. + " " + ($e.message | sub("^[ \t]+"; "") | sub("[ \t]+$"; "")))
+                 | .message |= sub("^ "; ""))}
+      end
+    )
+    | .lines + (if .cur then [.cur] else [] end)
+  )
+| flatten
+| map(.message |= gsub("[ \t]+"; " "))
+| sort_by(.timestamp)
+| .[]
+JQ_EOF
+
+reconstruct_flip_api_lines() {
+    local in_file="$1" out_file="$2"
+    jq -c -f "$RECONSTRUCT_JQ" "$in_file" < /dev/null > "$out_file"
+}
+
+# --------------------------------------------------------------------------------------
+# Step 1: coarse discovery — find the model's activity window in flip-api logs
+# --------------------------------------------------------------------------------------
+
+if [[ -n "$USER_START" ]]; then
+    SEARCH_START_MS="$(iso_to_ms "$USER_START")"
+    SEARCH_END_MS="$(iso_to_ms "$USER_END")"
+    log "Using user-supplied window: ${USER_START} to ${USER_END}"
+else
+    SEARCH_END_MS="$(now_ms)"
+    SEARCH_START_MS=$(( SEARCH_END_MS - SEARCH_DAYS * 24 * 60 * 60 * 1000 ))
+    log "Searching flip-api logs for model_id over the last ${SEARCH_DAYS} day(s) (retention is 7 days per deploy/providers/AWS/ecs.tf)"
+fi
+
+COARSE_HITS_FILE="${WORK_DIR}/flip_api_coarse_hits.jsonl"
+n_hits="$(fetch_log_events "$FLIP_API_LOG_GROUP" "$SEARCH_START_MS" "$SEARCH_END_MS" "\"${MODEL_ID}\"" "$COARSE_HITS_FILE")"
+
+if [[ "$n_hits" -eq 0 ]]; then
+    die "No flip-api log events mention model_id ${MODEL_ID} in the searched window. Either the model is older than the 7-day CloudWatch retention, it never started, or --start/--end need to be widened."
+fi
+
+log "Found ${n_hits} raw flip-api log events mentioning the model_id (coarse, pre-wrap-reassembly)"
+
+ROUGH_START_MS="$(jq -s 'map(.timestamp) | min' "$COARSE_HITS_FILE")"
+ROUGH_END_MS="$(jq -s 'map(.timestamp) | max' "$COARSE_HITS_FILE")"
+PAD_MS=$(( PAD_MINUTES * 60 * 1000 ))
+DISCOVERY_START_MS=$(( ROUGH_START_MS - PAD_MS ))
+DISCOVERY_END_MS=$(( ROUGH_END_MS + PAD_MS ))
+
+log "Rough model activity window: $(ms_to_iso "$ROUGH_START_MS") to $(ms_to_iso "$ROUGH_END_MS") (flip-api)"
+
+# --------------------------------------------------------------------------------------
+# Step 2: full flip-api dump over the padded window, reconstructed, then filtered to
+# lines that actually mention the model_id — this is the authoritative per-model timeline.
+# --------------------------------------------------------------------------------------
+
+FLIP_API_RAW="${LOGS_DIR}/flip-api.jsonl"
+n_all="$(fetch_log_events "$FLIP_API_LOG_GROUP" "$DISCOVERY_START_MS" "$DISCOVERY_END_MS" "" "$FLIP_API_RAW")"
+log "Dumped ${n_all} raw flip-api events in the padded window to ${FLIP_API_RAW}"
+
+FLIP_API_RECONSTRUCTED="${LOGS_DIR}/flip-api.reconstructed.log"
+reconstruct_flip_api_lines "$FLIP_API_RAW" "${WORK_DIR}/flip_api_reconstructed.jsonl"
+jq -r '"\(.timestamp | tostring) \(.logStreamName) \(.message)"' "${WORK_DIR}/flip_api_reconstructed.jsonl" > "$FLIP_API_RECONSTRUCTED"
+log "Reassembled wrapped flip-api lines -> ${FLIP_API_RECONSTRUCTED} (see header comment #3 for why this step exists)"
+
+MODEL_LINES_FILE="${LOGS_DIR}/flip-api.model-lines.log"
+grep -F "$MODEL_ID" "$FLIP_API_RECONSTRUCTED" > "$MODEL_LINES_FILE" || true
+log "Extracted $(wc -l < "$MODEL_LINES_FILE" | tr -d ' ') reconstructed lines mentioning the model -> ${MODEL_LINES_FILE}"
+
+if [[ ! -s "$MODEL_LINES_FILE" ]]; then
+    die "Reconstructed flip-api lines contain no mention of ${MODEL_ID} — this should not happen given the coarse hits above; please inspect ${FLIP_API_RECONSTRUCTED} manually."
+fi
+
+# Single-pass min/max in awk: `sort | head -1` under pipefail dies with SIGPIPE (141)
+# once the input outgrows the pipe buffer, because head exits after one line.
+TRUE_START_MS="$(awk 'NR==1||$1+0<min{min=$1+0} END{print min}' "$MODEL_LINES_FILE")"
+TRUE_END_MS="$(awk 'NR==1||$1+0>max{max=$1+0} END{print max}' "$MODEL_LINES_FILE")"
+
+# --------------------------------------------------------------------------------------
+# Step 3: status-transition timeline (metric #5: wall-clock time, phase breakdown)
+#
+# Primary source: "Attempting to set the model's status... ID: <model_id>, Status: <TOKEN>"
+# (flip_api/model_services/services/model_service.py:91). We deliberately do NOT also use
+# the paired "The status of Model ID: ... has been updated to <TOKEN>" confirmation line as
+# an independent source — it fires even on no-op refresh calls that pass status=None (which
+# resolve to the model's *current*, unchanged status), so using it standalone would fabricate
+# duplicate transitions. Consecutive duplicate tokens from the primary source are also
+# deduped defensively below.
+# --------------------------------------------------------------------------------------
+
+STATUS_TIMELINE_FILE="${WORK_DIR}/status_timeline.tsv"
+grep -F "Attempting to set the model's status" "$MODEL_LINES_FILE" \
+    | grep -oP "^\S+ \S+ .*ID: ${MODEL_ID}, Status: \K.*" \
+    > "${WORK_DIR}/status_raw.txt" || true
+
+# Re-pair timestamps (first field of the matching line) with the extracted status token.
+: > "$STATUS_TIMELINE_FILE"
+while IFS= read -r line; do
+    ts="$(awk '{print $1}' <<<"$line")"
+    token="$(grep -oP "Status: \K\S+" <<<"$line" || true)"
+    [[ "$token" == ModelStatus.* ]] && printf '%s\t%s\n' "$ts" "$token" >> "$STATUS_TIMELINE_FILE"
+done < <(grep -F "Attempting to set the model's status" "$MODEL_LINES_FILE")
+
+# Dedupe consecutive identical statuses, keep chronological order.
+STATUS_TIMELINE_DEDUP="${WORK_DIR}/status_timeline_dedup.tsv"
+sort -n -k1,1 "$STATUS_TIMELINE_FILE" \
+    | awk -F'\t' '$2 != prev {print; prev=$2}' \
+    > "$STATUS_TIMELINE_DEDUP"
+
+log "Status transitions found: $(wc -l < "$STATUS_TIMELINE_DEDUP" | tr -d ' ')"
+
+# --------------------------------------------------------------------------------------
+# Step 4: identify TRAINING_STARTED -> terminal-status "attempts" (handles retries: a model
+# can be started, error out, and be requeued/restarted).
+# --------------------------------------------------------------------------------------
+
+TERMINAL_STATUSES_RE='ModelStatus\.(ERROR|STOPPED|RESULTS_UPLOADED|RESULTS_UPLOAD_FAILED)$'
+ATTEMPTS_FILE="${WORK_DIR}/attempts.tsv"   # start_ms \t end_ms \t terminal_status (end_ms may be empty = still running/unknown)
+: > "$ATTEMPTS_FILE"
+
+pending_start=""
+while IFS=$'\t' read -r ts status; do
+    if [[ "$status" == "ModelStatus.TRAINING_STARTED" ]]; then
+        pending_start="$ts"
+    elif [[ -n "$pending_start" ]] && [[ "$status" =~ $TERMINAL_STATUSES_RE ]]; then
+        printf '%s\t%s\t%s\n' "$pending_start" "$ts" "$status" >> "$ATTEMPTS_FILE"
+        pending_start=""
+    fi
+done < "$STATUS_TIMELINE_DEDUP"
+
+if [[ -n "$pending_start" ]]; then
+    # Training started but no terminal status seen in-window (still running, or the window
+    # cut it off) — use the last known model-mention timestamp as a provisional end.
+    printf '%s\t%s\t%s\n' "$pending_start" "$TRUE_END_MS" "UNKNOWN (still training or window truncated)" >> "$ATTEMPTS_FILE"
+fi
+
+n_attempts="$(wc -l < "$ATTEMPTS_FILE" | tr -d ' ')"
+log "Identified ${n_attempts} training attempt(s) for this model"
+
+# --------------------------------------------------------------------------------------
+# Step 5: dump fl-api-net-*/fl-server-net-* logs across the union of all attempt windows
+# (padded). These logs carry no model_id/project_id — see header comment #2 for why time
+# correlation is the best available signal.
+# --------------------------------------------------------------------------------------
+
+FL_SPAN_START_MS="$TRUE_START_MS"
+FL_SPAN_END_MS="$TRUE_END_MS"
+if [[ -s "$ATTEMPTS_FILE" ]]; then
+    FL_SPAN_START_MS="$(awk -F'\t' 'NR==1||$1+0<min{min=$1+0} END{print min}' "$ATTEMPTS_FILE")"
+    FL_SPAN_END_MS="$(awk -F'\t' 'NR==1||$2+0>max{max=$2+0} END{print max}' "$ATTEMPTS_FILE")"
+fi
+FL_SPAN_START_MS=$(( FL_SPAN_START_MS - PAD_MS ))
+FL_SPAN_END_MS=$(( FL_SPAN_END_MS + PAD_MS ))
+
+log "Querying fl-api-net-*/fl-server-net-* over $(ms_to_iso "$FL_SPAN_START_MS") to $(ms_to_iso "$FL_SPAN_END_MS") (padded ${PAD_MINUTES}m)"
+
+FL_SERVER_DUMPS=()
+for grp in "${FL_SERVER_LOG_GROUPS[@]:-}"; do
+    [[ -z "$grp" ]] && continue
+    base="$(basename "$grp")"
+    out="${LOGS_DIR}/${base}.jsonl"
+    n="$(fetch_log_events "$grp" "$FL_SPAN_START_MS" "$FL_SPAN_END_MS" "" "$out")"
+    log "Dumped ${n} events from ${grp} -> ${out}"
+    FL_SERVER_DUMPS+=("$out")
+done
+
+FL_API_DUMPS=()
+for grp in "${FL_API_LOG_GROUPS[@]:-}"; do
+    [[ -z "$grp" ]] && continue
+    base="$(basename "$grp")"
+    out="${LOGS_DIR}/${base}.jsonl"
+    n="$(fetch_log_events "$grp" "$FL_SPAN_START_MS" "$FL_SPAN_END_MS" "" "$out")"
+    log "Dumped ${n} events from ${grp} -> ${out}"
+    FL_API_DUMPS+=("$out")
+done
+
+# Flattened, ANSI-stripped, plain-text views used for local parsing (raw .jsonl files above
+# are left untouched for reproducibility).
+strip_ansi_and_flatten() {
+    # $1 = jsonl file (may not exist / be empty) -> prints "timestamp message" lines
+    local f="$1"
+    [[ -s "$f" ]] || return 0
+    jq -r '"\(.timestamp) \(.message)"' "$f" | sed -E 's/\x1b\[[0-9;]*m//g'
+}
+
+FL_SERVER_TEXT="${WORK_DIR}/fl_server_all.txt"
+: > "$FL_SERVER_TEXT"
+for f in "${FL_SERVER_DUMPS[@]:-}"; do strip_ansi_and_flatten "$f" >> "$FL_SERVER_TEXT"; done
+sort -n -k1,1 -o "$FL_SERVER_TEXT" "$FL_SERVER_TEXT" 2>/dev/null || true
+
+FL_API_TEXT="${WORK_DIR}/fl_api_all.txt"
+: > "$FL_API_TEXT"
+for f in "${FL_API_DUMPS[@]:-}"; do strip_ansi_and_flatten "$f" >> "$FL_API_TEXT"; done
+sort -n -k1,1 -o "$FL_API_TEXT" "$FL_API_TEXT" 2>/dev/null || true
+
+# --------------------------------------------------------------------------------------
+# Step 6: detect FL backend from the log content actually observed in-window.
+#
+# NVFLARE's ScatterAndGather controller (flip-utils/flip/nvflare/controllers/
+# scatter_and_gather.py) logs "Round N started."/"Round N finished." and
+# "Start aggregation."/"End aggregation.". Flower has no equivalent in-repo server code
+# (stock flwr framework); the only round-tagged signal is flip-utils/flip/flower/metrics.py
+# forwarding "... (round N)" for each client metric.
+# --------------------------------------------------------------------------------------
+
+BACKEND="unknown"
+if grep -qP 'Round \d+ (started|finished)\.' "$FL_SERVER_TEXT" 2>/dev/null; then
+    BACKEND="nvflare"
+elif grep -qP '\(round \d+\)' "$FL_SERVER_TEXT" "$FL_API_TEXT" 2>/dev/null; then
+    BACKEND="flower"
+fi
+log "Detected FL backend from logs: ${BACKEND}"
+
+# --------------------------------------------------------------------------------------
+# Step 7: metrics #1/#3/#4 — communication rounds, aggregation time, per-round timing
+# --------------------------------------------------------------------------------------
+
+ROUND_TABLE_FILE="${WORK_DIR}/round_table.tsv"
+: > "$ROUND_TABLE_FILE"
+# Columns: round  started_ms  finished_ms  agg_start_ms  agg_end_ms  accepted  rejected
+
+if [[ "$BACKEND" == "nvflare" ]]; then
+    # Round boundaries.
+    ROUND_STARTS="${WORK_DIR}/round_starts.tsv"
+    ROUND_ENDS="${WORK_DIR}/round_ends.tsv"
+    grep -oP '^\d+ .*Round \d+ started\.' "$FL_SERVER_TEXT" \
+        | sed -E 's/^([0-9]+) .*Round ([0-9]+) started\..*/\2\t\1/' | sort -n -k1,1 > "$ROUND_STARTS" || true
+    grep -oP '^\d+ .*Round \d+ finished\.' "$FL_SERVER_TEXT" \
+        | sed -E 's/^([0-9]+) .*Round ([0-9]+) finished\..*/\2\t\1/' | sort -n -k1,1 > "$ROUND_ENDS" || true
+
+    # Aggregation start/end are not tagged with a round number in the log text itself, so we
+    # pair them up in chronological order (one Start/End pair per round, in round order —
+    # true because ScatterAndGather aggregates synchronously once per round; see
+    # scatter_and_gather.py lines ~207-267).
+    AGG_STARTS="${WORK_DIR}/agg_starts.tsv"
+    AGG_ENDS="${WORK_DIR}/agg_ends.tsv"
+    grep -oP '^\d+ .*Start aggregation\.' "$FL_SERVER_TEXT" | awk '{print $1}' > "$AGG_STARTS" || true
+    grep -oP '^\d+ .*End aggregation\.' "$FL_SERVER_TEXT" | awk '{print $1}' > "$AGG_ENDS" || true
+
+    # Per-contribution lines. NVFLARE's IntimeModelSelector logs
+    #   "Contribution from <client> ACCEPTED|REJECTED by the aggregator at round <N>."
+    # (older builds omit " at round <N>", hence the optional group). The round tag lets us
+    # break contributions out per-round in the table below.
+    # NB: the `|| true` on these is load-bearing — with `set -o pipefail`, a zero-match grep
+    # fails the whole pipeline and set -e would abort the script (wc still prints 0 first).
+    CONTRIB_FILE="${WORK_DIR}/contributions.tsv"   # verdict \t round ('-' if untagged)
+    grep -oP 'Contribution from \S+ (ACCEPTED|REJECTED) by the aggregator( at round \d+)?\.' "$FL_SERVER_TEXT" \
+        | sed -E 's/^Contribution from [^ ]+ ([A-Z]+) by the aggregator( at round ([0-9]+))?\./\1\t\3/' \
+        | sed -E 's/\t$/\t-/' > "$CONTRIB_FILE" || true
+    ACCEPTED_TOTAL="$(grep -c $'^ACCEPTED\t' "$CONTRIB_FILE" || true)"
+    REJECTED_TOTAL="$(grep -c $'^REJECTED\t' "$CONTRIB_FILE" || true)"
+
+    n_rounds="$(wc -l < "$ROUND_STARTS" | tr -d ' ')"
+    for i in $(seq 1 "$n_rounds"); do
+        round_num="$(awk -v i="$i" 'NR==i{print $1}' "$ROUND_STARTS")"
+        start_ms="$(awk -v i="$i" 'NR==i{print $2}' "$ROUND_STARTS")"
+        end_ms="$(awk -v r="$round_num" '$1==r{print $2; exit}' "$ROUND_ENDS")"
+        agg_start="$(awk -v i="$i" 'NR==i{print}' "$AGG_STARTS")"
+        agg_end="$(awk -v i="$i" 'NR==i{print}' "$AGG_ENDS")"
+        acc_r="$(awk -F'\t' -v r="$round_num" '$1=="ACCEPTED" && $2==r{n++} END{print n+0}' "$CONTRIB_FILE")"
+        rej_r="$(awk -F'\t' -v r="$round_num" '$1=="REJECTED" && $2==r{n++} END{print n+0}' "$CONTRIB_FILE")"
+        printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\n' "$round_num" "$start_ms" "${end_ms:-}" "${agg_start:-}" "${agg_end:-}" "$acc_r" "$rej_r" >> "$ROUND_TABLE_FILE"
+    done
+elif [[ "$BACKEND" == "flower" ]]; then
+    # Flower: no round-boundary or aggregation-timing log lines exist in the platform code
+    # (see flip-utils/flip/flower/metrics.py) — approximate each round's window from the
+    # spread of "Forwarded metric ... (round N)" timestamps for that round.
+    grep -oP '^\d+ .*\(round \d+\)' "$FL_SERVER_TEXT" "$FL_API_TEXT" 2>/dev/null \
+        | sed -E 's/^[^0-9]*([0-9]+) .*\(round ([0-9]+)\).*/\2\t\1/' \
+        | sort -n -k1,1 -k2,2 > "${WORK_DIR}/flower_rounds.tsv" || true
+    if [[ -s "${WORK_DIR}/flower_rounds.tsv" ]]; then
+        cut -f1 "${WORK_DIR}/flower_rounds.tsv" | sort -un | while read -r r; do
+            start_ms="$(awk -v r="$r" -F'\t' '$1==r && (m==""||$2+0<m){m=$2+0} END{print m}' "${WORK_DIR}/flower_rounds.tsv")"
+            end_ms="$(awk -v r="$r" -F'\t' '$1==r && (m==""||$2+0>m){m=$2+0} END{print m}' "${WORK_DIR}/flower_rounds.tsv")"
+            printf '%s\t%s\t%s\t-\t-\t-\t-\n' "$r" "$start_ms" "$end_ms" >> "$ROUND_TABLE_FILE"
+        done
+    fi
+fi
+
+TOTAL_ROUNDS="$(wc -l < "$ROUND_TABLE_FILE" | tr -d ' ')"
+
+# --------------------------------------------------------------------------------------
+# Step 7b: persist the per-round table as rounds.tsv (ms-precision, machine-readable —
+# the summary.md table truncates to whole seconds) and render the timing boxplot.
+#
+# The boxplot is best-effort: it needs pandas+seaborn, which are NOT dependencies of any
+# FLIP service. Preferred runner is `uv run --no-project --with ...` (ephemeral env, no
+# repo lockfile touched); falls back to a system python3 that already has both; skipped
+# with a warning otherwise. A plot failure never fails the extraction.
+# --------------------------------------------------------------------------------------
+
+ROUNDS_TSV="${MODEL_OUT_DIR}/rounds.tsv"
+
+# maybe_iso/maybe_dur: ROUND_TABLE_FILE uses "" (nvflare path) or "-" (flower path) for
+# missing values — normalise both to "-" in the TSV.
+maybe_iso() { [[ -n "${1:-}" && "${1:-}" != "-" ]] && ms_to_iso "$1" || echo "-"; }
+maybe_dur() {
+    if [[ -n "${1:-}" && "${1:-}" != "-" && -n "${2:-}" && "${2:-}" != "-" ]]; then
+        awk -v a="$1" -v b="$2" 'BEGIN{printf "%.3f", (b - a) / 1000}'
+    else
+        echo "-"
+    fi
+}
+
+{
+    printf 'round\tstarted_utc\tfinished_utc\tduration_s\tagg_started_utc\tagg_finished_utc\tagg_duration_s\taccepted\trejected\tstart_ms\tend_ms\tagg_start_ms\tagg_end_ms\n'
+    while IFS=$'\t' read -r round start_ms end_ms agg_start agg_end acc rej; do
+        printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+            "$round" \
+            "$(maybe_iso "$start_ms")" "$(maybe_iso "$end_ms")" "$(maybe_dur "$start_ms" "$end_ms")" \
+            "$(maybe_iso "$agg_start")" "$(maybe_iso "$agg_end")" "$(maybe_dur "$agg_start" "$agg_end")" \
+            "${acc:--}" "${rej:--}" \
+            "${start_ms:--}" "${end_ms:--}" "${agg_start:--}" "${agg_end:--}"
+    done < "$ROUND_TABLE_FILE"
+} > "$ROUNDS_TSV"
+log "Wrote per-round table: ${ROUNDS_TSV} (${TOTAL_ROUNDS} round(s))"
+
+# Mean / sample-std / n over a numeric-or-"-" column of rounds.tsv (1-based index).
+# Emits "mean\tstd\tn" ("-\t-\t0" when no values). Used by summary section 4.
+col_stats() {
+    awk -F'\t' -v c="$1" 'NR > 1 && $c != "-" {x = $c + 0; s += x; ss += x*x; n++}
+        END {
+            if (n == 0) {print "-\t-\t0"; exit}
+            m = s / n
+            sd = (n > 1) ? sqrt((ss - n*m*m) / (n - 1)) : 0
+            printf "%.3f\t%.3f\t%d\n", m, sd, n
+        }' "$ROUNDS_TSV"
+}
+
+DUR_STATS="$(col_stats 4)"    # duration_s
+AGG_STATS="$(col_stats 7)"    # agg_duration_s
+# Inter-round gap: this round's start_ms (col 10) minus the previous round's end_ms
+# (col 11); rows are in round order, and the first round has no predecessor.
+GAP_STATS="$(awk -F'\t' 'NR > 1 && $10 != "-" && $11 != "-" {
+        if (prev_end != "") {g = ($10 - prev_end) / 1000; s += g; ss += g*g; n++}
+        prev_end = $11
+    }
+    END {
+        if (n == 0) {print "-\t-\t0"; exit}
+        m = s / n
+        sd = (n > 1) ? sqrt((ss - n*m*m) / (n - 1)) : 0
+        printf "%.3f\t%.3f\t%d\n", m, sd, n
+    }' "$ROUNDS_TSV")"
+
+BOXPLOT_FILE="${MODEL_OUT_DIR}/round_timings_boxplot.png"
+PLOT_SCRIPT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/plot_round_timings.py"
+BOXPLOT_GENERATED=false
+if [[ "$TOTAL_ROUNDS" -gt 0 && -f "$PLOT_SCRIPT" ]]; then
+    plot_cmd=()
+    if command -v uv >/dev/null 2>&1; then
+        plot_cmd=(uv run --no-project --with pandas --with seaborn python)
+    elif command -v python3 >/dev/null 2>&1 && python3 -c 'import pandas, seaborn' >/dev/null 2>&1; then
+        plot_cmd=(python3)
+    fi
+    if [[ ${#plot_cmd[@]} -gt 0 ]]; then
+        if "${plot_cmd[@]}" "$PLOT_SCRIPT" "$ROUNDS_TSV" "$BOXPLOT_FILE" \
+                --model-id "$MODEL_ID" --backend "$BACKEND" >&2; then
+            BOXPLOT_GENERATED=true
+            log "Wrote round-timing boxplot: ${BOXPLOT_FILE}"
+        else
+            warn "plot_round_timings.py failed — continuing without the boxplot (rounds.tsv is still written)."
+        fi
+    else
+        warn "Neither uv nor a python3 with pandas+seaborn is available — skipping the boxplot (rounds.tsv is still written)."
+    fi
+elif [[ "$TOTAL_ROUNDS" -gt 0 ]]; then
+    warn "Plot script not found at ${PLOT_SCRIPT} — skipping the boxplot."
+fi
+
+# --------------------------------------------------------------------------------------
+# Step 8: metric #2 — update size (see header comment; per-round size is NOT available)
+# --------------------------------------------------------------------------------------
+
+UPLOAD_SIZE_LINES="${WORK_DIR}/upload_size_lines.txt"
+grep -F "$MODEL_ID" "$FLIP_API_RECONSTRUCTED" \
+    | grep -E "Size:|ContentLength|File has been added to the database" > "$UPLOAD_SIZE_LINES" || true
+
+# --------------------------------------------------------------------------------------
+# Step 9: metric #6 — deployment failures (errors, retries, dropouts, submission failures)
+# --------------------------------------------------------------------------------------
+
+FAILURES_FILE="${MODEL_OUT_DIR}/failures.tsv"
+: > "$FAILURES_FILE"
+
+{
+    # flip-api: ERROR/WARNING lines mentioning this model, plus known scheduler failure
+    # phrases within the model's attempt window(s) (these don't carry model_id themselves —
+    # see fl_scheduler_service.py:503-509 — so they're only attributable by time overlap).
+    grep -E '^\S+ \S+ *(ERROR|WARNING)' "$MODEL_LINES_FILE" | sed 's/^/flip-api\t/' || true
+
+    while IFS=$'\t' read -r start_ms end_ms _status; do
+        [[ -z "$start_ms" ]] && continue
+        awk -v s="$start_ms" -v e="$end_ms" '($1+0)>=s && ($1+0)<=e' "$FLIP_API_RECONSTRUCTED" \
+            | grep -E "Failed to start training:|Unsupported FL backend:|Database error|Failed to resolve|could not be resolved to a trust" \
+            | sed 's/^/flip-api\t/' || true
+    done < "$ATTEMPTS_FILE"
+
+    # fl-api-net-*: known failure/retry phrases (fl-services/nvflare/fl-api-base/fl_api/
+    # utils/flip_session.py and fl-services/flower/fl-api-flower/fl_api/app.py).
+    grep -E "Session inactive, trying to reconnect|attempting to reconnect and retry|Retry after reconnect failed|Failed to run Flower|Flower .* failed|Failed to parse Flower|Flower run command failed" "$FL_API_TEXT" 2>/dev/null \
+        | sed 's/^/fl-api\t/' || true
+
+    # fl-server-net-*: client rejects / aborts (NVFLARE) — a REJECTED contribution or an
+    # abort signal is evidence of a client-side dropout or protocol failure. A JobLogReceiver
+    # "Saving live log 'error_log.txt' as 'ERRORLOG' from <client>" line means that client
+    # produced an error log during the job — the error itself is only readable trust-side.
+    grep -E "REJECTED by the aggregator|Abort signal received|as 'ERRORLOG' from|ERROR -|CRITICAL -" "$FL_SERVER_TEXT" 2>/dev/null \
+        | sed 's/^/fl-server\t/' || true
+
+    # flip-api: "no clients connected" / unresolvable client -> trust mapping issues.
+    grep -E "No clients connected|not found in client statuses|Clients unavailable" "$FLIP_API_RECONSTRUCTED" 2>/dev/null \
+        | sed 's/^/flip-api\t/' || true
+} | sort -t$'\t' -k2,2 -n >> "$FAILURES_FILE" 2>/dev/null || true
+
+N_FAILURES="$(wc -l < "$FAILURES_FILE" | tr -d ' ')"
+
+# --------------------------------------------------------------------------------------
+# Step 10: metric #7 — infrastructure constraints
+# --------------------------------------------------------------------------------------
+
+INFRA_FILE="${MODEL_OUT_DIR}/infra_constraints.tsv"
+: > "$INFRA_FILE"
+
+# NB: HTTP 5xx is matched only as an HTTP-access-log status (`HTTP/1.1" 5xx`), never as a
+# bare number — the flattened lines are prefixed with an epoch-ms timestamp, and a bare
+# `503` matches inside the timestamp digits of essentially every line (found the hard way).
+INFRA_PATTERN='OutOfMemory|OOMKilled|MemoryError|No space left on device|disk quota|TimeoutError|timed? ?out|Connection refused|ConnectionError|ConnectionResetError|ECONNREFUSED|throttl|Rate exceeded|ResourceInitializationError|CannotPullContainerError|Service Unavailable|HTTP/1.1" 5[0-9][0-9]'
+
+{
+    grep -iE "$INFRA_PATTERN" "$FLIP_API_RECONSTRUCTED" 2>/dev/null | sed 's/^/flip-api\t/' || true
+    grep -iE "$INFRA_PATTERN" "$FL_API_TEXT" 2>/dev/null | sed 's/^/fl-api\t/' || true
+    grep -iE "$INFRA_PATTERN" "$FL_SERVER_TEXT" 2>/dev/null | sed 's/^/fl-server\t/' || true
+} > "$INFRA_FILE" 2>/dev/null || true
+
+N_INFRA="$(wc -l < "$INFRA_FILE" | tr -d ' ')"
+
+# Best-effort ECS stopped-task check. ECS's own API only retains stopped-task metadata for
+# roughly an hour, so this is only useful shortly after a run — it is NOT a log-based
+# signal and is skipped gracefully (not a hard failure) if permissions are missing or the
+# window is too old.
+ECS_STOPPED_TASKS_FILE="${MODEL_OUT_DIR}/ecs_stopped_tasks.json"
+ECS_CHECK_NOTE="Skipped (--skip-ecs-check)."
+if [[ "$SKIP_ECS_CHECK" != "true" ]]; then
+    ECS_CHECK_NOTE="No stopped tasks found (or none within the ECS API's ~1h retention window)."
+    services=(flip-api)
+    for grp in "${FL_API_LOG_GROUPS[@]:-}" "${FL_SERVER_LOG_GROUPS[@]:-}"; do
+        [[ -z "$grp" ]] && continue
+        services+=("$(basename "$grp")")
+    done
+    all_stopped="[]"
+    for svc in "${services[@]}"; do
+        arns="$(awscli ecs list-tasks --cluster "$ECS_CLUSTER" --service-name "$svc" --desired-status STOPPED --query 'taskArns' --output text 2>/dev/null || true)"
+        [[ -z "$arns" || "$arns" == "None" ]] && continue
+        # shellcheck disable=SC2086
+        details="$(awscli ecs describe-tasks --cluster "$ECS_CLUSTER" --tasks $arns \
+            --query 'tasks[].{service:`'"$svc"'`,stoppedAt:stoppedAt,stoppedReason:stoppedReason,containers:containers[].{name:name,reason:reason,exitCode:exitCode}}' 2>/dev/null || echo '[]')"
+        all_stopped="$(jq -c -s 'add' <(echo "$all_stopped") <(echo "$details") 2>/dev/null || echo "$all_stopped")"
+    done
+    echo "$all_stopped" > "$ECS_STOPPED_TASKS_FILE"
+    n_stopped="$(jq 'length' "$ECS_STOPPED_TASKS_FILE" 2>/dev/null || echo 0)"
+    [[ "$n_stopped" -gt 0 ]] && ECS_CHECK_NOTE="Found ${n_stopped} stopped task record(s) — see ecs_stopped_tasks.json (not necessarily within this run's window; ECS retention is independent of the log window)."
+else
+    echo "[]" > "$ECS_STOPPED_TASKS_FILE"
+fi
+
+# --------------------------------------------------------------------------------------
+# Step 11: write summary.md
+# --------------------------------------------------------------------------------------
+
+SUMMARY_FILE="${MODEL_OUT_DIR}/summary.md"
+
+{
+    echo "# FL Model Metrics — ${MODEL_ID}"
+    echo
+    echo "- **Source URL**: ${URL}"
+    echo "- **Project ID**: ${PROJECT_ID}"
+    echo "- **Model ID**: ${MODEL_ID}"
+    echo "- **Generated**: $(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+    echo "- **AWS profile / region**: ${AWS_PROFILE_ARG} / ${AWS_REGION_ARG}"
+    echo "- **Log groups queried**: ${FLIP_API_LOG_GROUP}, ${FL_API_LOG_GROUPS[*]:-<none found>}, ${FL_SERVER_LOG_GROUPS[*]:-<none found>}"
+    echo "- **Detected FL backend** (from log content in-window): ${BACKEND}"
+    echo "- **Model activity window (flip-api)**: $(ms_to_iso "$TRUE_START_MS") to $(ms_to_iso "$TRUE_END_MS")"
+    echo "- **fl-api/fl-server query window (padded ±${PAD_MINUTES}m around training attempts)**: $(ms_to_iso "$FL_SPAN_START_MS") to $(ms_to_iso "$FL_SPAN_END_MS")"
+    echo
+    echo "> Correlation caveat: fl-api-net-*/fl-server-net-* log lines carry no model_id or"
+    echo "> project_id (confirmed by source inspection — see the script header). Everything"
+    echo "> below from those two log groups is attributed to this model purely by falling"
+    echo "> inside its TRAINING_STARTED -> terminal-status window(s), padded by"
+    echo "> ${PAD_MINUTES} minutes. If another job trained concurrently on the same net in that"
+    echo "> window, its log lines would be indistinguishable from this model's."
+    echo
+
+    echo "## 1. Communication rounds"
+    echo
+    if [[ "$BACKEND" == "nvflare" && "$TOTAL_ROUNDS" -gt 0 ]]; then
+        echo "**${TOTAL_ROUNDS} round(s) executed** (source: fl-server-net-* \`Round N started.\`/\`Round N finished.\` lines, NVFLARE ScatterAndGather controller)."
+    elif [[ "$BACKEND" == "flower" && "$TOTAL_ROUNDS" -gt 0 ]]; then
+        echo "**${TOTAL_ROUNDS} round(s) observed** (PARTIAL — source: fl-server/fl-api \`(round N)\` tags in forwarded-metric log lines; Flower has no explicit round-start/finish log line in the platform code, so this is the highest round number seen, not necessarily confirmed as complete)."
+    else
+        echo "**NOT AVAILABLE** — no round-tagged log lines were found for either backend in the queried window (fl-server-net-*/fl-api-net-* logs may be outside the padded window, expired past the 7-day retention, or the run never reached the FL server)."
+    fi
+    echo
+
+    echo "## 2. Update size"
+    echo
+    echo "**NOT AVAILABLE for per-round model-weight updates.** No component on the hub side"
+    echo "logs the byte size of an individual round's weight update — checked flip-api,"
+    echo "fl-api (both backends), and flip-utils; only S3 \`ContentLength\` for the initial"
+    echo "*model-file bundle* upload is logged (flip-api file_services/uploaded_file.py)."
+    echo "This is a different artifact from a round's weight delta. Measuring per-round"
+    echo "update size would need new instrumentation in fl-api's upload/aggregation path or"
+    echo "on the trust side."
+    if [[ -s "$UPLOAD_SIZE_LINES" ]]; then
+        echo
+        echo "Initial model-file upload size log line(s) found for this model (auxiliary, NOT per-round):"
+        echo
+        echo '```'
+        cat "$UPLOAD_SIZE_LINES"
+        echo '```'
+    fi
+    echo
+
+    echo "## 3. Aggregation time"
+    echo
+    if [[ "$BACKEND" == "nvflare" && "$TOTAL_ROUNDS" -gt 0 ]]; then
+        echo "See per-round table below (\`agg_start\`/\`agg_end\` columns; source: fl-server-net-* \`Start aggregation.\`/\`End aggregation.\` lines). Aggregation-start/end pairs are matched to rounds in chronological order (NVFLARE's ScatterAndGather aggregates synchronously once per round)."
+    elif [[ "$BACKEND" == "flower" ]]; then
+        echo "**NOT AVAILABLE for Flower** — no aggregation start/end log line exists in the platform code for this backend (stock \`flwr\` strategy internals aren't captured by FLIP's own logging)."
+    else
+        echo "**NOT AVAILABLE** — backend not identified from logs in-window."
+    fi
+    echo
+
+    echo "## 4. Per-round communication time"
+    echo
+    if [[ "$TOTAL_ROUNDS" -gt 0 ]]; then
+        echo "| Round | Started | Finished | Duration (s) | Agg. start | Agg. end | Agg. duration (s) | Accepted | Rejected |"
+        echo "|---|---|---|---|---|---|---|---|---|"
+        while IFS=$'\t' read -r round start_ms end_ms agg_start agg_end acc rej; do
+            start_iso="-"; end_iso="-"; dur="-"; agg_s_iso="-"; agg_e_iso="-"; agg_dur="-"
+            [[ -n "$start_ms" && "$start_ms" != "-" ]] && start_iso="$(ms_to_iso "$start_ms")"
+            [[ -n "$end_ms" && "$end_ms" != "-" ]] && { end_iso="$(ms_to_iso "$end_ms")"; [[ -n "$start_ms" ]] && dur=$(( (end_ms - start_ms) / 1000 )); }
+            if [[ -n "$agg_start" && "$agg_start" != "-" ]]; then
+                agg_s_iso="$(ms_to_iso "$agg_start")"
+                [[ -n "$agg_end" && "$agg_end" != "-" ]] && { agg_e_iso="$(ms_to_iso "$agg_end")"; agg_dur=$(( (agg_end - agg_start) / 1000 )); }
+            fi
+            echo "| ${round} | ${start_iso} | ${end_iso} | ${dur} | ${agg_s_iso} | ${agg_e_iso} | ${agg_dur} | ${acc:--} | ${rej:--} |"
+        done < "$ROUND_TABLE_FILE"
+        echo
+        if [[ "$BACKEND" == "nvflare" ]]; then
+            echo "Client contributions in-window: **${ACCEPTED_TOTAL:-0} accepted**, **${REJECTED_TOTAL:-0} rejected** (source: fl-server-net-* \`Contribution from <client> ACCEPTED|REJECTED by the aggregator at round <N>.\` lines; per-round counts in the table above — untagged lines from older NVFLARE builds only appear in the totals)."
+        fi
+        echo
+        echo "Summary statistics (all rounds; std is the sample standard deviation):"
+        echo
+        echo "| Metric | Mean (s) | Std (s) | n |"
+        echo "|---|---|---|---|"
+        IFS=$'\t' read -r m sd n <<<"$DUR_STATS"
+        echo "| Round duration | ${m} | ${sd} | ${n} |"
+        IFS=$'\t' read -r m sd n <<<"$AGG_STATS"
+        echo "| Aggregation | ${m} | ${sd} | ${n} |"
+        IFS=$'\t' read -r m sd n <<<"$GAP_STATS"
+        echo "| Inter-round gap | ${m} | ${sd} | ${n} |"
+        echo
+        echo "Machine-readable copy of this table: \`rounds.tsv\` (ms-precision timestamps and durations; the table above truncates to whole seconds)."
+        if [[ "$BOXPLOT_GENERATED" == "true" ]]; then
+            echo "Timing distributions: \`round_timings_boxplot.png\` (seaborn boxplots — one panel per metric: round duration, aggregation time, inter-round gap)."
+        fi
+    else
+        echo "**NOT AVAILABLE** — no rounds detected (see section 1)."
+    fi
+    echo
+
+    echo "## 5. Wall-clock time"
+    echo
+    echo "Full model-status timeline (source: flip-api \`Attempting to set the model's status... ID: <model_id>, Status: <status>\` lines, deduplicated on consecutive-identical status):"
+    echo
+    echo "| Timestamp (UTC) | Status |"
+    echo "|---|---|"
+    while IFS=$'\t' read -r ts status; do
+        echo "| $(ms_to_iso "$ts") | ${status} |"
+    done < "$STATUS_TIMELINE_DEDUP"
+    echo
+    total_s=$(( (TRUE_END_MS - TRUE_START_MS) / 1000 ))
+    echo "Total observed span (first to last model-related flip-api log line): **${total_s}s** ($(ms_to_iso "$TRUE_START_MS") to $(ms_to_iso "$TRUE_END_MS"))."
+    echo
+    if [[ -s "$ATTEMPTS_FILE" ]]; then
+        echo "Training attempt(s) (TRAINING_STARTED -> terminal status; more than one row means the model was retried):"
+        echo
+        echo "| Attempt | Training started | Ended | Terminal status | Duration (s) |"
+        echo "|---|---|---|---|---|"
+        i=0
+        while IFS=$'\t' read -r s e status; do
+            i=$((i+1))
+            dur=$(( (e - s) / 1000 ))
+            echo "| ${i} | $(ms_to_iso "$s") | $(ms_to_iso "$e") | ${status} | ${dur} |"
+        done < "$ATTEMPTS_FILE"
+    fi
+    echo
+
+    echo "## 6. Deployment failures"
+    echo
+    if [[ "$N_FAILURES" -gt 0 ]]; then
+        echo "${N_FAILURES} failure/error/retry/dropout-related line(s) found (source \\t line):"
+        echo
+        echo '```'
+        cat "$FAILURES_FILE"
+        echo '```'
+        echo
+        echo "(Full detail: \`failures.tsv\` in this directory. fl-api/fl-server lines are time-correlated, not model_id-tagged — see the correlation caveat above.)"
+    else
+        echo "No failure/error/retry/dropout-related lines found in the queried window and log groups."
+    fi
+    echo
+
+    echo "## 7. Practical infrastructure constraints"
+    echo
+    if [[ "$N_INFRA" -gt 0 ]]; then
+        echo "${N_INFRA} line(s) matching resource-limit/timeout/throttling/connection-failure patterns (source \\t line):"
+        echo
+        echo '```'
+        cat "$INFRA_FILE"
+        echo '```'
+    else
+        echo "No log lines matched common infrastructure-constraint patterns (OOM, disk, timeout, throttling, connection-refused) in the queried window."
+    fi
+    echo
+    echo "ECS stopped-task check (best-effort; ECS retains stopped-task metadata for roughly"
+    echo "1 hour, independent of CloudWatch log retention — this is only informative for"
+    echo "runs investigated shortly after they happened): ${ECS_CHECK_NOTE}"
+    echo
+
+    echo "## Data provenance"
+    echo
+    echo "| # | Metric | Availability | Source |"
+    echo "|---|---|---|---|"
+    echo "| 1 | Communication rounds | Full (NVFLARE) / Partial (Flower) / None | fl-server-net-* |"
+    echo "| 2 | Update size (per round) | **Not available** (hub logs) | n/a — needs new instrumentation |"
+    echo "| 3 | Aggregation time | Full (NVFLARE) / **Not available** (Flower) | fl-server-net-* |"
+    echo "| 4 | Per-round communication time | Full (NVFLARE) / Partial (Flower) | fl-server-net-* |"
+    echo "| 5 | Wall-clock time | Full | flip-api |"
+    echo "| 6 | Deployment failures | Full, best-effort | flip-api + fl-api-net-* + fl-server-net-* |"
+    echo "| 7 | Infrastructure constraints | Best-effort (log greps); ECS stopped-task check is time-limited | all three + ECS API |"
+    echo
+    echo "## Raw logs"
+    echo
+    echo "See \`logs/\` in this directory:"
+    echo
+    for f in "$FLIP_API_RAW" "$FLIP_API_RECONSTRUCTED" "$MODEL_LINES_FILE" "${FL_API_DUMPS[@]:-}" "${FL_SERVER_DUMPS[@]:-}"; do
+        [[ -e "$f" ]] && echo "- \`logs/$(basename "$f")\`"
+    done
+} > "$SUMMARY_FILE"
+
+log "Wrote summary: ${SUMMARY_FILE}"
+log "Done. Output: ${MODEL_OUT_DIR}"

--- a/scripts/extract_simulator_metrics.sh
+++ b/scripts/extract_simulator_metrics.sh
@@ -1,0 +1,374 @@
+#!/bin/bash
+#
+# Copyright (c) 2026 Guy's and St Thomas' NHS Foundation Trust & King's College London
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# extract_simulator_metrics.sh — local-simulator counterpart of extract_model_metrics.sh.
+#
+# Parses an NVFLARE SimEnv workspace's logs for the SAME controller events the production
+# script pulls from CloudWatch (flip.nvflare.controllers.scatter_and_gather.ScatterAndGather
+# emits identical lines in both settings):
+#     "Round N started." / "Round N finished."
+#     "Start aggregation." / "End aggregation."
+#     "Contribution from <site> ACCEPTED|REJECTED by the aggregator."
+# and writes the same artefacts: rounds.tsv (identical schema, so plot_round_timings.py
+# works unchanged), a timing boxplot, and summary.md. Hub-only metrics (model-status
+# timeline, orchestration gap, upload sizes) are marked NOT APPLICABLE.
+#
+# With --compare <platform rounds.tsv> it also emits a side-by-side steady-state table:
+# platform round time minus simulator round time ≈ WAN transfer + platform overhead
+# (± hardware differences — see the interpretation caveats written into summary.md).
+#
+# Timestamps: simulator logs carry local wall-clock times with no timezone
+# ("YYYY-MM-DD HH:MM:SS,mmm"). They are parsed as local time; durations are exact,
+# absolute times are only as meaningful as the host clock.
+
+set -euo pipefail
+
+SCRIPT_NAME="$(basename "$0")"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+usage() {
+    cat <<EOF
+Usage: ${SCRIPT_NAME} [workspace-dir] [options]
+
+Extract FL round metrics from a local NVFLARE simulator workspace
+(default workspace: /tmp/nvflare/finetuning).
+
+Options:
+  -o, --output-dir DIR   Base output directory (default: ./model_metrics)
+      --run-name NAME    Output subdirectory name (default: simulator-<workspace basename>-<log mtime>)
+      --log FILE         Parse this log file directly (skips workspace discovery)
+      --compare TSV      Platform rounds.tsv (from extract_model_metrics.sh) to
+                         compare against — adds a steady-state overhead table
+  -h, --help             Show this help and exit
+
+Examples:
+  ${SCRIPT_NAME}                                    # after 'make sim' in the finetuning tutorial
+  ${SCRIPT_NAME} /tmp/nvflare/finetuning -o model_metrics \\
+      --compare model_metrics/eff70d90-5706-4cc9-8087-5059dfb40d96/rounds.tsv
+EOF
+}
+
+WORKSPACE="/tmp/nvflare/finetuning"
+OUTPUT_DIR="./model_metrics"
+RUN_NAME=""
+LOG_FILE=""
+COMPARE_TSV=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -o|--output-dir) OUTPUT_DIR="$2"; shift 2 ;;
+        --run-name)      RUN_NAME="$2"; shift 2 ;;
+        --log)           LOG_FILE="$2"; shift 2 ;;
+        --compare)       COMPARE_TSV="$2"; shift 2 ;;
+        -h|--help)       usage; exit 0 ;;
+        -*)              echo "Unknown option: $1" >&2; usage >&2; exit 1 ;;
+        *)               WORKSPACE="$1"; shift ;;
+    esac
+done
+
+log()  { echo "[$(date '+%Y-%m-%dT%H:%M:%S')] $*" >&2; }
+die()  { echo "[$(date '+%Y-%m-%dT%H:%M:%S')] ERROR: $*" >&2; exit 1; }
+warn() { echo "[$(date '+%Y-%m-%dT%H:%M:%S')] WARNING: $*" >&2; }
+
+for dep in date grep sed awk sort; do
+    command -v "$dep" >/dev/null 2>&1 || die "Required dependency '$dep' not found on PATH."
+done
+
+# --------------------------------------------------------------------------------------
+# Locate the log carrying the ScatterAndGather events. The SimEnv layout varies across
+# NVFLARE versions (workspace log.txt, simulate_job/log.txt, per-site logs), so pick the
+# candidate with the most "Round N started." matches instead of hardcoding a path.
+# --------------------------------------------------------------------------------------
+
+if [[ -z "$LOG_FILE" ]]; then
+    [[ -d "$WORKSPACE" ]] || die "Workspace directory not found: ${WORKSPACE} (run the simulator first, or pass --log)"
+    best_count=0
+    while IFS= read -r cand; do
+        n="$(grep -cE 'Round [0-9]+ started\.' "$cand" 2>/dev/null || true)"
+        if [[ "$n" -gt "$best_count" ]]; then
+            best_count="$n"
+            LOG_FILE="$cand"
+        fi
+    done < <(find "$WORKSPACE" -type f \( -name 'log*.txt' -o -name '*.log' \) 2>/dev/null)
+    [[ -n "$LOG_FILE" ]] || die "No log file under ${WORKSPACE} contains 'Round N started.' events."
+    log "Using log: ${LOG_FILE} (${best_count} round-start events)"
+else
+    [[ -f "$LOG_FILE" ]] || die "Log file not found: ${LOG_FILE}"
+fi
+
+if [[ -z "$RUN_NAME" ]]; then
+    RUN_NAME="simulator-$(basename "$WORKSPACE")-$(date -r "$LOG_FILE" '+%Y%m%dT%H%M%S')"
+fi
+OUT_DIR="${OUTPUT_DIR%/}/${RUN_NAME}"
+mkdir -p "$OUT_DIR"
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+log "Output directory: ${OUT_DIR}"
+
+# --------------------------------------------------------------------------------------
+# Event extraction. Simulator lines look like:
+#   2026-07-10 14:00:01,123 - ScatterAndGather - INFO - [identity=simulator_server, ...] - Round 0 started.
+# ts_ms converts "YYYY-MM-DD HH:MM:SS,mmm" to epoch milliseconds (local time).
+# --------------------------------------------------------------------------------------
+
+TS_RE='^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2},[0-9]{3}'
+
+ts_ms() {
+    # "$1" like "2026-07-10 14:00:00,100" — seconds via date(1), millis taken verbatim
+    # from the log string (date's %3N truncation is GNU-only and unreliable elsewhere).
+    local base="${1%,*}" frac="${1##*,}" s
+    s="$(date -d "$base" +%s 2>/dev/null)" || die "Could not parse timestamp: $1"
+    echo $(( s * 1000 + 10#$frac ))
+}
+
+extract_events() {
+    # $1 = pattern (ERE, matched anywhere in line); prints "ms<TAB>line" sorted by ms
+    local pattern="$1" out="$2"
+    : > "$out"
+    while IFS= read -r line; do
+        local ts
+        ts="$(grep -oE "$TS_RE" <<<"$line" | head -1)"
+        [[ -z "$ts" ]] && continue
+        printf '%s\t%s\n' "$(ts_ms "$ts")" "$line" >> "$out"
+    done < <(grep -E "$pattern" "$LOG_FILE" | sed -E 's/\x1b\[[0-9;]*m//g')
+    sort -n -k1,1 -o "$out" "$out"
+}
+
+ROUND_STARTS="${WORK_DIR}/round_starts.tsv"   # round \t ms
+ROUND_ENDS="${WORK_DIR}/round_ends.tsv"       # round \t ms
+AGG_STARTS="${WORK_DIR}/agg_starts.txt"       # ms
+AGG_ENDS="${WORK_DIR}/agg_ends.txt"           # ms
+CONTRIBS="${WORK_DIR}/contribs.tsv"           # ms \t ACCEPTED|REJECTED
+
+extract_events 'Round [0-9]+ started\.' "${WORK_DIR}/rs.raw"
+extract_events 'Round [0-9]+ finished\.' "${WORK_DIR}/re.raw"
+extract_events 'Start aggregation\.' "${WORK_DIR}/as.raw"
+extract_events 'End aggregation\.' "${WORK_DIR}/ae.raw"
+extract_events 'Contribution from [^ ]+ (ACCEPTED|REJECTED) by the aggregator' "${WORK_DIR}/co.raw"
+
+sed -E 's/^([0-9]+)\t.*Round ([0-9]+) started\..*/\2\t\1/' "${WORK_DIR}/rs.raw" | sort -n -k1,1 > "$ROUND_STARTS"
+sed -E 's/^([0-9]+)\t.*Round ([0-9]+) finished\..*/\2\t\1/' "${WORK_DIR}/re.raw" | sort -n -k1,1 > "$ROUND_ENDS"
+awk -F'\t' '{print $1}' "${WORK_DIR}/as.raw" > "$AGG_STARTS"
+awk -F'\t' '{print $1}' "${WORK_DIR}/ae.raw" > "$AGG_ENDS"
+sed -E 's/^([0-9]+)\t.*Contribution from [^ ]+ (ACCEPTED|REJECTED) by the aggregator.*/\1\t\2/' "${WORK_DIR}/co.raw" > "$CONTRIBS"
+
+n_rounds="$(wc -l < "$ROUND_STARTS" | tr -d ' ')"
+[[ "$n_rounds" -gt 0 ]] || die "No rounds parsed out of ${LOG_FILE}."
+ACCEPTED_TOTAL="$(grep -c $'\tACCEPTED' "$CONTRIBS" || true)"
+REJECTED_TOTAL="$(grep -c $'\tREJECTED' "$CONTRIBS" || true)"
+log "Parsed ${n_rounds} round(s); contributions: ${ACCEPTED_TOTAL} accepted, ${REJECTED_TOTAL} rejected"
+
+# --------------------------------------------------------------------------------------
+# Build rounds.tsv — identical schema to extract_model_metrics.sh, so
+# plot_round_timings.py consumes it unchanged. Aggregation start/end pairs are matched to
+# rounds chronologically (ScatterAndGather aggregates synchronously once per round);
+# contributions carry no round tag here, so they are attributed by time window.
+# NB: "started_utc"/"finished_utc" columns hold the log's LOCAL wall-clock time (the
+# simulator writes no timezone); the column names are kept for schema compatibility.
+# --------------------------------------------------------------------------------------
+
+ms_to_disp() { date -d "@$(( $1 / 1000 ))" '+%Y-%m-%dT%H:%M:%S'; }
+maybe_dur() {
+    if [[ -n "${1:-}" && "${1:-}" != "-" && -n "${2:-}" && "${2:-}" != "-" ]]; then
+        awk -v a="$1" -v b="$2" 'BEGIN{printf "%.3f", (b - a) / 1000}'
+    else
+        echo "-"
+    fi
+}
+
+ROUNDS_TSV="${OUT_DIR}/rounds.tsv"
+{
+    printf 'round\tstarted_utc\tfinished_utc\tduration_s\tagg_started_utc\tagg_finished_utc\tagg_duration_s\taccepted\trejected\tstart_ms\tend_ms\tagg_start_ms\tagg_end_ms\n'
+    i=0
+    while IFS=$'\t' read -r round_num start_ms; do
+        i=$((i + 1))
+        end_ms="$(awk -v r="$round_num" '$1==r{print $2; exit}' "$ROUND_ENDS")"
+        agg_start="$(awk -v i="$i" 'NR==i{print}' "$AGG_STARTS")"
+        agg_end="$(awk -v i="$i" 'NR==i{print}' "$AGG_ENDS")"
+        if [[ -n "$end_ms" ]]; then
+            acc_r="$(awk -F'\t' -v s="$start_ms" -v e="$end_ms" '$2=="ACCEPTED" && ($1+0)>=s && ($1+0)<=e {n++} END{print n+0}' "$CONTRIBS")"
+            rej_r="$(awk -F'\t' -v s="$start_ms" -v e="$end_ms" '$2=="REJECTED" && ($1+0)>=s && ($1+0)<=e {n++} END{print n+0}' "$CONTRIBS")"
+        else
+            acc_r="-"; rej_r="-"
+        fi
+        printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+            "$round_num" \
+            "$(ms_to_disp "$start_ms")" \
+            "$([[ -n "$end_ms" ]] && ms_to_disp "$end_ms" || echo "-")" \
+            "$(maybe_dur "$start_ms" "${end_ms:--}")" \
+            "$([[ -n "$agg_start" ]] && ms_to_disp "$agg_start" || echo "-")" \
+            "$([[ -n "$agg_end" ]] && ms_to_disp "$agg_end" || echo "-")" \
+            "$(maybe_dur "${agg_start:--}" "${agg_end:--}")" \
+            "$acc_r" "$rej_r" \
+            "$start_ms" "${end_ms:--}" "${agg_start:--}" "${agg_end:--}"
+    done < "$ROUND_STARTS"
+} > "$ROUNDS_TSV"
+log "Wrote per-round table: ${ROUNDS_TSV}"
+
+# --------------------------------------------------------------------------------------
+# Summary statistics (same definitions as the production script; steady-state = rounds >= 1)
+# --------------------------------------------------------------------------------------
+
+# col_stats COLUMN [MIN_ROUND] -> "mean \t std \t n" over numeric values of rounds >= MIN_ROUND
+col_stats() {
+    awk -F'\t' -v c="$1" -v minr="${2:-0}" 'NR > 1 && $1+0 >= minr && $c != "-" {x=$c+0; s+=x; ss+=x*x; n++}
+        END { if (n==0) {print "-\t-\t0"; exit}
+              m=s/n; sd=(n>1)?sqrt((ss-n*m*m)/(n-1)):0; printf "%.3f\t%.3f\t%d\n", m, sd, n }' "$ROUNDS_TSV"
+}
+gap_stats() {
+    awk -F'\t' 'NR > 1 && $10 != "-" && $11 != "-" {
+            if (prev_end != "") {g=($10-prev_end)/1000; s+=g; ss+=g*g; n++}
+            prev_end=$11 }
+        END { if (n==0) {print "-\t-\t0"; exit}
+              m=s/n; sd=(n>1)?sqrt((ss-n*m*m)/(n-1)):0; printf "%.3f\t%.3f\t%d\n", m, sd, n }' "$ROUNDS_TSV"
+}
+
+DUR_ALL="$(col_stats 4)";     DUR_SS="$(col_stats 4 1)"
+AGG_ALL="$(col_stats 7)";     AGG_SS="$(col_stats 7 1)"
+GAP_ALL="$(gap_stats)"
+ROUND0_DUR="$(awk -F'\t' 'NR>1 && $1==0 {print $4; exit}' "$ROUNDS_TSV")"
+SPAN_S="$(awk -F'\t' 'NR>1 && $10!="-" {if(min==""||$10+0<min)min=$10+0} NR>1 && $11!="-" {if($11+0>max)max=$11+0} END{printf "%.0f", (max-min)/1000}' "$ROUNDS_TSV")"
+
+# --------------------------------------------------------------------------------------
+# Boxplot (best-effort, same runner strategy as the production script)
+# --------------------------------------------------------------------------------------
+
+BOXPLOT="${OUT_DIR}/round_timings_boxplot.png"
+PLOT_SCRIPT="${SCRIPT_DIR}/plot_round_timings.py"
+BOXPLOT_GENERATED=false
+if [[ -f "$PLOT_SCRIPT" ]]; then
+    plot_cmd=()
+    if command -v uv >/dev/null 2>&1; then
+        plot_cmd=(uv run --no-project --with pandas --with seaborn python)
+    elif command -v python3 >/dev/null 2>&1 && python3 -c 'import pandas, seaborn' >/dev/null 2>&1; then
+        plot_cmd=(python3)
+    fi
+    if [[ ${#plot_cmd[@]} -gt 0 ]]; then
+        if "${plot_cmd[@]}" "$PLOT_SCRIPT" "$ROUNDS_TSV" "$BOXPLOT" \
+                --model-id "$RUN_NAME" --backend "nvflare-simulator" >&2; then
+            BOXPLOT_GENERATED=true
+            log "Wrote round-timing boxplot: ${BOXPLOT}"
+        else
+            warn "plot_round_timings.py failed — continuing without the boxplot."
+        fi
+    else
+        warn "Neither uv nor python3-with-pandas+seaborn available — skipping the boxplot."
+    fi
+fi
+
+# --------------------------------------------------------------------------------------
+# Optional platform comparison
+# --------------------------------------------------------------------------------------
+
+COMPARISON_MD=""
+if [[ -n "$COMPARE_TSV" ]]; then
+    [[ -f "$COMPARE_TSV" ]] || die "--compare file not found: ${COMPARE_TSV}"
+    p_stats() {  # same as col_stats but against the platform TSV
+        awk -F'\t' -v c="$1" -v minr="${2:-0}" 'NR > 1 && $1+0 >= minr && $c != "-" {x=$c+0; s+=x; ss+=x*x; n++}
+            END { if (n==0) {print "-\t-\t0"; exit}
+                  m=s/n; sd=(n>1)?sqrt((ss-n*m*m)/(n-1)):0; printf "%.3f\t%.3f\t%d\n", m, sd, n }' "$COMPARE_TSV"
+    }
+    P_DUR_SS="$(p_stats 4 1)"; P_AGG_SS="$(p_stats 7 1)"
+    P_ROUND0="$(awk -F'\t' 'NR>1 && $1==0 {print $4; exit}' "$COMPARE_TSV")"
+    P_GAP="$(awk -F'\t' 'NR > 1 && $10 != "-" && $11 != "-" {
+            if (prev_end != "") {g=($10-prev_end)/1000; s+=g; ss+=g*g; n++}
+            prev_end=$11 }
+        END { if (n==0) {print "-\t-\t0"; exit}
+              m=s/n; sd=(n>1)?sqrt((ss-n*m*m)/(n-1)):0; printf "%.3f\t%.3f\t%d\n", m, sd, n }' "$COMPARE_TSV")"
+
+    delta() { awk -v p="$1" -v s="$2" 'BEGIN{ if (p=="-"||s=="-") print "-"; else printf "%+.3f", p-s }'; }
+    IFS=$'\t' read -r pd psd _ <<<"$P_DUR_SS";  IFS=$'\t' read -r sd_ ssd _ <<<"$DUR_SS"
+    IFS=$'\t' read -r pa pasd _ <<<"$P_AGG_SS"; IFS=$'\t' read -r sa sasd _ <<<"$AGG_SS"
+    IFS=$'\t' read -r pg pgsd _ <<<"$P_GAP";    IFS=$'\t' read -r sg sgsd _ <<<"$GAP_ALL"
+
+    COMPARISON_MD=$(cat <<EOF
+
+## Platform vs simulator (steady-state rounds, i.e. round >= 1)
+
+| Metric | Platform (s) | Simulator (s) | Delta (platform − simulator, s) |
+|---|---|---|---|
+| Round duration | ${pd} ± ${psd} | ${sd_} ± ${ssd} | $(delta "$pd" "$sd_") |
+| Aggregation | ${pa} ± ${pasd} | ${sa} ± ${sasd} | $(delta "$pa" "$sa") |
+| Inter-round gap | ${pg} ± ${pgsd} | ${sg} ± ${sgsd} | $(delta "$pg" "$sg") |
+| Round 0 (initialisation) | ${P_ROUND0:--} | ${ROUND0_DUR:--} | $(delta "${P_ROUND0:--}" "${ROUND0_DUR:--}") |
+
+Platform source: \`${COMPARE_TSV}\`. The round-duration delta bundles WAN model
+transfer, platform transport/orchestration overhead, and any hardware difference
+between the production clients and this host — see the caveats below before
+attributing it to any single cause.
+EOF
+    )
+fi
+
+# --------------------------------------------------------------------------------------
+# summary.md
+# --------------------------------------------------------------------------------------
+
+SUMMARY="${OUT_DIR}/summary.md"
+fmt_row() { local IFS=$'\t'; read -r m s n <<<"$1"; echo "| $2 | ${m} | ${s} | ${n} |"; }
+
+{
+    echo "# FL simulator metrics — ${RUN_NAME}"
+    echo
+    echo "- **Workspace**: ${WORKSPACE}"
+    echo "- **Log parsed**: ${LOG_FILE}"
+    echo "- **Generated**: $(date '+%Y-%m-%dT%H:%M:%S')"
+    echo "- **Backend**: NVFLARE (local SimEnv simulator; FLIP ScatterAndGather controller)"
+    echo
+    echo "## Communication rounds"
+    echo
+    echo "**${n_rounds} round(s) executed**; contributions in-log: **${ACCEPTED_TOTAL} accepted**, **${REJECTED_TOTAL} rejected** (attributed to rounds by time window — simulator contribution lines carry no round tag)."
+    echo
+    echo "Total span (first round start to last round end): **${SPAN_S}s**."
+    echo
+    echo "## Timing summary (all rounds / steady-state)"
+    echo
+    echo "| Metric | Mean (s) | Std (s) | n |"
+    echo "|---|---|---|---|"
+    fmt_row "$DUR_ALL" "Round duration (all)"
+    fmt_row "$DUR_SS"  "Round duration (rounds >= 1)"
+    fmt_row "$AGG_ALL" "Aggregation (all)"
+    fmt_row "$AGG_SS"  "Aggregation (rounds >= 1)"
+    fmt_row "$GAP_ALL" "Inter-round gap"
+    echo
+    echo "Round 0 duration: **${ROUND0_DUR:-n/a}s** (one-off initialisation: weight load, data-loader start-up, first-access caching)."
+    echo
+    echo "Machine-readable copy: \`rounds.tsv\` (same schema as extract_model_metrics.sh)."
+    if [[ "$BOXPLOT_GENERATED" == "true" ]]; then
+        echo "Timing distributions: \`round_timings_boxplot.png\`."
+    fi
+    echo "$COMPARISON_MD"
+    echo
+    echo "## Not applicable in the simulator"
+    echo
+    echo "- Model-status timeline / wall-clock from model creation (no Central Hub API)."
+    echo "- Orchestration gap around the training attempt (no job dispatch / result upload)."
+    echo "- Application upload sizes (no S3 upload; files staged locally)."
+    echo
+    echo "## Interpretation caveats"
+    echo
+    echo "1. Both simulated clients run **on this single host, sharing one GPU** (SimEnv"
+    echo "   \`num_threads = num_clients\`), so per-round compute reflects GPU contention"
+    echo "   between the two clients, not two independent sites."
+    echo "2. There is **no WAN, TLS, task encryption, or trust-side polling** — the round"
+    echo "   envelope here is essentially pure local compute plus in-process transport."
+    echo "3. Same controller and privacy-filter configuration as production"
+    echo "   (FlipFedAvgRecipe defaults: percentile=95, gamma=2.0), so server-side"
+    echo "   aggregation cost is directly comparable."
+    echo "4. Platform-minus-simulator round-duration deltas therefore bundle network"
+    echo "   transfer + platform overhead ± hardware differences; use the aggregation and"
+    echo "   inter-round-gap rows (host-independent, tiny) as the sanity anchor."
+} > "$SUMMARY"
+
+log "Wrote summary: ${SUMMARY}"
+log "Done. Output: ${OUT_DIR}"

--- a/scripts/plot_round_timings.py
+++ b/scripts/plot_round_timings.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2026 Guy's and St Thomas' NHS Foundation Trust & King's College London
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Render seaborn boxplots of per-round FL timing metrics from a rounds.tsv.
+
+Companion to extract_model_metrics.sh, which writes rounds.tsv (one row per
+communication round, ms-precision epoch columns) and invokes this script
+best-effort via `uv run --no-project --with pandas --with seaborn`. Not part of
+any FLIP service — pandas/seaborn are deliberately NOT project dependencies.
+
+One subplot per metric, each on its own linear seconds axis (aggregation is ~3
+orders of magnitude below round duration, so a shared axis would flatten it):
+  - Round duration       (end_ms - start_ms per round)
+  - Aggregation time     (agg_end_ms - agg_start_ms; NVFLARE only — "-" for Flower)
+  - Inter-round gap      (next round's start_ms - this round's end_ms)
+"""
+
+import argparse
+import sys
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt
+import pandas as pd
+import seaborn as sns
+
+# Reference dataviz palette (light mode): blue series hue on a near-white surface.
+SURFACE = "#fcfcfb"
+SERIES = "#2a78d6"
+INK = "#0b0b0b"
+INK_2 = "#52514e"
+GRID = "#e4e3e0"
+
+METRIC_ORDER = ["Round duration", "Aggregation", "Inter-round gap"]
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("rounds_tsv", help="rounds.tsv written by extract_model_metrics.sh")
+    parser.add_argument("output_png", help="path of the PNG to write")
+    parser.add_argument("--model-id", default="unknown", help="model UUID (title only)")
+    parser.add_argument("--backend", default="unknown", help="detected FL backend (title only)")
+    parser.add_argument("--dpi", type=int, default=150)
+    return parser.parse_args()
+
+
+def load_metrics(rounds_tsv: str) -> tuple[pd.DataFrame, pd.DataFrame]:
+    """Returns (per-round wide frame, long frame of metric/seconds/round)."""
+    df = pd.read_csv(rounds_tsv, sep="\t", na_values=["-"])
+    if df.empty:
+        sys.exit("rounds.tsv has no data rows — nothing to plot.")
+
+    df = df.sort_values("round").reset_index(drop=True)
+    df["round_duration_s"] = (df["end_ms"] - df["start_ms"]) / 1000
+    df["aggregation_s"] = (df["agg_end_ms"] - df["agg_start_ms"]) / 1000
+    # Gap between this round finishing and the next one starting (last round has none).
+    df["inter_round_gap_s"] = (df["start_ms"].shift(-1) - df["end_ms"]) / 1000
+
+    long = df.melt(
+        id_vars=["round"],
+        value_vars=["round_duration_s", "aggregation_s", "inter_round_gap_s"],
+        var_name="metric",
+        value_name="seconds",
+    ).dropna(subset=["seconds"])
+    long["metric"] = long["metric"].map(
+        {
+            "round_duration_s": "Round duration",
+            "aggregation_s": "Aggregation",
+            "inter_round_gap_s": "Inter-round gap",
+        }
+    )
+    if long.empty:
+        sys.exit("No finite timing values in rounds.tsv — nothing to plot.")
+    return df, long
+
+
+def main() -> None:
+    args = parse_args()
+    df, long = load_metrics(args.rounds_tsv)
+
+    order = [m for m in METRIC_ORDER if m in set(long["metric"])]
+
+    sns.set_theme(style="whitegrid", rc={"axes.facecolor": SURFACE, "figure.facecolor": SURFACE})
+    fig, axes = plt.subplots(1, len(order), figsize=(3.4 * len(order) + 0.6, 4.8))
+    axes = [axes] if len(order) == 1 else list(axes)
+
+    for ax, metric in zip(axes, order):
+        sub = long[long["metric"] == metric]
+        sns.boxplot(
+            data=sub, y="seconds", color=SERIES,
+            width=0.4, linewidth=1.1, fliersize=0,
+            boxprops={"alpha": 0.35, "edgecolor": SERIES},
+            whiskerprops={"color": SERIES}, capprops={"color": SERIES},
+            medianprops={"color": SERIES, "linewidth": 1.6},
+            ax=ax,
+        )
+        sns.stripplot(data=sub, y="seconds", color=SERIES, size=3, alpha=0.55, jitter=0.1, ax=ax)
+
+        median = sub["seconds"].median()
+        ax.annotate(
+            f"median {median:.3g}s", (0, median), xytext=(0, 9),
+            textcoords="offset points", ha="center", fontsize=8.5, color=INK,
+        )
+
+        ax.set_title(metric, fontsize=10.5, color=INK)
+        ax.set_xlabel("")
+        ax.set_xticks([])
+        ax.set_ylabel("seconds", color=INK_2)
+        ax.tick_params(colors=INK)
+        ax.grid(True, axis="y", color=GRID, linewidth=0.7)
+        ax.margins(y=0.1)
+        sns.despine(ax=ax, left=True, bottom=True)
+
+    # Call out an extreme round-duration outlier (typically round 0: client startup).
+    durations = df.dropna(subset=["round_duration_s"])
+    if "Round duration" in order and len(durations) > 1:
+        top = durations.loc[durations["round_duration_s"].idxmax()]
+        if top["round_duration_s"] > 2 * durations["round_duration_s"].median():
+            axes[order.index("Round duration")].annotate(
+                f"round {int(top['round'])}: {top['round_duration_s']:.0f}s",
+                (0, top["round_duration_s"]), xytext=(8, -3),
+                textcoords="offset points", ha="left", fontsize=8.5, color=INK_2,
+            )
+
+    span_s = (df["end_ms"].max() - df["start_ms"].min()) / 1000
+    started = pd.to_datetime(df["start_ms"].min(), unit="ms", utc=True)
+    context = (
+        f"{len(df)} rounds | backend: {args.backend} | "
+        f"started {started:%Y-%m-%d %H:%M} UTC | rounds 0–{int(df['round'].max())} "
+        f"span {span_s / 3600:.1f} h"
+    )
+    fig.suptitle(f"Per-round timing — model {args.model_id[:8]}", fontsize=12, color=INK, x=0.06, y=0.985, ha="left")
+    fig.text(0.06, 0.925, context, fontsize=9, color=INK_2, ha="left")
+
+    fig.tight_layout(rect=(0, 0, 1, 0.9))
+    fig.savefig(args.output_png, dpi=args.dpi, facecolor=SURFACE)
+    print(f"Wrote {args.output_png}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
<!--
Copyright (c) 2026 Guy's and St Thomas' NHS Foundation Trust & King's College London
Licensed under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at
    http://www.apache.org/licenses/LICENSE-2.0
Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
-->

# Description

Adds tooling to measure FL round-by-round timing and failures, plus a tutorial that
exercises it:

- `scripts/extract_model_metrics.sh` — pulls per-round timing/failure metrics for one
  production model out of the Central Hub's CloudWatch logs (flip-api, fl-api-net-*,
  fl-server-net-*), writing `rounds.tsv` / `failures.tsv` / `infra_constraints.tsv` /
  `summary.md`.
- `scripts/extract_simulator_metrics.sh` — extracts the same shape of metrics from a
  local NVFLARE simulator run's logs, optionally with `--compare` against a production
  `rounds.tsv` for a platform-overhead comparison.
- `scripts/plot_round_timings.py` — renders the round-timing boxplot used by both
  extraction scripts.
- `fl-tutorials/nvflare/image_classification/finetuning/` — an Ark+ fine-tuning tutorial
  that replicates the cross-continental production run on the local simulator (same job
  type, controller, and privacy-filter config), wired to `make metrics` via the new
  simulator script so the platform overhead can be baselined.
- `.gitignore` — ignores `/model_metrics/`, the scripts' default local output directory
  (per-model round timings, logs, boxplots — analysis scratch, not repo content).

## Linked Issues

No related issue. This was pulled off `735-per-job-fl-server` — that branch had no
commits of its own (0 diff vs. `develop`) and issue #735 is an unrelated, still-open
per-job fl-server scaling feature, so this work was moved onto its own branch instead
of riding along on that one.

## Checklist

- [x] Follows the project's coding conventions and style guide
- [ ] Updates documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Type of Change

- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [x] In-line docstrings updated.
- [ ] Documentation updated, tested `make -C docs/ docs`.

## Testing

I did the following tests to verify my changes:

- `uv run ruff check` on the new Python files — all checks passed.
- `bash -n` on both new shell scripts — no syntax errors.
- `python -m py_compile` on `job.py`, `app_files/*.py`, and `plot_round_timings.py`.
- Pre-commit hooks (secret scanning, large-file check, etc.) passed on commit.
- The tutorial itself (`make sim` / `make metrics`) needs a GPU to exercise end-to-end
  and was not re-run in this environment; the app files are the same ones used for the
  production run this tutorial replicates.

## Additional Notes

The tutorial's own README documents `pretrained_weights/` (an unpacked copy of the
committed-nowhere `pretrained_weights.pt`, which is `*.pt`-gitignored already) as unused
and safe to delete — removed rather than carried into this PR.
