### PR TITLE
Post-migration teardown: external service configs for flip-fl-base merge

### DIFF
--- a/flip-utils/flip/__init__.py
+++ b/flip-utils/flip/__init__.py
@@ -37,4 +37,4 @@ from flip.exceptions import ResultsUploadError
 
 __all__ = ["FLIP", "FLIPBase", "ResultsUploadError"]
 
-__version__ = "0.3.0"
+__version__ = "0.4.0"


### PR DESCRIPTION
Bumps flip-utils from 0.3.0 to 0.4.0 in preparation for the first PyPI release from the FLIP monorepo via the new OIDC trusted publisher.

Part of #589.

Once merged to `develop`, `develop` will be merged into `main` to trigger `release-pypi.yml`.