### PR TITLE
fix(db): merge the fl_logs and RUNNING-rename alembic heads

### DIFF
--- a/flip-api/src/flip_api/db/migrations/versions/01af591a5cfc_merge_fl_logs_and_running_rename_heads.py
+++ b/flip-api/src/flip_api/db/migrations/versions/01af591a5cfc_merge_fl_logs_and_running_rename_heads.py
@@ -1,0 +1,41 @@
+# Copyright (c) 2026 Guy's and St Thomas' NHS Foundation Trust & King's College London
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""merge fl_logs and RUNNING-rename heads
+
+No-op merge point: #757 (8c4f2b9d31e7, fl_logs typed round events) and #783
+(8c41d0f2ab5e, TRAINING_STARTED -> RUNNING enum rename) both branched off
+23aff57898a0, leaving two heads after #757 merged. The two revisions touch
+disjoint objects (fl_logs columns vs the modelstatus/modelauditaction enums),
+so they commute and a database at either head — prod is at 8c4f2b9d31e7 —
+upgrades cleanly through this merge, running whichever branch it is missing.
+
+Revision ID: 01af591a5cfc
+Revises: 8c41d0f2ab5e, 8c4f2b9d31e7
+Create Date: 2026-07-21 15:00:00.000000
+
+"""
+from collections.abc import Sequence
+
+# revision identifiers, used by Alembic.
+revision: str = '01af591a5cfc'
+down_revision: str | Sequence[str] | None = ('8c41d0f2ab5e', '8c4f2b9d31e7')
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Apply this revision (no-op merge point)."""
+
+
+def downgrade() -> None:
+    """Revert this revision (no-op merge point)."""


### PR DESCRIPTION
## What

Adds a no-op alembic merge revision `01af591a5cfc` joining the two migration heads develop was left with after #757 merged:

- `8c4f2b9d31e7` — fl_logs typed round events (#757)
- `8c41d0f2ab5e` — TRAINING_STARTED → RUNNING enum rename (#783)

Both branched off `23aff57898a0`, so `alembic upgrade head` fails with *Multiple head revisions* — the cause of the 97 integration-test errors on develop's FLIP API CI run ([29839698069](https://github.com/londonaicentre/FLIP/actions/runs/29839698069)).

## Why a merge revision (not re-parenting)

Both revisions are already applied in real databases — the prod hub is at `8c4f2b9d31e7`. Re-parenting either revision would make some deployed database look at-head while missing the other branch's DDL. The two revisions touch disjoint objects (fl_logs columns vs the modelstatus/modelauditaction enums), so they commute and a no-op merge point lets any database upgrade through it, running whichever branch it is missing.

## Verification

- `alembic heads` → single head `01af591a5cfc`; `alembic history` shows the mergepoint.
- `make -C flip-api integration_test` locally: **97 passed** — the exact tests that errored on develop (includes the migration drift guard: empty-DB upgrade-to-head, no-drift, enum-value drift, downgrade-base round-trip).