### PR TITLE
docs: auto-regenerate admin user-action GIFs on merge to main

### DIFF
--- a/.github/workflows/regenerate_docs_gifs.yml
+++ b/.github/workflows/regenerate_docs_gifs.yml
@@ -9,8 +9,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Re-record the documentation GIFs whenever the UI changes on develop, then open
-# a PR back to develop with the regenerated assets. Functional CI
+# Re-record the documentation GIFs whenever the UI changes on main, then open
+# a PR against develop with the regenerated assets. Functional CI
 # (test_flip_ui.yml) is untouched — video stays off there so the 6-shard PR
 # pipeline isn't slowed down.
 #
@@ -21,7 +21,7 @@ name: Regenerate docs GIFs
 
 on:
   push:
-    branches: [develop]
+    branches: [main]
     paths:
       - "flip-ui/src/**"
       - "flip-ui/test/cypress/docs/**"
@@ -101,18 +101,18 @@ jobs:
           commit-message: |
             docs: regenerate documentation GIFs
 
-            Auto-regenerated from develop by .github/workflows/regenerate_docs_gifs.yml.
+            Auto-regenerated from main by .github/workflows/regenerate_docs_gifs.yml.
 
             Signed-off-by: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
           title: "docs: regenerate documentation GIFs"
           body: |
-            Auto-regenerated from `develop` @ ${{ github.sha }} by `.github/workflows/regenerate_docs_gifs.yml`.
+            Auto-regenerated from `main` @ ${{ github.sha }} by `.github/workflows/regenerate_docs_gifs.yml`.
 
             **Heads-up:** re-recording is nondeterministic (Cypress frame timing
             plus the animated demo cursor), so this PR shows *every* GIF as changed
             even where the UI didn't. Review the rendered GIFs under
             `docs/source/assets/admin/` and `docs/source/assets/flip/` and merge
             only if the genuinely-changed clips look right — otherwise close it.
-            This branch is reused, so later develop merges refresh this same PR.
+            This branch is reused, so later main merges refresh this same PR.
           signoff: true
           delete-branch: true


### PR DESCRIPTION
## Summary

The docs-GIF recorder was designed in #509 to re-record on every push to `main`, and CONTRIBUTING.md still documents exactly that ("auto-regenerated on every push to `main` … opens a PR against `develop` for human review") — but the workflow file triggered on `develop` pushes instead. This aligns the workflow with its documented design:

- `on.push.branches` is now `[main]` (path filters and `workflow_dispatch` unchanged).
- The bot PR still opens against `develop` for human review, per the documented flow and repo PR convention.
- The header comment, generated commit message, and bot-PR body now say the assets were regenerated from `main`.

No CONTRIBUTING.md change needed — it already describes this behaviour.

## Notes for reviewers

- Push triggers read the workflow from the pushed branch, so this takes effect once it reaches `main` via the normal develop → main flow.
- The bot branch is cut from the `main` checkout, so its PR into `develop` is a clean GIF-only diff while `main` is an ancestor of `develop`; if a hotfix lands on `main` first, the bot PR will also carry those commits until develop catches up.