### PR TITLE
[Feature]: Save both best and final models — NVFLARE backend

### DIFF
--- a/fl-services/nvflare/fl-api-base/fl_api/utils/prepare_config.py
+++ b/fl-services/nvflare/fl-api-base/fl_api/utils/prepare_config.py
@@ -664,7 +664,9 @@ def validate_config(config: dict) -> IOverridableConfig:
     if best_model_metric is not None:
         if not isinstance(best_model_metric, str) or not best_model_metric.strip():
             raise ValueError("BEST_MODEL_METRIC must be a non-empty string metric label")
-        validated.BEST_MODEL_METRIC = best_model_metric
+        # Store stripped: a stray space in the JSON would otherwise survive validation and never
+        # match the metric label the trainer reports.
+        validated.BEST_MODEL_METRIC = best_model_metric.strip()
 
         minimize = config.get("BEST_MODEL_METRIC_MINIMIZE", False)
         # Guard bool before int: in Python ``isinstance(True, int)`` is True, but we want to reject
@@ -672,6 +674,15 @@ def validate_config(config: dict) -> IOverridableConfig:
         if not isinstance(minimize, bool):
             raise ValueError("BEST_MODEL_METRIC_MINIMIZE must be a boolean")
         validated.BEST_MODEL_METRIC_MINIMIZE = minimize
+
+        # IntimeModelSelector always skips round 0, so a job whose effective GLOBAL_ROUNDS is 1 —
+        # the platform default when the key is unset or invalid (see upload.py) — can never fire
+        # the selector: the job would run fine but the results zip silently lacks the best model.
+        if (validated.GLOBAL_ROUNDS or TrainingRound.MIN) <= 1:
+            raise ValueError(
+                "BEST_MODEL_METRIC requires GLOBAL_ROUNDS >= 2: the best-model selector skips "
+                "round 0, so a single-round job can never save a best model"
+            )
     elif "BEST_MODEL_METRIC_MINIMIZE" in config:
         # BEST_MODEL_METRIC_MINIMIZE only has meaning alongside a selector metric — silently
         # accepting it without BEST_MODEL_METRIC would let a user believe it took effect.

--- a/fl-services/nvflare/fl-api-base/fl_api/utils/prepare_config.py
+++ b/fl-services/nvflare/fl-api-base/fl_api/utils/prepare_config.py
@@ -294,6 +294,35 @@ def _inject_trim_eval_broadcast_filter(config: dict, include_regex: str) -> None
     filters_blocks.append({"tasks": ["validate"], "filters": [trim_filter]})
 
 
+def _inject_intime_model_selector(config: dict, key_metric: str, minimize: bool) -> None:
+    """Append a stock ``IntimeModelSelector`` component keyed on ``key_metric`` (server-side, FLIP#673).
+
+    The production mirror of ``FlipFedAvgRecipe(best_model_metric=...)``: the selector averages the
+    client-reported validation metric each round and fires ``GLOBAL_BEST_MODEL_AVAILABLE`` on
+    improvement, which the persistor answers by saving ``best_FL_global_model.pt`` alongside the final
+    model. The FLIP ``ScatterAndGather`` controller (a thin subclass of stock) already fires the round
+    events the selector listens on, so only the component needs adding. The client trainer must report
+    ``key_metric`` on its returned ``FLModel`` (evaluated on the received global model) for selection
+    to fire; without it the selector stays dormant and no best model is saved.
+
+    Idempotent: a template that already carries an ``IntimeModelSelector`` (e.g. a recipe export built
+    with ``best_model_metric``) is left untouched — two selectors would drive best-model saves off
+    separate accumulators. Mutates ``config`` in place.
+    """
+    selector_path = "nvflare.app_common.widgets.intime_model_selector.IntimeModelSelector"
+    components = config.setdefault("components", [])
+    if any(component.get("path") == selector_path for component in components):
+        logger.info("IntimeModelSelector already present in server config; not injecting a second one")
+        return
+    components.append(
+        {
+            "id": "model_selector",
+            "path": selector_path,
+            "args": {"key_metric": key_metric, "negate_key_metric": minimize},
+        }
+    )
+
+
 def configure_client(
     job_dir: Path,
     app_name: str,
@@ -358,6 +387,8 @@ def configure_server(
     aggregator: str,
     aggregation_weights: dict,
     aggregate_only_regex: str | None = None,
+    best_model_metric: str | None = None,
+    best_model_metric_minimize: bool = False,
 ) -> Path:
     """
     Configures the server config file. Making sure the app name, global rounds, and other variables are set correctly.
@@ -375,6 +406,10 @@ def configure_server(
             TrimEvalBroadcastVars ``validate`` data filter so post-training cross-site validation also
             broadcasts only the head (frozen-backbone head-only downstream — the server-side mirror of
             the client KeepOnlyVars / ReconstructFullModelForEval; FLIP#684 / #730).
+        best_model_metric (str | None): when set, inject a stock IntimeModelSelector keyed on this
+            validation metric so the best global model is saved alongside the final one (FLIP#673).
+        best_model_metric_minimize (bool): when True, negate the selector's key metric for loss-like
+            metrics where lower is better. Defaults to False (higher is better).
 
     Returns:
         Path: path to the server config file that was updated.
@@ -457,6 +492,13 @@ def configure_server(
         logger.info(
             f"Injected TrimBroadcastVars (train) + TrimEvalBroadcastVars (validate) data filters "
             f"(include_vars={aggregate_only_regex!r}) for app '{app_name}'"
+        )
+
+    if best_model_metric:
+        _inject_intime_model_selector(config, best_model_metric, best_model_metric_minimize)
+        logger.info(
+            f"Injected IntimeModelSelector (key_metric={best_model_metric!r}, "
+            f"negate_key_metric={best_model_metric_minimize}) for app '{app_name}'"
         )
 
     write_config(config, config_file)
@@ -617,5 +659,18 @@ def validate_config(config: dict) -> IOverridableConfig:
         except re.error as exc:
             raise ValueError(f"AGGREGATE_ONLY_REGEX is not a valid regex: {exc}") from exc
         validated.AGGREGATE_ONLY_REGEX = regex
+
+    best_model_metric = config.get("BEST_MODEL_METRIC")
+    if best_model_metric is not None:
+        if not isinstance(best_model_metric, str):
+            raise ValueError("BEST_MODEL_METRIC must be a string metric label")
+        validated.BEST_MODEL_METRIC = best_model_metric
+
+        minimize = config.get("BEST_MODEL_METRIC_MINIMIZE", False)
+        # Guard bool before int: in Python ``isinstance(True, int)`` is True, but we want to reject
+        # a stray 1/0 here so the config stays explicit.
+        if not isinstance(minimize, bool):
+            raise ValueError("BEST_MODEL_METRIC_MINIMIZE must be a boolean")
+        validated.BEST_MODEL_METRIC_MINIMIZE = minimize
 
     return validated

--- a/fl-services/nvflare/fl-api-base/fl_api/utils/prepare_config.py
+++ b/fl-services/nvflare/fl-api-base/fl_api/utils/prepare_config.py
@@ -662,8 +662,8 @@ def validate_config(config: dict) -> IOverridableConfig:
 
     best_model_metric = config.get("BEST_MODEL_METRIC")
     if best_model_metric is not None:
-        if not isinstance(best_model_metric, str):
-            raise ValueError("BEST_MODEL_METRIC must be a string metric label")
+        if not isinstance(best_model_metric, str) or not best_model_metric.strip():
+            raise ValueError("BEST_MODEL_METRIC must be a non-empty string metric label")
         validated.BEST_MODEL_METRIC = best_model_metric
 
         minimize = config.get("BEST_MODEL_METRIC_MINIMIZE", False)
@@ -672,5 +672,9 @@ def validate_config(config: dict) -> IOverridableConfig:
         if not isinstance(minimize, bool):
             raise ValueError("BEST_MODEL_METRIC_MINIMIZE must be a boolean")
         validated.BEST_MODEL_METRIC_MINIMIZE = minimize
+    elif "BEST_MODEL_METRIC_MINIMIZE" in config:
+        # BEST_MODEL_METRIC_MINIMIZE only has meaning alongside a selector metric — silently
+        # accepting it without BEST_MODEL_METRIC would let a user believe it took effect.
+        raise ValueError("BEST_MODEL_METRIC_MINIMIZE requires BEST_MODEL_METRIC to also be set")
 
     return validated

--- a/fl-services/nvflare/fl-api-base/fl_api/utils/schemas.py
+++ b/fl-services/nvflare/fl-api-base/fl_api/utils/schemas.py
@@ -125,6 +125,13 @@ class IOverridableConfig(BaseModel):
     # are sent — e.g. a frozen-backbone fine-tune sends just its head, avoiding the large-payload
     # uplink timeout (FLIP#684). Unset (default) = full-model update, unchanged behaviour.
     AGGREGATE_ONLY_REGEX: str | None = None
+    # Validation-metric label driving best-global-model selection. When set, a stock
+    # IntimeModelSelector is injected server-side so the best global model is saved alongside the
+    # final one (FLIP#673); the client trainer must report this metric on its returned FLModel.
+    # Unset (default) = no selector, only the final model is saved.
+    BEST_MODEL_METRIC: str | None = None
+    # Whether lower metric values are better (loss-like). Negates the selector's key metric.
+    BEST_MODEL_METRIC_MINIMIZE: bool = False
 
 
 class JobStatus(StrEnum):

--- a/fl-services/nvflare/fl-api-base/fl_api/utils/upload.py
+++ b/fl-services/nvflare/fl-api-base/fl_api/utils/upload.py
@@ -323,6 +323,8 @@ def upload_application(model_id: str, body: UploadAppRequest, upload_dir: str) -
                 aggregator,
                 aggregation_weights,
                 aggregate_only_regex=config.AGGREGATE_ONLY_REGEX,
+                best_model_metric=config.BEST_MODEL_METRIC,
+                best_model_metric_minimize=config.BEST_MODEL_METRIC_MINIMIZE,
             )
 
             # Configure the environment.json file if it exists.

--- a/fl-services/nvflare/fl-api-base/tests/utils/test_prepare_config.py
+++ b/fl-services/nvflare/fl-api-base/tests/utils/test_prepare_config.py
@@ -696,6 +696,98 @@ class TestConfigureServer:
         assert "flip.nvflare.components.TrimBroadcastVars" not in injected_paths
         assert "flip.nvflare.components.TrimEvalBroadcastVars" not in injected_paths
 
+    _SELECTOR_PATH = "nvflare.app_common.widgets.intime_model_selector.IntimeModelSelector"
+
+    def test_configure_server_injects_intime_model_selector(self, mock_isfile, mock_read_config, mock_write_config):
+        """With best_model_metric set, a stock IntimeModelSelector component keyed on that metric is
+        appended so the best global model is saved alongside the final one (FLIP#673). This is the
+        production mirror of FlipFedAvgRecipe(best_model_metric=...) — the fl-server wires the selector
+        at job-assembly from the app's config.json, the same way AGGREGATE_ONLY_REGEX wires filters."""
+        mock_read_config.return_value = self._minimal_server_config()
+
+        configure_server(
+            job_dir=MOCK_JOB_APP_DIR,
+            app_name=MOCK_APP_NAME,
+            global_rounds=3,
+            trusts=MOCK_APP_CLIENTS,
+            ignore_result_error=True,
+            aggregator="agg",
+            aggregation_weights=MOCK_AGGREGATION_WEIGHTS,
+            best_model_metric="VAL_DICE",
+        )
+
+        modified_config = mock_write_config.call_args[0][0]
+        selector = next(c for c in modified_config["components"] if c.get("path") == self._SELECTOR_PATH)
+        assert selector["args"]["key_metric"] == "VAL_DICE"
+        assert selector["args"]["negate_key_metric"] is False
+
+    def test_configure_server_intime_selector_negates_for_minimize(
+        self, mock_isfile, mock_read_config, mock_write_config
+    ):
+        """Loss-like metrics (lower is better) inject with negate_key_metric=True."""
+        mock_read_config.return_value = self._minimal_server_config()
+
+        configure_server(
+            job_dir=MOCK_JOB_APP_DIR,
+            app_name=MOCK_APP_NAME,
+            global_rounds=3,
+            trusts=MOCK_APP_CLIENTS,
+            ignore_result_error=True,
+            aggregator="agg",
+            aggregation_weights=MOCK_AGGREGATION_WEIGHTS,
+            best_model_metric="VAL_LOSS",
+            best_model_metric_minimize=True,
+        )
+
+        modified_config = mock_write_config.call_args[0][0]
+        selector = next(c for c in modified_config["components"] if c.get("path") == self._SELECTOR_PATH)
+        assert selector["args"]["negate_key_metric"] is True
+
+    def test_configure_server_no_best_metric_leaves_components_untouched(
+        self, mock_isfile, mock_read_config, mock_write_config
+    ):
+        """No best_model_metric → no selector injected, so no best checkpoint is ever saved
+        (unchanged behaviour for every job that doesn't opt in)."""
+        mock_read_config.return_value = self._minimal_server_config()
+
+        configure_server(
+            job_dir=MOCK_JOB_APP_DIR,
+            app_name=MOCK_APP_NAME,
+            global_rounds=3,
+            trusts=MOCK_APP_CLIENTS,
+            ignore_result_error=True,
+            aggregator="agg",
+            aggregation_weights=MOCK_AGGREGATION_WEIGHTS,
+        )
+
+        modified_config = mock_write_config.call_args[0][0]
+        assert not any(c.get("path") == self._SELECTOR_PATH for c in modified_config["components"])
+
+    def test_configure_server_intime_selector_idempotent(self, mock_isfile, mock_read_config, mock_write_config):
+        """A template that already carries an IntimeModelSelector (e.g. a recipe-exported job built
+        with best_model_metric) must not get a second one — two selectors would both drive
+        best-model saves off different accumulators."""
+        config = self._minimal_server_config()
+        config["components"].append(
+            {"id": "model_selector", "path": self._SELECTOR_PATH, "args": {"key_metric": "VAL_DICE"}}
+        )
+        mock_read_config.return_value = config
+
+        configure_server(
+            job_dir=MOCK_JOB_APP_DIR,
+            app_name=MOCK_APP_NAME,
+            global_rounds=3,
+            trusts=MOCK_APP_CLIENTS,
+            ignore_result_error=True,
+            aggregator="agg",
+            aggregation_weights=MOCK_AGGREGATION_WEIGHTS,
+            best_model_metric="VAL_DICE",
+        )
+
+        modified_config = mock_write_config.call_args[0][0]
+        selectors = [c for c in modified_config["components"] if c.get("path") == self._SELECTOR_PATH]
+        assert len(selectors) == 1
+
     def test_configure_server_file_not_found(self, mock_isfile):
         # Setup
         mock_isfile.return_value = False

--- a/fl-services/nvflare/fl-api-base/tests/utils/test_upload.py
+++ b/fl-services/nvflare/fl-api-base/tests/utils/test_upload.py
@@ -323,16 +323,40 @@ def test_validate_config_aggregate_only_regex_defaults_none():
 
 
 def test_validate_config_accepts_best_model_metric():
-    config = validate_config({"BEST_MODEL_METRIC": "VAL_DICE"})
+    config = validate_config({"BEST_MODEL_METRIC": "VAL_DICE", "GLOBAL_ROUNDS": 3})
     assert config.BEST_MODEL_METRIC == "VAL_DICE"
     # Minimize defaults False (higher-is-better) when only the metric is given.
     assert config.BEST_MODEL_METRIC_MINIMIZE is False
 
 
 def test_validate_config_best_model_metric_minimize():
-    config = validate_config({"BEST_MODEL_METRIC": "VAL_LOSS", "BEST_MODEL_METRIC_MINIMIZE": True})
+    config = validate_config({"BEST_MODEL_METRIC": "VAL_LOSS", "BEST_MODEL_METRIC_MINIMIZE": True, "GLOBAL_ROUNDS": 3})
     assert config.BEST_MODEL_METRIC == "VAL_LOSS"
     assert config.BEST_MODEL_METRIC_MINIMIZE is True
+
+
+def test_validate_config_strips_best_model_metric():
+    # A stray space in the JSON must not survive into the stored label, where it would silently
+    # never match the metric the trainer reports.
+    config = validate_config({"BEST_MODEL_METRIC": " VAL-F1-SCORE ", "GLOBAL_ROUNDS": 3})
+    assert config.BEST_MODEL_METRIC == "VAL-F1-SCORE"
+
+
+def test_validate_config_rejects_best_model_metric_without_global_rounds():
+    # GLOBAL_ROUNDS unset resolves to the platform default of 1, where the selector can never fire.
+    with pytest.raises(ValueError, match="BEST_MODEL_METRIC requires GLOBAL_ROUNDS >= 2"):
+        validate_config({"BEST_MODEL_METRIC": "VAL_DICE"})
+
+
+def test_validate_config_rejects_best_model_metric_with_single_round():
+    with pytest.raises(ValueError, match="BEST_MODEL_METRIC requires GLOBAL_ROUNDS >= 2"):
+        validate_config({"BEST_MODEL_METRIC": "VAL_DICE", "GLOBAL_ROUNDS": 1})
+
+
+def test_validate_config_rejects_best_model_metric_with_invalid_rounds():
+    # An out-of-range GLOBAL_ROUNDS is silently dropped and also resolves to the 1-round default.
+    with pytest.raises(ValueError, match="BEST_MODEL_METRIC requires GLOBAL_ROUNDS >= 2"):
+        validate_config({"BEST_MODEL_METRIC": "VAL_DICE", "GLOBAL_ROUNDS": 0})
 
 
 def test_validate_config_rejects_non_string_best_model_metric():

--- a/fl-services/nvflare/fl-api-base/tests/utils/test_upload.py
+++ b/fl-services/nvflare/fl-api-base/tests/utils/test_upload.py
@@ -322,6 +322,35 @@ def test_validate_config_aggregate_only_regex_defaults_none():
     assert validate_config({"LOCAL_ROUNDS": 3}).AGGREGATE_ONLY_REGEX is None
 
 
+def test_validate_config_accepts_best_model_metric():
+    config = validate_config({"BEST_MODEL_METRIC": "VAL_DICE"})
+    assert config.BEST_MODEL_METRIC == "VAL_DICE"
+    # Minimize defaults False (higher-is-better) when only the metric is given.
+    assert config.BEST_MODEL_METRIC_MINIMIZE is False
+
+
+def test_validate_config_best_model_metric_minimize():
+    config = validate_config({"BEST_MODEL_METRIC": "VAL_LOSS", "BEST_MODEL_METRIC_MINIMIZE": True})
+    assert config.BEST_MODEL_METRIC == "VAL_LOSS"
+    assert config.BEST_MODEL_METRIC_MINIMIZE is True
+
+
+def test_validate_config_rejects_non_string_best_model_metric():
+    with pytest.raises(ValueError, match="BEST_MODEL_METRIC must be a string"):
+        validate_config({"BEST_MODEL_METRIC": 123})
+
+
+def test_validate_config_rejects_non_bool_best_model_metric_minimize():
+    with pytest.raises(ValueError, match="BEST_MODEL_METRIC_MINIMIZE must be a boolean"):
+        validate_config({"BEST_MODEL_METRIC": "VAL_DICE", "BEST_MODEL_METRIC_MINIMIZE": "yes"})
+
+
+def test_validate_config_best_model_metric_defaults_none():
+    result = validate_config({"LOCAL_ROUNDS": 3})
+    assert result.BEST_MODEL_METRIC is None
+    assert result.BEST_MODEL_METRIC_MINIMIZE is False
+
+
 def test_validate_config_rejects_non_dict_weights():
     with pytest.raises(ValueError, match="AGGREGATION_WEIGHTS must be a dictionary"):
         validate_config({"AGGREGATION_WEIGHTS": ["client1"]})

--- a/fl-services/nvflare/fl-api-base/tests/utils/test_upload.py
+++ b/fl-services/nvflare/fl-api-base/tests/utils/test_upload.py
@@ -336,13 +336,28 @@ def test_validate_config_best_model_metric_minimize():
 
 
 def test_validate_config_rejects_non_string_best_model_metric():
-    with pytest.raises(ValueError, match="BEST_MODEL_METRIC must be a string"):
+    with pytest.raises(ValueError, match="BEST_MODEL_METRIC must be a non-empty string"):
         validate_config({"BEST_MODEL_METRIC": 123})
+
+
+def test_validate_config_rejects_empty_best_model_metric():
+    with pytest.raises(ValueError, match="BEST_MODEL_METRIC must be a non-empty string"):
+        validate_config({"BEST_MODEL_METRIC": ""})
+
+
+def test_validate_config_rejects_whitespace_only_best_model_metric():
+    with pytest.raises(ValueError, match="BEST_MODEL_METRIC must be a non-empty string"):
+        validate_config({"BEST_MODEL_METRIC": "   "})
 
 
 def test_validate_config_rejects_non_bool_best_model_metric_minimize():
     with pytest.raises(ValueError, match="BEST_MODEL_METRIC_MINIMIZE must be a boolean"):
         validate_config({"BEST_MODEL_METRIC": "VAL_DICE", "BEST_MODEL_METRIC_MINIMIZE": "yes"})
+
+
+def test_validate_config_rejects_best_model_metric_minimize_without_metric():
+    with pytest.raises(ValueError, match="BEST_MODEL_METRIC_MINIMIZE requires BEST_MODEL_METRIC"):
+        validate_config({"BEST_MODEL_METRIC_MINIMIZE": True})
 
 
 def test_validate_config_best_model_metric_defaults_none():

--- a/fl-tutorials/nvflare/image_classification/xray_classification_client_api/README.md
+++ b/fl-tutorials/nvflare/image_classification/xray_classification_client_api/README.md
@@ -32,6 +32,19 @@ Binary Cross-Entropy loss with masking of don't-care labels (`-1`). Validation r
 each local round inside the trainer (`VALIDATE_EVERY` in `config.json`). Cross-site model evaluation
 is handled by the server workflow — no `validator.py` needed.
 
+### Best-model selection
+
+`BEST_MODEL_METRIC` in `config.json` enables saving the best global model alongside the final one
+(`BEST_MODEL_METRIC_MINIMIZE: true` for loss-like metrics where lower is better). Each round the
+trainer evaluates the *received* global model on its validation split before training
+(`evaluate_global_model`) and reports the metrics on the returned `FLModel`; the server's stock
+`IntimeModelSelector` averages the chosen metric across clients and saves
+`best_FL_global_model.pt` whenever it improves. Valid labels are `VAL_LOSS`, per-lesion
+`VAL-<METRIC>-<lesion>` and macro `VAL-<METRIC>` (mean across lesions) for
+`F1-SCORE`/`PRECISION`/`RECALL` — the default is macro `VAL-F1-SCORE`. Remove both keys to skip
+selection (and the extra per-round validation pass); the results zip then contains only the final
+model. Round 0 is never selected (no aggregated model exists yet).
+
 ## FLIP-specific values
 
 `FLIP_PROJECT_ID` and `FLIP_QUERY` are read from environment variables (set stubs in `.env.app`).

--- a/fl-tutorials/nvflare/image_classification/xray_classification_client_api/README.md
+++ b/fl-tutorials/nvflare/image_classification/xray_classification_client_api/README.md
@@ -44,7 +44,10 @@ trainer evaluates the *received* global model on its validation split before tra
 `F1-SCORE`/`PRECISION`/`RECALL` — the default is macro `VAL-F1-SCORE`. Remove both keys to skip
 selection (and the extra per-round validation pass); the results zip then contains only the final
 model. Round 0 is never selected (no aggregated model exists yet), so `BEST_MODEL_METRIC` requires
-`GLOBAL_ROUNDS >= 2` in `config.json` — platform uploads reject the combination otherwise.
+`GLOBAL_ROUNDS >= 2` in `config.json` — platform uploads reject the combination otherwise. Note
+that the final model is never a selection candidate: the metric is evaluated on the global model
+each client *receives*, and the last round's aggregate is never sent back out, so `best` means
+best among the intermediate global models — the final model may actually outperform it.
 
 ## FLIP-specific values
 

--- a/fl-tutorials/nvflare/image_classification/xray_classification_client_api/README.md
+++ b/fl-tutorials/nvflare/image_classification/xray_classification_client_api/README.md
@@ -43,7 +43,8 @@ trainer evaluates the *received* global model on its validation split before tra
 `VAL-<METRIC>-<lesion>` and macro `VAL-<METRIC>` (mean across lesions) for
 `F1-SCORE`/`PRECISION`/`RECALL` — the default is macro `VAL-F1-SCORE`. Remove both keys to skip
 selection (and the extra per-round validation pass); the results zip then contains only the final
-model. Round 0 is never selected (no aggregated model exists yet).
+model. Round 0 is never selected (no aggregated model exists yet), so `BEST_MODEL_METRIC` requires
+`GLOBAL_ROUNDS >= 2` in `config.json` — platform uploads reject the combination otherwise.
 
 ## FLIP-specific values
 

--- a/fl-tutorials/nvflare/image_classification/xray_classification_client_api/app_files/config.json
+++ b/fl-tutorials/nvflare/image_classification/xray_classification_client_api/app_files/config.json
@@ -6,6 +6,8 @@
   "VAL_SPLIT": 0.2,
   "TEST_SPLIT": 0.2,
   "BATCH_SIZE": 8,
+  "BEST_MODEL_METRIC": "VAL-F1-SCORE",
+  "BEST_MODEL_METRIC_MINIMIZE": false,
   "LESIONS": {
     "0": "Effusion",
     "1": "Edema",

--- a/fl-tutorials/nvflare/image_classification/xray_classification_client_api/app_files/config.json
+++ b/fl-tutorials/nvflare/image_classification/xray_classification_client_api/app_files/config.json
@@ -1,6 +1,7 @@
 {
   "job_type": "standard_client_api",
   "LOCAL_ROUNDS": 3,
+  "GLOBAL_ROUNDS": 3,
   "LR_START": 0.001,
   "LR_END": 0.0001,
   "VAL_SPLIT": 0.2,

--- a/fl-tutorials/nvflare/image_classification/xray_classification_client_api/app_files/trainer.py
+++ b/fl-tutorials/nvflare/image_classification/xray_classification_client_api/app_files/trainer.py
@@ -321,6 +321,41 @@ def load_global_weights(model: torch.nn.Module, input_model: flare.FLModel) -> d
     return torch_weights
 
 
+def evaluate_global_model(
+    model: torch.nn.Module,
+    val_loader: DataLoader,
+    lesions: LesionDict,
+    device: torch.device,
+) -> dict[str, float]:
+    """Evaluate the received global model on the local validation split for best-model selection.
+
+    Must run BEFORE local training so the metrics describe the aggregated global model the server
+    just broadcast — they ride back on the returned ``FLModel`` (DXO meta ``INITIAL_METRICS``) and
+    drive the server-side ``IntimeModelSelector``, which averages them across clients and saves the
+    best global checkpoint on improvement.
+
+    Args:
+        model (torch.nn.Module): Model already loaded with the received global weights.
+        val_loader (DataLoader): Local validation split loader.
+        lesions (LesionDict): The trainable lesion classes.
+        device (torch.device): Torch device to evaluate on.
+
+    Returns:
+        dict[str, float]: Flat metrics — ``VAL_LOSS``, per-lesion ``VAL-<METRIC>-<lesion>`` and
+        macro ``VAL-<METRIC>`` (mean across lesions) for f1-score/precision/recall. NaNs are
+        mapped to 0.0 (as in ``_publish``) so a masked-out lesion cannot poison the server-side
+        cross-client average.
+    """
+    metrics = epoch_loop(model, val_loader, lesions, device, optimizer=None, epoch=0, phase="Val")
+    flat = {"VAL_LOSS": _safe_mean(metrics["loss"])}
+    for metric in ["f1-score", "precision", "recall"]:
+        per_lesion = [_safe_mean(metrics[metric][name]) for name in lesions.get_lesion_list()]
+        for name, value in zip(lesions.get_lesion_list(), per_lesion):
+            flat[f"VAL-{metric.upper()}-{name}"] = value
+        flat[f"VAL-{metric.upper()}"] = _safe_mean(per_lesion)
+    return {label: (0.0 if np.isnan(value) else float(value)) for label, value in flat.items()}
+
+
 def main() -> None:
     args = parse_args()
     config = load_config()
@@ -377,6 +412,13 @@ def main() -> None:
             original_weights = load_global_weights(model, input_model)
             global_round = input_model.current_round or 0
 
+            # Best-model selection (FLIP#673): evaluate the received global model before local
+            # training mutates it. Gated on BEST_MODEL_METRIC so runs without selection skip the
+            # extra validation pass.
+            global_val_metrics = None
+            if config.get("BEST_MODEL_METRIC"):
+                global_val_metrics = evaluate_global_model(model, val_loader, lesions, device)
+
             n_iterations = local_train(
                 model,
                 train_loader,
@@ -398,6 +440,10 @@ def main() -> None:
                 flare.FLModel(
                     params=diff,
                     params_type="DIFF",
+                    # metrics of the *received* global model (see evaluate_global_model) — the
+                    # framework treats params+metrics as "evaluation on the global model" and
+                    # carries them as INITIAL_METRICS for IntimeModelSelector.
+                    metrics=global_val_metrics,
                     meta={"NUM_STEPS_CURRENT_ROUND": n_iterations},
                 )
             )

--- a/fl-tutorials/nvflare/image_classification/xray_classification_client_api/job.py
+++ b/fl-tutorials/nvflare/image_classification/xray_classification_client_api/job.py
@@ -43,6 +43,7 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import json
 import os
 import sys
 from pathlib import Path
@@ -102,6 +103,11 @@ def main() -> None:
     project_id = os.environ.get("FLIP_PROJECT_ID", "")
     query = os.environ.get("FLIP_QUERY", "SELECT * FROM Table;")
 
+    # Best-model selection (FLIP#673): the config.json keys wire a server-side IntimeModelSelector
+    # keyed on the metric the trainer reports for the received global model (see
+    # trainer.evaluate_global_model). Absent keys → no selector, no best checkpoint.
+    config = json.loads((_APP_FILES_DIR / "config.json").read_text())
+
     recipe = FlipFedAvgRecipe(
         num_rounds=args.num_rounds,
         min_clients=args.n_clients,
@@ -109,6 +115,8 @@ def main() -> None:
         train_args="--project_id {project_id}",
         project_id=project_id,
         query=query,
+        best_model_metric=config.get("BEST_MODEL_METRIC"),
+        best_model_metric_minimize=config.get("BEST_MODEL_METRIC_MINIMIZE", False),
     )
 
     # Stage the user app files into the job's custom/ dirs *before* execute() — this is what makes the

--- a/flip-utils/README.md
+++ b/flip-utils/README.md
@@ -123,8 +123,11 @@ loss-like metrics, `BEST_MODEL_METRIC_MINIMIZE: true`) wires NVFLARE's stock
   fabricated from the final model otherwise.
 
 The metric label must be one the trainer reports (e.g. the client-API x-ray tutorial reports
-`VAL_LOSS`, per-lesion `VAL-<METRIC>-<lesion>` and macro `VAL-<METRIC>` labels). Currently wired
-for the `standard_client_api` recipe path (`FlipFedAvgRecipe(best_model_metric=...)`).
+`VAL_LOSS`, per-lesion `VAL-<METRIC>-<lesion>` and macro `VAL-<METRIC>` labels). Wired for both
+supported paths: the `standard_client_api` recipe (`FlipFedAvgRecipe(best_model_metric=...)`) and
+platform-submitted jobs, where fl-api-base's job-assembly step (`prepare_config.validate_config` /
+`configure_server`) reads `BEST_MODEL_METRIC` / `BEST_MODEL_METRIC_MINIMIZE` straight from the
+uploaded `config.json` and injects the same selector.
 
 ### Job Types
 

--- a/flip-utils/README.md
+++ b/flip-utils/README.md
@@ -104,8 +104,27 @@ User-provided files go in the job's `custom/` directory and are dynamically impo
 | `trainer.py` | Training logic — must export `FLIP_TRAINER` class |
 | `validator.py` | Validation logic — must export `FLIP_VALIDATOR` class |
 | `models.py` | Model definitions — must export `get_model()` function |
-| `config.json` | Hyperparameters — must include `LOCAL_ROUNDS` and `LEARNING_RATE` |
+| `config.json` | Hyperparameters — must include `LOCAL_ROUNDS` and `LEARNING_RATE`; optional `BEST_MODEL_METRIC` / `BEST_MODEL_METRIC_MINIMIZE` enable best-model selection (see below) |
 | `transforms.py` | Data transforms (optional) |
+
+### Best-Model Selection (optional)
+
+By default only the final aggregated model is saved. Setting `BEST_MODEL_METRIC` (and, for
+loss-like metrics, `BEST_MODEL_METRIC_MINIMIZE: true`) wires NVFLARE's stock
+`IntimeModelSelector` into the job so the best global model is saved too:
+
+- Each round, clients evaluate the **received global model** on their local validation split
+  *before* training and report the metrics via `FLModel(metrics={...})` — so the selection metric
+  measures exactly the checkpoint being considered.
+- The selector averages the chosen metric across clients and, on improvement, has the persistor
+  save `best_FL_global_model.pt` next to `FL_global_model.pt` — same file format as the final
+  model. Round 0 is skipped (no aggregated model exists yet).
+- The results zip contains the best model only when selection ran and saved one; no best file is
+  fabricated from the final model otherwise.
+
+The metric label must be one the trainer reports (e.g. the client-API x-ray tutorial reports
+`VAL_LOSS`, per-lesion `VAL-<METRIC>-<lesion>` and macro `VAL-<METRIC>` labels). Currently wired
+for the `standard_client_api` recipe path (`FlipFedAvgRecipe(best_model_metric=...)`).
 
 ### Job Types
 

--- a/flip-utils/README.md
+++ b/flip-utils/README.md
@@ -120,6 +120,11 @@ loss-like metrics, `BEST_MODEL_METRIC_MINIMIZE: true`) wires NVFLARE's stock
   save `best_FL_global_model.pt` next to `FL_global_model.pt` — same file format as the final
   model. Round 0 is skipped (no aggregated model exists yet), so selection needs
   `GLOBAL_ROUNDS >= 2` — a single-round job can never save a best model.
+- The **final model itself is never a selection candidate**: metrics are evaluated on received
+  global models before training, and the last round's aggregate is never re-broadcast, so there
+  is no post-last-round evaluation. "Best" therefore means best among the intermediate global
+  models — the final model may in fact outperform the saved best, in which case the two files
+  differ even though the final is the better checkpoint.
 - The results zip contains the best model only when selection ran and saved one; no best file is
   fabricated from the final model otherwise.
 

--- a/flip-utils/README.md
+++ b/flip-utils/README.md
@@ -118,7 +118,8 @@ loss-like metrics, `BEST_MODEL_METRIC_MINIMIZE: true`) wires NVFLARE's stock
   measures exactly the checkpoint being considered.
 - The selector averages the chosen metric across clients and, on improvement, has the persistor
   save `best_FL_global_model.pt` next to `FL_global_model.pt` — same file format as the final
-  model. Round 0 is skipped (no aggregated model exists yet).
+  model. Round 0 is skipped (no aggregated model exists yet), so selection needs
+  `GLOBAL_ROUNDS >= 2` — a single-round job can never save a best model.
 - The results zip contains the best model only when selection ran and saved one; no best file is
   fabricated from the final model otherwise.
 
@@ -127,7 +128,9 @@ The metric label must be one the trainer reports (e.g. the client-API x-ray tuto
 supported paths: the `standard_client_api` recipe (`FlipFedAvgRecipe(best_model_metric=...)`) and
 platform-submitted jobs, where fl-api-base's job-assembly step (`prepare_config.validate_config` /
 `configure_server`) reads `BEST_MODEL_METRIC` / `BEST_MODEL_METRIC_MINIMIZE` straight from the
-uploaded `config.json` and injects the same selector.
+uploaded `config.json` and injects the same selector. On the platform path, a `config.json` that
+sets `BEST_MODEL_METRIC` without an explicit `GLOBAL_ROUNDS >= 2` is rejected at upload (the
+platform defaults to a single round, where selection could never fire).
 
 ### Job Types
 

--- a/flip-utils/flip/nvflare/components/persist_and_cleanup.py
+++ b/flip-utils/flip/nvflare/components/persist_and_cleanup.py
@@ -17,7 +17,7 @@ from pathlib import Path
 
 from nvflare.apis.fl_component import FLComponent
 from nvflare.apis.fl_context import FLContext
-from nvflare.app_common.app_constant import AppConstants
+from nvflare.app_common.app_constant import AppConstants, DefaultCheckpointFileName
 from nvflare.app_opt.pt.file_model_persistor import PTFileModelPersistor
 
 from flip import FLIP
@@ -134,6 +134,17 @@ class PersistToS3AndCleanup(FLComponent):
             if os.path.isfile(fl_global_model_filepath):
                 self.log_info(fl_ctx, f"Found global model: {fl_global_model_filepath}")
                 shutil.move(fl_global_model_filepath, run_dir)
+
+            # Move the best global model too, when best-model selection saved one (FLIP#673). The
+            # persistor writes it next to the final model on GLOBAL_BEST_MODEL_AVAILABLE (fired by
+            # IntimeModelSelector). Absent the selector no file exists and none is fabricated — a
+            # "best" artefact in the results must mean a selection actually happened.
+            fl_best_model_filepath = os.path.join(
+                os.path.dirname(fl_global_model_filepath), DefaultCheckpointFileName.BEST_GLOBAL_MODEL
+            )
+            if os.path.isfile(fl_best_model_filepath):
+                self.log_info(fl_ctx, f"Found best global model: {fl_best_model_filepath}")
+                shutil.move(fl_best_model_filepath, run_dir)
 
             # For certain workflows (e.g., diffusion_model), also move trainer.py and validator.py
             trainer_path = os.path.join(app_server_path, "custom", "trainer.py")

--- a/flip-utils/flip/nvflare/recipes/flip_fedavg_recipe.py
+++ b/flip-utils/flip/nvflare/recipes/flip_fedavg_recipe.py
@@ -57,6 +57,7 @@ from nvflare.apis.dxo import DataKind
 from nvflare.app_common.aggregators import InTimeAccumulateWeightedAggregator
 from nvflare.app_common.executors.in_process_client_api_executor import InProcessClientAPIExecutor
 from nvflare.app_common.shareablegenerators.full_model_shareable_generator import FullModelShareableGenerator
+from nvflare.app_common.widgets.intime_model_selector import IntimeModelSelector
 from nvflare.app_common.workflows.cross_site_model_eval import CrossSiteModelEval
 from nvflare.app_common.workflows.global_model_eval import GlobalModelEval
 from nvflare.job_config.defs import FilterType
@@ -146,6 +147,16 @@ class FlipFedAvgRecipe(Recipe):
             head-only broadcast to cross-site validation, superseding the recipe's train-only
             ``ReconstructFullModel`` (FLIP#730/#733). This arg stands alone only where that deploy step
             doesn't run (SimEnv/PocEnv), so the ``validate`` broadcast stays full-model there.
+        best_model_metric: when set, wire stock ``IntimeModelSelector`` keyed on this metric so the
+            best global model is saved alongside the final one (FLIP#673). Clients must report the
+            metric — evaluated on the *received* global model, before local training — via
+            ``FLModel(metrics={...})``; the selector weight-averages it across clients each round
+            and fires ``GLOBAL_BEST_MODEL_AVAILABLE`` on improvement, which the persistor answers
+            by saving ``best_FL_global_model.pt`` in the same format as the final model. Round 0 is
+            skipped (there is no aggregated model yet). Empty/None (default) wires no selector and
+            no best model is saved.
+        best_model_metric_minimize: True negates the key metric for selection, for loss-like
+            metrics where lower is better. Defaults to False (higher is better).
     """
 
     def __init__(
@@ -169,6 +180,8 @@ class FlipFedAvgRecipe(Recipe):
         params_exchange_format: str = "numpy",
         params_transfer_type: str = "FULL",
         aggregate_only_regex: str = "",
+        best_model_metric: str | None = None,
+        best_model_metric_minimize: bool = False,
     ):
         self.num_rounds = num_rounds
         self.min_clients = min_clients
@@ -188,6 +201,8 @@ class FlipFedAvgRecipe(Recipe):
         self.params_exchange_format = params_exchange_format
         self.params_transfer_type = params_transfer_type
         self.aggregate_only_regex = aggregate_only_regex
+        self.best_model_metric = best_model_metric
+        self.best_model_metric_minimize = best_model_metric_minimize
 
         super().__init__(self._build_fed_job())
 
@@ -222,6 +237,20 @@ class FlipFedAvgRecipe(Recipe):
         job.to_server(ValidationJsonGenerator(), id="json_generator")
         job.to_server(ServerEventHandler(), id="flip_server_event_handler")
         job.to_server(PersistToS3AndCleanup(persistor_id=persistor_id), id="persist_and_cleanup")
+
+        # Server: best-global-model selection (FLIP#673). Stock IntimeModelSelector averages the
+        # client-reported key metric (DXO meta INITIAL_METRICS, i.e. FLModel.metrics — evaluated by
+        # each client on the received global model before local training) and fires
+        # GLOBAL_BEST_MODEL_AVAILABLE on improvement; the persistor saves best_FL_global_model.pt.
+        # No selector wired when unset → no best checkpoint is ever written.
+        if self.best_model_metric:
+            job.to_server(
+                IntimeModelSelector(
+                    key_metric=self.best_model_metric,
+                    negate_key_metric=self.best_model_metric_minimize,
+                ),
+                id="model_selector",
+            )
 
         # Server workflows: init → train → model evaluation → post-validation cleanup.
         job.to_server(InitTraining(min_clients=self.min_clients))

--- a/flip-utils/flip/nvflare/recipes/flip_fedavg_recipe.py
+++ b/flip-utils/flip/nvflare/recipes/flip_fedavg_recipe.py
@@ -150,11 +150,16 @@ class FlipFedAvgRecipe(Recipe):
         best_model_metric: when set, wire stock ``IntimeModelSelector`` keyed on this metric so the
             best global model is saved alongside the final one (FLIP#673). Clients must report the
             metric — evaluated on the *received* global model, before local training — via
-            ``FLModel(metrics={...})``; the selector weight-averages it across clients each round
-            and fires ``GLOBAL_BEST_MODEL_AVAILABLE`` on improvement, which the persistor answers
-            by saving ``best_FL_global_model.pt`` in the same format as the final model. Round 0 is
-            skipped (there is no aggregated model yet). Empty/None (default) wires no selector and
-            no best model is saved.
+            ``FLModel(metrics={...})``; the selector averages it across clients each round (an
+            unweighted mean — stock defaults: no ``aggregation_weights``, ``weigh_by_local_iter``
+            off) and fires ``GLOBAL_BEST_MODEL_AVAILABLE`` on improvement, which the persistor
+            answers by saving ``best_FL_global_model.pt`` in the same format as the final model.
+            Round 0 is skipped (there is no aggregated model yet), so this requires
+            ``num_rounds >= 2`` — a single-round job raises ``ValueError`` at construction,
+            mirroring the fl-api's ``BEST_MODEL_METRIC`` upload guard. The *final* aggregated
+            model is never re-broadcast and therefore never evaluated for selection: "best" means
+            best among the intermediate global models, and the final model may in fact outperform
+            it. Empty/None (default) wires no selector and no best model is saved.
         best_model_metric_minimize: True negates the key metric for selection, for loss-like
             metrics where lower is better. Defaults to False (higher is better).
     """
@@ -183,6 +188,15 @@ class FlipFedAvgRecipe(Recipe):
         best_model_metric: str | None = None,
         best_model_metric_minimize: bool = False,
     ):
+        # IntimeModelSelector always skips round 0, so a single-round job could never fire it: the
+        # job would run fine but silently never save a best model. Fail fast instead, mirroring
+        # fl-api's validate_config guard on the platform path.
+        if best_model_metric and num_rounds <= 1:
+            raise ValueError(
+                "best_model_metric requires num_rounds >= 2: the best-model selector skips "
+                "round 0, so a single-round job can never save a best model"
+            )
+
         self.num_rounds = num_rounds
         self.min_clients = min_clients
         self.train_script = train_script if train_script.startswith("custom/") else f"custom/{train_script}"

--- a/flip-utils/tests/unit/nvflare/components/test_persist_and_cleanup.py
+++ b/flip-utils/tests/unit/nvflare/components/test_persist_and_cleanup.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, Mock, call, patch
 
 import pytest
+from nvflare.app_common.app_constant import DefaultCheckpointFileName
 from nvflare.app_opt.pt.file_model_persistor import PTFileModelPersistor
 
 from flip.constants import PTConstants
@@ -190,7 +191,9 @@ class TestPersistToS3AndCleanup:
         fabricated: shipping a copy of the final model as "best" would imply a selection happened.
         """
         mock_constants.LOCAL_DEV = False
-        best_model_path = os.path.join("/mock/workspace", "app_server", "model", "best_FL_global_model.pt")
+        best_model_path = os.path.join(
+            "/mock/workspace", "app_server", "model", DefaultCheckpointFileName.BEST_GLOBAL_MODEL
+        )
 
         flip = MagicMock()
         component = PersistToS3AndCleanup(model_id="123e4567-e89b-12d3-a456-426614174000", flip=flip)

--- a/flip-utils/tests/unit/nvflare/components/test_persist_and_cleanup.py
+++ b/flip-utils/tests/unit/nvflare/components/test_persist_and_cleanup.py
@@ -170,10 +170,44 @@ class TestPersistToS3AndCleanup:
 
         flip.upload_results_to_s3.assert_called_once()
 
-        # Should move global model, trainer.py, and validator.py if they exist
-        assert mock_move.call_count == 3
+        # Should move global model, best model, trainer.py, and validator.py if they exist
+        assert mock_move.call_count == 4
         # Two dirs are pruned before zipping: app_server + cross_site_val/model_shareables.
         assert mock_rmtree.call_count == 2
+
+    @patch("flip.nvflare.components.persist_and_cleanup.FlipConstants")
+    @patch("shutil.move")
+    @patch("shutil.rmtree")
+    @patch("os.path.isfile")
+    @patch("os.path.isdir")
+    def test_upload_results_ships_no_best_model_when_none_was_saved(
+        self, mock_isdir, mock_isfile, mock_rmtree, mock_move, mock_constants
+    ):
+        """A best model appears in the results only when selection actually saved one.
+
+        The best checkpoint is written by the persistor on GLOBAL_BEST_MODEL_AVAILABLE (fired by
+        IntimeModelSelector) — when no selector was wired, no best file exists, and none must be
+        fabricated: shipping a copy of the final model as "best" would imply a selection happened.
+        """
+        mock_constants.LOCAL_DEV = False
+        best_model_path = os.path.join("/mock/workspace", "app_server", "model", "best_FL_global_model.pt")
+
+        flip = MagicMock()
+        component = PersistToS3AndCleanup(model_id="123e4567-e89b-12d3-a456-426614174000", flip=flip)
+
+        fl_ctx = MagicMock()
+        fl_ctx.get_peer_context.return_value = None
+        fl_ctx.get_job_id.return_value = "job-123"
+        fl_ctx.get_engine.return_value.get_workspace.return_value.get_run_dir.return_value = "/mock/workspace"
+
+        mock_isfile.side_effect = lambda p: p != best_model_path
+        mock_isdir.return_value = True
+
+        component.upload_results_to_s3_bucket(fl_ctx)
+
+        assert mock_move.call_count == 3
+        assert not any("best" in str(c.args[0]) for c in mock_move.call_args_list)
+        flip.upload_results_to_s3.assert_called_once()
 
     @patch("flip.nvflare.components.persist_and_cleanup.FlipConstants")
     @patch("shutil.move")

--- a/flip-utils/tests/unit/nvflare/recipes/test_flip_fedavg_recipe.py
+++ b/flip-utils/tests/unit/nvflare/recipes/test_flip_fedavg_recipe.py
@@ -244,3 +244,45 @@ class TestFlipFedAvgRecipeAggregateOnly:
 
         assert _filter_args(client_cfg, "task_result_filters", "KeepOnlyVars").get("include_vars") == "omni_heads"
         assert _filter_args(server_cfg, "task_data_filters", "TrimBroadcastVars").get("include_vars") == "omni_heads"
+
+
+class TestFlipFedAvgRecipeBestModel:
+    """Optional best-global-model selection via stock IntimeModelSelector (FLIP#673)."""
+
+    def _export_server_cfg(self, tmp_path: Path, **kwargs) -> dict:
+        import torch
+
+        sys.modules["models"].get_model = lambda: torch.nn.Linear(1, 1)
+        try:
+            recipe = FlipFedAvgRecipe(**kwargs)
+            recipe.export(tmp_path)
+            base = tmp_path / recipe.job.name / "app" / "config"
+            return json.loads((base / "config_fed_server.json").read_text())
+        finally:
+            sys.modules["models"].get_model = lambda: object()
+
+    def test_default_wires_no_model_selector(self, tmp_path: Path):
+        """Without best_model_metric no selector is wired, so no best checkpoint is ever saved."""
+        server_cfg = self._export_server_cfg(tmp_path)
+        assert not any("IntimeModelSelector" in c.get("path", "") for c in server_cfg["components"])
+
+    def test_best_model_metric_wires_stock_intime_model_selector(self, tmp_path: Path):
+        """best_model_metric wires stock IntimeModelSelector keyed on that metric.
+
+        The selector averages the client-reported metric (evaluated on the received global model,
+        carried in DXO meta INITIAL_METRICS from FLModel.metrics) across clients each round and
+        fires GLOBAL_BEST_MODEL_AVAILABLE on improvement; the persistor answers by saving
+        best_FL_global_model.pt alongside the final model, in the same persistence format.
+        """
+        server_cfg = self._export_server_cfg(tmp_path, best_model_metric="VAL_DICE")
+        selector = next(c for c in server_cfg["components"] if "IntimeModelSelector" in c.get("path", ""))
+        assert selector["path"] == "nvflare.app_common.widgets.intime_model_selector.IntimeModelSelector"
+        assert selector["args"]["key_metric"] == "VAL_DICE"
+        # FedJob export omits default-valued args; absent means stock's default (False).
+        assert selector["args"].get("negate_key_metric", False) is False
+
+    def test_best_model_metric_minimize_negates_key_metric(self, tmp_path: Path):
+        """Loss-like metrics (lower is better) export with negate_key_metric=True."""
+        server_cfg = self._export_server_cfg(tmp_path, best_model_metric="VAL_LOSS", best_model_metric_minimize=True)
+        selector = next(c for c in server_cfg["components"] if "IntimeModelSelector" in c.get("path", ""))
+        assert selector["args"]["negate_key_metric"] is True

--- a/flip-utils/tests/unit/nvflare/recipes/test_flip_fedavg_recipe.py
+++ b/flip-utils/tests/unit/nvflare/recipes/test_flip_fedavg_recipe.py
@@ -14,6 +14,8 @@ import sys
 import types
 from pathlib import Path
 
+import pytest
+
 # PTFileModelPersistor's model={"path": "models.get_model"} triggers an import of the user's
 # ``models`` module at construction. In a real job that module lives in custom/; under unit
 # tests we inject a stub before importing the recipe.
@@ -286,3 +288,17 @@ class TestFlipFedAvgRecipeBestModel:
         server_cfg = self._export_server_cfg(tmp_path, best_model_metric="VAL_LOSS", best_model_metric_minimize=True)
         selector = next(c for c in server_cfg["components"] if "IntimeModelSelector" in c.get("path", ""))
         assert selector["args"]["negate_key_metric"] is True
+
+    def test_best_model_metric_with_single_round_raises(self):
+        """best_model_metric on a 1-round job fails fast instead of silently never saving a best model.
+
+        IntimeModelSelector always skips round 0, so a single-round job can never fire it —
+        mirrors the fl-api validate_config guard on the platform path.
+        """
+        with pytest.raises(ValueError, match="num_rounds >= 2"):
+            FlipFedAvgRecipe(num_rounds=1, best_model_metric="VAL_DICE")
+
+    def test_best_model_metric_with_two_rounds_constructs(self, tmp_path: Path):
+        """num_rounds=2 is the minimum where selection can fire; the selector is wired normally."""
+        server_cfg = self._export_server_cfg(tmp_path, num_rounds=2, best_model_metric="VAL_DICE")
+        assert any("IntimeModelSelector" in c.get("path", "") for c in server_cfg["components"])


### PR DESCRIPTION
<!--
Copyright (c) 2026 Guy's and St Thomas' NHS Foundation Trust & King's College London
Licensed under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at
    http://www.apache.org/licenses/LICENSE-2.0
Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
-->

# Description

Saves the **best global model** alongside the final one on NVFLARE jobs, using NVFLARE's built-in machinery end to end — an alternative to the hand-rolled controller approach in #718 (no `ScatterAndGather` changes at all).

**How it works:**

- `FlipFedAvgRecipe` grows `best_model_metric` / `best_model_metric_minimize`. When set, it wires stock **`IntimeModelSelector`** keyed on that metric (`negate_key_metric` handles loss-like metrics where lower is better). Unset → no selector, no best checkpoint, zero behaviour change.
- Clients evaluate the **received global model** on their local validation split *before* local training and report the metrics via `FLModel(metrics=...)` (carried as DXO meta `INITIAL_METRICS`). The selection metric therefore measures exactly the checkpoint being considered — not the client-local post-training models.
- The selector **averages the metric across clients** each round (no single client dictates selection) and fires `GLOBAL_BEST_MODEL_AVAILABLE` on improvement; the persistor saves `best_FL_global_model.pt` next to `FL_global_model.pt`, in the **same persistence format** (`{model, train_conf}`). Round 0 is skipped (no aggregated model exists yet).
- `PersistToS3AndCleanup` ships the best model in the results zip when one was saved. Nothing is fabricated from the final model otherwise — a "best" artefact in the results always means a selection actually happened.
- The `xray_classification_client_api` tutorial wires the user-facing contract: `BEST_MODEL_METRIC` / `BEST_MODEL_METRIC_MINIMIZE` in `config.json` → `job.py` → recipe, and the trainer reports `VAL_LOSS`, per-lesion `VAL-<METRIC>-<lesion>` and macro `VAL-<METRIC>` labels (default: macro `VAL-F1-SCORE`).

**Production path (fl-api job assembly):** `prepare_config` now injects the stock `IntimeModelSelector` into a deployed job's server config from the app's `config.json` `BEST_MODEL_METRIC` keys, mirroring how `AGGREGATE_ONLY_REGEX` injects head-only filters — so the feature works for jobs submitted through the platform, not just recipe/SimEnv runs. `validate_config` validates the keys (stored stripped) and rejects a config that sets `BEST_MODEL_METRIC` with an effective `GLOBAL_ROUNDS` <= 1 — the platform default when the key is unset — since the selector skips round 0 and could never fire on a single-round job; injection is idempotent and a no-op when unset. The uploaded client trainer must report the metric on its returned `FLModel` for selection to fire (documented; dormant otherwise).

## Linked Issues

Part of #673 (parent issue) — this PR is the NVFLARE half; the Flower half is #815.
Alternative implementation to #718.

Fixes #814

## Checklist

- [x] Follows the project's coding conventions and style guide
- [x] Updates documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Type of Change

- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [x] In-line docstrings updated.
- [ ] Documentation updated, tested `make -C docs/ docs`.

## Testing

- [x] Quick tests passed locally: full `flip-utils` suite (590) + full `fl-api-base` suite (141), ruff + mypy clean on both. New unit tests cover the recipe selector wiring/negation, the best-model shipping / no-fabrication paths in `PersistToS3AndCleanup`, and the fl-api `validate_config` + `configure_server` injection (wiring, negation, idempotency, no-op-when-unset) — all watched failing first.
- [x] End-to-end on the NVFLARE simulator (2 clients, 3 rounds, GPU) via `job.py --export` + `nvflare simulator`: round 0 skipped; both clients' metrics averaged per round (`validation metric 0.0 → new best at round 1`, `1.0 → new best at round 2`); `best_FL_global_model.pt` and `FL_global_model.pt` both in the results dir with identical `{model, train_conf}` structure and all 727 tensors differing (a genuinely distinct earlier checkpoint, not a copy).
- [x] Production injection verified against the real `standard_client_api` server template: selector lands with the right args next to the existing `ScatterAndGather` + `PersistToS3AndCleanup`, idempotent on re-run, no-op when unset.
- [x] Review round (garciadias): `validate_config` now fails fast on `BEST_MODEL_METRIC` with effective `GLOBAL_ROUNDS` <= 1 and stores the metric label stripped — unit tests cover unset/=1/out-of-range rounds and whitespace-padded labels (watched failing first); full `fl-api-base` gate green (ruff + mypy + 148 tests).
- [x] **Live platform e2e smoke** (NVFLARE, both trusts GSTT+KCH, branch-built `:dev` FL images): a job submitted through the platform had the fl-api inject `IntimeModelSelector (key_metric='VAL-F1-SCORE')` into the assembled server config (confirmed in the live fl-api log); the fl-server then averaged the metric across both trusts each round (round 1: Trust_1=0.867, Trust_2=0.794 → 0.830; round 2: 0.955 / 0.952 → 0.953) and saved on improvement; the downloaded results zip contained `best_FL_global_model.pt` alongside `FL_global_model.pt` — identical `{model, train_conf}` format, all 727 tensors differing (best = the higher-scoring earlier aggregate, not a copy of the final). Also caught that the tutorial `config.json` needed `GLOBAL_ROUNDS` (a 1-round job can never fire the selector), now fixed.
- [x] Review round (garciadias + virginiafdez): `FlipFedAvgRecipe` now raises on `best_model_metric` with `num_rounds <= 1` (mirroring the fl-api guard; unit test watched failing first) so recipe/SimEnv callers get the same fail-fast as platform uploads; READMEs + docstring document that the final model is never a selection candidate (no post-last-round evaluation, so the final may outperform the saved best); docstring corrected to describe the cross-client metric average as an unweighted mean. flip-utils gate green (ruff + 592 tests).

## Additional Notes

Why not extend #718's approach: the controller-side implementation compares metrics computed on client-local post-training models against the *next* aggregate (semantic mismatch), keeps last-writer-wins per round instead of averaging, and `torch.save`s a raw `ModelLearnable` so the best and final files have different internal formats. The `VAL-F1-SCORE` default in #718's config also matched no published label (labels are per-lesion there), so its best file was always the fallback copy of the final model. The macro labels added here make it a real metric. Full comparison is in the review on #718.



## Acceptance Criteria

*Imported from issue #814*

- [x] Opt-in via the app's `config.json` (`BEST_MODEL_METRIC`, `BEST_MODEL_METRIC_MINIMIZE`); unset means no
  behaviour change and no fabricated "best" artefact in the results.
- [x] The selection metric measures the aggregated global checkpoint under consideration (not client-local
  post-training models), aggregated across clients so no single site dictates selection.
- [x] `best_FL_global_model.pt` is saved next to `FL_global_model.pt` in the same persistence format, and is
  included in the results zip only when a selection actually happened.
- [x] Works both for recipe/SimEnv runs (`FlipFedAvgRecipe`) and for jobs assembled by the fl-api
  (`prepare_config` injection from `config.json`).
- [x] A tutorial demonstrates the user-facing contract end to end (metric reporting from the trainer through
  to the best-model file in the downloaded results).


