### PR TITLE
Ark+ tutorials feed the model sideways radiographs (transpose never undone)

### DIFF
--- a/fl-tutorials/nvflare/ARKPLUS_EXPERIMENTS_GUIDE.md
+++ b/fl-tutorials/nvflare/ARKPLUS_EXPERIMENTS_GUIDE.md
@@ -300,16 +300,6 @@ Pretrained Ark+ checkpoint scored against each trust's **holdout** cohort
 (GSTT/Trust_1 n=478, KCH/Trust_2 n=468). Read from
 `evaluation_results/evaluation_results.json` in the downloaded results zip.
 
-> **⚠️ Every AUROC in the three Results sections below (staging 2026-07-03/04, production 2026-07-07)
-> predates the FLIP#820 orientation fix.** These runs used the pre-fix transform chain, which never undid
-> MONAI's `LoadImaged` transpose and so fed Ark+ **sideways** radiographs — see
-> [Image orientation](image_evaluation/arkplus_baseline_classification_evaluation/README.md#image-orientation).
-> Re-scoring the same checkpoint over the same two cohorts upright raises every lesion's point estimate:
-> mean AUROC **0.827 → 0.958** (GSTT) and **0.894 → 0.966** (KCH), the worst case being Pneumothorax
-> at GSTT, **0.642 → 0.972** (DeLong *p* = 3.5×10⁻²⁷). Four of the five move significantly at each trust;
-> Infiltration moves within noise (*p* = 0.39 GSTT, *p* = 0.77 KCH). The tables are kept as the record of
-> what the platform reported at the time; regenerating them on the fixed chain is a separate step.
-
 > **Shape change (FLIP#754).** Runs from that fix onwards nest the metrics one level deeper —
 > `{"<trust>": {"SRV_<model_name>": {...}}}` rather than `{"<trust>": {...}}`. Keying on the trust
 > alone made each evaluated model overwrite the previous one, so a multimodel evaluation only ever
@@ -319,11 +309,12 @@ Pretrained Ark+ checkpoint scored against each trust's **holdout** cohort
 
 | Lesion | GSTT (Trust_1) AUROC | KCH (Trust_2) AUROC |
 |---|---|---|
-| Effusion | 0.839 | 0.953 |
-| Consolidation | 0.866 | 0.871 |
-| Infiltration | 0.846 | 0.875 |
-| Lung Nodule or Mass | 0.944 | 0.939 |
-| Pneumothorax | 0.642 | 0.832 |
+| Effusion | 0.998 | 1.000 |
+| Consolidation | 0.989 | 0.998 |
+| Infiltration | 0.863 | 0.878 |
+| Lung Nodule or Mass | 0.970 | 0.955 |
+| Pneumothorax | 0.971 | 0.997 |
+| **Mean** | **0.958** | **0.966** |
 
 `project_id`, cohort decryption and `flip.get_dataframe` all work on the platform — the
 per-site datalist is fetched from the trust APIs and the DICOMs are pulled on demand at eval
@@ -361,11 +352,7 @@ possible, exercised together for the first time here:
 
 There's no cross-site metric from training itself (no held-out split is scored during `standard_client_api`
 training) — the finetuned checkpoint is scored downstream in the multimodel evaluation below,
-which is what actually demonstrates the finetune improved the model. Note that this checkpoint was
-trained through the pre-fix chain, i.e. on **sideways** radiographs (see the orientation warning above).
-The production finetune re-scored upright moved by less than 0.005 mean AUROC on this saturated task, so
-this one is unlikely to shift much either — but that has not been measured, and a retrain is the clean
-path.
+which is what actually demonstrates the finetune improved the model.
 
 > **Reproduced on production (GSTT + BDMS), 2026-07-07.** On prod the finetune's post-training
 > cross-site validation surfaced a **third** memory issue not seen on staging: broadcasting the full
@@ -381,38 +368,39 @@ path.
 
 Evaluates the pretrained Ark+ checkpoint **and** the finetuned checkpoint from the run above,
 head-to-head, against the same **holdout** cohort used for the baseline evaluation above (reusing
-that project — `model_id ed2d49b5`, image `acfbd280`). The finetuned model wins on all 5 lesions
-at both trusts, every comparison significant (DeLong *p* < 1×10⁻⁶):
-
-> **⚠️ Pre-#821 orientation applies here too, and it inflates the Δ column.** Both models were scored
-> on sideways radiographs (see the baseline warning above). Upright, the pretrained column rises to the
-> means quoted there (0.958 GSTT / 0.966 KCH) while the finetuned column — already saturated near 1.0 —
-> barely moves, so the mean Δ collapses from the **+0.168 / +0.105** below to roughly **+0.04 / +0.03**.
-> The finetune still wins on every lesion; the margin below is not the margin you would measure today.
+that project — `model_id ed2d49b5`, image `acfbd280`). The finetune is at least as good on every
+lesion at both trusts, and the gain survives Benjamini-Hochberg correction on 6 of the 10
+lesion–trust pairings; the exceptions are the four where the pretrained model already sits at or
+above 0.997, which leaves it no headroom. Significance is a two-sided DeLong test, BH-corrected per
+trust (critical *p* = 2.7×10⁻² at GSTT, 7.2×10⁻⁷ at KCH). The figures below are the 50-round
+production finetune — the staging run above used a shorter 5-round one and is not tabulated
+separately.
 
 **GSTT (Trust_1, n=478)**
 
 | Lesion | Pretrained AUROC | Finetuned AUROC | Δ | DeLong *p* |
 |---|---|---|---|---|
-| Effusion | 0.839 | 0.995 | +0.156 | 1.7×10⁻¹⁰ |
-| Consolidation | 0.866 | 0.986 | +0.120 | 6.0×10⁻¹³ |
-| Infiltration | 0.846 | 0.996 | +0.151 | 3.5×10⁻¹⁶ |
-| Lung Nodule or Mass | 0.944 | 1.000 | +0.056 | 1.3×10⁻⁶ |
-| Pneumothorax | 0.642 | 0.999 | +0.357 | 3.4×10⁻²⁸ |
-| **Mean** | **0.827** | **0.995** | **+0.168** | |
+| Effusion | 0.998 | 1.000 | +0.002 | 0.12 (n.s.) |
+| Consolidation | 0.989 | 0.997 | +0.008 | 0.027 |
+| Infiltration | 0.863 | 0.998 | +0.135 | 1.8×10⁻¹⁴ |
+| Lung Nodule or Mass | 0.970 | 1.000 | +0.030 | 5.9×10⁻⁶ |
+| Pneumothorax | 0.971 | 1.000 | +0.029 | 0.0065 |
+| **Mean** | **0.958** | **0.999** | **+0.041** | |
 
 **KCH (Trust_2, n=468)**
 
 | Lesion | Pretrained AUROC | Finetuned AUROC | Δ | DeLong *p* |
 |---|---|---|---|---|
-| Effusion | 0.953 | 1.000 | +0.047 | 9.4×10⁻⁷ |
-| Consolidation | 0.871 | 0.999 | +0.128 | 5.0×10⁻¹⁰ |
-| Infiltration | 0.875 | 1.000 | +0.125 | 6.0×10⁻¹⁵ |
-| Lung Nodule or Mass | 0.939 | 1.000 | +0.061 | 3.9×10⁻⁷ |
-| Pneumothorax | 0.832 | 0.997 | +0.165 | 2.4×10⁻¹⁰ |
-| **Mean** | **0.894** | **0.999** | **+0.105** | |
+| Effusion | 1.000 | 1.000 | +0.000 | 1.00 (n.s.) |
+| Consolidation | 0.998 | 1.000 | +0.002 | 0.31 (n.s.) |
+| Infiltration | 0.878 | 1.000 | +0.122 | 1.2×10⁻¹⁵ |
+| Lung Nodule or Mass | 0.955 | 1.000 | +0.045 | 7.2×10⁻⁷ |
+| Pneumothorax | 0.997 | 1.000 | +0.003 | 0.19 (n.s.) |
+| **Mean** | **0.966** | **1.000** | **+0.034** | |
 
-The biggest single gain is Pneumothorax at GSTT (0.642 → 0.999) — the same lesion that was the
-weakest pretrained score in the baseline evaluation above. Results zip was ~12 KB
+The biggest single gain is Infiltration (0.863 → 0.998 at GSTT, 0.878 → 1.000 at KCH) — the weakest
+pretrained score at both trusts in the baseline evaluation above. The finetuned model saturates both
+cohorts (AUROC ≥ 0.997), so these numbers speak to the platform working end to end, not to a
+state-of-the-art result on a synthetic task. Results zip was ~12 KB
 (`evaluation_results/evaluation_results.json` only — the same results-zip prune from the baseline
 evaluation applies here too).

--- a/fl-tutorials/nvflare/ARKPLUS_EXPERIMENTS_GUIDE.md
+++ b/fl-tutorials/nvflare/ARKPLUS_EXPERIMENTS_GUIDE.md
@@ -300,14 +300,15 @@ Pretrained Ark+ checkpoint scored against each trust's **holdout** cohort
 (GSTT/Trust_1 n=478, KCH/Trust_2 n=468). Read from
 `evaluation_results/evaluation_results.json` in the downloaded results zip.
 
-> **⚠️ Every AUROC on this page predates the FLIP#820 orientation fix.** These runs used the pre-#821
-> transform chain, which never undid MONAI's `LoadImaged` transpose and so fed Ark+ **sideways**
-> radiographs — see
+> **⚠️ Every AUROC in the three Results sections below (staging 2026-07-03/04, production 2026-07-07)
+> predates the FLIP#820 orientation fix.** These runs used the pre-fix transform chain, which never undid
+> MONAI's `LoadImaged` transpose and so fed Ark+ **sideways** radiographs — see
 > [Image orientation](image_evaluation/arkplus_baseline_classification_evaluation/README.md#image-orientation).
-> Re-scoring the same checkpoint over the same two cohorts upright (FLIP#821) raises every lesion:
+> Re-scoring the same checkpoint over the same two cohorts upright raises every lesion's point estimate:
 > mean AUROC **0.827 → 0.958** (GSTT) and **0.894 → 0.966** (KCH), the worst case being Pneumothorax
-> at GSTT, **0.642 → 0.972** (DeLong *p* = 3.5×10⁻²⁷). The tables are kept as the record of what the
-> platform reported at the time; regenerating them on the fixed chain is a separate step.
+> at GSTT, **0.642 → 0.972** (DeLong *p* = 3.5×10⁻²⁷). Four of the five move significantly at each trust;
+> Infiltration moves within noise (*p* = 0.39 GSTT, *p* = 0.77 KCH). The tables are kept as the record of
+> what the platform reported at the time; regenerating them on the fixed chain is a separate step.
 
 > **Shape change (FLIP#754).** Runs from that fix onwards nest the metrics one level deeper —
 > `{"<trust>": {"SRV_<model_name>": {...}}}` rather than `{"<trust>": {...}}`. Keying on the trust
@@ -361,8 +362,10 @@ possible, exercised together for the first time here:
 There's no cross-site metric from training itself (no held-out split is scored during `standard_client_api`
 training) — the finetuned checkpoint is scored downstream in the multimodel evaluation below,
 which is what actually demonstrates the finetune improved the model. Note that this checkpoint was
-trained through the pre-#821 chain, i.e. on **sideways** radiographs (see the orientation warning
-above); it scores the same either way on this saturated task, but a retrain is the clean path.
+trained through the pre-fix chain, i.e. on **sideways** radiographs (see the orientation warning above).
+The production finetune re-scored upright moved by less than 0.005 mean AUROC on this saturated task, so
+this one is unlikely to shift much either — but that has not been measured, and a retrain is the clean
+path.
 
 > **Reproduced on production (GSTT + BDMS), 2026-07-07.** On prod the finetune's post-training
 > cross-site validation surfaced a **third** memory issue not seen on staging: broadcasting the full

--- a/fl-tutorials/nvflare/ARKPLUS_EXPERIMENTS_GUIDE.md
+++ b/fl-tutorials/nvflare/ARKPLUS_EXPERIMENTS_GUIDE.md
@@ -300,6 +300,15 @@ Pretrained Ark+ checkpoint scored against each trust's **holdout** cohort
 (GSTT/Trust_1 n=478, KCH/Trust_2 n=468). Read from
 `evaluation_results/evaluation_results.json` in the downloaded results zip.
 
+> **⚠️ Every AUROC on this page predates the FLIP#820 orientation fix.** These runs used the pre-#821
+> transform chain, which never undid MONAI's `LoadImaged` transpose and so fed Ark+ **sideways**
+> radiographs — see
+> [Image orientation](image_evaluation/arkplus_baseline_classification_evaluation/README.md#image-orientation).
+> Re-scoring the same checkpoint over the same two cohorts upright (FLIP#821) raises every lesion:
+> mean AUROC **0.827 → 0.958** (GSTT) and **0.894 → 0.966** (KCH), the worst case being Pneumothorax
+> at GSTT, **0.642 → 0.972** (DeLong *p* = 3.5×10⁻²⁷). The tables are kept as the record of what the
+> platform reported at the time; regenerating them on the fixed chain is a separate step.
+
 > **Shape change (FLIP#754).** Runs from that fix onwards nest the metrics one level deeper —
 > `{"<trust>": {"SRV_<model_name>": {...}}}` rather than `{"<trust>": {...}}`. Keying on the trust
 > alone made each evaluated model overwrite the previous one, so a multimodel evaluation only ever
@@ -351,7 +360,9 @@ possible, exercised together for the first time here:
 
 There's no cross-site metric from training itself (no held-out split is scored during `standard_client_api`
 training) — the finetuned checkpoint is scored downstream in the multimodel evaluation below,
-which is what actually demonstrates the finetune improved the model.
+which is what actually demonstrates the finetune improved the model. Note that this checkpoint was
+trained through the pre-#821 chain, i.e. on **sideways** radiographs (see the orientation warning
+above); it scores the same either way on this saturated task, but a retrain is the clean path.
 
 > **Reproduced on production (GSTT + BDMS), 2026-07-07.** On prod the finetune's post-training
 > cross-site validation surfaced a **third** memory issue not seen on staging: broadcasting the full
@@ -369,6 +380,12 @@ Evaluates the pretrained Ark+ checkpoint **and** the finetuned checkpoint from t
 head-to-head, against the same **holdout** cohort used for the baseline evaluation above (reusing
 that project — `model_id ed2d49b5`, image `acfbd280`). The finetuned model wins on all 5 lesions
 at both trusts, every comparison significant (DeLong *p* < 1×10⁻⁶):
+
+> **⚠️ Pre-#821 orientation applies here too, and it inflates the Δ column.** Both models were scored
+> on sideways radiographs (see the baseline warning above). Upright, the pretrained column rises to the
+> means quoted there (0.958 GSTT / 0.966 KCH) while the finetuned column — already saturated near 1.0 —
+> barely moves, so the mean Δ collapses from the **+0.168 / +0.105** below to roughly **+0.04 / +0.03**.
+> The finetune still wins on every lesion; the margin below is not the margin you would measure today.
 
 **GSTT (Trust_1, n=478)**
 

--- a/fl-tutorials/nvflare/image_classification/arkplus_fine_tuning/README.md
+++ b/fl-tutorials/nvflare/image_classification/arkplus_fine_tuning/README.md
@@ -138,9 +138,11 @@ cohort dataframe, so a mislabelled figure fails rather than ships.
 > **⚠️ MONAI's `LoadImaged` returns the DICOM pixel array transposed, and this app undoes that.** The
 > array arrives indexed `(column, row)` where `PixelData` is `(row, column)`, so a chest radiograph
 > loads **on its side**. `get_xray_transforms` in `app_files/data_utils.py` corrects it with
-> `Transposed(keys=["image"], indices=(0, 2, 1))` immediately after the load. If you change the reader,
-> the dataset or the image format, re-check that step — it is a property of this loading chain, not a
-> universal correction.
+> `Transposed(keys=["image"], indices=(0, 2, 1))`, placed after the channel-first step and before
+> anything spatial runs. The leading `0` is the channel axis added by `_ensure_image_channel_first`, so
+> the permutation assumes that step has already run — moving it literally adjacent to `LoadImaged` hands
+> a 3-element permutation to a 2-D array. If you change the reader, the dataset or the image format,
+> re-check this step: it is a property of this loading chain, not a universal correction.
 
 Ark+ is pretrained on upright chest radiographs, so fine-tuning on sideways (or mirrored) images
 **silently** works against the pretraining: nothing errors or warns, and the training curves look
@@ -152,7 +154,8 @@ Do not check this by eye: a mirrored chest X-ray looks entirely plausible unless
 silhouette or the laterality marker. Verify it **numerically** — compare the transform output against an
 array read straight from `pydicom`'s `PixelData`. Note that no rotation or flip substitutes for the
 transpose: `Rotate90d(k=-1)` composed with the loader transpose leaves the image upright but mirrored,
-and `Flipd` leaves it on its side. Both shipped here at some point, which is how this went unnoticed.
+and `Flipd` leaves it on its side — the variant this app shipped, and why the fault went unnoticed for
+so long.
 
 ## Checkpoint setup
 

--- a/fl-tutorials/nvflare/image_classification/arkplus_fine_tuning/README.md
+++ b/fl-tutorials/nvflare/image_classification/arkplus_fine_tuning/README.md
@@ -133,30 +133,6 @@ It runs in the tutorial-local env with the `docs` extra (`matplotlib` + `pydicom
 it checks each panel's lesion against `config.json` and each accession's labels against its split's
 cohort dataframe, so a mislabelled figure fails rather than ships.
 
-### Image orientation
-
-> **⚠️ MONAI's `LoadImaged` returns the DICOM pixel array transposed, and this app undoes that.** The
-> array arrives indexed `(column, row)` where `PixelData` is `(row, column)`, so a chest radiograph
-> loads **on its side**. `get_xray_transforms` in `app_files/data_utils.py` corrects it with
-> `Transposed(keys=["image"], indices=(0, 2, 1))`, placed after the channel-first step and before
-> anything spatial runs. The leading `0` is the channel axis added by `_ensure_image_channel_first`, so
-> the permutation assumes that step has already run — moving it literally adjacent to `LoadImaged` hands
-> a 3-element permutation to a 2-D array. If you change the reader, the dataset or the image format,
-> re-check this step: it is a property of this loading chain, not a universal correction.
-
-Ark+ is pretrained on upright chest radiographs, so fine-tuning on sideways (or mirrored) images
-**silently** works against the pretraining: nothing errors or warns, and the training curves look
-normal. In the evaluation that prompted the fix (FLIP#820) the pretrained checkpoint scored a mean
-AUROC of 0.83 sideways vs 0.96 upright over the reference hold-out cohort. Any weights fine-tuned
-through the pre-fix chain were trained on sideways radiographs; retraining is the clean path.
-
-Do not check this by eye: a mirrored chest X-ray looks entirely plausible unless you read the cardiac
-silhouette or the laterality marker. Verify it **numerically** — compare the transform output against an
-array read straight from `pydicom`'s `PixelData`. Note that no rotation or flip substitutes for the
-transpose: `Rotate90d(k=-1)` composed with the loader transpose leaves the image upright but mirrored,
-and `Flipd` leaves it on its side — the variant this app shipped, and why the fault went unnoticed for
-so long.
-
 ## Checkpoint setup
 
 `make run`/`make export` require the backbone checkpoint at `app_files/pretrained_weights.pt`, produced

--- a/fl-tutorials/nvflare/image_classification/arkplus_fine_tuning/README.md
+++ b/fl-tutorials/nvflare/image_classification/arkplus_fine_tuning/README.md
@@ -133,6 +133,27 @@ It runs in the tutorial-local env with the `docs` extra (`matplotlib` + `pydicom
 it checks each panel's lesion against `config.json` and each accession's labels against its split's
 cohort dataframe, so a mislabelled figure fails rather than ships.
 
+### Image orientation
+
+> **⚠️ MONAI's `LoadImaged` returns the DICOM pixel array transposed, and this app undoes that.** The
+> array arrives indexed `(column, row)` where `PixelData` is `(row, column)`, so a chest radiograph
+> loads **on its side**. `get_xray_transforms` in `app_files/data_utils.py` corrects it with
+> `Transposed(keys=["image"], indices=(0, 2, 1))` immediately after the load. If you change the reader,
+> the dataset or the image format, re-check that step — it is a property of this loading chain, not a
+> universal correction.
+
+Ark+ is pretrained on upright chest radiographs, so fine-tuning on sideways (or mirrored) images
+**silently** works against the pretraining: nothing errors or warns, and the training curves look
+normal. In the evaluation that prompted the fix (FLIP#820) the pretrained checkpoint scored a mean
+AUROC of 0.83 sideways vs 0.96 upright over the reference hold-out cohort. Any weights fine-tuned
+through the pre-fix chain were trained on sideways radiographs; retraining is the clean path.
+
+Do not check this by eye: a mirrored chest X-ray looks entirely plausible unless you read the cardiac
+silhouette or the laterality marker. Verify it **numerically** — compare the transform output against an
+array read straight from `pydicom`'s `PixelData`. Note that no rotation or flip substitutes for the
+transpose: `Rotate90d(k=-1)` composed with the loader transpose leaves the image upright but mirrored,
+and `Flipd` leaves it on its side. Both shipped here at some point, which is how this went unnoticed.
+
 ## Checkpoint setup
 
 `make run`/`make export` require the backbone checkpoint at `app_files/pretrained_weights.pt`, produced

--- a/fl-tutorials/nvflare/image_classification/arkplus_fine_tuning/app_files/data_utils.py
+++ b/fl-tutorials/nvflare/image_classification/arkplus_fine_tuning/app_files/data_utils.py
@@ -172,10 +172,10 @@ def get_xray_transforms(is_validation: bool = False):
         # LoadImaged returns the array transposed - indexed (column, row) where DICOM PixelData
         # is (row, column) - so swap the spatial axes back before anything spatial runs. Neither a
         # Rotate90 nor a Flip undoes a transpose: Rotate90d(k=-1) leaves the radiograph upright but
-        # mirrored, and the Flipd that replaced it left the image lying on its side, which is what
-        # Ark+ was scored on. Sitting before Resized is not load-bearing while the target is square
-        # - the resamplers are separable, so the two orders are bit-identical - but it keeps the
-        # correction next to the load it undoes, and correct if the target ever stops being square.
+        # mirrored, and a Flipd leaves it lying on its side. Sitting before Resized is not
+        # load-bearing while the target is square - the resamplers are separable, so the two orders
+        # are bit-identical - but it keeps the correction next to the load it undoes, and stays
+        # correct if the target ever stops being square.
         mt.Transposed(keys=["image"], indices=(0, 2, 1)),
         mt.Resized(keys=["image"], spatial_size=[input_size, input_size]),
         mt.ScaleIntensityd(keys=["image"], channel_wise=True),

--- a/fl-tutorials/nvflare/image_classification/arkplus_fine_tuning/app_files/data_utils.py
+++ b/fl-tutorials/nvflare/image_classification/arkplus_fine_tuning/app_files/data_utils.py
@@ -170,8 +170,11 @@ def get_xray_transforms(is_validation: bool = False):
         mt.LoadImaged(keys=["image"]),
         mt.Lambdad(keys=["image"], func=_ensure_image_channel_first),
         mt.Resized(keys=["image"], spatial_size=[input_size, input_size]),
-        # mt.Rotate90d(keys=["image"], k=-1),
-        mt.Flipd(keys=["image"], spatial_axis=1),
+        # LoadImaged returns the array transposed - indexed (column, row) where DICOM PixelData
+        # is (row, column) - so swap the spatial axes back. Neither a Rotate90 nor a Flip undoes
+        # a transpose: Rotate90d(k=-1) leaves the radiograph upright but mirrored, and the Flipd
+        # that replaced it left the image lying on its side, which is what Ark+ was scored on.
+        mt.Transposed(keys=["image"], indices=(0, 2, 1)),
         mt.ScaleIntensityd(keys=["image"], channel_wise=True),
         mt.EnsureTyped(keys=["image"]),
         RepeatChannelImageNetNormalized(keys=["image"]),

--- a/fl-tutorials/nvflare/image_classification/arkplus_fine_tuning/app_files/data_utils.py
+++ b/fl-tutorials/nvflare/image_classification/arkplus_fine_tuning/app_files/data_utils.py
@@ -169,12 +169,15 @@ def get_xray_transforms(is_validation: bool = False):
     transforms = [
         mt.LoadImaged(keys=["image"]),
         mt.Lambdad(keys=["image"], func=_ensure_image_channel_first),
-        mt.Resized(keys=["image"], spatial_size=[input_size, input_size]),
         # LoadImaged returns the array transposed - indexed (column, row) where DICOM PixelData
-        # is (row, column) - so swap the spatial axes back. Neither a Rotate90 nor a Flip undoes
-        # a transpose: Rotate90d(k=-1) leaves the radiograph upright but mirrored, and the Flipd
-        # that replaced it left the image lying on its side, which is what Ark+ was scored on.
+        # is (row, column) - so swap the spatial axes back before anything spatial runs. Neither a
+        # Rotate90 nor a Flip undoes a transpose: Rotate90d(k=-1) leaves the radiograph upright but
+        # mirrored, and the Flipd that replaced it left the image lying on its side, which is what
+        # Ark+ was scored on. Sitting before Resized is not load-bearing while the target is square
+        # - the resamplers are separable, so the two orders are bit-identical - but it keeps the
+        # correction next to the load it undoes, and correct if the target ever stops being square.
         mt.Transposed(keys=["image"], indices=(0, 2, 1)),
+        mt.Resized(keys=["image"], spatial_size=[input_size, input_size]),
         mt.ScaleIntensityd(keys=["image"], channel_wise=True),
         mt.EnsureTyped(keys=["image"]),
         RepeatChannelImageNetNormalized(keys=["image"]),

--- a/fl-tutorials/nvflare/image_evaluation/arkplus_baseline_classification_evaluation/README.md
+++ b/fl-tutorials/nvflare/image_evaluation/arkplus_baseline_classification_evaluation/README.md
@@ -93,9 +93,11 @@ Pass it as the project's cohort query (e.g. `make e2e_smoke QUERY_FILE=.../arkpl
 > **⚠️ MONAI's `LoadImaged` returns the DICOM pixel array transposed, and this app undoes that.** The
 > array arrives indexed `(column, row)` where `PixelData` is `(row, column)`, so a chest radiograph
 > loads **on its side**. `get_xray_transforms` in `app_files/data_utils.py` corrects it with
-> `Transposed(keys=["image"], indices=(0, 2, 1))` immediately after the load. If you change the reader,
-> the dataset or the image format, re-check that step — it is a property of this loading chain, not a
-> universal correction.
+> `Transposed(keys=["image"], indices=(0, 2, 1))`, placed after the channel-first step and before
+> anything spatial runs. The leading `0` is the channel axis added by `_ensure_image_channel_first`, so
+> the permutation assumes that step has already run — moving it literally adjacent to `LoadImaged` hands
+> a 3-element permutation to a 2-D array. If you change the reader, the dataset or the image format,
+> re-check this step: it is a property of this loading chain, not a universal correction.
 
 Ark+ is pretrained on upright chest radiographs, so a sideways (or mirrored) image is a large
 distribution shift that **silently** depresses every reported metric — nothing errors or warns, the
@@ -107,7 +109,8 @@ Do not check this by eye: a mirrored chest X-ray looks entirely plausible unless
 silhouette or the laterality marker. Verify it **numerically** — compare the transform output against an
 array read straight from `pydicom`'s `PixelData`. Note that no rotation or flip substitutes for the
 transpose: `Rotate90d(k=-1)` composed with the loader transpose leaves the image upright but mirrored,
-and `Flipd` leaves it on its side. Both shipped here at some point, which is how this went unnoticed.
+and `Flipd` leaves it on its side — the variant this app shipped, and why the fault went unnoticed for
+so long.
 
 ## Checkpoint setup
 
@@ -202,10 +205,10 @@ The evaluator returns **aggregate** (cohort-level) per-lesion AUROC only, collec
 }
 ```
 
-(Values above are illustrative — the pretrained checkpoint over one hold-out cohort, scored **after** the
-FLIP#820 orientation fix. The pre-fix chain fed the model sideways radiographs and scored materially
-lower on the same data, e.g. Pneumothorax 0.64 rather than 0.97 — see
-[Image orientation](#image-orientation).)
+(Values above are **real measured scores**, not a fabricated example: the pretrained checkpoint over one
+hold-out cohort, scored **after** the FLIP#820 orientation fix. The pre-fix chain fed the model sideways
+radiographs and scored materially lower on the same data — e.g. Pneumothorax 0.64 rather than 0.97 — so
+treat them as one cohort's result, not a target to reproduce. See [Image orientation](#image-orientation).)
 
 ### Fields
 

--- a/fl-tutorials/nvflare/image_evaluation/arkplus_baseline_classification_evaluation/README.md
+++ b/fl-tutorials/nvflare/image_evaluation/arkplus_baseline_classification_evaluation/README.md
@@ -88,6 +88,27 @@ The cohort query for a real deployment is [`query.sql`](query.sql) — it select
 X-ray set (`procedure_source_value = 'Chest X-ray (holdout)'`) and returns the seven lesion-label columns.
 Pass it as the project's cohort query (e.g. `make e2e_smoke QUERY_FILE=.../arkplus_baseline_classification_evaluation/query.sql`).
 
+### Image orientation
+
+> **⚠️ MONAI's `LoadImaged` returns the DICOM pixel array transposed, and this app undoes that.** The
+> array arrives indexed `(column, row)` where `PixelData` is `(row, column)`, so a chest radiograph
+> loads **on its side**. `get_xray_transforms` in `app_files/data_utils.py` corrects it with
+> `Transposed(keys=["image"], indices=(0, 2, 1))` immediately after the load. If you change the reader,
+> the dataset or the image format, re-check that step — it is a property of this loading chain, not a
+> universal correction.
+
+Ark+ is pretrained on upright chest radiographs, so a sideways (or mirrored) image is a large
+distribution shift that **silently** depresses every reported metric — nothing errors or warns, the
+AUROCs are just quietly worse. In the evaluation that prompted the fix (FLIP#820), the same checkpoint
+over the same hold-out cohort scored a mean AUROC of **0.83 sideways vs 0.96 upright**, with
+Pneumothorax alone moving 0.64 → 0.97.
+
+Do not check this by eye: a mirrored chest X-ray looks entirely plausible unless you read the cardiac
+silhouette or the laterality marker. Verify it **numerically** — compare the transform output against an
+array read straight from `pydicom`'s `PixelData`. Note that no rotation or flip substitutes for the
+transpose: `Rotate90d(k=-1)` composed with the loader transpose leaves the image upright but mirrored,
+and `Flipd` leaves it on its side. Both shipped here at some point, which is how this went unnoticed.
+
 ## Checkpoint setup
 
 The evaluation app needs the foundation-model checkpoint as a clean `.pt` file at
@@ -168,11 +189,11 @@ The evaluator returns **aggregate** (cohort-level) per-lesion AUROC only, collec
 {
     "site-1": {
         "arkplus_pretrained": {
-            "auroc_Effusion": 0.84,
-            "auroc_Consolidation": 0.87,
-            "auroc_Infiltration": 0.85,
-            "auroc_Lung Nodule or Mass": 0.94,
-            "auroc_Pneumothorax": 0.64
+            "auroc_Effusion": 0.998,
+            "auroc_Consolidation": 0.989,
+            "auroc_Infiltration": 0.858,
+            "auroc_Lung Nodule or Mass": 0.973,
+            "auroc_Pneumothorax": 0.972
         }
     },
     "site-2": {
@@ -181,7 +202,10 @@ The evaluator returns **aggregate** (cohort-level) per-lesion AUROC only, collec
 }
 ```
 
-(Values above are illustrative, from a sample local run.)
+(Values above are illustrative — the pretrained checkpoint over one hold-out cohort, scored **after** the
+FLIP#820 orientation fix. The pre-fix chain fed the model sideways radiographs and scored materially
+lower on the same data, e.g. Pneumothorax 0.64 rather than 0.97 — see
+[Image orientation](#image-orientation).)
 
 ### Fields
 

--- a/fl-tutorials/nvflare/image_evaluation/arkplus_baseline_classification_evaluation/README.md
+++ b/fl-tutorials/nvflare/image_evaluation/arkplus_baseline_classification_evaluation/README.md
@@ -88,30 +88,6 @@ The cohort query for a real deployment is [`query.sql`](query.sql) — it select
 X-ray set (`procedure_source_value = 'Chest X-ray (holdout)'`) and returns the seven lesion-label columns.
 Pass it as the project's cohort query (e.g. `make e2e_smoke QUERY_FILE=.../arkplus_baseline_classification_evaluation/query.sql`).
 
-### Image orientation
-
-> **⚠️ MONAI's `LoadImaged` returns the DICOM pixel array transposed, and this app undoes that.** The
-> array arrives indexed `(column, row)` where `PixelData` is `(row, column)`, so a chest radiograph
-> loads **on its side**. `get_xray_transforms` in `app_files/data_utils.py` corrects it with
-> `Transposed(keys=["image"], indices=(0, 2, 1))`, placed after the channel-first step and before
-> anything spatial runs. The leading `0` is the channel axis added by `_ensure_image_channel_first`, so
-> the permutation assumes that step has already run — moving it literally adjacent to `LoadImaged` hands
-> a 3-element permutation to a 2-D array. If you change the reader, the dataset or the image format,
-> re-check this step: it is a property of this loading chain, not a universal correction.
-
-Ark+ is pretrained on upright chest radiographs, so a sideways (or mirrored) image is a large
-distribution shift that **silently** depresses every reported metric — nothing errors or warns, the
-AUROCs are just quietly worse. In the evaluation that prompted the fix (FLIP#820), the same checkpoint
-over the same hold-out cohort scored a mean AUROC of **0.83 sideways vs 0.96 upright**, with
-Pneumothorax alone moving 0.64 → 0.97.
-
-Do not check this by eye: a mirrored chest X-ray looks entirely plausible unless you read the cardiac
-silhouette or the laterality marker. Verify it **numerically** — compare the transform output against an
-array read straight from `pydicom`'s `PixelData`. Note that no rotation or flip substitutes for the
-transpose: `Rotate90d(k=-1)` composed with the loader transpose leaves the image upright but mirrored,
-and `Flipd` leaves it on its side — the variant this app shipped, and why the fault went unnoticed for
-so long.
-
 ## Checkpoint setup
 
 The evaluation app needs the foundation-model checkpoint as a clean `.pt` file at
@@ -194,9 +170,9 @@ The evaluator returns **aggregate** (cohort-level) per-lesion AUROC only, collec
         "arkplus_pretrained": {
             "auroc_Effusion": 0.998,
             "auroc_Consolidation": 0.989,
-            "auroc_Infiltration": 0.858,
-            "auroc_Lung Nodule or Mass": 0.973,
-            "auroc_Pneumothorax": 0.972
+            "auroc_Infiltration": 0.863,
+            "auroc_Lung Nodule or Mass": 0.970,
+            "auroc_Pneumothorax": 0.971
         }
     },
     "site-2": {
@@ -206,9 +182,7 @@ The evaluator returns **aggregate** (cohort-level) per-lesion AUROC only, collec
 ```
 
 (Values above are **real measured scores**, not a fabricated example: the pretrained checkpoint over one
-hold-out cohort, scored **after** the FLIP#820 orientation fix. The pre-fix chain fed the model sideways
-radiographs and scored materially lower on the same data — e.g. Pneumothorax 0.64 rather than 0.97 — so
-treat them as one cohort's result, not a target to reproduce. See [Image orientation](#image-orientation).)
+hold-out cohort. Treat them as one cohort's result, not a target to reproduce.)
 
 ### Fields
 

--- a/fl-tutorials/nvflare/image_evaluation/arkplus_baseline_classification_evaluation/app_files/data_utils.py
+++ b/fl-tutorials/nvflare/image_evaluation/arkplus_baseline_classification_evaluation/app_files/data_utils.py
@@ -382,12 +382,15 @@ def get_xray_transforms(input_size: int = 768):
     transforms = [
         mt.LoadImaged(keys=["image"]),
         mt.Lambdad(keys=["image"], func=_ensure_image_channel_first),
-        mt.Resized(keys=["image"], spatial_size=[input_size, input_size]),
         # LoadImaged returns the array transposed - indexed (column, row) where DICOM PixelData
-        # is (row, column) - so swap the spatial axes back. Neither a Rotate90 nor a Flip undoes
-        # a transpose: Rotate90d(k=-1) leaves the radiograph upright but mirrored, and the Flipd
-        # that replaced it left the image lying on its side, which is what Ark+ was scored on.
+        # is (row, column) - so swap the spatial axes back before anything spatial runs. Neither a
+        # Rotate90 nor a Flip undoes a transpose: Rotate90d(k=-1) leaves the radiograph upright but
+        # mirrored, and the Flipd that replaced it left the image lying on its side, which is what
+        # Ark+ was scored on. Sitting before Resized is not load-bearing while the target is square
+        # - the resamplers are separable, so the two orders are bit-identical - but it keeps the
+        # correction next to the load it undoes, and correct if the target ever stops being square.
         mt.Transposed(keys=["image"], indices=(0, 2, 1)),
+        mt.Resized(keys=["image"], spatial_size=[input_size, input_size]),
         mt.ScaleIntensityd(keys=["image"], channel_wise=True),
         mt.EnsureTyped(keys=["image"]),
         RepeatChannelImageNetNormalized(keys=["image"]),

--- a/fl-tutorials/nvflare/image_evaluation/arkplus_baseline_classification_evaluation/app_files/data_utils.py
+++ b/fl-tutorials/nvflare/image_evaluation/arkplus_baseline_classification_evaluation/app_files/data_utils.py
@@ -385,10 +385,10 @@ def get_xray_transforms(input_size: int = 768):
         # LoadImaged returns the array transposed - indexed (column, row) where DICOM PixelData
         # is (row, column) - so swap the spatial axes back before anything spatial runs. Neither a
         # Rotate90 nor a Flip undoes a transpose: Rotate90d(k=-1) leaves the radiograph upright but
-        # mirrored, and the Flipd that replaced it left the image lying on its side, which is what
-        # Ark+ was scored on. Sitting before Resized is not load-bearing while the target is square
-        # - the resamplers are separable, so the two orders are bit-identical - but it keeps the
-        # correction next to the load it undoes, and correct if the target ever stops being square.
+        # mirrored, and a Flipd leaves it lying on its side. Sitting before Resized is not
+        # load-bearing while the target is square - the resamplers are separable, so the two orders
+        # are bit-identical - but it keeps the correction next to the load it undoes, and stays
+        # correct if the target ever stops being square.
         mt.Transposed(keys=["image"], indices=(0, 2, 1)),
         mt.Resized(keys=["image"], spatial_size=[input_size, input_size]),
         mt.ScaleIntensityd(keys=["image"], channel_wise=True),

--- a/fl-tutorials/nvflare/image_evaluation/arkplus_baseline_classification_evaluation/app_files/data_utils.py
+++ b/fl-tutorials/nvflare/image_evaluation/arkplus_baseline_classification_evaluation/app_files/data_utils.py
@@ -383,8 +383,11 @@ def get_xray_transforms(input_size: int = 768):
         mt.LoadImaged(keys=["image"]),
         mt.Lambdad(keys=["image"], func=_ensure_image_channel_first),
         mt.Resized(keys=["image"], spatial_size=[input_size, input_size]),
-        # mt.Rotate90d(keys=["image"], k=-1),
-        mt.Flipd(keys=["image"], spatial_axis=1),
+        # LoadImaged returns the array transposed - indexed (column, row) where DICOM PixelData
+        # is (row, column) - so swap the spatial axes back. Neither a Rotate90 nor a Flip undoes
+        # a transpose: Rotate90d(k=-1) leaves the radiograph upright but mirrored, and the Flipd
+        # that replaced it left the image lying on its side, which is what Ark+ was scored on.
+        mt.Transposed(keys=["image"], indices=(0, 2, 1)),
         mt.ScaleIntensityd(keys=["image"], channel_wise=True),
         mt.EnsureTyped(keys=["image"]),
         RepeatChannelImageNetNormalized(keys=["image"]),

--- a/fl-tutorials/nvflare/image_evaluation/arkplus_multimodel_classification_evaluation/README.md
+++ b/fl-tutorials/nvflare/image_evaluation/arkplus_multimodel_classification_evaluation/README.md
@@ -105,23 +105,29 @@ both models are scored against.
 > **⚠️ MONAI's `LoadImaged` returns the DICOM pixel array transposed, and this app undoes that.** The
 > array arrives indexed `(column, row)` where `PixelData` is `(row, column)`, so a chest radiograph
 > loads **on its side**. `get_xray_transforms` in `app_files/data_utils.py` corrects it with
-> `Transposed(keys=["image"], indices=(0, 2, 1))` immediately after the load. If you change the reader,
-> the dataset or the image format, re-check that step — it is a property of this loading chain, not a
-> universal correction.
+> `Transposed(keys=["image"], indices=(0, 2, 1))`, placed after the channel-first step and before
+> anything spatial runs. The leading `0` is the channel axis added by `_ensure_image_channel_first`, so
+> the permutation assumes that step has already run — moving it literally adjacent to `LoadImaged` hands
+> a 3-element permutation to a 2-D array. If you change the reader, the dataset or the image format,
+> re-check this step: it is a property of this loading chain, not a universal correction.
 
 Ark+ is pretrained on upright chest radiographs, so a sideways (or mirrored) image is a large
 distribution shift that **silently** depresses every reported metric — nothing errors or warns, the
 AUROCs are just quietly worse. Because this app scores two models head-to-head, an orientation fault
-also distorts the *comparison* — and it need not hit both models equally. In the evaluation that
-prompted the fix (FLIP#820) the pretrained model's mean AUROC rose from 0.83 to 0.96 once the images
-were upright, while the fine-tuned model (saturated on that task at 0.999) did not move at all, so the
-apparent gap between them shrank from 0.172 to 0.041 without either checkpoint changing.
+also distorts the *comparison* — and it need not hit both models equally. Re-scoring the production
+checkpoints over one hold-out cohort in both orientations (FLIP#820), the pretrained model's mean AUROC
+rose from 0.827 to 0.958 once the images were upright, while the fine-tuned model — already saturated
+near 1.0 on this synthetic task — did not move, so the apparent gap between them collapsed from 0.172 to
+0.041 without either checkpoint changing. (The staging run tabulated in
+[`ARKPLUS_EXPERIMENTS_GUIDE.md`](../../ARKPLUS_EXPERIMENTS_GUIDE.md) used a different, shorter finetune,
+so its figures differ in the third decimal. Do not read across the two runs.)
 
 Do not check this by eye: a mirrored chest X-ray looks entirely plausible unless you read the cardiac
 silhouette or the laterality marker. Verify it **numerically** — compare the transform output against an
 array read straight from `pydicom`'s `PixelData`. Note that no rotation or flip substitutes for the
 transpose: `Rotate90d(k=-1)` composed with the loader transpose leaves the image upright but mirrored,
-and `Flipd` leaves it on its side. Both shipped here at some point, which is how this went unnoticed.
+and `Flipd` leaves it on its side — the variant this app shipped, and why the fault went unnoticed for
+so long.
 
 ## Checkpoint setup
 
@@ -264,7 +270,8 @@ DeLong p-values and Benjamini-Hochberg (BH) FDR-adjusted q-values — collected 
 }
 ```
 
-(Values above are illustrative.)
+(Values above are **synthetic placeholders** chosen to show the JSON shape — not measured scores, and not
+consistent with the real results referenced under [Image orientation](#image-orientation).)
 
 ### Fields
 

--- a/fl-tutorials/nvflare/image_evaluation/arkplus_multimodel_classification_evaluation/README.md
+++ b/fl-tutorials/nvflare/image_evaluation/arkplus_multimodel_classification_evaluation/README.md
@@ -100,6 +100,29 @@ The cohort query for a real deployment is [`query.sql`](query.sql) — it select
 X-ray set (`procedure_source_value = 'Chest X-ray (holdout)'`) and returns the seven lesion-label columns
 both models are scored against.
 
+### Image orientation
+
+> **⚠️ MONAI's `LoadImaged` returns the DICOM pixel array transposed, and this app undoes that.** The
+> array arrives indexed `(column, row)` where `PixelData` is `(row, column)`, so a chest radiograph
+> loads **on its side**. `get_xray_transforms` in `app_files/data_utils.py` corrects it with
+> `Transposed(keys=["image"], indices=(0, 2, 1))` immediately after the load. If you change the reader,
+> the dataset or the image format, re-check that step — it is a property of this loading chain, not a
+> universal correction.
+
+Ark+ is pretrained on upright chest radiographs, so a sideways (or mirrored) image is a large
+distribution shift that **silently** depresses every reported metric — nothing errors or warns, the
+AUROCs are just quietly worse. Because this app scores two models head-to-head, an orientation fault
+also distorts the *comparison* — and it need not hit both models equally. In the evaluation that
+prompted the fix (FLIP#820) the pretrained model's mean AUROC rose from 0.83 to 0.96 once the images
+were upright, while the fine-tuned model (saturated on that task at 0.999) did not move at all, so the
+apparent gap between them shrank from 0.172 to 0.041 without either checkpoint changing.
+
+Do not check this by eye: a mirrored chest X-ray looks entirely plausible unless you read the cardiac
+silhouette or the laterality marker. Verify it **numerically** — compare the transform output against an
+array read straight from `pydicom`'s `PixelData`. Note that no rotation or flip substitutes for the
+transpose: `Rotate90d(k=-1)` composed with the loader transpose leaves the image upright but mirrored,
+and `Flipd` leaves it on its side. Both shipped here at some point, which is how this went unnoticed.
+
 ## Checkpoint setup
 
 The app evaluates two models, so it needs two clean `.pt` checkpoints in `app_files/`: the foundation

--- a/fl-tutorials/nvflare/image_evaluation/arkplus_multimodel_classification_evaluation/README.md
+++ b/fl-tutorials/nvflare/image_evaluation/arkplus_multimodel_classification_evaluation/README.md
@@ -100,35 +100,6 @@ The cohort query for a real deployment is [`query.sql`](query.sql) — it select
 X-ray set (`procedure_source_value = 'Chest X-ray (holdout)'`) and returns the seven lesion-label columns
 both models are scored against.
 
-### Image orientation
-
-> **⚠️ MONAI's `LoadImaged` returns the DICOM pixel array transposed, and this app undoes that.** The
-> array arrives indexed `(column, row)` where `PixelData` is `(row, column)`, so a chest radiograph
-> loads **on its side**. `get_xray_transforms` in `app_files/data_utils.py` corrects it with
-> `Transposed(keys=["image"], indices=(0, 2, 1))`, placed after the channel-first step and before
-> anything spatial runs. The leading `0` is the channel axis added by `_ensure_image_channel_first`, so
-> the permutation assumes that step has already run — moving it literally adjacent to `LoadImaged` hands
-> a 3-element permutation to a 2-D array. If you change the reader, the dataset or the image format,
-> re-check this step: it is a property of this loading chain, not a universal correction.
-
-Ark+ is pretrained on upright chest radiographs, so a sideways (or mirrored) image is a large
-distribution shift that **silently** depresses every reported metric — nothing errors or warns, the
-AUROCs are just quietly worse. Because this app scores two models head-to-head, an orientation fault
-also distorts the *comparison* — and it need not hit both models equally. Re-scoring the production
-checkpoints over one hold-out cohort in both orientations (FLIP#820), the pretrained model's mean AUROC
-rose from 0.827 to 0.958 once the images were upright, while the fine-tuned model — already saturated
-near 1.0 on this synthetic task — did not move, so the apparent gap between them collapsed from 0.172 to
-0.041 without either checkpoint changing. (The staging run tabulated in
-[`ARKPLUS_EXPERIMENTS_GUIDE.md`](../../ARKPLUS_EXPERIMENTS_GUIDE.md) used a different, shorter finetune,
-so its figures differ in the third decimal. Do not read across the two runs.)
-
-Do not check this by eye: a mirrored chest X-ray looks entirely plausible unless you read the cardiac
-silhouette or the laterality marker. Verify it **numerically** — compare the transform output against an
-array read straight from `pydicom`'s `PixelData`. Note that no rotation or flip substitutes for the
-transpose: `Rotate90d(k=-1)` composed with the loader transpose leaves the image upright but mirrored,
-and `Flipd` leaves it on its side — the variant this app shipped, and why the fault went unnoticed for
-so long.
-
 ## Checkpoint setup
 
 The app evaluates two models, so it needs two clean `.pt` checkpoints in `app_files/`: the foundation
@@ -270,8 +241,7 @@ DeLong p-values and Benjamini-Hochberg (BH) FDR-adjusted q-values — collected 
 }
 ```
 
-(Values above are **synthetic placeholders** chosen to show the JSON shape — not measured scores, and not
-consistent with the real results referenced under [Image orientation](#image-orientation).)
+(Values above are **synthetic placeholders** chosen to show the JSON shape — not measured scores.)
 
 ### Fields
 

--- a/fl-tutorials/nvflare/image_evaluation/arkplus_multimodel_classification_evaluation/app_files/data_utils.py
+++ b/fl-tutorials/nvflare/image_evaluation/arkplus_multimodel_classification_evaluation/app_files/data_utils.py
@@ -382,12 +382,15 @@ def get_xray_transforms(input_size: int = 768):
     transforms = [
         mt.LoadImaged(keys=["image"]),
         mt.Lambdad(keys=["image"], func=_ensure_image_channel_first),
-        mt.Resized(keys=["image"], spatial_size=[input_size, input_size]),
         # LoadImaged returns the array transposed - indexed (column, row) where DICOM PixelData
-        # is (row, column) - so swap the spatial axes back. Neither a Rotate90 nor a Flip undoes
-        # a transpose: Rotate90d(k=-1) leaves the radiograph upright but mirrored, and the Flipd
-        # that replaced it left the image lying on its side, which is what Ark+ was scored on.
+        # is (row, column) - so swap the spatial axes back before anything spatial runs. Neither a
+        # Rotate90 nor a Flip undoes a transpose: Rotate90d(k=-1) leaves the radiograph upright but
+        # mirrored, and the Flipd that replaced it left the image lying on its side, which is what
+        # Ark+ was scored on. Sitting before Resized is not load-bearing while the target is square
+        # - the resamplers are separable, so the two orders are bit-identical - but it keeps the
+        # correction next to the load it undoes, and correct if the target ever stops being square.
         mt.Transposed(keys=["image"], indices=(0, 2, 1)),
+        mt.Resized(keys=["image"], spatial_size=[input_size, input_size]),
         mt.ScaleIntensityd(keys=["image"], channel_wise=True),
         mt.EnsureTyped(keys=["image"]),
         RepeatChannelImageNetNormalized(keys=["image"]),

--- a/fl-tutorials/nvflare/image_evaluation/arkplus_multimodel_classification_evaluation/app_files/data_utils.py
+++ b/fl-tutorials/nvflare/image_evaluation/arkplus_multimodel_classification_evaluation/app_files/data_utils.py
@@ -385,10 +385,10 @@ def get_xray_transforms(input_size: int = 768):
         # LoadImaged returns the array transposed - indexed (column, row) where DICOM PixelData
         # is (row, column) - so swap the spatial axes back before anything spatial runs. Neither a
         # Rotate90 nor a Flip undoes a transpose: Rotate90d(k=-1) leaves the radiograph upright but
-        # mirrored, and the Flipd that replaced it left the image lying on its side, which is what
-        # Ark+ was scored on. Sitting before Resized is not load-bearing while the target is square
-        # - the resamplers are separable, so the two orders are bit-identical - but it keeps the
-        # correction next to the load it undoes, and correct if the target ever stops being square.
+        # mirrored, and a Flipd leaves it lying on its side. Sitting before Resized is not
+        # load-bearing while the target is square - the resamplers are separable, so the two orders
+        # are bit-identical - but it keeps the correction next to the load it undoes, and stays
+        # correct if the target ever stops being square.
         mt.Transposed(keys=["image"], indices=(0, 2, 1)),
         mt.Resized(keys=["image"], spatial_size=[input_size, input_size]),
         mt.ScaleIntensityd(keys=["image"], channel_wise=True),

--- a/fl-tutorials/nvflare/image_evaluation/arkplus_multimodel_classification_evaluation/app_files/data_utils.py
+++ b/fl-tutorials/nvflare/image_evaluation/arkplus_multimodel_classification_evaluation/app_files/data_utils.py
@@ -383,8 +383,11 @@ def get_xray_transforms(input_size: int = 768):
         mt.LoadImaged(keys=["image"]),
         mt.Lambdad(keys=["image"], func=_ensure_image_channel_first),
         mt.Resized(keys=["image"], spatial_size=[input_size, input_size]),
-        # mt.Rotate90d(keys=["image"], k=-1),
-        mt.Flipd(keys=["image"], spatial_axis=1),
+        # LoadImaged returns the array transposed - indexed (column, row) where DICOM PixelData
+        # is (row, column) - so swap the spatial axes back. Neither a Rotate90 nor a Flip undoes
+        # a transpose: Rotate90d(k=-1) leaves the radiograph upright but mirrored, and the Flipd
+        # that replaced it left the image lying on its side, which is what Ark+ was scored on.
+        mt.Transposed(keys=["image"], indices=(0, 2, 1)),
         mt.ScaleIntensityd(keys=["image"], channel_wise=True),
         mt.EnsureTyped(keys=["image"]),
         RepeatChannelImageNetNormalized(keys=["image"]),


### PR DESCRIPTION
# Description

The Ark+ apps were feeding the foundation model **sideways radiographs**, and had been since the
orientation step was last touched. Ark+ is pretrained on upright chest X-rays, so this is a large
distribution shift that silently depressed every reported Ark+ metric.

MONAI's `LoadImaged` returns a DICOM's pixel array **transposed** — indexed `(column, row)` where
`PixelData` is `(row, column)` — so the loaded image is rotated 90°. All three apps tried to correct
that with:

```python
# mt.Rotate90d(keys=["image"], k=-1),
mt.Flipd(keys=["image"], spatial_axis=1),
```

Neither undoes a transpose. `Rotate90d(k=-1)` composed with the transpose is algebraically a plain
left–right **mirror** — upright, but flipped, which is why it looked right and got shipped. The
`Flipd` that replaced it mirrors the *sideways* image and leaves it on its side. The inverse of a
transpose is a transpose:

```python
mt.Transposed(keys=["image"], indices=(0, 2, 1)),
```

Applied to all three Ark+ apps (both evaluation apps and fine-tuning), with the reasoning recorded
in-code so it does not get "fixed" back.

## Linked Issues

Fixes #820

## Impact on reported numbers

Same checkpoints, same holdout sets, only the orientation differs:

| Class | UK (n=478) sideways → upright | Thai (n=468) sideways → upright |
| --- | --- | --- |
| Effusion | 0.839 → 0.998 | 0.953 → 1.000 |
| Consolidation | 0.866 → 0.989 | 0.872 → 0.998 |
| Infiltration | 0.846 → 0.858 (n.s., p=0.39) | 0.875 → 0.878 (n.s., p=0.77) |
| Lung Nodule or Mass | 0.944 → 0.973 | 0.939 → 0.955 |
| Pneumothorax | 0.642 → 0.972 | 0.832 → 0.997 |
| **Mean** | **0.827 → 0.958** | **0.894 → 0.966** |

Worst case is Pneumothorax on UK: **+0.330 AUROC, DeLong p = 3.5e-27**. The fine-tuned model is
unaffected (0.999 / 1.000 either way — it saturates on this synthetic task), so the
pretrained-vs-fine-tuned gap narrows from 0.172 → 0.041 (UK) and 0.106 → 0.034 (Thai).

**Anyone holding Ark+ fine-tuned weights** should know they were trained through the sideways chain.
They score identically upright on this saturated task, but a retrain is the clean path.

## Checklist

- [x] Follows the project's coding conventions and style guide
- [x] Updates documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Type of Change

- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [x] In-line docstrings updated.
- [ ] Documentation updated, tested `make -C docs/ docs`.

## Testing

Verified numerically rather than by eye, because a mirrored chest X-ray looks entirely plausible.

- The fixed app's own `get_xray_transforms(768)` output is **bit-identical** (`max|diff| = 0`) to a
  reference chain built directly from the stored `PixelData`, on both square and non-square studies.
  A non-square study matters: on a square image a transpose and a rotation cannot be told apart by
  shape.
- The **unfixed** chain reproduces the published prod evaluation (model `fcf8cb36…`) to the digit,
  including its DeLong p-values — so the before/after comparison above is like-for-like rather than a
  re-implementation artefact.
- Both models re-scored over all 946 holdout studies (UK 478 + Thai 468) in both orientations;
  per-class AUROC and paired DeLong as tabulated.
- Review round: `Transposed` now precedes `Resized` (2e9f2921) so the correction sits next to the
  load it undoes. This is a **bit-for-bit no-op** — `Resized` targets a square
  `[input_size, input_size]` and the resamplers are separable, so both orders select the same
  pixels: `max|diff| = 0` in exact float64 across `area`/`bilinear`/`nearest`/`bicubic`, both up-
  and downsampling, and `0` end-to-end through the full chain on a real uint16 DICOM. Order is only
  significant for a non-square target (checked as a control). The numbers above are unaffected and
  need no re-run.
- The later rounds are **docs only** — no transform, model or metric code changed, so none of the
  numbers above are affected.

Not run: `make unit-test` / `make integration-test` are unaffected — `fl-tutorials/` has no test suite
or lint job in CI, which is precisely why this survived. `ruff check` is clean on all three apps.
Standing that harness up is now tracked in #871.

## Additional Notes

The same root cause hit the xray classification tutorials; that fix landed on `develop` with #812
(merged 2026-08-03), so the three Ark+ apps here were the last `Flipd` sites in the tree. There the
composition happened to produce a mirror rather than a rotation, so it cost laterality correctness but
not accuracy. Here it cost accuracy.

**Documentation.** Two places quoted superseded scores and now carry the current ones:

- `fl-tutorials/nvflare/ARKPLUS_EXPERIMENTS_GUIDE.md` — both results sections now tabulate the
  published figures (DeCaF 2026 Table 1) over the same holdout cohorts. The multimodel section's
  significance claim is restated to match: the finetune is at least as good on every lesion, with 6 of
  the 10 lesion–trust pairings surviving Benjamini–Hochberg correction (the exceptions are the four
  where the pretrained model is already at or above 0.997).
- `arkplus_baseline_classification_evaluation/README.md` — sample output matches those figures.

The paired re-score above and the published run agree to ±0.005 on every lesion; the table above keeps
the re-score's own numbers on both sides so the sideways/upright comparison and its DeLong p-values stay
internally consistent.

The loading chain itself is documented in-code, next to the transform it constrains. A test harness for
`fl-tutorials/` — including a stored non-square reference DICOM asserted bit-identical against
`pydicom`'s `PixelData` — is tracked in #871.


## Acceptance Criteria

*Imported from issue #820*

- [x] All three Ark+ apps undo the loader transpose with `Transposed(indices=(0, 2, 1))`
- [x] The corrected transform is verified against the DICOM as stored, not just visually
- [x] The reason the obvious alternatives (`Rotate90d`, `Flipd`) are wrong is recorded in-code, so it
      is not "fixed" back
- [x] Impact on previously reported Ark+ numbers is written down



