### PR TITLE
refactor(round-metrics): unambiguous names + dedicated scripts/fl_round_metrics/ home

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -469,7 +469,7 @@ fl-services/flower/provision/creds/
 fl-services/flower/runs/
 fl-tutorials/flower/data/
 
-# Round-metric extraction output (scripts/extract_model_metrics.sh /
-# scripts/extract_simulator_metrics.sh and the tutorials' `make metrics` write
+# Round-timing extraction output (scripts/fl_round_metrics/ extractors and the
+# tutorials' `make round-metrics` write
 # rounds.tsv + summary.md + boxplots here) — data artifacts, not source.
-model_metrics/
+round_metrics/

--- a/docs/source/user-guides/reproducing-platform-overhead.rst
+++ b/docs/source/user-guides/reproducing-platform-overhead.rst
@@ -129,7 +129,7 @@ The extracted metrics are also available standalone under the tutorial directory
 .. code-block:: bash
 
    make run NUM_ROUNDS=50            # just simulate (skip bundling)
-   make round-metrics                      # extract rounds.tsv + summary from the server log
+   make round-metrics                # extract rounds.tsv + summary from the server log
 
 .. _overhead-platform-run:
 

--- a/docs/source/user-guides/reproducing-platform-overhead.rst
+++ b/docs/source/user-guides/reproducing-platform-overhead.rst
@@ -72,7 +72,7 @@ GPU machine:
 Requirement                    Purpose
 =============================  ====================================================================
 FLIP account (``researcher``)  Submit and monitor the platform run
-AWS prod credentials           Extract round metrics from CloudWatch (``extract_model_metrics.sh``)
+AWS prod credentials           Extract round metrics from CloudWatch (``extract_platform_round_timings.sh``)
 Linux + NVIDIA GPU + ``uv``    Run the local simulator replica
 ~15 GB free disk               Tutorial dataset (~6.3 GB) plus simulator output
 Ark+ backbone checkpoint       Request via `this form <https://forms.gle/qkoDGXNiKRPTDdCe8>`_
@@ -97,7 +97,7 @@ preparation, 50-round simulation, metric extraction, and bundling:
 
    git clone https://github.com/londonaicentre/FLIP.git
    cd FLIP/fl-tutorials/nvflare/image_classification/arkplus_fine_tuning
-   make experiment
+   make reproduce-overhead
 
 This produces a timestamped bundle in the tutorial directory:
 
@@ -117,19 +117,19 @@ The bundle contains:
 * ``provenance/host_info.txt`` — GPU model, driver version, OS, git commit
 
 If you already ran the simulator and only need to re-bundle (e.g., the simulation completed but
-packing failed), use ``make package`` instead — it re-packs the last run without re-simulating.
+packing failed), use ``make package-overhead-bundle`` instead — it re-packs the last run without re-simulating.
 
-On a multi-GPU host pick a device with ``CUDA_VISIBLE_DEVICES=<n> make experiment``. You can
-change the round count from the default 50 with ``EXPERIMENT_ROUNDS=<n>`` if you are testing.
+On a multi-GPU host pick a device with ``CUDA_VISIBLE_DEVICES=<n> make reproduce-overhead``. You can
+change the round count from the default 50 with ``OVERHEAD_ROUNDS=<n>`` if you are testing.
 
 .. _overhead-metrics:
 
-The extracted metrics are also available standalone under ``model_metrics/`` at the repo root:
+The extracted metrics are also available standalone under the tutorial directory's ``round_metrics/``:
 
 .. code-block:: bash
 
    make run NUM_ROUNDS=50            # just simulate (skip bundling)
-   make metrics                      # extract rounds.tsv + summary from the server log
+   make round-metrics                      # extract rounds.tsv + summary from the server log
 
 .. _overhead-platform-run:
 
@@ -161,7 +161,7 @@ Step 3: Extract platform metrics from CloudWatch
 **************************************************
 
 The platform run's round-level timing is logged by the FL server (``fl-server``) to CloudWatch.
-The extraction script ``scripts/extract_model_metrics.sh`` pulls these log lines and writes the
+The extraction script ``scripts/fl_round_metrics/extract_platform_round_timings.sh`` pulls these log lines and writes the
 same artefacts the simulator produces (``rounds.tsv``, ``summary.md``, boxplot):
 
 .. code-block:: bash
@@ -172,12 +172,12 @@ same artefacts the simulator produces (``rounds.tsv``, ``summary.md``, boxplot):
    aws sso login --profile prod
 
    # Extract metrics for a specific model — pass the FLIP UI model page URL, not a bare ID
-   ./scripts/extract_model_metrics.sh '<flip-ui-model-url>' -o <output-directory>
+   ./scripts/fl_round_metrics/extract_platform_round_timings.sh '<flip-ui-model-url>' -o <output-directory>
 
    # Example
-   ./scripts/extract_model_metrics.sh \
+   ./scripts/fl_round_metrics/extract_platform_round_timings.sh \
        'https://app.flip.aicentre.co.uk/project/f48850b7-3101-46d1-8fa7-a00bf01d2597/model/24985ec3-3349-435b-afcd-f38972d8695d' \
-       -o model_metrics
+       -o round_metrics
 
 The script parses the ``project_id``/``model_id`` pair out of that URL, then discovers the model's
 activity window itself: it searches the ``/ecs/flip-api`` CloudWatch log group for log lines
@@ -195,7 +195,7 @@ controller events from the ``fl-server-net-*``/``fl-api-net-*`` log groups and w
   lines found in the time window (useful for diagnosing runs that didn't complete)
 
 The script requires the ``aws`` CLI (authenticated with the ``prod`` profile) and ``jq``; run
-``./scripts/extract_model_metrics.sh --help`` for the full option list.
+``./scripts/fl_round_metrics/extract_platform_round_timings.sh --help`` for the full option list.
 
 .. _overhead-compare:
 
@@ -209,9 +209,9 @@ metrics`` target:
 .. code-block:: bash
 
    cd fl-tutorials/nvflare/image_classification/arkplus_fine_tuning
-   make metrics COMPARE=../../../../model_metrics/24985ec3-3349-435b-afcd-f38972d8695d/rounds.tsv
+   make round-metrics COMPARE=../../../../round_metrics/24985ec3-3349-435b-afcd-f38972d8695d/rounds.tsv
 
-The output ``summary.md`` in ``model_metrics/simulator-<workspace>-<timestamp>/`` now includes a
+The output ``summary.md`` in ``round_metrics/simulator-<workspace>-<timestamp>/`` now includes a
 side-by-side comparison table with platform − simulator deltas for every metric, plus an
 interpretation section.
 
@@ -265,8 +265,8 @@ The same extraction-and-compare workflow works for any FLIP run — not just the
 #. **Run your model on FLIP** as usual through the UI
 #. **Run the same model in the local simulator** — use the tutorial harness or NVFLARE's
    ``SimulatorRunner`` directly, matching the deployed ``config.json`` round count
-#. **Extract platform metrics** with ``extract_model_metrics.sh <your-model-id>``
-#. **Compare** with ``make metrics COMPARE=/path/to/platform/rounds.tsv``
+#. **Extract platform metrics** with ``extract_platform_round_timings.sh <your-model-id>``
+#. **Compare** with ``make round-metrics COMPARE=/path/to/platform/rounds.tsv``
 
 The comparison will show your model's platform overhead profile:
 
@@ -292,17 +292,17 @@ the simulator baseline on their own GPU with a single command:
 
    git clone https://github.com/londonaicentre/FLIP.git
    cd FLIP/fl-tutorials/nvflare/image_classification/arkplus_fine_tuning
-   make experiment
+   make reproduce-overhead
 
 They send back the ``arkplus_sim_experiment_<host>_<timestamp>.zip`` bundle. Extract it — the
 bundle already contains that site's own ``rounds.tsv``/``summary.md``, produced by their
-``make experiment`` run, so there is nothing left to (re-)compute:
+``make reproduce-overhead`` run, so there is nothing left to (re-)compute:
 
 .. code-block:: bash
 
    unzip arkplus_sim_experiment_bdms-gpu-1_20260714T120000.zip -d /tmp/bdms-sim
 
-``make metrics`` (and ``extract_simulator_metrics.sh`` underneath it) takes a single
+``make round-metrics`` (and ``extract_simulator_round_timings.sh`` underneath it) takes a single
 ``COMPARE``/``--compare`` baseline at a time — there is no ``COMPARE_2`` for a combined
 multi-column table. To line a third site's numbers up against the platform baseline, either read
 its extracted ``summary.md``/``rounds.tsv`` alongside the platform run's, or re-run the comparison
@@ -311,7 +311,7 @@ platform-vs-that-site ``summary.md``:
 
 .. code-block:: bash
 
-   bash scripts/extract_simulator_metrics.sh /tmp/bdms-sim/simulator-arkplus-*/logs \
+   bash scripts/fl_round_metrics/extract_simulator_round_timings.sh /tmp/bdms-sim/simulator-arkplus-*/logs \
        --compare /path/to/platform/rounds.tsv -o /tmp/bdms-sim-compare
 
 Repeat once per collaborating site's bundle. The provenance folder in each bundle (GPU model,
@@ -326,5 +326,5 @@ differences.
    `arkplus_fine_tuning README <https://github.com/londonaicentre/FLIP/blob/develop/fl-tutorials/nvflare/image_classification/arkplus_fine_tuning/README.md>`_
       Technical reference for the app internals (model architecture, finetuning mechanisms, ``job.py``).
 
-   `scripts/extract_model_metrics.sh <https://github.com/londonaicentre/FLIP/blob/develop/scripts/extract_model_metrics.sh>`_
+   `scripts/fl_round_metrics/extract_platform_round_timings.sh <https://github.com/londonaicentre/FLIP/blob/develop/scripts/fl_round_metrics/extract_platform_round_timings.sh>`_
       The CloudWatch extraction script used in Step 3.

--- a/fl-tutorials/nvflare/Makefile
+++ b/fl-tutorials/nvflare/Makefile
@@ -77,7 +77,7 @@ download-arkplus-finetuning-data:
 	@# Written last, only on a fully successful run: `experiment`'s dataset-present check in
 	@# arkplus_fine_tuning/Makefile looks for this marker (not just directory existence), so an
 	@# interrupted download/copy (e.g. Ctrl+C mid-run) can't be mistaken for complete data on the
-	@# next `make experiment`.
+	@# next `make reproduce-overhead`.
 	@touch data/arkplus/site1/.download-complete data/arkplus/site2/.download-complete
 	@echo "✅ Ark+ training data ready at data/arkplus/site{1,2}/ — run: make run-tutorial TUTORIAL=arkplus_fine_tuning"
 

--- a/fl-tutorials/nvflare/image_classification/arkplus_fine_tuning/.gitignore
+++ b/fl-tutorials/nvflare/image_classification/arkplus_fine_tuning/.gitignore
@@ -3,5 +3,7 @@
 fl_job/
 uv.lock
 models/
-# `make experiment`/`make package` result bundles (sent back for comparison, not committed)
+# `make reproduce-overhead`/`make package-overhead-bundle` result bundles (sent back for comparison, not committed)
 arkplus_sim_experiment_*
+# `make round-metrics` output (rounds.tsv / summary.md / boxplots per run)
+round_metrics/

--- a/fl-tutorials/nvflare/image_classification/arkplus_fine_tuning/Makefile
+++ b/fl-tutorials/nvflare/image_classification/arkplus_fine_tuning/Makefile
@@ -37,15 +37,15 @@ NUM_ROUNDS ?= 3
 N_CLIENTS ?= 2
 
 # Simulator workspace + metrics output. WORKSPACE matches job.py's default and is deliberately NOT
-# the shared harness dir (../../testing/runs/workspace): `make metrics` auto-discovers the log with
+# the shared harness dir (../../testing/runs/workspace): `make round-metrics` auto-discovers the log with
 # the most round events under the workspace tree, and the shared dir accumulates round logs from
 # other tutorials' runs, so a stale log could be picked up instead of this tutorial's.
 WORKSPACE ?= /tmp/nvflare/arkplus_finetuning_client_api
-METRICS_OUT ?= $(REPO_ROOT)/model_metrics
+METRICS_OUT ?= $(APP_DIR)/round_metrics
 
-# Round count for the one-shot `make experiment` replica — matches the deployed run's
+# Round count for the one-shot `make reproduce-overhead` replica — matches the deployed run's
 # GLOBAL_ROUNDS (config.json), unlike the quick-smoke NUM_ROUNDS default of 3.
-EXPERIMENT_ROUNDS ?= 50
+OVERHEAD_ROUNDS ?= 50
 
 # The backbone checkpoint the server loads (config.json SERVER_CHECKPOINT). Staged into app_files/ so
 # stage_app_files() bundles it into the server custom dir; clients receive the backbone at round 0.
@@ -67,7 +67,7 @@ override SITE2_IMAGES_DIR := $(call abspath_app,$(SITE2_IMAGES_DIR))
 override SITE2_DATAFRAME  := $(call abspath_app,$(SITE2_DATAFRAME))
 override DATA_ROOT        := $(call abspath_app,$(DATA_ROOT))
 
-.PHONY: run export sim metrics experiment package download-raw-checkpoint prepare-checkpoint dataset-figure clean
+.PHONY: run export sim round-metrics reproduce-overhead package-overhead-bundle download-raw-checkpoint prepare-checkpoint dataset-figure clean
 
 # --- Raw checkpoint download ---
 download-raw-checkpoint:
@@ -156,20 +156,20 @@ sim:
 
 # --- Extract round metrics from the simulator logs (run after `make sim`/`make run`) ---
 # Parses the FLIP ScatterAndGather controller events in the simulator server log and writes the same
-# rounds.tsv / summary.md / boxplot artefacts as scripts/extract_model_metrics.sh produces for a
+# rounds.tsv / summary.md / boxplot artefacts as scripts/fl_round_metrics/extract_platform_round_timings.sh produces for a
 # platform run, so the two are directly comparable. Optional:
 # COMPARE=/path/to/platform/rounds.tsv adds a side-by-side steady-state overhead table.
-metrics:
-	bash "$(REPO_ROOT)/scripts/extract_simulator_metrics.sh" "$(WORKSPACE)" \
+round-metrics:
+	bash "$(REPO_ROOT)/scripts/fl_round_metrics/extract_simulator_round_timings.sh" "$(WORKSPACE)" \
 		-o "$(METRICS_OUT)" $(if $(COMPARE),--compare "$(COMPARE)") $(if $(RUN_NAME),--run-name "$(RUN_NAME)")
 
-# --- One-shot cross-site experiment (no hub / AWS access needed) ---
+# --- One-shot cross-site overhead reproduction (no hub / AWS access needed) ---
 # Everything a collaborating site needs to reproduce the simulator baseline and send the results
 # back: fetch the HF tutorial data (~6.3 GB) and the Ark+ checkpoint when missing, run the
-# full-length simulator replica (EXPERIMENT_ROUNDS, default 50), then extract the round metrics
+# full-length simulator replica (OVERHEAD_ROUNDS, default 50), then extract the round metrics
 # and pack metrics + simulator logs + host/provenance info into a single archive in this
 # directory. Requires Linux, uv, and an NVIDIA GPU (pick one with CUDA_VISIBLE_DEVICES).
-experiment:
+reproduce-overhead:
 	@# Directory existence alone doesn't mean the download finished (an interrupted `snapshot_download`
 	@# or Ctrl+C mid-copy leaves the directories present but partial) — check for the
 	@# .download-complete marker download-arkplus-finetuning-data writes only on success.
@@ -182,18 +182,18 @@ experiment:
 		$(MAKE) --no-print-directory download-raw-checkpoint; \
 	fi
 	@$(MAKE) --no-print-directory prepare-checkpoint
-	@$(MAKE) --no-print-directory sim NUM_ROUNDS="$(EXPERIMENT_ROUNDS)"
-	@$(MAKE) --no-print-directory package
+	@$(MAKE) --no-print-directory sim NUM_ROUNDS="$(OVERHEAD_ROUNDS)"
+	@$(MAKE) --no-print-directory package-overhead-bundle
 
 # Extract metrics from the last simulator run and bundle them with the workspace logs (model
 # files excluded), config.json, .env.app, and host info (GPU, OS, git commit) into
 # arkplus_sim_experiment_<host>_<stamp>.zip (.tar.gz when zip is not installed). Split out from
-# `experiment` so a finished run can be re-packaged without re-simulating.
-package:
+# `reproduce-overhead` so a finished run can be re-packaged without re-simulating.
+package-overhead-bundle:
 	@set -e; \
 	stamp="$$(date +%Y%m%dT%H%M%S)"; host="$$(hostname -s)"; \
 	run_name="simulator-arkplus-$${host}-$${stamp}"; \
-	$(MAKE) --no-print-directory metrics RUN_NAME="$$run_name"; \
+	$(MAKE) --no-print-directory round-metrics RUN_NAME="$$run_name"; \
 	out="$(METRICS_OUT)/$$run_name"; \
 	observed_rounds="$$(tail -n +2 "$$out/rounds.tsv" 2>/dev/null | wc -l | tr -d ' ')"; \
 	mkdir -p "$$out/logs" "$$out/provenance"; \
@@ -213,7 +213,7 @@ package:
 	  echo "host: $$(hostname)"; \
 	  echo "git_commit: $$(git -C "$(REPO_ROOT)" rev-parse HEAD 2>/dev/null || echo unknown)"; \
 	  echo "git_branch: $$(git -C "$(REPO_ROOT)" rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)"; \
-	  echo "experiment_rounds: $${observed_rounds:-$(EXPERIMENT_ROUNDS)} (observed in rounds.tsv; requested EXPERIMENT_ROUNDS=$(EXPERIMENT_ROUNDS))"; \
+	  echo "overhead_rounds: $${observed_rounds:-$(OVERHEAD_ROUNDS)} (observed in rounds.tsv; requested OVERHEAD_ROUNDS=$(OVERHEAD_ROUNDS))"; \
 	  echo "workspace: $(WORKSPACE)"; \
 	  echo; uname -a; \
 	  echo; nvidia-smi 2>/dev/null || echo "nvidia-smi unavailable"; \

--- a/fl-tutorials/nvflare/image_classification/arkplus_fine_tuning/README.md
+++ b/fl-tutorials/nvflare/image_classification/arkplus_fine_tuning/README.md
@@ -177,19 +177,19 @@ uv run --project ../../../../flip-utils --extra full python job.py --n_clients 3
 
 ## Round metrics & platform comparison
 
-After a simulator run, `make metrics` parses the FLIP `ScatterAndGather` controller events
+After a simulator run, `make round-metrics` parses the FLIP `ScatterAndGather` controller events
 (`Round N started/finished`, `Start/End aggregation`, `Contribution ... ACCEPTED`) from the
-simulator server log — the same lines `scripts/extract_model_metrics.sh` pulls from CloudWatch for
+simulator server log — the same lines `scripts/fl_round_metrics/extract_platform_round_timings.sh` pulls from CloudWatch for
 a deployed run — and writes the same artefacts (`rounds.tsv`, `summary.md`, a timing boxplot) under
-`model_metrics/` at the repo root:
+`round_metrics/` in this directory:
 
 ```bash
 make run NUM_ROUNDS=50            # full-length local replica (GPU, hours; smoke-test with the default 3 first)
-make metrics                      # -> model_metrics/simulator-<workspace>-<timestamp>/
-make metrics COMPARE=/path/to/platform/rounds.tsv   # adds a platform − simulator overhead table
+make round-metrics                      # -> round_metrics/simulator-<workspace>-<timestamp>/
+make round-metrics COMPARE=/path/to/platform/rounds.tsv   # adds a platform − simulator overhead table
 ```
 
-`COMPARE` takes a `rounds.tsv` produced by `scripts/extract_model_metrics.sh` for a platform run of
+`COMPARE` takes a `rounds.tsv` produced by `scripts/fl_round_metrics/extract_platform_round_timings.sh` for a platform run of
 this same app; the summary then includes a side-by-side steady-state table (round duration,
 aggregation time, inter-round gap), i.e. a baseline for the overhead the platform adds over bare
 local training. Knobs: `WORKSPACE` (simulator workspace parsed for logs; defaults to `job.py`'s
@@ -210,7 +210,7 @@ everything to send back:
 
 ```bash
 git clone <repo> && cd FLIP/fl-tutorials/nvflare/image_classification/arkplus_fine_tuning
-make experiment          # hours on GPU; produces arkplus_sim_experiment_<host>_<stamp>.zip here
+make reproduce-overhead          # hours on GPU; produces arkplus_sim_experiment_<host>_<stamp>.zip here
 ```
 
 The bundle contains the metrics artefacts (`rounds.tsv`, `summary.md`, boxplot), the simulator
@@ -220,9 +220,9 @@ logs (model files excluded), and a `provenance/` folder (`config.json`, `.env.ap
 Prerequisites: Linux with an NVIDIA GPU + drivers, [`uv`](https://docs.astral.sh/uv/) on `PATH`
 (the first run builds the flip-utils environment automatically), internet access (Hugging Face +
 Dropbox), and ~15 GB free disk. On a multi-GPU host pick a device with
-`CUDA_VISIBLE_DEVICES=<n> make experiment`. Knobs: `EXPERIMENT_ROUNDS` (default `50`, the deployed
+`CUDA_VISIBLE_DEVICES=<n> make reproduce-overhead`. Knobs: `OVERHEAD_ROUNDS` (default `50`, the deployed
 run's `GLOBAL_ROUNDS`). If the simulation finished but packing failed (or you want to re-send),
-`make package` re-bundles the last run without re-simulating.
+`make package-overhead-bundle` re-bundles the last run without re-simulating.
 
 ## Key files
 

--- a/fl-tutorials/nvflare/image_classification/arkplus_fine_tuning/README.md
+++ b/fl-tutorials/nvflare/image_classification/arkplus_fine_tuning/README.md
@@ -185,7 +185,7 @@ a deployed run — and writes the same artefacts (`rounds.tsv`, `summary.md`, a 
 
 ```bash
 make run NUM_ROUNDS=50            # full-length local replica (GPU, hours; smoke-test with the default 3 first)
-make round-metrics                      # -> round_metrics/simulator-<workspace>-<timestamp>/
+make round-metrics                # -> round_metrics/simulator-<workspace>-<timestamp>/
 make round-metrics COMPARE=/path/to/platform/rounds.tsv   # adds a platform − simulator overhead table
 ```
 

--- a/scripts/fl_round_metrics/README.md
+++ b/scripts/fl_round_metrics/README.md
@@ -1,0 +1,46 @@
+# FL round-timing metrics
+
+Tooling for extracting and comparing **per-round FL timings** — how long each
+global round and aggregation took — from the two places a FLIP training run can
+happen. Not to be confused with FLIP's *model metrics* (the `FLMetrics` training
+curves served by `/model/{id}/metrics` and plotted in the UI): everything here
+measures wall-clock platform behaviour, not model performance.
+
+| Tool | Source | Needs |
+|------|--------|-------|
+| `extract_platform_round_timings.sh` | Central Hub CloudWatch logs (`/ecs/flip-api`, `/ecs/fl-api-net-*`, `/ecs/fl-server-net-*`) for one model, NVFLARE or Flower | read-only AWS credentials |
+| `extract_simulator_round_timings.sh` | A local NVFLARE simulator workspace (FLIP `ScatterAndGather` controller events in the server log) | nothing beyond the workspace |
+| `plot_round_timings.py` | A `rounds.tsv` from either extractor | `uv run` (matplotlib) |
+
+The arkplus fine-tuning tutorial wraps the simulator side as
+`make round-metrics` / `make reproduce-overhead`
+(`fl-tutorials/nvflare/image_classification/arkplus_fine_tuning/`); the full
+cross-site protocol is documented in
+`docs/source/user-guides/reproducing-platform-overhead.rst`.
+
+## The `rounds.tsv` schema is the contract
+
+Both extractors emit an identical `rounds.tsv`, which is what makes a simulator
+baseline directly comparable against a platform run (`--compare`), and what
+`plot_round_timings.py` consumes. **If you change these columns, change both
+extractors, the plotter, and the `--compare` header validation together** —
+they live in one directory precisely so that drift is a one-directory diff:
+
+```
+round  started_utc  finished_utc  duration_s  agg_started_utc  agg_finished_utc  agg_duration_s  accepted  rejected  start_ms  end_ms  agg_start_ms  agg_end_ms
+```
+
+- `round` — 1-based global round number.
+- `*_utc` — ISO-8601 timestamps; `-` when the event was not observed.
+- `duration_s` / `agg_duration_s` — derived spans in seconds.
+- `accepted` / `rejected` — client contributions the aggregator accepted/rejected.
+- `*_ms` — raw epoch-millisecond counterparts of the timestamp columns.
+
+Each extractor also writes a human-readable `summary.md` (with explicit
+`NOT AVAILABLE` / `NOT APPLICABLE` / `PARTIAL DATA` markers rather than silent
+gaps) and a timing boxplot via the plotter.
+
+## Tests
+
+`tests/` is the home for the extractor fixture tests (synthetic log in, golden
+`rounds.tsv` diff out) — run them with `bash`, no AWS or GPU required.

--- a/scripts/fl_round_metrics/README.md
+++ b/scripts/fl_round_metrics/README.md
@@ -42,5 +42,7 @@ gaps) and a timing boxplot via the plotter.
 
 ## Tests
 
-`tests/` is the home for the extractor fixture tests (synthetic log in, golden
-`rounds.tsv` diff out) — run them with `bash`, no AWS or GPU required.
+**None yet — nothing to run today.** `tests/` is the reserved home for the
+extractor fixture tests proposed in #778's review (synthetic log in, golden
+`rounds.tsv` diff out); when they land they will need only `bash`, no AWS or
+GPU.

--- a/scripts/fl_round_metrics/extract_platform_round_timings.sh
+++ b/scripts/fl_round_metrics/extract_platform_round_timings.sh
@@ -12,7 +12,7 @@
 # limitations under the License.
 #
 #
-# extract_model_metrics.sh — pull FL-run metrics for one model out of the Central Hub's
+# extract_platform_round_timings.sh — pull FL-run metrics for one model out of the Central Hub's
 # production CloudWatch logs (flip-api, fl-api-net-*, fl-server-net-*). Trust-side logs
 # (EC2, not CloudWatch) are out of scope — see the "NOT AVAILABLE" notes this script writes
 # into summary.md for anything that can only be observed there.
@@ -127,7 +127,7 @@ Arguments:
   <flip-ui-model-url>   e.g. https://app.flip.aicentre.co.uk/project/<project_id>/model/<model_id>
 
 Options:
-  -o, --output-dir DIR      Base output directory (default: ./model_metrics)
+  -o, --output-dir DIR      Base output directory (default: ./round_metrics)
       --profile PROFILE     AWS CLI profile (default: prod)
       --region REGION       AWS region (default: eu-west-2)
       --start ISO8601       Start of the search window (skips auto-discovery), e.g. 2026-06-30T09:00:00Z
@@ -152,7 +152,7 @@ Examples:
 EOF
 }
 
-OUTPUT_DIR="./model_metrics"
+OUTPUT_DIR="./round_metrics"
 AWS_PROFILE_ARG="prod"
 AWS_REGION_ARG="eu-west-2"
 USER_START=""

--- a/scripts/fl_round_metrics/extract_simulator_round_timings.sh
+++ b/scripts/fl_round_metrics/extract_simulator_round_timings.sh
@@ -11,7 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# extract_simulator_metrics.sh — local-simulator counterpart of extract_model_metrics.sh.
+# extract_simulator_round_timings.sh — local-simulator counterpart of extract_platform_round_timings.sh.
 #
 # Parses an NVFLARE SimEnv workspace's logs for the SAME controller events the production
 # script pulls from CloudWatch (flip.nvflare.controllers.scatter_and_gather.ScatterAndGather
@@ -44,22 +44,22 @@ Extract FL round metrics from a local NVFLARE simulator workspace
 (default workspace: /tmp/nvflare/arkplus_finetuning_client_api).
 
 Options:
-  -o, --output-dir DIR   Base output directory (default: ./model_metrics)
+  -o, --output-dir DIR   Base output directory (default: ./round_metrics)
       --run-name NAME    Output subdirectory name (default: simulator-<workspace basename>-<log mtime>)
       --log FILE         Parse this log file directly (skips workspace discovery)
-      --compare TSV      Platform rounds.tsv (from extract_model_metrics.sh) to
+      --compare TSV      Platform rounds.tsv (from extract_platform_round_timings.sh) to
                          compare against — adds a steady-state overhead table
   -h, --help             Show this help and exit
 
 Examples:
   ${SCRIPT_NAME}                                    # after 'make sim' in the finetuning tutorial
-  ${SCRIPT_NAME} /tmp/nvflare/arkplus_finetuning_client_api -o model_metrics \\
-      --compare model_metrics/eff70d90-5706-4cc9-8087-5059dfb40d96/rounds.tsv
+  ${SCRIPT_NAME} /tmp/nvflare/arkplus_finetuning_client_api -o round_metrics \\
+      --compare round_metrics/eff70d90-5706-4cc9-8087-5059dfb40d96/rounds.tsv
 EOF
 }
 
 WORKSPACE="/tmp/nvflare/arkplus_finetuning_client_api"
-OUTPUT_DIR="./model_metrics"
+OUTPUT_DIR="./round_metrics"
 RUN_NAME=""
 LOG_FILE=""
 COMPARE_TSV=""
@@ -183,7 +183,7 @@ extract_events 'Start aggregation\.' "${WORK_DIR}/as.raw"
 extract_events 'End aggregation\.' "${WORK_DIR}/ae.raw"
 # Pinned NVFLARE (2.8.0)'s stock ScatterAndGather unconditionally tags this line with the
 # round number ("... by the aggregator at round <N>."); the optional group is a defensive
-# fallback for older builds that omitted it, matching extract_model_metrics.sh's pattern.
+# fallback for older builds that omitted it, matching extract_platform_round_timings.sh's pattern.
 extract_events 'Contribution from [^ ]+ (ACCEPTED|REJECTED) by the aggregator( at round [0-9]+)?\.' "${WORK_DIR}/co.raw"
 
 sed -E 's/^([0-9]+)\t.*Round ([0-9]+) started\..*/\2\t\1/' "${WORK_DIR}/rs.raw" | sort -n -k1,1 > "$ROUND_STARTS"
@@ -201,11 +201,11 @@ REJECTED_TOTAL="$(grep -c $'^REJECTED\t' "$CONTRIBS" || true)"
 log "Parsed ${n_rounds} round(s); contributions: ${ACCEPTED_TOTAL} accepted, ${REJECTED_TOTAL} rejected"
 
 # --------------------------------------------------------------------------------------
-# Build rounds.tsv — identical schema to extract_model_metrics.sh, so
+# Build rounds.tsv — identical schema to extract_platform_round_timings.sh, so
 # plot_round_timings.py consumes it unchanged. Aggregation start/end pairs are matched to
 # rounds chronologically (ScatterAndGather aggregates synchronously once per round);
 # contributions are matched by their own round tag (see CONTRIBS above) exactly like
-# extract_model_metrics.sh — untagged ('-') lines only count towards the grand totals above,
+# extract_platform_round_timings.sh — untagged ('-') lines only count towards the grand totals above,
 # not any specific round.
 # NB: "started_utc"/"finished_utc" columns hold the log's LOCAL wall-clock time (the
 # simulator writes no timezone); the column names are kept for schema compatibility.
@@ -387,7 +387,7 @@ fmt_row() { local IFS=$'\t'; read -r m s n <<<"$1"; echo "| $2 | ${m} | ${s} | $
     echo
     echo "Round 0 duration: **${ROUND0_DUR:-n/a}s** (one-off initialisation: weight load, data-loader start-up, first-access caching)."
     echo
-    echo "Machine-readable copy: \`rounds.tsv\` (same schema as extract_model_metrics.sh)."
+    echo "Machine-readable copy: \`rounds.tsv\` (same schema as extract_platform_round_timings.sh)."
     if [[ "$BOXPLOT_GENERATED" == "true" ]]; then
         echo "Timing distributions: \`round_timings_boxplot.png\`."
     fi

--- a/scripts/fl_round_metrics/plot_round_timings.py
+++ b/scripts/fl_round_metrics/plot_round_timings.py
@@ -13,7 +13,7 @@
 #
 """Render seaborn boxplots of per-round FL timing metrics from a rounds.tsv.
 
-Companion to extract_model_metrics.sh, which writes rounds.tsv (one row per
+Companion to extract_platform_round_timings.sh (and its simulator sibling), which writes rounds.tsv (one row per
 communication round, ms-precision epoch columns) and invokes this script
 best-effort via `uv run --no-project --with pandas --with seaborn`. Not part of
 any FLIP service — pandas/seaborn are deliberately NOT project dependencies.
@@ -48,7 +48,7 @@ METRIC_ORDER = ["Round duration", "Aggregation", "Inter-round gap"]
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
-    parser.add_argument("rounds_tsv", help="rounds.tsv written by extract_model_metrics.sh")
+    parser.add_argument("rounds_tsv", help="rounds.tsv written by either extractor")
     parser.add_argument("output_png", help="path of the PNG to write")
     parser.add_argument("--model-id", default="unknown", help="model UUID (title only)")
     parser.add_argument("--backend", default="unknown", help="detected FL backend (title only)")


### PR DESCRIPTION
# Description

Layout/naming suggestions for #778, implemented as a mergeable diff (same pattern as #801 was for #784). **No behaviour changes** — pure rename/move with every cross-reference updated:

- **`scripts/fl_round_metrics/`** now houses the trio — both extractors, `plot_round_timings.py`, and (future) fixture tests — with a README that declares the shared `rounds.tsv` schema as the contract. The schema is what makes simulator-vs-platform comparison work; keeping its producers and consumer in one directory makes drift a one-directory diff.
- **`extract_model_metrics.sh` → `extract_platform_round_timings.sh`**, **`extract_simulator_metrics.sh` → `extract_simulator_round_timings.sh`** — "model metrics" already means the `FLMetrics` training curves (`/model/{id}/metrics`, the UI plots); these scripts extract *round timings*, and now match the plotter's naming.
- **Tutorial Makefile targets renamed for specificity**: `metrics` → `round-metrics`, `experiment` → `reproduce-overhead` (matches `reproducing-platform-overhead.rst`, so collaborators find the target by the guide's name), `package` → `package-overhead-bundle` (per the `package-onprem-trust-kit` namespacing precedent). `EXPERIMENT_ROUNDS` → `OVERHEAD_ROUNDS`.
- **Default output moves** from repo-root `model_metrics/` to the tutorial's `round_metrics/` (root-checkout pollution + the same name collision); both `.gitignore`s follow.
- Docs page, tutorial README, and the fl-tutorials harness comment all updated in lockstep.

Deliberately **not** done: moving `reproducing-platform-overhead.rst` out of user-guides (flagged as fine-either-way in review discussion — relocating it out of the Sphinx tree would drop it from ReadTheDocs, so that's the author's call), and the `arkplus_sim_experiment_*` bundle filename (self-describing as is). The new `scripts/fl_round_metrics/tests/` home is where the fixture test from the review round can land.

## Review round (@garciadias, 2026-07-28) — addressed at 920d660b

- **Comment-column alignment** (docs page + tutorial README): the six-character `metrics` → `round-metrics` rename pushed the trailing `#` off the grid the two short commands shared. Both blocks realigned. The longer `COMPARE=...` line keeps its own three-space gap, unchanged from before the rename — its command alone is 55 characters, so it was never on that grid.
- **`scripts/fl_round_metrics/README.md` Tests section**: now opens with "None yet — nothing to run today" and describes `tests/` as the *reserved* home for the fixture tests proposed in #778's review, instead of reading like a runnable suite.
- **PR title**: was copied verbatim from #778 and read as a new feature; retitled to `refactor(round-metrics): unambiguous names + dedicated scripts/fl_round_metrics/ home`, matching the commit subject and the actual diff.

## Linked Issues

<!-- Suggestions PR into #778's branch — no standalone issue -->
Contributes to #778 (no standalone issue).

## Checklist

- [x] Follows the project's coding conventions and style guide
- [x] Updates documentation
- [ ] I have added tests that prove my fix is effective or that my feature works *(N/A — rename/move only; the fixture test from #778's review has its home reserved at `scripts/fl_round_metrics/tests/`)*
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Type of Change

- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] In-line docstrings updated.
- [x] Documentation updated, tested `make -C docs/ docs`.

## Testing

I did the following tests to verify my changes:

- [x] `bash -n` on both renamed extractors — clean.
- [x] `ruff check` + `py_compile` on `plot_round_timings.py` — clean.
- [x] `make -n round-metrics` — resolves the new script path and the tutorial-local `round_metrics/` output dir.
- [x] `make -n reproduce-overhead` — the renamed target chain resolves (`reproduce-overhead` → `sim` → `package-overhead-bundle` → `round-metrics`); the dry-run only stops where it always would on a box with no simulator workspace (`$(MAKE)`-bearing recipe lines execute under `-n`).
- [x] Repo-wide grep: zero remaining references to the old names (`extract_model_metrics`, `extract_simulator_metrics`, `model_metrics`, `EXPERIMENT_ROUNDS`, `make experiment`, `make metrics`).
- [x] `make docs` from `docs/` after the review round — `build succeeded, 8 warnings` (all pre-existing, none on the edited page).

## Additional Notes

Rationale thread on #778. Cheapest moment for this is pre-merge, while the docs/Makefile/scripts cross-reference each other — post-merge these become breaking renames of documented commands.
