### PR TITLE
docs: fix drift across READMEs, Sphinx docs, and AWS CLAUDE.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ for FL server/client/API), and [`fl-apps/`](fl-apps/) (job-type implementations 
 | [`docs/`](docs/) | Sphinx documentation source (ReadTheDocs) |
 | [`flip-utils/`](flip-utils/) | `flip` Python package — platform logic, NVFLARE components, Flower helpers |
 | [`fl-services/`](fl-services/) | Docker images for FL networks, nested per backend ([`fl-services/nvflare/`](fl-services/nvflare/): `fl-server`, `fl-client`, `fl-api-base`, `fl-base`; [`fl-services/flower/`](fl-services/flower/): `superlink`, `supernode`, `fl-api-flower`, `fl-base`) |
-| [`fl-apps/`](fl-apps/) | FL job-type implementations / app templates, nested per backend ([`fl-apps/nvflare/`](fl-apps/nvflare/): `standard`, `evaluation`, `diffusion_model`, `fed_opt`; [`fl-apps/flower/`](fl-apps/flower/): `standard`, `evaluation`) |
+| [`fl-apps/`](fl-apps/) | FL job-type implementations / app templates, nested per backend ([`fl-apps/nvflare/`](fl-apps/nvflare/): `standard`, `standard_client_api`, `evaluation`, `evaluation_client_api`, `diffusion_model`, `fed_opt`; [`fl-apps/flower/`](fl-apps/flower/): `standard`, `evaluation`) |
 | [`fl-tutorials/`](fl-tutorials/) | End-to-end tutorial examples, nested per backend ([`fl-tutorials/nvflare/`](fl-tutorials/nvflare/): xray classification, spleen seg/eval, diffusion; [`fl-tutorials/flower/`](fl-tutorials/flower/): xray classification, spleen seg/eval, numpy) |
 
 Both backends are now provisioned in-tree (gitignored): the NVFLARE workspace at
@@ -439,7 +439,7 @@ The repository is organised as follows:
 - `flip-utils`: The `flip` Python package (pip-installable `flip-utils`) — platform logic, NVFLARE components, Flower helpers
 - `fl-services`: Docker images for FL networks, per backend: `fl-services/nvflare/{fl-server,fl-client,fl-api-base,fl-base}` and `fl-services/flower/{superlink,supernode,fl-api-flower,fl-base}`. Each backend's `Makefile` also owns its network provisioning under `provision/`.
 - `fl-apps`: FL app templates per backend: `fl-apps/nvflare/{standard,standard_client_api,evaluation,evaluation_client_api,diffusion_model,fed_opt}`, `fl-apps/flower/{standard,evaluation}` (plus `check_required_files.sh`)
-- `fl-tutorials`: End-to-end tutorial examples per backend: `fl-tutorials/nvflare/` (xray classification, spleen seg/eval, diffusion) and `fl-tutorials/flower/` (xray classification, 3D spleen seg, numpy)
+- `fl-tutorials`: End-to-end tutorial examples per backend: `fl-tutorials/nvflare/` (xray classification, spleen seg/eval, diffusion) and `fl-tutorials/flower/` (xray classification, spleen seg/eval, numpy)
 - `trust`: Services deployed inside each trust environment
   - `data-access-api`: Data-access API (OMOP queries)
   - `imaging-api`: DICOM image retrieval API

--- a/deploy/providers/AWS/AGENTS.md
+++ b/deploy/providers/AWS/AGENTS.md
@@ -10,13 +10,14 @@
 | `ecs.tf` | ECS cluster, capacity providers, ECS CloudWatch log groups (ALB / NLB / target groups / listener rules live in `main.tf`) |
 | `ecs_services.tf` | ECS Fargate services (flip-api, FL services) |
 | `ecs_tasks.tf` | ECS task definitions for Central Hub services (flip-api + FL) |
-| `ecs_efs_provision.tf` | EFS access points + ECS provisioning task for FL workspace |
+| `efs.tf` | EFS file system, mount targets, and access points (FL workspace) |
+| `ecs_efs_provision.tf` | ECS provisioning task that pre-populates the FL EFS workspace |
 | `ecs_sg.tf` | ECS security groups |
 | `certificate.tf` | ACM certificates (ALB + CloudFront) |
 | `cloudfront.tf` | CloudFront distribution for flip-ui |
 | `iam_ecs.tf` | IAM roles, instance profiles, SSM policies |
 | `parameter_store.tf` | SSM Parameter Store entries |
-| `backend.tf` | S3 backend + DynamoDB lock |
+| `backend.tf` | S3 backend with S3 native locking (`use_lockfile`) |
 | `variables.tf` | All Terraform variables with defaults |
 
 ## AWS Profiles
@@ -73,6 +74,6 @@ An FL redeploy is `make deploy-centralhub` (branch-tip resolution, or `TAG=sha-<
 
 ## State Management
 
-- Remote state in S3 (`FLIP_TFSTATE_BUCKET_NAME`) with DynamoDB locking
+- Remote state in S3 (`FLIP_TFSTATE_BUCKET_NAME`) with S3 native locking (`use_lockfile = true` in `backend.tf`; no DynamoDB lock table)
 - Persistent resources (S3, Secrets, Cognito) preserved during destroy
 - `make import-persistent` to import pre-existing resources

--- a/deploy/providers/AWS/CLAUDE.md
+++ b/deploy/providers/AWS/CLAUDE.md
@@ -10,13 +10,14 @@
 | `ecs.tf` | ECS cluster, capacity providers, ECS CloudWatch log groups (ALB / NLB / target groups / listener rules live in `main.tf`) |
 | `ecs_services.tf` | ECS Fargate services (flip-api, FL services) |
 | `ecs_tasks.tf` | ECS task definitions for Central Hub services (flip-api + FL) |
-| `ecs_efs_provision.tf` | EFS access points + ECS provisioning task for FL workspace |
+| `efs.tf` | EFS file system, mount targets, and access points (FL workspace) |
+| `ecs_efs_provision.tf` | ECS provisioning task that pre-populates the FL EFS workspace |
 | `ecs_sg.tf` | ECS security groups |
 | `certificate.tf` | ACM certificates (ALB + CloudFront) |
 | `cloudfront.tf` | CloudFront distribution for flip-ui |
 | `iam_ecs.tf` | IAM roles, instance profiles, SSM policies |
 | `parameter_store.tf` | SSM Parameter Store entries |
-| `backend.tf` | S3 backend + DynamoDB lock |
+| `backend.tf` | S3 backend with S3 native locking (`use_lockfile`) |
 | `variables.tf` | All Terraform variables with defaults |
 
 ## AWS Profiles
@@ -73,6 +74,6 @@ An FL redeploy is `make deploy-centralhub` (branch-tip resolution, or `TAG=sha-<
 
 ## State Management
 
-- Remote state in S3 (`FLIP_TFSTATE_BUCKET_NAME`) with DynamoDB locking
+- Remote state in S3 (`FLIP_TFSTATE_BUCKET_NAME`) with S3 native locking (`use_lockfile = true` in `backend.tf`; no DynamoDB lock table)
 - Persistent resources (S3, Secrets, Cognito) preserved during destroy
 - `make import-persistent` to import pre-existing resources

--- a/deploy/providers/AWS/README.md
+++ b/deploy/providers/AWS/README.md
@@ -749,7 +749,7 @@ the direction of the request flow.
 - **CloudWatch**: Logging and monitoring for ECS tasks, the Trust EC2, the WAFv2 ACL, and VPC endpoints. The minimal Central Hub bastion does not run the CloudWatch agent.
 - **Secrets Manager**: Secure storage for API secrets and database credentials (`FLIP_API` secret).
 - **SSM Parameter Store**: Configuration values read by ECS tasks at startup — bucket URIs, internal service URL, internal-service-key header name.
-- **S3 Backend**: Remote state storage with environment-specific buckets, DynamoDB lock table.
+- **S3 Backend**: Remote state storage with environment-specific buckets, using S3 native locking (`use_lockfile = true` in `backend.tf`; no DynamoDB lock table).
 
 ### Subnet placement at a glance
 

--- a/docs/source/deploy-flip/deploy-central-hub.rst
+++ b/docs/source/deploy-flip/deploy-central-hub.rst
@@ -96,19 +96,21 @@ This runs, in order:
 2. ``aws-login`` — AWS SSO auth for the selected profile.
 3. ``init`` — initialise Terraform with the environment-specific S3 backend.
 4. ``import-persistent`` — import existing persistent resources (Cognito, S3, Secrets) to prevent replacement.
-5. ``plan`` and ``apply`` — apply infrastructure changes.
-6. ``update-env`` — refresh the root env file with Terraform outputs.
-7. ``ssh-config`` — write SSH config blocks with SSM ProxyCommand.
-8. ``ansible-init`` — install ``psql`` on the minimal Central Hub SSM bastion
+5. ``generate-internal-service-key`` — mint the fl-server → flip-api internal service key.
+6. ``plan`` and ``apply`` — apply infrastructure changes.
+7. ``update-env`` — refresh the root env file with Terraform outputs.
+8. ``ssh-config`` — write SSH config blocks with SSM ProxyCommand.
+9. ``ansible-init`` — install ``psql`` on the minimal Central Hub SSM bastion
    and provision Docker, CloudWatch, and FL assets on the Trust EC2.
-9. ``deploy-centralhub`` — deploy the Central Hub ECS Fargate services at the
-   tip of the env's branch via immutable ``sha-<short7>`` task-definition
-   revisions, and publish the UI to S3/CloudFront. ``make rollback-centralhub``
-   repoints the services at the previous revision; see the "Central Hub deploys
-   and rollback" section of ``deploy/providers/AWS/README.md`` for the tag
-   resolution, the ``TAG=`` override, and the production rollout timing.
-10. ``deploy-trust`` — deploy any AWS-hosted trust services (skip when only using on-prem trusts).
-11. ``status`` — comprehensive health checks.
+10. ``deploy-centralhub`` — deploy the Central Hub ECS Fargate services at the
+    tip of the env's branch via immutable ``sha-<short7>`` task-definition
+    revisions, and publish the UI to S3/CloudFront. ``make rollback-centralhub``
+    repoints the services at the previous revision; see the "Central Hub deploys
+    and rollback" section of ``deploy/providers/AWS/README.md`` for the tag
+    resolution, the ``TAG=`` override, and the production rollout timing.
+11. ``register-trusts`` — register the shipped trust roster on the hub (after ``deploy-centralhub`` seeds the FL kit-slot pool).
+12. ``deploy-trust`` — deploy any AWS-hosted trust services (skip when only using on-prem trusts).
+13. ``status`` — comprehensive health checks.
 
 The ``PROD`` variable selects the environment file (``stag`` → ``.env.stag``,
 ``true`` → ``.env.production``) and is mapped onto ``TF_VAR_environment``

--- a/docs/source/deploy-flip/deploy-flip-node-on-prem.rst
+++ b/docs/source/deploy-flip/deploy-flip-node-on-prem.rst
@@ -267,12 +267,13 @@ endpoints — different hostnames behind different load balancers, so both must 
   default 8002) — the NLB (e.g. ``fl.app.flip.aicentre.co.uk``).
 
 If the trust's public IP changes (common with residential broadband), update
-the NLB security group by re-running the ``allow-local-trust-nlb`` target
-(the Terraform variable is ``local_trust_public_ips``, a list):
+the NLB security group. Add the new IP to the ``LOCAL_TRUST_PUBLIC_IPS`` HCL
+list in the hub env file (``.env.stag`` / ``.env.production``), then apply
+the targeted security-group change:
 
 .. code-block:: shell
 
-   make -C deploy/providers/AWS allow-local-trust-nlb LOCAL_TRUST_IP=<new-ip>
+   make -C deploy/providers/AWS allow-local-trust-nlb LOCAL_TRUST_IP=<new-ip> PROD=<stag|true>
 
 ***************
 Troubleshooting

--- a/docs/source/deploy-flip/deploy-flip-node-on-prem.rst
+++ b/docs/source/deploy-flip/deploy-flip-node-on-prem.rst
@@ -267,11 +267,12 @@ endpoints — different hostnames behind different load balancers, so both must 
   default 8002) — the NLB (e.g. ``fl.app.flip.aicentre.co.uk``).
 
 If the trust's public IP changes (common with residential broadband), update
-the NLB security group:
+the NLB security group by re-running the ``allow-local-trust-nlb`` target
+(the Terraform variable is ``local_trust_public_ips``, a list):
 
 .. code-block:: shell
 
-   TF_VAR_local_trust_public_ip=<new-ip> make -C deploy/providers/AWS plan apply
+   make -C deploy/providers/AWS allow-local-trust-nlb LOCAL_TRUST_IP=<new-ip>
 
 ***************
 Troubleshooting

--- a/docs/source/user-guides/user-common.rst
+++ b/docs/source/user-guides/user-common.rst
@@ -419,13 +419,13 @@ Prior to commencing training you may also upload an optional ``config.json`` fil
 
 **GLOBAL_ROUNDS**
    Number of global training iterations. How many times the server should execute the ``trainer.py``.
-   Must be greater than 0. Less than 100.
+   Must be between 1 and 1000 (inclusive).
 
    *Default=1*
 
 **LOCAL_ROUNDS**
    Number of local training iterations at client sites.
-   Must be greater than 0. Less than 100.
+   Must be between 1 and 1000 (inclusive).
 
    *Default=1*
 

--- a/flip-utils/README.md
+++ b/flip-utils/README.md
@@ -157,11 +157,13 @@ uv run pytest -s -vv
 
 ## Tutorials
 
-The [`../fl-tutorials/`](../fl-tutorials/) directory contains ready-to-use example applications that can be uploaded to the FLIP platform UI. Each tutorial is designed to work with a specific app template from `../fl-apps/`, and runs on the local NVFLARE simulator via `make -C fl-tutorials run-tutorial TUTORIAL=<name>`.
+The [`../fl-tutorials/`](../fl-tutorials/) directory contains ready-to-use example applications that can be uploaded to the FLIP platform UI. Each tutorial is designed to work with a specific app template from `../fl-apps/<backend>/`, and runs on the local FL simulator via `make -C fl-tutorials run-tutorial TUTORIAL=<name>` (defaults to `FL_BACKEND=nvflare`; pass `FL_BACKEND=flower` for Flower).
 
 ![FL app structure](./assets/fl_app_structure.png)
 
 ### App / Tutorial Compatibility
+
+Paths below are relative to `../fl-tutorials/nvflare/` (the NVFLARE tutorials tree):
 
 | App | Tutorial |
 |-----|----------|

--- a/flip-utils/README.md
+++ b/flip-utils/README.md
@@ -102,10 +102,11 @@ crashed-reply exceptions — extracted from Flower reply Messages in `Strategy.a
 
 ### User Application Requirements
 
-User-provided files are dynamically imported by the executor wrappers at run time. In each
-tutorial they live under `fl-tutorials/nvflare/**/<tutorial>/app_files/`; the tutorial
-harness merges them onto the matching `fl-apps/nvflare/<template>/app/` template when the
-job is submitted (there is no static `custom/` directory to place them in):
+The executor wrappers dynamically import user-provided files from the job's `custom/`
+directory. For most templates that directory is materialised at run time by the tutorial
+harness (`fl-tutorials/nvflare/testing/app_organiser.sh`), which copies each file from
+the tutorial's `app_files/` into `./tmp/app/custom/`; the `diffusion_model` template
+already carries a git-tracked `custom/` with baseline files that the same overlay extends.
 
 | File | Description |
 | ------ | ------------- |

--- a/flip-utils/README.md
+++ b/flip-utils/README.md
@@ -82,9 +82,14 @@ flip/
 ├── nvflare/      # NVFLARE-specific logic and components
 │   ├── executors/    # RUN_TRAINER, RUN_VALIDATOR, RUN_EVALUATOR wrappers
 │   ├── controllers/  # FLIP workflows (ScatterAndGather, BroadcastTask, …)
-│   └── components/   # Event handlers, persistors, privacy filters, locators, …
+│   ├── components/   # Event handlers, persistors, privacy filters, locators, …
+│   ├── recipes/      # High-level NVFLARE job recipes
+│   ├── runtime.py    # Runtime helpers for NVFLARE apps
+│   └── metrics.py    # Metrics collection and reporting
 └── flower/       # Flower-specific server-side helpers
-    └── metrics.py    # handle_client_metrics / handle_client_exception
+    ├── strategy.py   # Flower Strategy implementations (FedAvgWithClientMetrics)
+    ├── metrics.py    # handle_client_metrics / handle_client_exception
+    └── progress.py   # Progress / status reporting helpers
 ```
 
 The `FLIP()` factory selects `FLIPStandardDev` (local CSV/filesystem) or `FLIPStandardProd` (FLIP platform APIs) based
@@ -97,7 +102,10 @@ crashed-reply exceptions — extracted from Flower reply Messages in `Strategy.a
 
 ### User Application Requirements
 
-User-provided files go in the job's `custom/` directory and are dynamically imported by the executor wrappers:
+User-provided files are dynamically imported by the executor wrappers at run time. In each
+tutorial they live under `fl-tutorials/nvflare/**/<tutorial>/app_files/`; the tutorial
+harness merges them onto the matching `fl-apps/nvflare/<template>/app/` template when the
+job is submitted (there is no static `custom/` directory to place them in):
 
 | File | Description |
 | ------ | ------------- |
@@ -109,7 +117,8 @@ User-provided files go in the job's `custom/` directory and are dynamically impo
 
 ### Job Types
 
-Set via the `JOB_TYPE` environment variable:
+Pass the job type to the `FLIP()` factory (`FLIP(job_type=...)`). The `JobType` enum
+(`flip.constants.job_types`) defines the values recognised by `FLIP()`:
 
 | Type | Description |
 | ------ | ------------- |
@@ -117,10 +126,11 @@ Set via the `JOB_TYPE` environment variable:
 | `evaluation` | Distributed model evaluation without training |
 | `diffusion_model` | Two-stage training (VAE encoder + diffusion) |
 | `fed_opt` | Custom federated optimization |
-| `standard_client_api` | Federated averaging via the modern NVFLARE Client API (script-driven, uses `nvflare.client`) |
-| `evaluation_client_api` | Distributed model evaluation via the modern NVFLARE Client API |
 
-The corresponding configs live in `fl-apps/nvflare/<job_type>/app/config/`.
+The NVFLARE backend additionally ships template directories under `fl-apps/nvflare/` for
+the Client-API variants (`standard_client_api`, `evaluation_client_api`); these are
+selected as app templates and are not `JobType` enum members. The corresponding configs
+live in `fl-apps/nvflare/<template>/app/config/`.
 
 ### Development Mode
 

--- a/flip-utils/docs/overview.rst
+++ b/flip-utils/docs/overview.rst
@@ -75,12 +75,16 @@ The ``flip`` package is organized into logical modules:
    - ``executors/`` — RUN_TRAINER, RUN_VALIDATOR, RUN_EVALUATOR wrappers
    - ``controllers/`` — Workflow controllers (ScatterAndGather, CrossSiteModelEval, etc.)
    - ``components/`` — Event handlers, persistors, privacy filters, model locators, etc.
+   - ``recipes/`` — High-level NVFLARE job recipes
+   - ``runtime.py`` — Runtime helpers for NVFLARE apps
    - ``metrics.py`` — Metrics collection and reporting
 
 ``flip.flower``
    Flower-specific helpers:
 
+   - ``strategy.py`` — Flower ``Strategy`` implementations (e.g. ``FedAvgWithClientMetrics``)
    - ``metrics.py`` — Server-side metrics collection and reporting for Flower runs
+   - ``progress.py`` — Progress/status reporting helpers for Flower runs
 
 
 Using the FLIP Factory
@@ -103,21 +107,25 @@ See the API reference for detailed method documentation.
 Job Types
 ---------
 
-Set the job type via the ``JOB_TYPE`` environment variable:
+Pass the job type to the ``FLIP()`` factory (``FLIP(job_type=...)``). The
+``JobType`` enum (``flip.constants.job_types``) defines the values recognised by
+``FLIP()``:
 
 ===========================  ====================================================================================
 Type                         Description
 ===========================  ====================================================================================
-``standard``                 Federated training with FedAvg aggregation (default; NVFLARE Executor API)
-``standard_client_api``      Federated training via the NVFLARE Client API (Client-API path used for Ark+ etc.)
-``evaluation``               Distributed model evaluation without training (NVFLARE Executor API)
-``evaluation_client_api``    Distributed model evaluation via the NVFLARE Client API (head-only eval path)
+``standard``                 Federated training with FedAvg aggregation (default)
+``evaluation``               Distributed model evaluation without training
 ``diffusion_model``          Two-stage training: VAE encoder followed by diffusion model training
 ``fed_opt``                  Custom federated optimization with flexible aggregation strategies
 ===========================  ====================================================================================
 
-The Flower backend ships its own ``standard`` and ``evaluation`` templates under
-``fl-apps/flower/`` — selected at the deploy layer by ``FL_BACKEND=flower``.
+The NVFLARE backend additionally ships template directories under
+``fl-apps/nvflare/`` for the Client-API variants (``standard_client_api``,
+``evaluation_client_api``); these are selected as app templates and are not
+``JobType`` enum values. The Flower backend ships its own ``standard`` and
+``evaluation`` templates under ``fl-apps/flower/`` — selected at the deploy
+layer by ``FL_BACKEND=flower``.
 
 
 User Application Requirements
@@ -149,9 +157,11 @@ To test FL applications locally before deploying to production:
       LOCAL_DEV=true
       DEV_IMAGES_DIR=../data/accession-resources
       DEV_DATAFRAME=../data/sample_get_dataframe.csv
-      JOB_TYPE=standard
 
-2. Place your application files in ``fl-apps/nvflare/<JOB_TYPE>/app/custom/`` (e.g. fl-apps/nvflare/standard/app/custom/).
+2. Place your application files under the corresponding template's ``app/`` directory
+   (e.g. ``fl-apps/nvflare/standard/app/``). Tutorial-local overrides live in a
+   sibling ``app_files/`` directory (e.g. ``fl-tutorials/nvflare/image_classification/xray_classification/app_files/``)
+   which the tutorial harness merges onto the template at run-time.
 
 3. Run one of the shipped tutorials against the NVFLARE simulator from the repository root:
 

--- a/flip-utils/docs/overview.rst
+++ b/flip-utils/docs/overview.rst
@@ -131,8 +131,13 @@ layer by ``FL_BACKEND=flower``.
 User Application Requirements
 -----------------------------
 
-User-provided application code goes in the job's ``custom/`` directory. The
-executor wrappers dynamically import these files:
+The executor wrappers dynamically import user-provided code from the job's
+``custom/`` directory. For most templates that directory is materialised at
+run time by the tutorial harness
+(``fl-tutorials/nvflare/testing/app_organiser.sh``), which copies each file
+from the tutorial's ``app_files/`` into ``./tmp/app/custom/``; the
+``diffusion_model`` template already carries a git-tracked ``custom/`` with
+baseline files that the same overlay extends.
 
 ====================  ================================================================
 File                  Description
@@ -158,10 +163,10 @@ To test FL applications locally before deploying to production:
       DEV_IMAGES_DIR=../data/accession-resources
       DEV_DATAFRAME=../data/sample_get_dataframe.csv
 
-2. Place your application files under the corresponding template's ``app/`` directory
-   (e.g. ``fl-apps/nvflare/standard/app/``). Tutorial-local overrides live in a
-   sibling ``app_files/`` directory (e.g. ``fl-tutorials/nvflare/image_classification/xray_classification/app_files/``)
-   which the tutorial harness merges onto the template at run-time.
+2. Place your application files in the tutorial's ``app_files/`` directory
+   (e.g. ``fl-tutorials/nvflare/image_classification/xray_classification/app_files/``).
+   At run time the harness copies them into ``./tmp/app/custom/`` on top of the
+   matching ``fl-apps/nvflare/<template>/app/`` template.
 
 3. Run one of the shipped tutorials against the NVFLARE simulator from the repository root:
 


### PR DESCRIPTION
> **Note:** This PR is an automated scheduled weekly task by Alex's Claude Code — a periodic sweep for documentation drift.

# Description

Docs-only cleanup surfaced by an audit of `develop`. No code changes.

### Root README.md
- `fl-apps/nvflare` listing (line 62): add missing `standard_client_api` and `evaluation_client_api` template dirs.
- `fl-tutorials/flower` listing (line 442): match line 63 wording ("spleen seg/eval") so both the segmentation and evaluation tutorials are represented.

### flip-utils/README.md
- App/Tutorial compatibility table: clarify paths are under `../fl-tutorials/nvflare/` (all listed tutorials live under the NVFLARE backend tree).
- Tutorial harness note: mention the `FL_BACKEND=flower` override.

### flip-utils/docs/overview.rst
- `flip.nvflare` module listing: add `recipes/` and `runtime.py` (present in the tree, previously undocumented).
- `flip.flower` module listing: add `strategy.py` and `progress.py`.
- Job Types section: `FLIP()` takes `job_type` as a Python argument, not a `JOB_TYPE` env var. Drop the invalid `standard_client_api` / `evaluation_client_api` rows from the `JobType` table (the enum defines only `STANDARD`, `EVALUATION`, `FED_OPT`, `DIFFUSION` — see `flip-utils/flip/constants/job_types.py`) and clarify the `*_client_api` names are template directories under `fl-apps/nvflare/`, not `JobType` members.
- Development Mode: drop the non-existent `JOB_TYPE=standard` env var and the non-existent `fl-apps/nvflare/<JOB_TYPE>/app/custom/` path; point users at the template `app/` dir and the tutorial-local `app_files/` overlay.

### docs/source/user-guides/user-common.rst
- `GLOBAL_ROUNDS` / `LOCAL_ROUNDS` bound: "Less than 100" → "between 1 and 1000 (inclusive)" to match `TrainingRound.MAX = 1000` in `fl-services/nvflare/fl-api-base/fl_api/utils/schemas.py`.

### docs/source/deploy-flip/deploy-flip-node-on-prem.rst
- On-prem trust IP rotation: `TF_VAR_local_trust_public_ip` is not a valid variable (the Terraform variable is `local_trust_public_ips`, a list). Replace with the supported `make allow-local-trust-nlb LOCAL_TRUST_IP=<ip>` target, which is already the flow used earlier in the same doc.

### docs/source/deploy-flip/deploy-central-hub.rst
- `full-deploy` step listing: add `generate-internal-service-key` (between `import-persistent` and `plan`) and `register-trusts` (between `deploy-centralhub` and `deploy-trust`) to match the actual target chain in `deploy/providers/AWS/Makefile:952`.

### deploy/providers/AWS/CLAUDE.md (+ regenerated AGENTS.md mirror)
- Terraform files table: EFS file system, mount targets, and access points live in `efs.tf`; `ecs_efs_provision.tf` only holds the ECS provisioning task.
- `backend.tf`: the S3 backend uses S3 native locking (`use_lockfile = true`), not DynamoDB.
- State Management bullet: same fix (no DynamoDB lock table anywhere in the Terraform).

## Linked Issues

None — the audit did not surface an existing tracker issue for these items.

## Checklist

- [x] Follows the project's coding conventions and style guide
- [x] Updates documentation
- [ ] I have added tests that prove my fix is effective or that my feature works — N/A (docs-only)
- [ ] New and existing unit tests pass locally with my changes — not run (docs-only)
- [ ] Any dependent changes have been merged and published — N/A

## Type of Change

- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [x] In-line docstrings updated. (CLAUDE.md — Terraform-file table wording.)
- [x] Documentation updated. (Sphinx not rebuilt locally in this environment.)

## Testing

- [ ] Quick tests passed locally by running `make unit-test` — N/A (docs-only).
- [ ] Integration tests pass (if applicable) by running `make integration-test` — N/A (docs-only).

## Additional Notes

- CLAUDE.md ↔ AGENTS.md pairs remain in sync after this change (the AWS AGENTS.md was regenerated from CLAUDE.md via `sed`, per project rule).
- Return-type annotations: an AST audit found ~30 missing `-> …` on `__init__` methods in `flip-utils/flip/nvflare/**` and `flip/flower/**`. Left out of this PR as a separate, more mechanical change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RsSjWrYvZhcZyHKxFk56sS

---
_Generated by [Claude Code](https://claude.ai/code/session_01RsSjWrYvZhcZyHKxFk56sS)_