### PR TITLE
Migrate the NVFLARE latent diffusion model tutorial to the Client API (new multi-stage recipe + sibling tutorial)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ FLIP/
 ├── flip-ui/            # Frontend UI (Vue 3 / TypeScript / TailwindCSS)
 ├── flip-utils/         # FLIP Python library (pip-installable flip-utils)
 ├── fl-services/        # FL Docker services + network provisioning, per backend (Makefile owns build/provision/up/down/submit; flower also up-secure): fl-services/nvflare/{fl-base,fl-server,fl-client,fl-api-base, provision/{net-*_project_*.yml, scripts/, workspace-{dev,stag,prod}/ gitignored}}, fl-services/flower/{fl-base,superlink,supernode,fl-api-flower, provision/{scripts/, creds/ gitignored}} (#622)
-├── fl-apps/            # FL app templates per backend: fl-apps/nvflare/{standard,standard_client_api,fed_opt,evaluation,evaluation_client_api,diffusion_model}, fl-apps/flower/{standard,evaluation} + check_required_files.sh (cross-backend CI validator at root)
+├── fl-apps/            # FL app templates per backend: fl-apps/nvflare/{standard,standard_client_api,fed_opt,evaluation,evaluation_client_api,diffusion_model,diffusion_model_client_api}, fl-apps/flower/{standard,evaluation} + check_required_files.sh (cross-backend CI validator at root)
 ├── fl-tutorials/       # FL tutorials per backend: fl-tutorials/nvflare/{image_*,testing}, fl-tutorials/flower/{xray_classification,3d_spleen_segmentation*,numpy} (root Makefile forwards by FL_BACKEND); xray classification, spleen seg/eval, diffusion
 ├── trust/
 │   ├── trust-api/      # Trust API gateway (Python/FastAPI)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ FLIP/
 ├── flip-ui/            # Frontend UI (Vue 3 / TypeScript / TailwindCSS)
 ├── flip-utils/         # FLIP Python library (pip-installable flip-utils)
 ├── fl-services/        # FL Docker services + network provisioning, per backend (Makefile owns build/provision/up/down/submit; flower also up-secure): fl-services/nvflare/{fl-base,fl-server,fl-client,fl-api-base, provision/{net-*_project_*.yml, scripts/, workspace-{dev,stag,prod}/ gitignored}}, fl-services/flower/{fl-base,superlink,supernode,fl-api-flower, provision/{scripts/, creds/ gitignored}} (#622)
-├── fl-apps/            # FL app templates per backend: fl-apps/nvflare/{standard,standard_client_api,fed_opt,evaluation,evaluation_client_api,diffusion_model}, fl-apps/flower/{standard,evaluation} + check_required_files.sh (cross-backend CI validator at root)
+├── fl-apps/            # FL app templates per backend: fl-apps/nvflare/{standard,standard_client_api,fed_opt,evaluation,evaluation_client_api,diffusion_model,diffusion_model_client_api}, fl-apps/flower/{standard,evaluation} + check_required_files.sh (cross-backend CI validator at root)
 ├── fl-tutorials/       # FL tutorials per backend: fl-tutorials/nvflare/{image_*,testing}, fl-tutorials/flower/{xray_classification,3d_spleen_segmentation*,numpy} (root Makefile forwards by FL_BACKEND); xray classification, spleen seg/eval, diffusion
 ├── trust/
 │   ├── trust-api/      # Trust API gateway (Python/FastAPI)

--- a/docs/source/components/component-fl-nodes.rst
+++ b/docs/source/components/component-fl-nodes.rst
@@ -32,9 +32,10 @@ that the user can choose based on their needs.
 Currently, these job types include federated averaging (job type `standard`),
 evaluation task (job type `evaluation`), federated optimisation (job type `fed_opt`)
 and diffusion model training (job type `diffusion_model`), which covers multi-stage federated training.
-For NVFLARE, two further job types drive the client code through the modern **NVFLARE Client API**
+For NVFLARE, three further job types drive the client code through the modern **NVFLARE Client API**
 (a plain training/evaluation script using ``nvflare.client`` instead of a class-based ``Executor``):
-federated averaging (job type `standard_client_api`) and model evaluation (job type `evaluation_client_api`).
+federated averaging (job type `standard_client_api`), model evaluation (job type `evaluation_client_api`)
+and two-stage diffusion model training (job type `diffusion_model_client_api`).
 More job types will be added in the future, adjusting to the community's needs.
 
 **How to choose a job type?**
@@ -53,7 +54,8 @@ Then, the Central Hub API will take care of bundling together:
 
 For more information about currently supported apps, see the per-job-type implementations under
 `fl-apps/ <https://github.com/londonaicentre/FLIP/tree/develop/fl-apps/nvflare>`_ (``standard``, ``evaluation``,
-``diffusion_model``, ``fed_opt``, ``standard_client_api``, ``evaluation_client_api``).
+``diffusion_model``, ``fed_opt``, ``standard_client_api``, ``evaluation_client_api``,
+``diffusion_model_client_api``).
 
 Examples of how the same job type (standard -> federated averaging) can run different user-uploaded applications are:
 
@@ -66,6 +68,7 @@ The NVFLARE Client API job types have their own tutorials:
 
 - `xray_classification_client_api <https://github.com/londonaicentre/FLIP/tree/develop/fl-tutorials/nvflare/image_classification/xray_classification_client_api>`_ (job type `standard_client_api`)
 - `3d_spleen_segmentation_evaluation_client_api <https://github.com/londonaicentre/FLIP/tree/develop/fl-tutorials/nvflare/image_evaluation/3d_spleen_segmentation_evaluation_client_api>`_ (job type `evaluation_client_api`)
+- `latent_diffusion_model_client_api <https://github.com/londonaicentre/FLIP/tree/develop/fl-tutorials/nvflare/image_synthesis/latent_diffusion_model_client_api>`_ (job type `diffusion_model_client_api`)
 
 These tutorials run on the local NVFLARE simulator from the repo root — e.g.
 ``make -C fl-tutorials run-tutorial TUTORIAL=xray_classification`` (requires a GPU and the
@@ -109,8 +112,10 @@ Privacy filters on shared model updates
 ---------------------------------------
 
 Before a client's training result leaves a site, the NVFLARE training job types (`standard`, `fed_opt`,
-`diffusion_model`, `standard_client_api`) pass it through a percentile-based privacy filter
-(``PercentilePrivacy``, following Shokri & Shmatikov, "Privacy-preserving deep learning", CCS '15):
+`diffusion_model`, `standard_client_api`, `diffusion_model_client_api`) pass it through a percentile-based
+privacy filter (``PercentilePrivacy``, following Shokri & Shmatikov, "Privacy-preserving deep learning",
+CCS '15; the diffusion job types use the stage-aware ``StagePercentilePrivacy`` subclass, which computes
+the cutoff per training stage):
 
 - weight-diff components with magnitude **below** the ``percentile``-th percentile are zeroed, so only the
   largest ``100 - percentile`` % of each update's components are shared;
@@ -143,6 +148,6 @@ the description above:
   the static (non-modifiable) templates baked into the flip-api image at `FL_APP_BASE_DIR` (`fl-apps/`, see FLIP#724).
   These templates used to be published to an S3 bucket; that path has been removed. You can check what a fully bundled app looks like by consulting
   the per-job-type implementations under `fl-apps/ <https://github.com/londonaicentre/FLIP/tree/develop/fl-apps/nvflare>`_.
-- the modern NVFLARE Client API job types (`standard_client_api`, `evaluation_client_api`) instead let the user upload a plain training/evaluation script that calls
+- the modern NVFLARE Client API job types (`standard_client_api`, `evaluation_client_api`, `diffusion_model_client_api`) instead let the user upload a plain training/evaluation script that calls
   ``nvflare.client`` directly. Over time, more job types will migrate to this recipe-driven model.
 

--- a/fl-apps/nvflare/diffusion_model/README.md
+++ b/fl-apps/nvflare/diffusion_model/README.md
@@ -13,6 +13,9 @@
 
 # Latent diffusion model
 
+> **Note:** this is the legacy Executor-based job type. The NVFLARE **Client API**
+> counterpart is [`diffusion_model_client_api`](../diffusion_model_client_api/README.md).
+
 This app allows to train a two-stage diffusion model from a single validator and trainer file.
 The `scatter_and_gather` function has been modified to persist the first stage (autoenocder-like network) to train the second stage (diffusion model).
 

--- a/fl-apps/nvflare/diffusion_model_client_api/README.md
+++ b/fl-apps/nvflare/diffusion_model_client_api/README.md
@@ -1,0 +1,91 @@
+<!--
+    Copyright (c) 2026 Guy's and St Thomas' NHS Foundation Trust & King's College London
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+        http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+
+# Client API latent diffusion model (two-stage)
+
+## Overview
+
+This is the NVFLARE **Client API** latent-diffusion job type (`JOB_TYPE=diffusion_model_client_api`).
+It runs the same **two-stage** federated training as the
+[`diffusion_model`](../diffusion_model/README.md) template — an autoencoder (+ GAN discriminator)
+FedAvg stage followed by a diffusion-model FedAvg stage over the frozen autoencoder's latent space,
+each stage with its own cross-site validation — but drives the clients through the NVFLARE Client
+API (`InProcessClientAPIExecutor`) rather than the legacy `RUN_TRAINER`/`RUN_VALIDATOR` executor
+pairs.
+
+The base configs (`app/config/config_fed_server.json`, `app/config/config_fed_client.json`) and
+`meta.json` are **recipe-generated** from `flip.nvflare.recipes.FlipDiffusionRecipe`. Do not
+hand-edit them — regenerate via `recipe.py` after any recipe change and commit the result.
+
+## What's the logic?
+
+The two stages run back to back on the server, sharing one persistor — the `train_dm` controller
+seeds itself with the autoencoder weights the `train_ae` controller persisted (the stage-1 → stage-2
+handoff):
+
+1. Stage 1 (`train_ae`): each site trains the autoencoder + discriminator locally; the server
+   aggregates and, when the stage's rounds finish, cross-site-validates the aggregated autoencoder
+   (`validate_ae`).
+2. Stage 2 (`train_dm`): each site trains the diffusion model over the frozen autoencoder's latent
+   space; the server aggregates and cross-site-validates (`validate_dm`).
+
+Per-stage round counts come from the user `config.json` (`GLOBAL_ROUNDS_AE` / `GLOBAL_ROUNDS_DM`
+globally, `LOCAL_ROUNDS_AE` / `LOCAL_ROUNDS_DM` per site) — the `ScatterAndGatherLDM` controllers
+re-read them at start, so the values baked into the template are simulator defaults only.
+
+Unlike the single-phase Client API templates, **one client script serves four task names**
+(`train_ae` / `train_dm` / `validate_ae` / `validate_dm`): the single-name `flare.is_train()` /
+`flare.is_evaluate()` predicates cannot distinguish the two train stages, so the user's `trainer.py`
+dispatches on `nvflare.client.api.get_task_name()`. `validator.py` is still required — it holds the
+validation passes (and shared latent-geometry helpers) that `trainer.py` imports; it is a plain
+module, not an NVFLARE component.
+
+Training results return as a full-model weight **diff** (`params_type="DIFF"`; the FLIP
+`ScatterAndGather` base rebuilds full weights server-side before the `WEIGHTS` aggregator runs),
+filtered through `StagePercentilePrivacy` — the stage-aware DP filter computes its percentile
+cutoff over exactly the modules the stage trained, scoped by the `FlipMetaKey.STAGE` meta the
+script stamps on the outgoing `FLModel`.
+
+## Execution sequence
+
+**Server — `config_fed_server.json` `workflows` (run in order):**
+
+1. `flip.nvflare.controllers.InitTraining`
+2. `flip.nvflare.controllers.ScatterAndGatherLDM` (stage 1: autoencoder, `train_ae`)
+3. stock `nvflare.app_common.workflows.global_model_eval.GlobalModelEval` (`validate_ae`)
+4. `flip.nvflare.controllers.BroadcastTask` (`post_validation` cleanup)
+5. `flip.nvflare.controllers.ScatterAndGatherLDM` (stage 2: diffusion, `train_dm`)
+6. stock `GlobalModelEval` (`validate_dm`)
+7. `flip.nvflare.controllers.BroadcastTask` (`post_validation` cleanup)
+
+**Client — `config_fed_client.json` `executors` / `filters`:**
+
+- `init_training`, `post_validation` → `flip.nvflare.components.CleanupImages`
+- `train_ae`, `train_dm`, `validate_ae`, `validate_dm` → ONE
+  `nvflare.app_common.executors.InProcessClientAPIExecutor` running `custom/trainer.py`
+- `train_ae`/`train_dm` results → `flip.nvflare.components.StagePercentilePrivacy` (stage-aware DP
+  noise filter)
+- Event handlers: `ClientEventHandler`, `FlipAnalyticsBridge`
+
+## Required user files
+
+| File | Role |
+| --- | --- |
+| `trainer.py` | The Client API script: `flare.init()` loop dispatching all four tasks on `get_task_name()` |
+| `validator.py` | Validation passes + latent-geometry helpers imported by `trainer.py` |
+| `models.py` | `get_model()` returning the composite network (`autoencoder` / `discriminator` / `diffusion_model` sub-modules) |
+| `config.json` | `job_type`, per-stage rounds, learning rates, loss weights, `net_config`, `spatial_shape` |
+
+Reference implementation: the
+[`latent_diffusion_model_client_api`](../../../fl-tutorials/nvflare/image_synthesis/latent_diffusion_model_client_api/)
+tutorial.

--- a/fl-apps/nvflare/diffusion_model_client_api/app/config/config_fed_client.json
+++ b/fl-apps/nvflare/diffusion_model_client_api/app/config/config_fed_client.json
@@ -1,0 +1,64 @@
+{
+  "format_version": 2,
+  "executors": [
+    {
+      "tasks": [
+        "init_training",
+        "post_validation"
+      ],
+      "executor": {
+        "path": "flip.nvflare.components.cleanup.CleanupImages",
+        "args": {}
+      }
+    },
+    {
+      "tasks": [
+        "train_ae",
+        "train_dm",
+        "validate_ae",
+        "validate_dm"
+      ],
+      "executor": {
+        "path": "nvflare.app_common.executors.in_process_client_api_executor.InProcessClientAPIExecutor",
+        "args": {
+          "task_script_path": "custom/trainer.py",
+          "task_script_args": "--project_id {project_id}"
+        }
+      }
+    }
+  ],
+  "components": [
+    {
+      "id": "flip_client_event_handler",
+      "path": "flip.nvflare.components.flip_client_event_handler.ClientEventHandler",
+      "args": {}
+    },
+    {
+      "id": "flip_analytics_bridge",
+      "path": "flip.nvflare.components.flip_analytics_bridge.FlipAnalyticsBridge",
+      "args": {}
+    }
+  ],
+  "task_data_filters": [],
+  "task_result_filters": [
+    {
+      "tasks": [
+        "train_dm",
+        "train_ae"
+      ],
+      "filters": [
+        {
+          "path": "flip.nvflare.components.stage_percentile_privacy.StagePercentilePrivacy",
+          "args": {
+            "data_kinds": [
+              "WEIGHT_DIFF",
+              "WEIGHTS"
+            ]
+          }
+        }
+      ]
+    }
+  ],
+  "project_id": "",
+  "query": "SELECT * FROM Table;"
+}

--- a/fl-apps/nvflare/diffusion_model_client_api/app/config/config_fed_server.json
+++ b/fl-apps/nvflare/diffusion_model_client_api/app/config/config_fed_server.json
@@ -1,0 +1,146 @@
+{
+    "format_version": 2,
+    "workflows": [
+        {
+            "id": "controller",
+            "path": "flip.nvflare.controllers.init_training.InitTraining",
+            "args": {
+                "model_id": null
+            }
+        },
+        {
+            "id": "controller1",
+            "path": "flip.nvflare.controllers.scatter_and_gather_ldm.ScatterAndGatherLDM",
+            "args": {
+                "model_id": null,
+                "min_clients": 1,
+                "num_rounds_ae": 1,
+                "num_rounds_dm": 1,
+                "model_locator_id": "model_locator_initial",
+                "train_task_name": "train_ae",
+                "ignore_result_error": false
+            }
+        },
+        {
+            "id": "controller2",
+            "path": "nvflare.app_common.workflows.global_model_eval.GlobalModelEval",
+            "args": {
+                "validation_timeout": 12000,
+                "model_locator_id": "model_locator",
+                "validation_task_name": "validate_ae"
+            }
+        },
+        {
+            "id": "controller3",
+            "path": "flip.nvflare.controllers.broadcast_task.BroadcastTask",
+            "args": {
+                "task_name": "post_validation"
+            }
+        },
+        {
+            "id": "controller4",
+            "path": "flip.nvflare.controllers.scatter_and_gather_ldm.ScatterAndGatherLDM",
+            "args": {
+                "model_id": null,
+                "min_clients": 1,
+                "num_rounds_ae": 1,
+                "num_rounds_dm": 1,
+                "model_locator_id": "model_locator",
+                "train_task_name": "train_dm",
+                "ignore_result_error": false
+            }
+        },
+        {
+            "id": "controller5",
+            "path": "nvflare.app_common.workflows.global_model_eval.GlobalModelEval",
+            "args": {
+                "validation_timeout": 12000,
+                "model_locator_id": "model_locator",
+                "validation_task_name": "validate_dm"
+            }
+        },
+        {
+            "id": "controller6",
+            "path": "flip.nvflare.controllers.broadcast_task.BroadcastTask",
+            "args": {
+                "task_name": "post_validation"
+            }
+        }
+    ],
+    "components": [
+        {
+            "id": "persistor",
+            "path": "nvflare.app_opt.pt.file_model_persistor.PTFileModelPersistor",
+            "args": {
+                "model": {
+                    "path": "models.get_model"
+                }
+            }
+        },
+        {
+            "id": "shareable_generator",
+            "path": "nvflare.app_common.shareablegenerators.full_model_shareable_generator.FullModelShareableGenerator",
+            "args": {}
+        },
+        {
+            "id": "aggregator",
+            "path": "nvflare.app_common.aggregators.intime_accumulate_model_aggregator.InTimeAccumulateWeightedAggregator",
+            "args": {
+                "expected_data_kind": "WEIGHTS"
+            }
+        },
+        {
+            "id": "model_locator",
+            "path": "flip.nvflare.components.pt_model_locator.PTModelLocator",
+            "args": {
+                "model": {
+                    "path": "models.get_model"
+                }
+            }
+        },
+        {
+            "id": "model_locator_initial",
+            "path": "flip.nvflare.components.pt_model_locator.InitialPTModelLocator",
+            "args": {
+                "model": {
+                    "path": "models.get_model"
+                }
+            }
+        },
+        {
+            "id": "json_generator",
+            "path": "flip.nvflare.components.validation_json_generator.ValidationJsonGenerator",
+            "args": {}
+        },
+        {
+            "id": "flip_server_event_handler",
+            "path": "flip.nvflare.components.flip_server_event_handler.ServerEventHandler",
+            "args": {
+                "model_id": null
+            }
+        },
+        {
+            "id": "persist_and_cleanup",
+            "path": "flip.nvflare.components.persist_and_cleanup.PersistToS3AndCleanup",
+            "args": {
+                "model_id": null
+            }
+        }
+    ],
+    "task_data_filters": [],
+    "task_result_filters": [
+        {
+            "tasks": [
+                "validate_dm",
+                "validate_ae",
+                "post_validation"
+            ],
+            "filters": [
+                {
+                    "path": "flip.nvflare.components.client_exception_reporter.ClientExceptionReporter",
+                    "args": {}
+                }
+            ]
+        }
+    ]
+}

--- a/fl-apps/nvflare/diffusion_model_client_api/meta.json
+++ b/fl-apps/nvflare/diffusion_model_client_api/meta.json
@@ -1,0 +1,13 @@
+{
+    "name": "flip_diffusion",
+    "resource_spec": {},
+    "min_clients": 1,
+    "deploy_map": {
+        "app": [
+            "@ALL"
+        ]
+    },
+    "custom_props": {
+        "model_id": "00000000-0000-0000-0000-000000000001"
+    }
+}

--- a/fl-apps/nvflare/diffusion_model_client_api/recipe.py
+++ b/fl-apps/nvflare/diffusion_model_client_api/recipe.py
@@ -27,6 +27,7 @@ import argparse
 import os
 import sys
 import tempfile
+import types
 from pathlib import Path
 
 # Pin the hash seed before importing NVFLARE (via flip): export_job serialises some task lists via
@@ -36,6 +37,16 @@ from pathlib import Path
 if os.environ.get("PYTHONHASHSEED") != "0":
     os.environ["PYTHONHASHSEED"] = "0"
     os.execv(sys.executable, [sys.executable, *sys.argv])
+
+import torch  # noqa: E402  (imported after the hash-seed pin)
+
+# The base template ships no models.py (each app supplies its own), but constructing the recipe
+# imports ``models`` via the persistor/locator ``model={"path": "models.get_model"}`` wiring — stub
+# it so this script runs standalone. Only the import path lands in the generated JSON, never the
+# stub itself (mirrors the recipe unit tests).
+_stub_models = types.ModuleType("models")
+_stub_models.get_model = lambda: torch.nn.Linear(1, 1)
+sys.modules.setdefault("models", _stub_models)
 
 from flip.nvflare.recipes import FlipDiffusionRecipe  # noqa: E402  (imported after the hash-seed pin)
 

--- a/fl-apps/nvflare/diffusion_model_client_api/recipe.py
+++ b/fl-apps/nvflare/diffusion_model_client_api/recipe.py
@@ -1,0 +1,87 @@
+# Copyright (c) 2026 Guy's and St Thomas' NHS Foundation Trust & King's College London
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Driver script: regenerate the committed diffusion_model_client_api app/config JSONs and meta.json.
+
+Run from the flip-utils venv (needs the ``full`` extra — flip + nvflare + torch):
+
+    cd flip-utils && uv run --no-sync python \\
+        ../fl-apps/nvflare/diffusion_model_client_api/recipe.py \\
+        --output ../fl-apps/nvflare/diffusion_model_client_api
+
+Do NOT hand-edit the generated JSON files — regenerate them via this script after any
+recipe change and commit the result.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+# Pin the hash seed before importing NVFLARE (via flip): export_job serialises some task lists via
+# sets, whose iteration order depends on PYTHONHASHSEED, so an unpinned seed yields spurious
+# task-order diffs on every regeneration. The seed must be set before interpreter start, so re-exec
+# once when it isn't already fixed.
+if os.environ.get("PYTHONHASHSEED") != "0":
+    os.environ["PYTHONHASHSEED"] = "0"
+    os.execv(sys.executable, [sys.executable, *sys.argv])
+
+from flip.nvflare.recipes import FlipDiffusionRecipe  # noqa: E402  (imported after the hash-seed pin)
+
+
+def _copy_json(src: Path, dest: Path) -> None:
+    """Copy a generated JSON file, guaranteeing exactly one trailing newline.
+
+    NVFLARE's ``export_job`` emits ``config_fed_server.json`` / ``meta.json`` without a trailing
+    newline. Normalising on copy keeps the committed templates stable across regenerations and
+    satisfies the ``end-of-file-fixer`` pre-commit hook.
+    """
+    text = src.read_text()
+    if not text.endswith("\n"):
+        text += "\n"
+    dest.write_text(text)
+
+
+def main() -> None:
+    """Export FlipDiffusionRecipe configs into the diffusion_model_client_api template directory."""
+    parser = argparse.ArgumentParser(
+        description="Regenerate the diffusion_model_client_api app/config JSONs and meta.json from FlipDiffusionRecipe."
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path(__file__).parent,
+        help="Template dir (writes app/config/ and meta.json).",
+    )
+    args = parser.parse_args()
+
+    dest_config = args.output / "app" / "config"
+    dest_config.mkdir(parents=True, exist_ok=True)
+
+    with tempfile.TemporaryDirectory() as tmp:
+        recipe = FlipDiffusionRecipe()
+        recipe.export(tmp)
+        exported_root = Path(tmp) / recipe.job.name
+        exported_config = exported_root / "app" / "config"
+        for name in ("config_fed_server.json", "config_fed_client.json"):
+            _copy_json(exported_config / name, dest_config / name)
+        _copy_json(exported_root / "meta.json", args.output / "meta.json")
+
+    print(f"Wrote {dest_config}/config_fed_server.json")
+    print(f"Wrote {dest_config}/config_fed_client.json")
+    print(f"Wrote {args.output}/meta.json")
+
+
+if __name__ == "__main__":
+    main()

--- a/fl-apps/nvflare/diffusion_model_client_api/required_files.json
+++ b/fl-apps/nvflare/diffusion_model_client_api/required_files.json
@@ -1,0 +1,1 @@
+["trainer.py", "validator.py", "config.json", "models.py"]

--- a/fl-apps/nvflare/required_files.json
+++ b/fl-apps/nvflare/required_files.json
@@ -5,6 +5,12 @@
     "config.json",
     "models.py"
   ],
+  "diffusion_model_client_api": [
+    "trainer.py",
+    "validator.py",
+    "config.json",
+    "models.py"
+  ],
   "evaluation": [
     "config.json",
     "evaluator.py"

--- a/fl-services/nvflare/fl-api-base/tests/utils/test_prepare_config.py
+++ b/fl-services/nvflare/fl-api-base/tests/utils/test_prepare_config.py
@@ -542,6 +542,36 @@ class TestConfigureServer:
         assert modified_config["workflows"][1]["args"]["min_clients"] == "{min_clients}"
         assert modified_config["min_clients"] == len(MOCK_APP_CLIENTS)
 
+    def test_configure_server_diffusion_recipe_overrides_min_clients_only(
+        self, mock_isfile, mock_read_config, mock_write_config
+    ):
+        """The diffusion_model_client_api template's ScatterAndGatherLDM workflows carry literal
+        min_clients (must be overridden to the trust count, as for the other recipe templates) but
+        num_rounds_ae/num_rounds_dm instead of num_rounds — those must pass through untouched:
+        the controller re-reads GLOBAL_ROUNDS_AE/GLOBAL_ROUNDS_DM from the app config.json at
+        start, so the deployed per-stage round counts come from the user config, not from here."""
+        config = self._minimal_server_config()
+        config["workflows"][0]["args"].update(
+            {"min_clients": 1, "num_rounds_ae": 1, "num_rounds_dm": 1, "train_task_name": "train_ae"}
+        )
+        mock_read_config.return_value = config
+
+        configure_server(
+            job_dir=MOCK_JOB_APP_DIR,
+            app_name=MOCK_APP_NAME,
+            global_rounds=20,
+            trusts=MOCK_APP_CLIENTS,
+            ignore_result_error=True,
+            aggregator="agg",
+            aggregation_weights=MOCK_AGGREGATION_WEIGHTS,
+        )
+
+        (modified_config, _), _ = mock_write_config.call_args
+        sag_args = modified_config["workflows"][0]["args"]
+        assert sag_args["min_clients"] == len(MOCK_APP_CLIENTS)
+        assert sag_args["num_rounds_ae"] == 1
+        assert sag_args["num_rounds_dm"] == 1
+
     def test_configure_server_injects_trim_broadcast_filter(self, mock_isfile, mock_read_config, mock_write_config):
         """With aggregate_only_regex set, a TrimBroadcastVars filter is appended to the train
         task_data_filters — the server half of the head-only broadcast (after round 0 it broadcasts

--- a/fl-tutorials/nvflare/image_synthesis/latent_diffusion_model/README.md
+++ b/fl-tutorials/nvflare/image_synthesis/latent_diffusion_model/README.md
@@ -1,5 +1,8 @@
 # Latent diffusion model
 
+> **Note:** this is the legacy Executor-based tutorial. The NVFLARE **Client API**
+> sibling is [`latent_diffusion_model_client_api`](../latent_diffusion_model_client_api/README.md).
+
 This code allows to train a two-stage latent diffusion model. The main model is made up of several stages: a variational autoencoder and a diffusion model.
 The code is entirely based on `MONAI` functions.
 

--- a/fl-tutorials/nvflare/image_synthesis/latent_diffusion_model_client_api/.env.app
+++ b/fl-tutorials/nvflare/image_synthesis/latent_diffusion_model_client_api/.env.app
@@ -1,0 +1,11 @@
+JOB_TYPE=diffusion_model_client_api
+DEV_IMAGES_DIR=../../data/spleen/images
+DEV_DATAFRAME=../../data/spleen/dataframe.csv
+FLIP_PROJECT_ID=
+FLIP_QUERY=
+
+# Optional local-run knobs (Makefile defaults: NUM_ROUNDS_AE=1, NUM_ROUNDS_DM=1, N_CLIENTS=2;
+# CLI overrides win, e.g. `make run NUM_ROUNDS_AE=2`)
+# NUM_ROUNDS_AE=2
+# NUM_ROUNDS_DM=2
+# N_CLIENTS=2

--- a/fl-tutorials/nvflare/image_synthesis/latent_diffusion_model_client_api/.gitignore
+++ b/fl-tutorials/nvflare/image_synthesis/latent_diffusion_model_client_api/.gitignore
@@ -1,0 +1,2 @@
+fl_job/
+app_files/torch_hub/

--- a/fl-tutorials/nvflare/image_synthesis/latent_diffusion_model_client_api/Makefile
+++ b/fl-tutorials/nvflare/image_synthesis/latent_diffusion_model_client_api/Makefile
@@ -1,0 +1,74 @@
+# Copyright (c) 2026 Guy's and St Thomas' NHS Foundation Trust & King's College London
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+APP_DIR := $(CURDIR)
+
+# Run job.py in the flip-utils environment with the `full` ML extra — the same package set the
+# flare-fl-base FL image installs (`uv sync --extra full`), so a local SimEnv run matches the deployed
+# image. A bare `uv run` would resolve to the repo-root venv, which has no torch/nvflare/monai.
+FLIP_UTILS := $(abspath $(APP_DIR)/../../../../flip-utils)
+UV_RUN := uv run --project $(FLIP_UTILS) --extra full
+
+# --- Load app-specific env ---
+# Comment lines must be dropped before building the export list: a leading `#` token would start a
+# make comment inside the `export` directive and silently un-export every variable listed after it.
+ifneq ("$(wildcard .env.app)","")
+include ./.env.app
+export $(shell sed -e '/^[[:space:]]*#/d' -e 's/=.*//' ./.env.app)
+endif
+
+# --- Local-run knobs ---
+# Local-sim/export values passed to job.py; override per invocation (`make run NUM_ROUNDS_AE=2`),
+# via the harness (`make -C fl-tutorials run-tutorial TUTORIAL=latent_diffusion_model_client_api
+# NUM_ROUNDS_AE=2`), or in .env.app. Local only: in production the FL API reads
+# GLOBAL_ROUNDS_AE/GLOBAL_ROUNDS_DM from config.json at submit time (the ScatterAndGatherLDM
+# controllers re-read them at start), overriding whatever the recipe baked in.
+NUM_ROUNDS_AE ?= 1
+NUM_ROUNDS_DM ?= 1
+N_CLIENTS ?= 2
+
+.PHONY: run export sim clean
+
+# --- Tutorial-harness entrypoint ---
+# The shared harness (fl-tutorials/nvflare/Makefile) auto-discovers any dir with a .env.app
+# and invokes `make run`. The Client API variant has no legacy testing/ harness path, so
+# `run` delegates to `sim` (the recipe/simulator path via job.py).
+run: sim
+
+# --- Export job config (no GPU needed) ---
+# Builds a complete NVFLARE job under ./fl_job/flip_diffusion/ including meta.json,
+# app/config/, and app/custom/ (bundled flip/ package + staged app_files/).
+# FLIP-specific values (project_id, query) are injected via environment variables.
+export:
+	$(UV_RUN) python job.py \
+		--export \
+		--export-dir ./fl_job \
+		--n_clients $(N_CLIENTS) \
+		--num_rounds_ae $(NUM_ROUNDS_AE) \
+		--num_rounds_dm $(NUM_ROUNDS_DM)
+
+# --- SimEnv local simulation (requires GPU + data) ---
+# Runs the job under the NVFLARE simulator. Requires a GPU and the reference
+# dataset (run `make -C fl-tutorials download-spleen-data` first).
+# FLIP-specific values are read from FLIP_PROJECT_ID and FLIP_QUERY env vars.
+# DEV_IMAGES_DIR/DEV_DATAFRAME are resolved to absolute paths so the simulator's client workers
+# (which run from the workspace dir, not here) find the LOCAL_DEV dataset.
+sim:
+	@echo "Running tutorial with: n_clients=$(N_CLIENTS), num_rounds_ae=$(NUM_ROUNDS_AE), num_rounds_dm=$(NUM_ROUNDS_DM)"
+	DEV_IMAGES_DIR="$(abspath $(DEV_IMAGES_DIR))" \
+	DEV_DATAFRAME="$(abspath $(DEV_DATAFRAME))" \
+	$(UV_RUN) python job.py \
+		--n_clients $(N_CLIENTS) \
+		--num_rounds_ae $(NUM_ROUNDS_AE) \
+		--num_rounds_dm $(NUM_ROUNDS_DM)
+
+clean:
+	rm -rf ./fl_job

--- a/fl-tutorials/nvflare/image_synthesis/latent_diffusion_model_client_api/README.md
+++ b/fl-tutorials/nvflare/image_synthesis/latent_diffusion_model_client_api/README.md
@@ -1,0 +1,87 @@
+# Latent Diffusion Model — NVFLARE Client API variant
+
+This tutorial trains a two-stage latent diffusion model (a variational autoencoder with a GAN
+discriminator, then a diffusion model over the frozen autoencoder's latent space) using the
+**NVFLARE Client API** (`nvflare.client`) rather than the legacy Executor API. The job is defined
+entirely in Python via `FlipDiffusionRecipe` — no hand-written JSON configs required. The code is
+entirely based on `MONAI` functions.
+
+This is the sibling tutorial to `latent_diffusion_model/`, which uses the legacy Executor API. The
+training and validation maths are identical; what changes is the NVFLARE plumbing:
+
+- **One client script serves four task names.** The job's two training phases (`train_ae`,
+  `train_dm`) and two cross-site validation passes (`validate_ae`, `validate_dm`) all run through a
+  single `InProcessClientAPIExecutor` driving `app_files/trainer.py`. The single-name
+  `flare.is_train()` / `flare.is_evaluate()` predicates cannot distinguish the two train phases, so
+  the script dispatches on `nvflare.client.api.get_task_name()`.
+- **`validator.py` is a plain module**, not an Executor: it holds the validation passes and the
+  latent-geometry helpers (`derive_new_latent_shape`, `build_inferer`) that `trainer.py` imports.
+- **The DP filter is live.** Training results carry a `FlipMetaKey.STAGE` meta naming the modules
+  the phase trained (`autoencoder`+`discriminator`, then `diffusion_model`), which scopes the
+  `StagePercentilePrivacy` percentile cutoff per stage. The legacy tutorial never stamped this
+  meta, so its filter passed every update through unfiltered.
+
+Validation provides L1 loss and SSIM for stage 1 and the noise-prediction loss for the diffusion
+model.
+
+## Compatible job type
+
+These files are compatible with `JOB_TYPE=diffusion_model_client_api` in the base application
+([`fl-apps/nvflare/diffusion_model_client_api/`](../../../../fl-apps/nvflare/diffusion_model_client_api/)).
+
+## Rounds configuration
+
+Each stage has its own round counts in `app_files/config.json`: `GLOBAL_ROUNDS_AE` /
+`GLOBAL_ROUNDS_DM` (federated rounds — re-read by the `ScatterAndGatherLDM` controllers at start,
+so they win over whatever the recipe baked in) and `LOCAL_ROUNDS_AE` / `LOCAL_ROUNDS_DM` (local
+epochs per round).
+
+## Base-image dependency (torchvision)
+
+Unlike most tutorials, this one needs `torchvision` at runtime: the perceptual loss uses `lpips`,
+which calls `torchvision.ops` operators (e.g. `nms`). Those must be built against the **same
+torch** as the `flare-fl-base` image (pinned `torch>=2.11`, cu128, in
+[`flip-utils/pyproject.toml`](../../../../flip-utils/pyproject.toml)). A base image whose
+`torchvision` predates that pin fails at runtime with
+`RuntimeError: operator torchvision::nms does not exist`. (The `app_files/requirements.txt` lists
+`torchvision` too, but that file is a dependency *spec* — the runtime deps come from the base
+image, not from installing it per job.)
+
+## FLIP-specific values
+
+`FLIP_PROJECT_ID` and `FLIP_QUERY` are read from environment variables (set stubs in `.env.app`).
+They are NOT passed as CLI flags because the SQL query contains spaces that don't survive
+argparse whitespace-splitting. The trainer reads the query from `config_fed_client.json` at
+runtime via `load_query()`.
+
+## How to run
+
+### Export (primary — no GPU needed)
+
+Produces a complete NVFLARE job directory under `./fl_job/flip_diffusion/` including:
+- `meta.json` with `custom_props.model_id` (dev UUID for local use)
+- `app/config/config_fed_server.json` and `config_fed_client.json`
+- `app/custom/` with the bundled `flip/` package and all user app files staged alongside it
+
+```bash
+make export
+```
+
+### SimEnv local simulation (requires GPU + data)
+
+```bash
+make -C fl-tutorials download-spleen-data   # once, from the repo root
+make -C fl-tutorials run-tutorial TUTORIAL=latent_diffusion_model_client_api
+# or, from this directory:
+make run NUM_ROUNDS_AE=1 NUM_ROUNDS_DM=1 N_CLIENTS=2
+```
+
+The spleen CT volumes are only a convenient openly-licensed 3D dataset — the labels are unused;
+any 3D CT NIfTI collection works.
+
+### Against a running FLIP stack
+
+Upload `app_files/` as the model files of a project whose `config.json` declares
+`"job_type": "diffusion_model_client_api"` (the e2e smoke does this with
+`MODEL_FILES_DIR=fl-tutorials/nvflare/image_synthesis/latent_diffusion_model_client_api/app_files
+QUERY_FILE=...`).

--- a/fl-tutorials/nvflare/image_synthesis/latent_diffusion_model_client_api/app_files/config.json
+++ b/fl-tutorials/nvflare/image_synthesis/latent_diffusion_model_client_api/app_files/config.json
@@ -1,0 +1,81 @@
+{
+    "job_type": "diffusion_model_client_api",
+    "GLOBAL_ROUNDS": 1,
+    "LOCAL_ROUNDS_AE": 1,
+    "LOCAL_ROUNDS_DM": 1,
+    "GLOBAL_ROUNDS_AE": 1,
+    "GLOBAL_ROUNDS_DM": 1,
+    "PATIENCE_STEPS": 10,
+    "CEILING_NUM_ROUNDS": 100,
+    "LR_G": 0.0001,
+    "LR_D": 0.0002,
+    "LR_DM": 0.0001,
+    "VAL_SPLIT": 0.2,
+    "BATCH_SIZE_AE": 1,
+    "BATCH_SIZE_DM": 4,
+    "w_reconstruction_loss": 1.0,
+    "w_perceptual_loss": 1,
+    "w_gan_loss": 0.1,
+    "w_kl_loss": 1e-09,
+    "spatial_shape": [
+        128,
+        128,
+        32
+    ],
+    "net_config": {
+        "spatial_dims": 3,
+        "stage_1": {
+            "in_channels": 1,
+            "spatial_dims": 3,
+            "out_channels": 1,
+            "num_res_blocks": [
+                1,
+                1,
+                2
+            ],
+            "channels": [
+                64,
+                96,
+                128
+            ],
+            "attention_levels": [
+                false,
+                false,
+                false
+            ],
+            "latent_channels": 3
+        },
+        "discriminator": {
+            "spatial_dims": 2,
+            "in_channels": 1,
+            "channels": 64,
+            "num_layers_d": 4,
+            "out_channels": 1
+        },
+        "diffusion_model": {
+            "spatial_dims": 3,
+            "in_channels": 3,
+            "out_channels": 3,
+            "with_conditioning": false,
+            "cross_attention_dim": 0,
+            "channels": [
+                32,
+                64,
+                128,
+                128
+            ],
+            "num_res_blocks": [
+                2,
+                2,
+                2,
+                2
+            ],
+            "attention_levels": [
+                false,
+                false,
+                true,
+                true
+            ]
+        }
+    }
+}

--- a/fl-tutorials/nvflare/image_synthesis/latent_diffusion_model_client_api/app_files/models.py
+++ b/fl-tutorials/nvflare/image_synthesis/latent_diffusion_model_client_api/app_files/models.py
@@ -1,0 +1,102 @@
+# Copyright (c) 2026 Guy's and St Thomas' NHS Foundation Trust & King's College London
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from monai.networks.nets import AutoencoderKL, DiffusionModelUNet, PatchDiscriminator
+from torch import nn
+
+
+# Here is where we can load the config file with network params if necessary, for example:
+def load_net_config():
+    config_path = Path(__file__).parent / "config.json"
+    with open(config_path, "r") as f:
+        config = json.load(f)
+    net_config = config.get("net_config", {})
+    print(f"Loaded network config: {net_config}")
+    return net_config
+
+
+class LatentDiffusionModelNetwork(nn.Module):
+    """Creates a multi-stage latent diffusion model containing a:
+    - Variational Autoencoder (to compress inputs into latent space)
+    - Discriminator (to adversarially train the autoencoder)
+    - Diffusion Model (to generate samples in the latent space)
+    """
+
+    def __init__(self):
+        super().__init__()
+        net_config = load_net_config()
+        self.autoencoder = AutoencoderKL(
+            spatial_dims=net_config["spatial_dims"],
+            in_channels=net_config["stage_1"]["in_channels"],
+            out_channels=net_config["stage_1"]["out_channels"],
+            num_res_blocks=net_config["stage_1"]["num_res_blocks"],
+            channels=net_config["stage_1"]["channels"],
+            attention_levels=net_config["stage_1"]["attention_levels"],
+            latent_channels=net_config["stage_1"]["latent_channels"],
+            with_encoder_nonlocal_attn=False,
+            with_decoder_nonlocal_attn=False,
+        )
+
+        self.discriminator = PatchDiscriminator(
+            spatial_dims=net_config["discriminator"]["spatial_dims"],
+            in_channels=net_config["discriminator"]["in_channels"],
+            channels=net_config["discriminator"]["channels"],
+            out_channels=net_config["discriminator"]["out_channels"],
+            num_layers_d=net_config["discriminator"]["num_layers_d"],
+        )
+
+        self.diffusion_model = DiffusionModelUNet(
+            spatial_dims=net_config["spatial_dims"],
+            in_channels=net_config["diffusion_model"]["in_channels"],
+            out_channels=net_config["diffusion_model"]["out_channels"],
+            with_conditioning=net_config["diffusion_model"]["with_conditioning"],
+            cross_attention_dim=None
+            if net_config["diffusion_model"]["cross_attention_dim"] == 0
+            else net_config["diffusion_model"]["cross_attention_dim"],
+            channels=net_config["diffusion_model"]["channels"],
+            num_res_blocks=net_config["diffusion_model"]["num_res_blocks"],
+            attention_levels=net_config["diffusion_model"]["attention_levels"],
+        )
+
+    def forward_ae(self, x):
+        return self.autoencoder(x)
+
+    def forward_dm(self, x):
+        return self.diffusion_model(x)
+
+    def discriminate(self, x):
+        return self.discriminator(x)
+
+    def load_autoencoder_dict(self, state_dict: Mapping[str, Any], strict: bool = True):
+        self.autoencoder.load_state_dict(state_dict, strict=strict)
+
+    def load_discriminator_dict(self, state_dict: Mapping[str, Any], strict: bool = True):
+        self.discriminator.load_state_dict(state_dict, strict=strict)
+
+    def load_diffusion_model_dict(self, state_dict: Mapping[str, Any], strict: bool = True):
+        self.diffusion_model.load_state_dict(state_dict, strict=strict)
+
+
+_net = LatentDiffusionModelNetwork()
+
+
+def get_model() -> nn.Module:
+    """
+    Returns the model defined in this file.
+    NOTE: This function needs to exist and cannot take any input arguments. If you would like to parameterize the
+    configuration of your model, for example loaded from a config file, do it when instantiating the model above.
+    """
+    return _net

--- a/fl-tutorials/nvflare/image_synthesis/latent_diffusion_model_client_api/app_files/requirements.txt
+++ b/fl-tutorials/nvflare/image_synthesis/latent_diffusion_model_client_api/app_files/requirements.txt
@@ -1,0 +1,15 @@
+boto3>=1.38.31
+monai>=1.4.0
+nibabel>=5.3.2
+nvflare==2.8.0
+pandas>=2.3.0
+pydantic>=2.11.7
+pydantic-settings>=2.10.1
+gdown
+einops
+pydicom
+matplotlib
+lpips
+# Needed by lpips / MONAI PerceptualLoss (provides torchvision.ops.nms). Must match the base
+# image's torch (>=2.11, cu128); the authoritative pin lives in flip-utils/pyproject.toml.
+torchvision>=0.26.0

--- a/fl-tutorials/nvflare/image_synthesis/latent_diffusion_model_client_api/app_files/trainer.py
+++ b/fl-tutorials/nvflare/image_synthesis/latent_diffusion_model_client_api/app_files/trainer.py
@@ -1,0 +1,645 @@
+# Copyright (c) 2026 Guy's and St Thomas' NHS Foundation Trust & King's College London
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""NVFLARE Client API script for the FLIP latent diffusion tutorial.
+
+One script serves all four ML task names of the two-phase latent-diffusion job — the two training
+phases (``train_ae``: autoencoder + GAN discriminator; ``train_dm``: diffusion model over the frozen
+autoencoder's latent space) and their cross-site validation passes (``validate_ae`` /
+``validate_dm``). The single-name ``flare.is_train()`` / ``flare.is_evaluate()`` predicates cannot
+distinguish the two train phases, so dispatch is on ``get_task_name()``.
+
+Training tasks send back a full-model weight **diff** (``params_type="DIFF"``; the FLIP
+ScatterAndGather controller rebuilds full weights server-side before aggregation) stamped with the
+``FlipMetaKey.STAGE`` meta that scopes the ``StagePercentilePrivacy`` DP filter to the modules the
+phase actually trains. Validation tasks send back aggregate metrics only.
+
+Ported from the legacy Executor-based ``FLIP_TRAINER`` / ``FLIP_VALIDATOR`` pair — the training and
+validation maths are unchanged; only the NVFLARE plumbing moved to the Client API.
+"""
+
+import argparse
+import json
+import logging
+from pathlib import Path
+
+import einops
+import nibabel as nib
+import numpy as np
+import nvflare.client as flare
+import torch
+from flip import FLIP
+from flip.constants import FlipMetaKey, ResourceType
+from models import get_model
+from monai.data import DataLoader, Dataset
+from monai.losses import PatchAdversarialLoss, PerceptualLoss
+from monai.networks.schedulers import DDPMScheduler
+from nvflare.client.api import get_task_name
+from nvflare.client.tracking import SummaryWriter
+from torch.amp import GradScaler, autocast
+from transforms import get_train_transforms, get_val_transforms
+from validator import build_inferer, validate_ae, validate_dm
+
+logger = logging.getLogger(__name__)
+
+TRAIN_AE_TASK = "train_ae"
+TRAIN_DM_TASK = "train_dm"
+VALIDATE_AE_TASK = "validate_ae"
+VALIDATE_DM_TASK = "validate_dm"
+
+# Module prefixes trained by each phase — stamped as FlipMetaKey.STAGE on the outgoing update so
+# the StagePercentilePrivacy filter computes its percentile cutoff over exactly the trained params.
+STAGE_MODULES = {
+    TRAIN_AE_TASK: [["autoencoder", "discriminator"]],
+    TRAIN_DM_TASK: [["diffusion_model"]],
+}
+
+
+class KLDivergenceLoss:
+    """
+    Expects z_mu (B, *latent_shape) and z_sigma (B, *latent_shape).
+    Returns per-batch mean KL (averaged over batch).
+    """
+
+    def __call__(
+        self,
+        z_mu: torch.Tensor,
+        z_sigma: torch.Tensor,
+    ) -> torch.Tensor:
+        # We remove spatial notion
+        z_mu_m = z_mu.flatten(start_dim=2)
+        z_sigma_m = z_sigma.flatten(start_dim=2)
+        kl_loss = 0.5 * torch.sum(z_mu_m.pow(2) + z_sigma_m.pow(2) - torch.log(z_sigma_m.pow(2)) - 1, dim=[-1])
+        kl_loss = torch.sum(kl_loss) / kl_loss.shape[0]
+
+        return kl_loss
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--project_id", type=str, default="")
+    return parser.parse_args()
+
+
+def load_query() -> str:
+    """Read the cohort query from the client app config.
+
+    NVFlare's TaskScriptRunner does a naive whitespace split on task_script_args, so the SQL query
+    (which can contain spaces) is plumbed via the top-level ``query`` key in
+    ``config/config_fed_client.json`` rather than as a CLI flag. In dev/simulator mode this is
+    ignored by ``flip.get_dataframe``.
+    """
+    client_cfg = Path(__file__).parent.parent / "config" / "config_fed_client.json"
+    if client_cfg.exists():
+        try:
+            return json.loads(client_cfg.read_text()).get("query", "")
+        except Exception:
+            return ""
+    return ""
+
+
+def load_config() -> dict:
+    """Load the user-supplied config.json that sits next to this script."""
+    config_path = Path(__file__).parent.resolve() / "config.json"
+    with open(config_path) as f:
+        return json.load(f)
+
+
+def batch_accumulation_step(batch_size: int) -> int:
+    """Accumulate gradients up to an effective batch of 8 when the configured batch is smaller."""
+    if batch_size < 8:
+        return 8 // batch_size
+    return 1
+
+
+class DiffusionTrainer:
+    """Holds the model, losses, optimizers, and data for both training phases.
+
+    One instance lives for the whole ``flare.is_running()`` loop, so — as with the legacy per-phase
+    executor instances — each phase's optimizer state persists across that phase's global rounds.
+    """
+
+    def __init__(self, config: dict, project_id: str, query: str):
+        self.config = config
+        self.project_id = project_id
+        working_dir = Path(__file__).parent.resolve()
+
+        #  Training parameters for the autoencoder and the diffusion model
+        self.params_autoencoder = {
+            "lr_g": config["LR_G"],
+            "lr_d": config["LR_D"],
+            "epochs": config.get("LOCAL_ROUNDS_AE", 5),
+        }
+        self.params_diffusion = {"lr": config["LR_DM"], "epochs": config.get("LOCAL_ROUNDS_DM", 5)}
+
+        # Model creation
+        self.model = get_model()
+        self.device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+
+        # Losses, optimizers etc.
+        torch.hub.set_dir(f"{working_dir}/torch_hub")
+        self.losses_ae = {
+            "reconstruction_loss": torch.nn.L1Loss(),
+            "kld_loss": KLDivergenceLoss(),
+            "gan_loss": PatchAdversarialLoss(criterion="least_squares"),
+            "perceptual_loss": PerceptualLoss(2, network_type="alex"),
+        }
+        self.perceptual_slices = 12
+        self.losses_dm = {"loss": torch.nn.functional.mse_loss}
+        self.weights_ae = {
+            "w_reconstruction_loss": config["w_reconstruction_loss"],
+            "w_perceptual_loss": config["w_perceptual_loss"],
+            "w_kl_loss": config["w_kl_loss"],
+            "w_gan_loss": config["w_gan_loss"],
+        }
+
+        self.optimizers_ae = {
+            "optimizer_g": torch.optim.Adam(
+                self.model.autoencoder.parameters(), lr=self.params_autoencoder["lr_g"], weight_decay=1e-6, amsgrad=True
+            ),
+            "optimizer_d": torch.optim.Adam(
+                self.model.discriminator.parameters(),
+                lr=self.params_autoencoder["lr_d"],
+                weight_decay=1e-6,
+                amsgrad=True,
+            ),
+        }
+        self.optimizers_dm = {
+            "optimizer": torch.optim.Adam(
+                self.model.diffusion_model.parameters(), lr=self.params_diffusion["lr"], weight_decay=1e-6, amsgrad=True
+            ),
+            "scheduler": DDPMScheduler(
+                num_train_timesteps=1000,
+                schedule="scaled_linear_beta",
+                clip_sample=False,
+                prediction_type="epsilon",
+                beta_start=0.0015,
+                beta_end=0.0195,
+            ),
+        }
+
+        # Data loading
+        self.flip = FLIP()
+        self.axial_anisotropy: bool | None = None
+        dataframe = self.flip.get_dataframe(project_id=project_id, query=query)
+        self.train_items, self.val_items = self.get_image_list(dataframe)
+
+        # Per-site split for local/simulator runs where every client reads the same DEV dataset;
+        # in production each trust's data-access API already scopes the cohort to its own data.
+        site_name = flare.get_site_name()
+        if site_name == "site1":
+            self.train_items = self.train_items[: len(self.train_items) // 2]
+        elif site_name == "site2":
+            self.train_items = self.train_items[len(self.train_items) // 2 :]
+
+        self._train_dataset = Dataset(self.train_items, transform=get_train_transforms(config["spatial_shape"]))
+        self._val_dataset = Dataset(self.val_items, transform=get_val_transforms(config["spatial_shape"]))
+
+    def get_image_list(self, dataframe) -> tuple[list, list]:
+        """Fetch each accession's converted NIfTI images and split into train/validation lists.
+
+        Also detects axial anisotropy (thick-slice data) from the first readable image, which
+        switches the perceptual loss to its 2D sliced form.
+        """
+        datalist: list[dict[str, str]] = []
+
+        for accession_id in dataframe["accession_id"]:
+            try:
+                accession_folder_path = self.flip.get_by_accession_number(
+                    self.project_id,
+                    accession_id,
+                    resource_type=[
+                        ResourceType.NIFTI,
+                    ],
+                )
+            except Exception as err:
+                logger.info(f"Could not get image data folder path for {accession_id}: {err}")
+                continue
+
+            all_images = list(accession_folder_path.rglob("input_*.nii.gz"))
+            if not all_images:
+                continue
+            if self.axial_anisotropy is None:
+                try:
+                    nib_image = np.asarray(nib.load(str(all_images[0])).dataobj)
+                    # ! We assume that it's axial anisotropy: aka, thick slice.
+                    ip_2_op = nib_image.shape[0] / nib_image.shape[-1]
+                    if ip_2_op > 1.5:
+                        self.axial_anisotropy = True
+                        logger.info(f"Found axial anisotropy (in-plane to out-plane ratio is {ip_2_op}).")
+                        self.reset_perceptual_to_anisotropic()
+                        if self.config["net_config"]["discriminator"]["spatial_dims"] == 3:
+                            logger.warning(
+                                "Warning: your data is anisotropic on the axial plane "
+                                "but the discriminator is still 3D. This might lead to low performance."
+                            )
+                    else:
+                        self.axial_anisotropy = False
+                except Exception as e:
+                    logger.info(f"Error loading NIfTI image for {accession_id}: {e}")
+
+            for image in all_images:
+                datalist.append({"image": str(image)})
+
+        logger.info(f"Found {len(datalist)} files in total.")
+
+        # Validation / train splits:
+        val_size = int(self.config["VAL_SPLIT"] * len(datalist))
+        return datalist[val_size:], datalist[:val_size]
+
+    def reset_perceptual_to_anisotropic(self):
+        """If we spot axial anisotropy, we reset the perceptual loss to 2D if it was 3D to have better results."""
+        if self.axial_anisotropy and self.losses_ae["perceptual_loss"].spatial_dims == 3:
+            self.losses_ae["perceptual_loss"] = PerceptualLoss(spatial_dims=2, network_type="radimagenet_resnet50")
+            if self.weights_ae["w_perceptual_loss"] <= 1.0:
+                self.weights_ae["w_perceptual_loss"] = 10
+                # This perceptual loss tends to have very low values.
+            logger.info("Resetting perceptual loss to 2D versions due to axial anisotropy.")
+
+    def make_loaders(self, batch_size: int, shuffle: bool = True) -> tuple[DataLoader, DataLoader]:
+        train_loader = DataLoader(self._train_dataset, batch_size=batch_size, shuffle=shuffle, num_workers=1)
+        val_loader = DataLoader(self._val_dataset, batch_size=batch_size, shuffle=shuffle, num_workers=1)
+        return train_loader, val_loader
+
+    def val_loader(self, batch_size: int) -> DataLoader:
+        return DataLoader(self._val_dataset, batch_size=batch_size, shuffle=False, num_workers=1)
+
+    def load_weights(self, weights: dict[str, torch.Tensor]) -> None:
+        self.model.load_state_dict(state_dict=weights, strict=False)
+
+    def train_ae(self, writer: SummaryWriter, global_round: int) -> int:
+        """One ``train_ae`` round: local AE + discriminator epochs. Returns the iteration count."""
+        accumulation_step = batch_accumulation_step(self.config["BATCH_SIZE_AE"])
+        train_loader, val_loader = self.make_loaders(self.config["BATCH_SIZE_AE"])
+        self.model.autoencoder.to(device=self.device)
+        self.model.discriminator.to(device=self.device)
+        self.losses_ae["perceptual_loss"].to(self.device)
+
+        # Create GradScalers - ensure they don't accumulate state
+        scaler_g = GradScaler(enabled=True)
+        scaler_d = GradScaler(enabled=True)
+
+        # Basic training
+        self.model.autoencoder.train()
+        self.model.discriminator.train()
+        epochs = self.params_autoencoder["epochs"]
+        for epoch in range(epochs):
+            train_g_loss = 0
+            train_d_loss = 0
+            train_g_l1loss = 0
+            train_g_percloss = 0
+            train_g_ganloss = 0
+            train_g_klloss = 0
+
+            batch_acc_counter = 0
+            for ind, batch in enumerate(train_loader):
+                images = batch["image"].to(self.device)
+                perceptual_slices = None  # Just in case!
+
+                # TRAIN GENERATOR
+                with autocast(enabled=True, device_type=self.device.type):
+                    reconstruction, z_mu, z_sigma = self.model.autoencoder(images)
+                    if True in torch.isnan(reconstruction):
+                        logger.error("Found NaN in the autoencoder reconstruction; stopping training on site.")
+                        raise RuntimeError("NaN in autoencoder reconstruction during train_ae")
+                    kl_loss = self.weights_ae["w_kl_loss"] * self.losses_ae["kld_loss"](z_mu, z_sigma)
+                    l1_loss = self.weights_ae["w_reconstruction_loss"] * self.losses_ae["reconstruction_loss"](
+                        reconstruction.float(), images.float()
+                    )
+                    if self.axial_anisotropy or self.config["net_config"]["stage_1"]["spatial_dims"] == 2:
+                        perceptual_slices = np.random.randint(0, images.shape[-1], size=self.perceptual_slices)
+                        p_loss = self.losses_ae["perceptual_loss"](
+                            einops.rearrange(
+                                reconstruction[..., perceptual_slices], "b c h w d -> (b d) c h w"
+                            ).float(),
+                            einops.rearrange(images[..., perceptual_slices], "b c h w d -> (b d) c h w").float(),
+                        )
+                        p_loss = self.weights_ae["w_perceptual_loss"] * p_loss
+                    else:
+                        p_loss = self.losses_ae["perceptual_loss"](reconstruction.float(), images.float())
+                        p_loss = self.weights_ae["w_perceptual_loss"] * p_loss
+
+                    if (
+                        self.config["net_config"]["stage_1"]["spatial_dims"] == 3
+                        and self.config["net_config"]["discriminator"]["spatial_dims"] == 2
+                    ):
+                        if perceptual_slices is None:
+                            perceptual_slices = np.random.randint(0, images.shape[-1], size=self.perceptual_slices)
+                        logits_fake = self.model.discriminator(
+                            einops.rearrange(reconstruction[..., perceptual_slices], "b c h w d -> (b d) c h w")
+                            .contiguous()
+                            .float()
+                        )[-1]
+                    else:
+                        logits_fake = self.model.discriminator(reconstruction.contiguous().float())[-1]
+
+                    gan_loss = self.weights_ae["w_gan_loss"] * self.losses_ae["gan_loss"](
+                        logits_fake, target_is_real=True, for_discriminator=False
+                    )
+
+                    # Loss generator
+                    train_g_loss_ = l1_loss + kl_loss + p_loss + gan_loss
+
+                # Scale and backprop
+                scaler_g.scale(train_g_loss_).backward()
+
+                batch_acc_counter += 1
+                if batch_acc_counter % accumulation_step == 0 or ind == (len(train_loader) - 1):
+                    scaler_g.step(self.optimizers_ae["optimizer_g"])
+                    scaler_g.update()
+                    self.optimizers_ae["optimizer_g"].zero_grad(set_to_none=True)
+
+                del z_mu, z_sigma, logits_fake
+
+                # TRAIN DISCRIMINATOR
+                self.optimizers_ae["optimizer_d"].zero_grad(set_to_none=True)
+                if (
+                    self.config["net_config"]["stage_1"]["spatial_dims"] == 3
+                    and self.config["net_config"]["discriminator"]["spatial_dims"] == 2
+                ):
+                    if perceptual_slices is None:
+                        perceptual_slices = np.random.randint(0, images.shape[-1], size=self.perceptual_slices)
+
+                    logits_fake = self.model.discriminator(
+                        einops.rearrange(reconstruction.detach()[..., perceptual_slices], "b c h w d -> (b d) c h w")
+                        .contiguous()
+                        .float()
+                    )[-1]
+                    logits_real = self.model.discriminator(
+                        einops.rearrange(images[..., perceptual_slices], "b c h w d -> (b d) c h w")
+                        .contiguous()
+                        .float()
+                    )[-1]
+                else:
+                    logits_real = self.model.discriminator(images.float())[-1]
+                    logits_fake = self.model.discriminator(reconstruction.detach().contiguous().float())[-1]
+
+                loss_d_fake = self.losses_ae["gan_loss"](logits_fake, target_is_real=False, for_discriminator=True)
+                loss_d_real = self.losses_ae["gan_loss"](logits_real, target_is_real=True, for_discriminator=True)
+                d_loss = self.weights_ae["w_gan_loss"] * (loss_d_fake + loss_d_real) * 0.5
+                scaler_d.scale(d_loss).backward()
+
+                if batch_acc_counter % accumulation_step == 0 or ind == (len(train_loader) - 1):
+                    scaler_d.step(self.optimizers_ae["optimizer_d"])
+                    scaler_d.update()
+
+                del logits_real, logits_fake, reconstruction
+
+                # Aggregate
+                train_g_loss += train_g_loss_.item()
+                train_g_ganloss += gan_loss.item()
+                train_g_percloss += p_loss.item()
+                train_g_l1loss += l1_loss.item()
+                train_g_klloss += kl_loss.item()
+                train_d_loss += d_loss.item()
+
+                del train_g_loss_, gan_loss, p_loss, l1_loss, kl_loss, d_loss, images
+
+                # Force CUDA cache clearing to prevent memory fragmentation
+                if torch.cuda.is_available():
+                    torch.cuda.empty_cache()
+                    torch.cuda.synchronize()
+
+            # Aggregate at the end
+            train_g_loss /= max(1, len(train_loader))
+            train_g_ganloss /= max(1, len(train_loader))
+            train_g_percloss /= max(1, len(train_loader))
+            train_g_l1loss /= max(1, len(train_loader))
+            train_g_klloss /= max(1, len(train_loader))
+            train_d_loss /= max(1, len(train_loader))
+
+            # Validation
+            val_loss = 0
+            self.model.autoencoder.eval()
+            for batch in val_loader:
+                images = batch["image"].to(self.device)
+                with autocast(enabled=True, device_type=self.device.type):
+                    with torch.no_grad():
+                        reconstruction, _, _ = self.model.autoencoder(images)
+                    if True in torch.isnan(reconstruction):
+                        break
+                    val_loss += (
+                        self.weights_ae["w_reconstruction_loss"]
+                        * self.losses_ae["reconstruction_loss"](reconstruction.float(), images.float()).item()
+                    )
+
+            val_loss /= max(1, len(val_loader))
+            self.model.autoencoder.train()
+
+            logger.info(
+                f"Epoch {epoch + 1} / {epochs};\n "
+                f"Total loss G: {train_g_loss}, GAN: {train_g_ganloss} "
+                f"Perceptual: {train_g_percloss}, L1: {train_g_l1loss} "
+                f"KLD: {train_g_klloss} \n"
+                f"Total loss D: {train_d_loss},Validation loss (L1): {val_loss}"
+            )
+
+            # Send metrics to FLIP. Labels match the legacy tutorial's series names; the "@epoch"
+            # suffix names the x-axis and `step` (cumulative local epoch) is the coordinate.
+            step = global_round * epochs + epoch + 1
+            writer.add_scalar("Train loss (G)@epoch", train_g_loss, global_step=step)
+            writer.add_scalar("Train loss (D)@epoch", train_d_loss, global_step=step)
+            writer.add_scalar("Perceptual loss (G)@epoch", train_g_percloss, global_step=step)
+            writer.add_scalar("KLD loss (G)@epoch", train_g_klloss, global_step=step)
+            writer.add_scalar("Reconstruction loss (G)@epoch", train_g_l1loss, global_step=step)
+            writer.add_scalar("GAN loss (G)@epoch", train_g_ganloss, global_step=step)
+            writer.add_scalar("Validation loss (L1)@epoch", val_loss, global_step=step)
+
+        return epochs * len(train_loader)
+
+    def train_dm(self, writer: SummaryWriter, global_round: int) -> int:
+        """One ``train_dm`` round: local diffusion-model epochs. Returns the iteration count."""
+        accumulation_step = batch_accumulation_step(self.config["BATCH_SIZE_DM"])
+        train_loader, val_loader = self.make_loaders(self.config["BATCH_SIZE_DM"])
+        self.model.diffusion_model.to(device=self.device)
+        self.model.autoencoder.to(device=self.device)
+
+        inferer, ldm_latent_shape = build_inferer(
+            self.model,
+            self.optimizers_dm["scheduler"],
+            self.config["spatial_shape"],
+            next(iter(train_loader))["image"],
+            self.device,
+        )
+        scaler = GradScaler()
+
+        # Basic training
+        train_loss = []
+        val_loss = []
+        epochs = self.params_diffusion["epochs"]
+        for epoch in range(epochs):
+            self.model.diffusion_model.train()
+            batch_acc_counter = 0
+            train_loss_epoch = 0
+
+            for batch in train_loader:
+                images = batch["image"].to(self.device)
+
+                with autocast(enabled=False, device_type=self.device.type):
+                    noise = torch.randn(
+                        [images.shape[0]]
+                        + [self.model.autoencoder.encoder.blocks[-1].out_channels]
+                        + ldm_latent_shape
+                    ).to(self.device)
+                    timesteps = torch.randint(
+                        0,
+                        self.optimizers_dm["scheduler"].num_train_timesteps,
+                        (images.shape[0],),
+                        device=self.device,
+                    ).long()
+                    noise_pred = inferer(
+                        inputs=images,
+                        diffusion_model=self.model.diffusion_model,
+                        autoencoder_model=self.model.autoencoder,
+                        noise=noise,
+                        timesteps=timesteps,
+                        condition=None,
+                        mode="crossattn",
+                    )
+                    loss = self.losses_dm["loss"](noise.float(), noise_pred.float())
+
+                if True in torch.isnan(loss) or True in torch.isnan(noise_pred):
+                    logger.error("Found NaN on training loss; stopping training on site.")
+                    raise RuntimeError("NaN loss during train_dm")
+
+                scaler.scale(loss).backward()
+                batch_acc_counter += 1
+                if batch_acc_counter == accumulation_step:
+                    scaler.step(self.optimizers_dm["optimizer"])
+                    scaler.update()
+                    batch_acc_counter = 0
+                    self.optimizers_dm["optimizer"].zero_grad(set_to_none=True)
+                train_loss_epoch += loss.item()
+
+            train_loss.append(train_loss_epoch / max(1, len(train_loader)))
+
+            # Validation loss
+            val_loss_epoch = 0
+            for batch in val_loader:
+                images = batch["image"].to(self.device)
+                self.model.diffusion_model.eval()
+                with autocast(enabled=False, device_type=self.device.type):
+                    noise = torch.randn(
+                        [images.shape[0]]
+                        + [self.model.autoencoder.encoder.blocks[-1].out_channels]
+                        + ldm_latent_shape
+                    ).to(self.device)
+                    timesteps = torch.randint(
+                        0,
+                        self.optimizers_dm["scheduler"].num_train_timesteps,
+                        (images.shape[0],),
+                        device=self.device,
+                    ).long()
+                    noise_pred = inferer(
+                        inputs=images,
+                        diffusion_model=self.model.diffusion_model,
+                        autoencoder_model=self.model.autoencoder,
+                        noise=noise,
+                        timesteps=timesteps,
+                        condition=None,
+                        mode="crossattn",
+                    )
+                    val_loss_epoch += self.losses_dm["loss"](noise.float(), noise_pred.float()).item()
+
+            val_loss.append(val_loss_epoch / max(1, len(val_loader)))
+
+            logger.info(f"Epoch {epoch + 1} / {epochs};\n Total loss DM: {np.mean(train_loss)}")
+
+            step = global_round * epochs + epoch + 1
+            writer.add_scalar("Total loss DM@epoch", float(np.mean(train_loss)), global_step=step)
+            writer.add_scalar("Validation loss DM@epoch", float(np.mean(val_loss)), global_step=step)
+
+        return epochs * len(train_loader)
+
+
+def to_torch_weights(input_model: flare.FLModel) -> dict[str, torch.Tensor]:
+    return {k: torch.as_tensor(v) for k, v in input_model.params.items()}
+
+
+def send_weight_diff(original_params: dict, model: torch.nn.Module, n_iterations: int, task_name: str) -> None:
+    """Send the full-model weight diff for a completed training round.
+
+    Built one tensor at a time to avoid holding a second full copy of the model in RAM (mirrors
+    ``flip.utils.get_model_weights_diff``). The ``STAGE`` meta scopes the DP filter's percentile
+    cutoff to the modules this phase trained.
+    """
+    diff = {}
+    for k, v in model.state_dict().items():
+        new_arr = v.detach().cpu().numpy()
+        diff[k] = new_arr - np.asarray(original_params[k])
+        del new_arr
+
+    flare.send(
+        flare.FLModel(
+            params=diff,
+            params_type="DIFF",
+            meta={
+                "NUM_STEPS_CURRENT_ROUND": n_iterations,
+                FlipMetaKey.STAGE.value: STAGE_MODULES[task_name],
+            },
+        )
+    )
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO)
+    args = parse_args()
+    config = load_config()
+
+    flare.init()
+    writer = SummaryWriter()
+
+    trainer = DiffusionTrainer(config, project_id=args.project_id, query=load_query())
+
+    while flare.is_running():
+        input_model = flare.receive()
+        if input_model is None:
+            break
+
+        task_name = get_task_name()
+        logger.info(f"[LDM trainer] received task '{task_name}' (round {input_model.current_round})")
+        weights = to_torch_weights(input_model)
+        global_round = input_model.current_round or 0
+
+        if task_name == TRAIN_AE_TASK:
+            trainer.load_weights(weights)
+            n_iterations = trainer.train_ae(writer, global_round)
+            send_weight_diff(input_model.params, trainer.model, n_iterations, task_name)
+
+        elif task_name == TRAIN_DM_TASK:
+            trainer.load_weights(weights)
+            n_iterations = trainer.train_dm(writer, global_round)
+            send_weight_diff(input_model.params, trainer.model, n_iterations, task_name)
+
+        elif task_name == VALIDATE_AE_TASK:
+            trainer.model.load_state_dict({k: v.to(trainer.device) for k, v in weights.items()})
+            test_loader = trainer.val_loader(config["BATCH_SIZE_AE"])
+            val_loss, val_ssim = validate_ae(trainer.model, test_loader, trainer.device, writer)
+            logger.info(f"Validating the aggregated autoencoder on {flare.get_site_name()}'s data: SSIM {val_ssim}")
+            flare.send(flare.FLModel(metrics={f"metrics_{task_name}": {"val_loss": val_loss, "val_ssim": val_ssim}}))
+
+        elif task_name == VALIDATE_DM_TASK:
+            trainer.model.load_state_dict(
+                {k: v.to(trainer.device) for k, v in weights.items()}, strict=False
+            )
+            test_loader = trainer.val_loader(config["BATCH_SIZE_DM"])
+            val_loss = validate_dm(
+                trainer.model, test_loader, trainer.optimizers_dm["scheduler"], config, trainer.device, writer
+            )
+            logger.info(f"Validating the aggregated diffusion model on {flare.get_site_name()}'s data: {val_loss}")
+            flare.send(flare.FLModel(metrics={f"metrics_{task_name}": {"val_loss": val_loss}}))
+
+        else:
+            logger.warning(f"Received unknown task '{task_name}'; ignoring.")
+
+
+if __name__ == "__main__":
+    main()

--- a/fl-tutorials/nvflare/image_synthesis/latent_diffusion_model_client_api/app_files/transforms.py
+++ b/fl-tutorials/nvflare/image_synthesis/latent_diffusion_model_client_api/app_files/transforms.py
@@ -1,0 +1,52 @@
+# Copyright (c) 2026 Guy's and St Thomas' NHS Foundation Trust & King's College London
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import monai.transforms as mt
+
+
+def get_train_transforms(spatial_shape: tuple | list):
+    return mt.Compose([
+        mt.LoadImaged(keys=["image"], image_only=True),
+        mt.EnsureChannelFirstd(keys=["image"], channel_dim="no_channel"),
+        mt.Orientationd(keys=["image"], axcodes="RAS"),
+        mt.Spacingd(
+            keys=["image"],
+            pixdim=(1.5, 1.5, 2.0),
+            mode=("bilinear"),
+        ),
+        mt.ResizeWithPadOrCropd(keys=["image"], spatial_size=spatial_shape),
+        mt.RandAffined(
+            keys=["image"],
+            shear_range=(-0.1, 0.1),
+            scale_range=(0.01, 0.05),
+            rotate_range=(-0.05, 0.05),
+            translate_range=(-0.05, 0.05),
+            prob=1.0,
+            padding_mode="border",
+        ),
+        mt.ScaleIntensityRanged(keys=["image"], a_min=-57, a_max=250, b_min=0.0, b_max=1.0, clip=True),
+    ])
+
+
+def get_val_transforms(spatial_shape: tuple | list):
+    return mt.Compose([
+        mt.LoadImaged(keys=["image"], image_only=True),
+        mt.EnsureChannelFirstd(keys=["image"], channel_dim="no_channel"),
+        mt.Orientationd(keys=["image"], axcodes="RAS"),
+        mt.Spacingd(
+            keys=["image"],
+            pixdim=(1.5, 1.5, 2.0),
+            mode=("bilinear"),
+        ),
+        mt.ResizeWithPadOrCropd(keys=["image"], spatial_size=spatial_shape),
+        mt.ScaleIntensityRanged(keys=["image"], a_min=-57, a_max=250, b_min=0.0, b_max=1.0, clip=True),
+    ])

--- a/fl-tutorials/nvflare/image_synthesis/latent_diffusion_model_client_api/app_files/validator.py
+++ b/fl-tutorials/nvflare/image_synthesis/latent_diffusion_model_client_api/app_files/validator.py
@@ -1,0 +1,243 @@
+# Copyright (c) 2026 Guy's and St Thomas' NHS Foundation Trust & King's College London
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Cross-site validation passes and latent-geometry helpers for the latent diffusion tutorial.
+
+Ported from the legacy Executor-based ``FLIP_VALIDATOR``: the ``Executor``/``Shareable`` plumbing is
+gone — ``trainer.py`` (the Client API script) receives the ``validate_ae`` / ``validate_dm`` tasks,
+loads the broadcast global weights, and calls :func:`validate_ae` / :func:`validate_dm` here. The
+latent-geometry helpers (:func:`derive_new_latent_shape`, :func:`build_inferer`) live here because
+the training and validation passes of the diffusion phase share them.
+"""
+
+import logging
+
+import numpy as np
+import torch
+from flip.constants import FlipConstants
+from monai.data import DataLoader
+from monai.inferers import LatentDiffusionInferer
+from monai.metrics import compute_ssim_and_cs
+from monai.networks.schedulers import DDPMScheduler
+from nvflare.client.tracking import SummaryWriter
+from torch.amp import autocast
+
+logger = logging.getLogger(__name__)
+
+
+def derive_new_latent_shape(input_shape: list, num_downsamplings: int) -> list:
+    """
+    For diffusion model, adjusts the stage 1 latent space so that the latent space input to the
+    diffusion model can be downsampled as many times as needed without errors due to odd dimensions.
+    """
+    output_shape = []
+    for shape_el in input_shape:
+        new_shape = shape_el
+        remainder_0 = shape_el % 2**num_downsamplings
+        while remainder_0 != 0:
+            new_shape += 1
+            remainder_0 = new_shape % 2**num_downsamplings
+
+        output_shape.append(new_shape)
+    return [int(i) for i in output_shape]
+
+
+def latent_shapes(model: torch.nn.Module, spatial_shape: list) -> tuple[list, list]:
+    """Infer the autoencoder latent shape and the diffusion-model-compatible (padded) latent shape.
+
+    Args:
+        model (torch.nn.Module): The composite LDM network (``models.get_model()``).
+        spatial_shape (list): The input spatial shape from ``config.json``.
+
+    Returns:
+        tuple[list, list]: ``(autoencoder_latent_shape, ldm_latent_shape)``.
+    """
+    autoencoder_latent_shape = [i / (2 ** (len(model.autoencoder.decoder.channels) - 1)) for i in spatial_shape]
+    ldm_latent_shape = derive_new_latent_shape(
+        autoencoder_latent_shape, len(model.diffusion_model.block_out_channels) - 1
+    )
+    return autoencoder_latent_shape, ldm_latent_shape
+
+
+def build_inferer(
+    model: torch.nn.Module,
+    scheduler: DDPMScheduler,
+    spatial_shape: list,
+    sample_images: torch.Tensor,
+    device: torch.device,
+) -> tuple[LatentDiffusionInferer, list]:
+    """Build the ``LatentDiffusionInferer`` for the diffusion phase.
+
+    The scale factor is inferred from a sample batch encoded through the (frozen) autoencoder, as in
+    the legacy trainer/validator.
+
+    Args:
+        model (torch.nn.Module): The composite LDM network with trained autoencoder weights loaded.
+        scheduler (DDPMScheduler): The DDPM noise scheduler.
+        spatial_shape (list): The input spatial shape from ``config.json``.
+        sample_images (torch.Tensor): A batch of images used to infer the latent scale factor.
+        device (torch.device): Device the model lives on.
+
+    Returns:
+        tuple[LatentDiffusionInferer, list]: The inferer and the padded LDM latent shape (needed by
+        callers to shape the sampling noise).
+    """
+    autoencoder_latent_shape, ldm_latent_shape = latent_shapes(model, spatial_shape)
+
+    with torch.no_grad():
+        with autocast(enabled=True, device_type=device.type):
+            sample_z = model.autoencoder.encode_stage_2_inputs(sample_images.to(device))
+            scale_factor = 1 / torch.std(sample_z)
+            del sample_z
+
+    inferer = LatentDiffusionInferer(
+        scheduler=scheduler,
+        ldm_latent_shape=ldm_latent_shape,
+        autoencoder_latent_shape=autoencoder_latent_shape,
+        scale_factor=scale_factor.item(),
+    )
+    return inferer, ldm_latent_shape
+
+
+def validate_ae(
+    model: torch.nn.Module,
+    test_loader: DataLoader,
+    device: torch.device,
+    writer: SummaryWriter,
+) -> tuple[float, float]:
+    """Score the aggregated autoencoder on the local held-out split.
+
+    Args:
+        model (torch.nn.Module): The composite LDM network with the broadcast global weights loaded.
+        test_loader (DataLoader): Held-out data loader.
+        device (torch.device): Device to run on.
+        writer (SummaryWriter): NVFLARE Client API metrics writer (relayed to FLIP by the
+            analytics bridge).
+
+    Returns:
+        tuple[float, float]: ``(l1_test_loss, ssim_test)`` averaged over the held-out split.
+    """
+    reconstruction_loss = torch.nn.L1Loss()
+    model.autoencoder.to(device=device)
+    model.eval()
+
+    l1_test_loss = 0.0
+    ssim_test = 0.0
+
+    for batch in test_loader:
+        images = batch["image"].to(device)
+
+        with torch.no_grad():
+            reconstruction, _, _ = model.autoencoder(images)
+        reconstruction = reconstruction.detach().cpu()
+        images = images.detach().cpu()
+        reconstruction_norm = (reconstruction - reconstruction.min()) / (reconstruction.max() - reconstruction.min())
+
+        _, ssim_metric = compute_ssim_and_cs(
+            reconstruction_norm,
+            images.detach().cpu(),
+            spatial_dims=len(reconstruction.shape[2:]),
+            data_range=1,
+            kernel_size=[11] * len(reconstruction.shape[2:]),
+            kernel_sigma=[1.5] * len(reconstruction.shape[2:]),
+        )
+        l1_loss = reconstruction_loss(reconstruction.float(), images.float())
+        ssim_test += ssim_metric.mean().item()
+        l1_test_loss += l1_loss.item()
+
+    l1_test_loss /= max(1, len(test_loader))
+    ssim_test /= max(1, len(test_loader))
+
+    logger.info(f"Validation loss: {l1_test_loss} SSIM: {ssim_test}")
+
+    writer.add_scalar("val_l1_loss", l1_test_loss, global_step=0)
+    writer.add_scalar("val_ssim", ssim_test, global_step=0)
+
+    return l1_test_loss, ssim_test
+
+
+def validate_dm(
+    model: torch.nn.Module,
+    test_loader: DataLoader,
+    scheduler: DDPMScheduler,
+    config: dict,
+    device: torch.device,
+    writer: SummaryWriter,
+) -> float:
+    """Score the aggregated diffusion model on the local held-out split.
+
+    Args:
+        model (torch.nn.Module): The composite LDM network with the broadcast global weights loaded.
+        test_loader (DataLoader): Held-out data loader.
+        scheduler (DDPMScheduler): The DDPM noise scheduler.
+        config (dict): The user app config (``config.json``).
+        device (torch.device): Device to run on.
+        writer (SummaryWriter): NVFLARE Client API metrics writer.
+
+    Returns:
+        float: Mean noise-prediction MSE over the held-out split.
+    """
+    loss_fn = torch.nn.functional.mse_loss
+
+    model.diffusion_model.to(device=device)
+    model.autoencoder.to(device=device)
+    inferer, ldm_latent_shape = build_inferer(
+        model, scheduler, config["spatial_shape"], next(iter(test_loader))["image"], device
+    )
+
+    model.diffusion_model.eval()
+    model.autoencoder.eval()
+
+    val_loss = []
+    for batch in test_loader:
+        images = batch["image"].to(device)
+        with autocast(enabled=False, device_type=device.type):
+            with torch.no_grad():
+                noise = torch.randn(
+                    [images.shape[0]] + [model.autoencoder.encoder.blocks[-1].out_channels] + ldm_latent_shape
+                ).to(device)
+                timesteps = torch.randint(
+                    0, scheduler.num_train_timesteps, (images.shape[0],), device=device
+                ).long()
+                logger.info(f"Sizes: images = {images.shape}, noise = {noise.shape}")
+                noise_pred = inferer(
+                    inputs=images,
+                    diffusion_model=model.diffusion_model,
+                    autoencoder_model=model.autoencoder,
+                    noise=noise,
+                    timesteps=timesteps,
+                    condition=None,
+                    mode="crossattn",
+                )
+            val_loss.append(loss_fn(noise.float(), noise_pred.float()).item())
+
+    if FlipConstants.LOCAL_DEV:
+        # Dev-only sanity check that end-to-end sampling works with the aggregated weights.
+        logger.info("[DEV]: Sampling images...")
+        noise = torch.randn(
+            [config["BATCH_SIZE_DM"]] + [model.autoencoder.encoder.blocks[-1].out_channels] + ldm_latent_shape
+        ).to(device)
+        sampled_images, _ = inferer.sample(
+            input_noise=noise,
+            conditioning=None,
+            diffusion_model=model.diffusion_model,
+            scheduler=scheduler,
+            save_intermediates=True,
+            autoencoder_model=model.autoencoder,
+        )
+        logger.info(f"Sampled images shape: {sampled_images.detach().cpu().numpy().shape}")
+
+    mean_val_loss = float(np.mean(val_loss)) if val_loss else float("nan")
+    logger.info(f"Validation DM: {mean_val_loss}")
+
+    writer.add_scalar("Total loss DM (val)", mean_val_loss, global_step=0)
+
+    return mean_val_loss

--- a/fl-tutorials/nvflare/image_synthesis/latent_diffusion_model_client_api/job.py
+++ b/fl-tutorials/nvflare/image_synthesis/latent_diffusion_model_client_api/job.py
@@ -1,0 +1,135 @@
+# Copyright (c) 2026 Guy's and St Thomas' NHS Foundation Trust & King's College London
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Two-stage latent-diffusion Client API job definition for FLIP.
+
+This module defines the federated learning job using :class:`FlipDiffusionRecipe`.
+It supports two execution modes:
+
+*Export* (``--export --export-dir <path>``):
+    Writes the complete NVFLARE job to ``<path>/flip_diffusion/``, including
+    ``meta.json`` (carrying ``custom_props.model_id`` for lazy resolution),
+    ``app/config/`` (server + client configs), and ``app/custom/`` (the bundled
+    ``flip/`` package plus the staged user app files). This is the primary,
+    fully-local-verifiable path — no GPU or data required.
+
+*SimEnv* (default, no flags):
+    Runs a local simulation under the NVFLARE simulator. Requires a GPU and the
+    reference dataset (``make -C fl-tutorials download-spleen-data``). FLIP-specific
+    values are injected via environment variables (``FLIP_PROJECT_ID``,
+    ``FLIP_QUERY``) rather than CLI flags because SQL queries contain spaces that
+    don't survive argparse whitespace-splitting.
+
+Both modes go through NVFLARE's :meth:`Recipe.execute`, which consumes ``--export``/``--export-dir``
+from ``sys.argv`` itself (it strips them before this script's own ``argparse`` runs) and
+exports-or-runs accordingly — so there is no separate ``--export`` branch here.
+
+Usage:
+    # Export job config for review or Docker deployment (no GPU needed)
+    python job.py --export --export-dir ./fl_job --n_clients 2 --num_rounds_ae 1 --num_rounds_dm 1
+
+    # SimEnv local simulation (requires GPU + data)
+    python job.py --n_clients 2 --num_rounds_ae 1 --num_rounds_dm 1
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+# app_files/ must be importable at recipe-construction time so PTFileModelPersistor
+# and the model locators can reference 'models.get_model' correctly.
+_APP_FILES_DIR = Path(__file__).parent / "app_files"
+if str(_APP_FILES_DIR) not in sys.path:
+    sys.path.insert(0, str(_APP_FILES_DIR))
+
+from flip.nvflare.recipes import FlipDiffusionRecipe  # noqa: E402
+from nvflare import FedJob  # noqa: E402
+from nvflare.recipe import SimEnv  # noqa: E402
+
+
+def stage_app_files(job: FedJob) -> None:
+    """Bundle every file in ``app_files/`` into the job's server + client ``custom/`` directories.
+
+    The recipe wires only the NVFLARE components; the user-supplied app files (``trainer.py``,
+    ``validator.py``, ``models.py``, ``config.json``, ``transforms.py``) must be added to the job
+    explicitly so they land in every site's ``app/custom/``. ``FedJob.add_file_to_{server,clients}``
+    registers them with the job's file sources, so they are bundled for **both** the SimEnv/simulator run
+    (``recipe.execute``) and ``--export`` — unlike a post-export filesystem copy, which the SimEnv path
+    never triggered.
+
+    Args:
+        job: The recipe's underlying :class:`~nvflare.job_config.api.FedJob` (``recipe.job``).
+    """
+    for src in sorted(_APP_FILES_DIR.iterdir()):
+        if src.is_file():
+            job.add_file_to_server(str(src))
+            job.add_file_to_clients(str(src))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="FLIP Latent Diffusion Client API Job")
+    parser.add_argument("--n_clients", type=int, default=2, help="Number of clients")
+    parser.add_argument("--num_rounds_ae", type=int, default=1, help="Federated rounds for the autoencoder stage")
+    parser.add_argument("--num_rounds_dm", type=int, default=1, help="Federated rounds for the diffusion stage")
+    parser.add_argument(
+        "--workspace",
+        type=str,
+        default="/tmp/nvflare/ldm_client_api",
+        help="SimEnv workspace root",
+    )
+    # NOTE: ``--export``/``--export-dir`` are handled by NVFLARE's ``Recipe.execute`` (it strips them
+    # from ``sys.argv`` before this parser runs), so they are intentionally not declared here.
+    args = parser.parse_args()
+
+    # ------------------------------------------------------------------
+    # FLIP-specific values are read from environment variables rather than
+    # CLI flags.  SQL queries contain spaces that don't survive argparse
+    # whitespace-splitting when forwarded via train_args.  The trainer
+    # reads the query from config_fed_client.json at runtime (via
+    # load_query()), and project_id is passed as --project_id {project_id}
+    # which the FLIP-API substitutes before job submission.
+    # ------------------------------------------------------------------
+    project_id = os.environ.get("FLIP_PROJECT_ID", "")
+    query = os.environ.get("FLIP_QUERY", "SELECT * FROM Table;")
+
+    recipe = FlipDiffusionRecipe(
+        num_rounds_ae=args.num_rounds_ae,
+        num_rounds_dm=args.num_rounds_dm,
+        min_clients=args.n_clients,
+        train_script="trainer.py",
+        train_args="--project_id {project_id}",
+        project_id=project_id,
+        query=query,
+    )
+
+    # Stage the user app files into the job's custom/ dirs *before* execute() — this is what makes the
+    # exported/simulated job self-contained (the recipe only wires components). execute() then either
+    # exports (when --export is on sys.argv, exiting afterwards) or runs the SimEnv simulation.
+    stage_app_files(recipe.job)
+
+    env = SimEnv(
+        num_clients=args.n_clients,
+        num_threads=args.n_clients,
+        workspace_root=args.workspace,
+    )
+    run = recipe.execute(env)
+
+    print()
+    print(f"Job status:  {run.get_status()}")
+    print(f"Job results: {run.get_result()}")
+    print()
+
+
+if __name__ == "__main__":
+    main()

--- a/flip-utils/flip/nvflare/components/stage_percentile_privacy.py
+++ b/flip-utils/flip/nvflare/components/stage_percentile_privacy.py
@@ -63,10 +63,17 @@ class StagePercentilePrivacy(PercentilePrivacy):
             self.log_info(fl_ctx, "Stage info is missing in DXO meta; not applying privacy filter.")
             return dxo
 
+        # One output dict for the whole update: each stage filters only its own parameters in it,
+        # so every stage's filtering survives, and parameters outside all stages pass through
+        # untouched (they never get the per-step scaling applied).
+        filtered = dict(model_diff)
         for stage in stages:
             # We handle the privacy filtering for each stage separately
             named_parameters_to_filter = [name for name in model_diff if name.split(".")[0] in stage]
-            delta_w = {name: model_diff[name] / total_steps for name in model_diff}
+            if not named_parameters_to_filter:
+                self.log_info(fl_ctx, f"Stage {stage!r} matches no parameters; skipping.")
+                continue
+            delta_w = {name: model_diff[name] / total_steps for name in named_parameters_to_filter}
             # abs delta
             all_abs_values = np.concatenate([np.abs(delta_w[name].ravel()) for name in named_parameters_to_filter])
             cutoff = np.percentile(a=all_abs_values, q=self.percentile, overwrite_input=False)
@@ -77,17 +84,14 @@ class StagePercentilePrivacy(PercentilePrivacy):
                 f"cutoff: {cutoff}, scale: {total_steps}.",
             )
 
-            for name in delta_w:
-                if name not in named_parameters_to_filter:
-                    continue
-                diff_w = delta_w[name]
+            for name, diff_w in delta_w.items():
                 if np.ndim(diff_w) == 0:  # single scalar, no clipping
-                    delta_w[name] = diff_w * total_steps
+                    filtered[name] = diff_w * total_steps
                     continue
                 selector = (diff_w > -cutoff) & (diff_w < cutoff)
                 diff_w[selector] = 0.0
                 diff_w = np.clip(diff_w, a_min=-self.gamma, a_max=self.gamma)
-                delta_w[name] = diff_w * total_steps
+                filtered[name] = diff_w * total_steps
 
-        dxo.data = delta_w
+        dxo.data = filtered
         return dxo

--- a/flip-utils/flip/nvflare/controllers/scatter_and_gather_ldm.py
+++ b/flip-utils/flip/nvflare/controllers/scatter_and_gather_ldm.py
@@ -100,6 +100,13 @@ class ScatterAndGatherLDM(ScatterAndGather):
         self._fatal_error_delay = fatal_error_delay
         self.model_locator_id = model_locator_id
         self.model_locator = None
+        # FedJob/recipe serialisation omits args equal to their declared defaults, but the
+        # fl-server's deploy-time configure_server can only override workflow args that EXIST in
+        # the exported config — min_clients must always be emitted or a deployed job silently runs
+        # min_clients=1 and closes every round on the fastest trust's update. The per-phase round
+        # counts are emitted too so the exported template documents them (runtime re-reads
+        # GLOBAL_ROUNDS_AE/GLOBAL_ROUNDS_DM from config.json regardless).
+        self._always_serialize_args = {"min_clients", "num_rounds_ae", "num_rounds_dm"}
 
     def start_controller(self, fl_ctx: FLContext) -> None:
         engine = fl_ctx.get_engine()

--- a/flip-utils/flip/nvflare/recipes/__init__.py
+++ b/flip-utils/flip/nvflare/recipes/__init__.py
@@ -15,7 +15,8 @@ Recipes replace hand-written ``config_fed_server.json`` / ``config_fed_client.js
 templates with a Python class that produces the same JSON layout via ``export()``.
 """
 
+from flip.nvflare.recipes.flip_diffusion_recipe import FlipDiffusionRecipe
 from flip.nvflare.recipes.flip_eval_recipe import FlipEvalRecipe
 from flip.nvflare.recipes.flip_fedavg_recipe import FlipFedAvgRecipe
 
-__all__ = ["FlipFedAvgRecipe", "FlipEvalRecipe"]
+__all__ = ["FlipFedAvgRecipe", "FlipEvalRecipe", "FlipDiffusionRecipe"]

--- a/flip-utils/flip/nvflare/recipes/flip_diffusion_recipe.py
+++ b/flip-utils/flip/nvflare/recipes/flip_diffusion_recipe.py
@@ -1,0 +1,290 @@
+# Copyright (c) 2026 Guy's and St Thomas' NHS Foundation Trust & King's College London
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Recipe describing a FLIP latent-diffusion job that drives clients via the NVFLARE Client API.
+
+This is the Client-API counterpart of the legacy ``diffusion_model`` job type. The job is
+**multi-phase**: an autoencoder (+ GAN discriminator) FedAvg phase followed by a diffusion-model
+FedAvg phase over the frozen autoencoder's latent space, each phase followed by its own cross-site
+validation and a post-validation cleanup broadcast. The server workflow chain mirrors the legacy
+template exactly:
+
+``InitTraining`` → ``ScatterAndGatherLDM(train_ae)`` → ``GlobalModelEval(validate_ae)`` →
+``BroadcastTask(post_validation)`` → ``ScatterAndGatherLDM(train_dm)`` →
+``GlobalModelEval(validate_dm)`` → ``BroadcastTask(post_validation)``
+
+The two :class:`~flip.nvflare.controllers.ScatterAndGatherLDM` instances share one persistor: the
+``train_dm`` controller seeds its phase with the autoencoder weights the ``train_ae`` controller
+persisted (the phase-1 → phase-2 handoff, unchanged from the legacy job).
+
+Client-side, a **single** stock ``InProcessClientAPIExecutor`` serves all four ML task names
+(``train_ae`` / ``train_dm`` / ``validate_ae`` / ``validate_dm``): the executor forwards the actual
+task name to the script, which dispatches on ``flare.get_task_name()`` (the single-name
+``flare.is_train()`` / ``flare.is_evaluate()`` predicates cannot distinguish the two train phases).
+The ``StagePercentilePrivacy`` DP filter stays wired on both train tasks' results, as in the legacy
+client config; the script activates its per-stage filtering by stamping ``FlipMetaKey.STAGE`` on the
+outgoing ``FLModel`` meta.
+
+The recipe runs identically across SimEnv/PocEnv/ProdEnv and exports the standard NVFLARE FedJob
+layout for the FLIP-API, exactly like :class:`FlipFedAvgRecipe`. ``model_id`` is resolved lazily by
+the FLIP components from ``meta.json['custom_props']['model_id']`` (written here for SimEnv/PocEnv;
+overwritten by the FLIP-API in production). The per-phase round counts are likewise soft: the
+``ScatterAndGatherLDM`` controllers re-read ``GLOBAL_ROUNDS_AE`` / ``GLOBAL_ROUNDS_DM`` from the app
+``config.json`` at start, so the values baked here are SimEnv/PocEnv defaults only.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from nvflare import FedJob
+from nvflare.apis.dxo import DataKind
+from nvflare.app_common.aggregators import InTimeAccumulateWeightedAggregator
+from nvflare.app_common.executors.in_process_client_api_executor import InProcessClientAPIExecutor
+from nvflare.app_common.shareablegenerators.full_model_shareable_generator import FullModelShareableGenerator
+from nvflare.app_common.workflows.global_model_eval import GlobalModelEval
+from nvflare.app_opt.pt.file_model_persistor import PTFileModelPersistor
+from nvflare.job_config.defs import FilterType
+from nvflare.recipe.spec import Recipe
+
+from flip.constants import FlipTasks
+from flip.nvflare.components import (
+    CleanupImages,
+    ClientEventHandler,
+    ClientExceptionReporter,
+    FlipAnalyticsBridge,
+    InitialPTModelLocator,
+    PersistToS3AndCleanup,
+    PTModelLocator,
+    ServerEventHandler,
+    StagePercentilePrivacy,
+    ValidationJsonGenerator,
+)
+from flip.nvflare.controllers import BroadcastTask, InitTraining, ScatterAndGatherLDM
+from flip.nvflare.recipes.flip_fedavg_recipe import PercentilePrivacy
+from flip.nvflare.runtime import FLIP_CUSTOM_PROPS_KEY, FLIP_MODEL_ID_KEY
+
+# Default UUID used by SimEnv/PocEnv runs when the caller doesn't pass one. Pinned so dev runs are
+# reproducible. Production runs override this via meta.json['custom_props']['model_id'].
+_DEV_MODEL_ID = "00000000-0000-0000-0000-000000000001"
+
+TRAIN_AE_TASK = "train_ae"
+TRAIN_DM_TASK = "train_dm"
+VALIDATE_AE_TASK = "validate_ae"
+VALIDATE_DM_TASK = "validate_dm"
+
+
+class FlipDiffusionRecipe(Recipe):
+    """FLIP latent-diffusion recipe wired for the NVFLARE Client API.
+
+    Args:
+        num_rounds_ae: Federated rounds for the autoencoder phase (SimEnv/PocEnv default — in a
+            deployed job ``ScatterAndGatherLDM`` re-reads ``GLOBAL_ROUNDS_AE`` from ``config.json``).
+        num_rounds_dm: Federated rounds for the diffusion-model phase (deployed jobs re-read
+            ``GLOBAL_ROUNDS_DM`` from ``config.json``).
+        min_clients: Minimum number of clients required per round.
+        train_script: Client script path serving all four ML tasks. ``"trainer.py"`` is taken to
+            mean ``"custom/trainer.py"`` inside the job; pass an explicit ``custom/`` prefix to
+            override that convention.
+        train_args: Argument string for the script. NVFlare's TaskScriptRunner whitespace-splits
+            this — any FLIP-API placeholder used here must substitute into a single token. The SQL
+            query is plumbed via the client config's top-level ``query`` key instead.
+        model_id: Real UUID for SimEnv/PocEnv runs. Written into ``meta.json['custom_props']`` so
+            FLIP components can resolve it lazily at first event/task. Production runs override
+            this via the FLIP-API which writes the real model id into the same key.
+        percentile_privacy: Configuration for the stage-aware percentile DP filter applied to both
+            train tasks' results (:class:`~flip.nvflare.components.StagePercentilePrivacy`).
+        heart_beat_timeout, validation_timeout, wait_time_after_min_received: NVFlare timing knobs.
+        project_id, query: Top-level keys on the client config (consumed by the FLIP-API
+            placeholder substitution and read by the script at runtime).
+        params_exchange_format, params_transfer_type: NVFlare param-exchange knobs for the
+            Client API.
+    """
+
+    def __init__(
+        self,
+        *,
+        num_rounds_ae: int = 1,
+        num_rounds_dm: int = 1,
+        min_clients: int = 1,
+        train_script: str = "trainer.py",
+        train_args: str = "--project_id {project_id}",
+        model_id: str = _DEV_MODEL_ID,
+        percentile_privacy: PercentilePrivacy | None = None,
+        heart_beat_timeout: int = 600,
+        validation_timeout: int = 12000,
+        wait_time_after_min_received: int = 10,
+        project_id: str = "",
+        query: str = "SELECT * FROM Table;",
+        params_exchange_format: str = "numpy",
+        params_transfer_type: str = "FULL",
+    ):
+        self.num_rounds_ae = num_rounds_ae
+        self.num_rounds_dm = num_rounds_dm
+        self.min_clients = min_clients
+        self.train_script = train_script if train_script.startswith("custom/") else f"custom/{train_script}"
+        self.train_args = train_args
+        self.model_id = model_id
+        self.percentile_privacy = percentile_privacy or PercentilePrivacy()
+        self.heart_beat_timeout = heart_beat_timeout
+        self.validation_timeout = validation_timeout
+        self.wait_time_after_min_received = wait_time_after_min_received
+        self.project_id = project_id
+        self.query = query
+        self.params_exchange_format = params_exchange_format
+        self.params_transfer_type = params_transfer_type
+
+        super().__init__(self._build_fed_job())
+
+    def _add_train_phase(self, job: FedJob, train_task_name: str, model_locator_id: str) -> None:
+        """Wire one training phase: SAG-LDM round loop, cross-site validation, cleanup broadcast.
+
+        Both phases share the aggregator/persistor/shareable-generator wired in
+        :meth:`_build_fed_job`; ``model_locator_id`` is the phase-1 → phase-2 handoff hook —
+        ``train_dm`` passes the ``PTModelLocator`` it uses to seed itself with the persisted
+        autoencoder weights (``train_ae`` receives the initial-model locator, which its controller
+        never reads).
+        """
+        validate_task_name = VALIDATE_AE_TASK if train_task_name == TRAIN_AE_TASK else VALIDATE_DM_TASK
+        job.to_server(
+            ScatterAndGatherLDM(
+                min_clients=self.min_clients,
+                num_rounds_ae=self.num_rounds_ae,
+                num_rounds_dm=self.num_rounds_dm,
+                start_round=0,
+                wait_time_after_min_received=self.wait_time_after_min_received,
+                aggregator_id="aggregator",
+                persistor_id="persistor",
+                model_locator_id=model_locator_id,
+                shareable_generator_id="shareable_generator",
+                train_task_name=train_task_name,
+                train_timeout=0,
+                ignore_result_error=False,
+            )
+        )
+        job.to_server(
+            GlobalModelEval(
+                model_locator_id="model_locator",
+                validation_task_name=validate_task_name,
+                validation_timeout=self.validation_timeout,
+            )
+        )
+        job.to_server(BroadcastTask(task_name=FlipTasks.POST_VALIDATION.value))
+
+    def _build_fed_job(self) -> FedJob:
+        """Construct the FedJob NVFLARE's Recipe uses for ``execute(env)``.
+
+        ``meta_props`` carries the FLIP runtime config (currently just ``model_id``) into the
+        exported ``meta.json`` so the lazily-resolving components can find it.
+        """
+        job = FedJob(
+            name="flip_diffusion",
+            min_clients=self.min_clients,
+            meta_props={FLIP_CUSTOM_PROPS_KEY: {FLIP_MODEL_ID_KEY: self.model_id}},
+        )
+
+        # Server: persistence and aggregation primitives, shared by both phases (the shared
+        # persistor is what carries the trained autoencoder from phase 1 into phase 2).
+        job.to_server(PTFileModelPersistor(model={"path": "models.get_model"}), id="persistor")
+        job.to_server(FullModelShareableGenerator(), id="shareable_generator")
+        job.to_server(InTimeAccumulateWeightedAggregator(expected_data_kind=DataKind.WEIGHTS), id="aggregator")
+
+        # Server: FLIP components (locators, JSON generator, event handler, S3 persistor). The
+        # initial-model locator mirrors the legacy template's ``model_locator_initial`` wiring for
+        # the autoencoder phase; the run-dir locator serves cross-site validation and the
+        # phase-1 → phase-2 weight handoff.
+        job.to_server(PTModelLocator(model={"path": "models.get_model"}), id="model_locator")
+        job.to_server(InitialPTModelLocator(model={"path": "models.get_model"}), id="model_locator_initial")
+        job.to_server(ValidationJsonGenerator(), id="json_generator")
+        job.to_server(ServerEventHandler(), id="flip_server_event_handler")
+        job.to_server(PersistToS3AndCleanup(persistor_id="persistor"), id="persist_and_cleanup")
+
+        # Server workflows: init, then the two training phases in sequence.
+        job.to_server(InitTraining(min_clients=self.min_clients))
+        self._add_train_phase(job, TRAIN_AE_TASK, model_locator_id="model_locator_initial")
+        self._add_train_phase(job, TRAIN_DM_TASK, model_locator_id="model_locator")
+
+        job.to_server(
+            ClientExceptionReporter(),
+            filter_type=FilterType.TASK_RESULT,
+            tasks=[VALIDATE_AE_TASK, VALIDATE_DM_TASK, FlipTasks.POST_VALIDATION.value],
+        )
+
+        # Clients: cleanup executor for the init/post-validation tasks.
+        job.to_clients(CleanupImages(), tasks=["init_training", FlipTasks.POST_VALIDATION.value])
+
+        # Clients: ONE Client API executor serving all four ML tasks. The executor forwards the
+        # actual task name to the script, which dispatches on ``flare.get_task_name()`` — the
+        # executor's own train/evaluate task-name knobs are single-valued, so they are left at
+        # their stock defaults and intentionally unused.
+        job.to_clients(
+            InProcessClientAPIExecutor(
+                task_script_path=self.train_script,
+                task_script_args=self.train_args,
+                params_exchange_format=self.params_exchange_format,
+                params_transfer_type=self.params_transfer_type,
+            ),
+            tasks=[TRAIN_AE_TASK, TRAIN_DM_TASK, VALIDATE_AE_TASK, VALIDATE_DM_TASK],
+        )
+
+        # Clients: stage-aware percentile-privacy DP noise on both phases' training results.
+        job.to_clients(
+            StagePercentilePrivacy(
+                gamma=self.percentile_privacy.gamma,
+                percentile=self.percentile_privacy.percentile,
+                off=self.percentile_privacy.off,
+            ),
+            filter_type=FilterType.TASK_RESULT,
+            tasks=[TRAIN_AE_TASK, TRAIN_DM_TASK],
+            id="percentile_privacy",
+        )
+
+        # Clients: event handlers — client event handler + analytics bridge (SummaryWriter relay).
+        job.to_clients(ClientEventHandler(), id="flip_client_event_handler")
+        job.to_clients(FlipAnalyticsBridge(), id="flip_analytics_bridge")
+
+        return job
+
+    def export(self, job_dir: str | Path, **_kwargs: Any) -> None:
+        """Export the job using NVFLARE's standard FedJob layout.
+
+        Produces ``<job_dir>/<job_name>/{meta.json, app/config/, app/custom/}`` — the same structure
+        NVFLARE's admin client uploads to the cluster. The FLIP-API consumes this directory,
+        optionally rewrites ``meta.json['custom_props']`` with the real model_id at submit time, and
+        forwards the job to the fl-server stack.
+        """
+        self.job.export_job(str(job_dir))
+        self._write_client_config_params(Path(job_dir))
+
+    def _write_client_config_params(self, job_dir: Path) -> None:
+        """Emit ``project_id`` / ``query`` as top-level keys on the exported ``config_fed_client.json``.
+
+        These are not NVFLARE components, so they don't fall out of ``export_job`` — but the client
+        contract expects them at the config top level: the script's ``--project_id {project_id}``
+        arg resolves the ``{project_id}`` reference against the top-level ``project_id`` key, and
+        ``trainer.load_query()`` reads the top-level ``query``. We write the recipe's (placeholder)
+        defaults so the exported template is self-documenting and the ``{project_id}`` reference
+        always resolves. In production the fl-server's ``configure_client`` overwrites
+        ``project_id`` / ``query`` with the real submission values; in SimEnv/LOCAL_DEV they're
+        ignored (data comes from the ``DEV_DATAFRAME`` / ``DEV_IMAGES_DIR`` env). Mirrors the
+        hand-written ``diffusion_model`` template.
+        """
+        client_cfg = job_dir / self.job.name / "app" / "config" / "config_fed_client.json"
+        if not client_cfg.exists():
+            return
+        config = json.loads(client_cfg.read_text())
+        config.setdefault("project_id", self.project_id)
+        config.setdefault("query", self.query)
+        # Trailing newline: keeps the committed diffusion_model_client_api template stable across
+        # regenerations and satisfies the end-of-file-fixer pre-commit hook.
+        client_cfg.write_text(json.dumps(config, indent=2) + "\n")

--- a/flip-utils/tests/unit/nvflare/components/test_stage_percentile_privacy.py
+++ b/flip-utils/tests/unit/nvflare/components/test_stage_percentile_privacy.py
@@ -183,4 +183,56 @@ class TestStagePercentilePrivacy:
 
         # Scalar: delta_w = 1.0/5 = 0.2, then multiplied back: 0.2 * 5 = 1.0
         assert result is not None
+
+    def test_every_stage_filtering_survives(self):
+        """Each stage's zeroing must survive into the final DXO — a later stage must not reset an
+        earlier stage's filtered params back to their raw values (the pre-fix behaviour rebuilt the
+        whole delta dict per stage, so only the last stage's filtering was kept)."""
+        f = StagePercentilePrivacy(percentile=50, gamma=10.0)
+        weights = {
+            "encoder.w": np.array([0.001, 0.002, 1.0, 2.0]),
+            "decoder.w": np.array([0.003, 0.004, 3.0, 4.0]),
+        }
+        dxo = DXO(data_kind=DataKind.WEIGHT_DIFF, data=weights)
+        dxo.set_meta_prop(MetaKey.NUM_STEPS_CURRENT_ROUND, 1)
+        dxo.set_meta_prop(FlipMetaKey.STAGE, [["encoder"], ["decoder"]])
+
+        result = f.process_dxo(dxo, self.shareable, self.fl_ctx)
+
         assert result is not None
+        # Both stages: the two small components sit below their stage's 50th-percentile cutoff
+        # and must be zeroed; the two large ones survive (clipped to gamma=10, i.e. unchanged).
+        np.testing.assert_array_equal(result.data["encoder.w"], np.array([0.0, 0.0, 1.0, 2.0]))
+        np.testing.assert_array_equal(result.data["decoder.w"], np.array([0.0, 0.0, 3.0, 4.0]))
+
+    def test_params_outside_all_stages_pass_through_untouched(self):
+        """Params not matched by any stage keep their exact values — the pre-fix behaviour left them
+        divided by NUM_STEPS_CURRENT_ROUND (silent shrink for total_steps > 1)."""
+        f = StagePercentilePrivacy(percentile=50, gamma=10.0)
+        untouched = np.array([0.5, -0.5])
+        weights = {
+            "encoder.w": np.array([0.001, 1.0]),
+            "frozen.w": untouched.copy(),
+        }
+        dxo = DXO(data_kind=DataKind.WEIGHT_DIFF, data=weights)
+        dxo.set_meta_prop(MetaKey.NUM_STEPS_CURRENT_ROUND, 4)
+        dxo.set_meta_prop(FlipMetaKey.STAGE, [["encoder"]])
+
+        result = f.process_dxo(dxo, self.shareable, self.fl_ctx)
+
+        assert result is not None
+        np.testing.assert_array_equal(result.data["frozen.w"], untouched)
+
+    def test_stage_matching_no_params_is_skipped(self):
+        """A stage that matches no parameters is skipped instead of crashing on an empty
+        percentile input."""
+        f = StagePercentilePrivacy(percentile=50, gamma=10.0)
+        weights = {"encoder.w": np.array([0.001, 1.0])}
+        dxo = DXO(data_kind=DataKind.WEIGHT_DIFF, data=weights)
+        dxo.set_meta_prop(MetaKey.NUM_STEPS_CURRENT_ROUND, 1)
+        dxo.set_meta_prop(FlipMetaKey.STAGE, [["encoder"], ["no_such_module"]])
+
+        result = f.process_dxo(dxo, self.shareable, self.fl_ctx)
+
+        assert result is not None
+        np.testing.assert_array_equal(result.data["encoder.w"], np.array([0.0, 1.0]))

--- a/flip-utils/tests/unit/nvflare/recipes/test_flip_diffusion_recipe.py
+++ b/flip-utils/tests/unit/nvflare/recipes/test_flip_diffusion_recipe.py
@@ -1,0 +1,179 @@
+# Copyright (c) 2026 Guy's and St Thomas' NHS Foundation Trust & King's College London
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import sys
+import types
+from pathlib import Path
+
+# PTFileModelPersistor's model={"path": "models.get_model"} triggers an import of the user's
+# ``models`` module at construction. In a real job that module lives in custom/; under unit
+# tests we inject a stub before importing the recipe.
+_stub_models = types.ModuleType("models")
+_stub_models.get_model = lambda: object()
+sys.modules.setdefault("models", _stub_models)
+
+from flip.nvflare.recipes import FlipDiffusionRecipe  # noqa: E402
+from flip.nvflare.recipes.flip_diffusion_recipe import _DEV_MODEL_ID  # noqa: E402
+from flip.nvflare.recipes.flip_fedavg_recipe import PercentilePrivacy  # noqa: E402
+from flip.nvflare.runtime import FLIP_CUSTOM_PROPS_KEY, FLIP_MODEL_ID_KEY  # noqa: E402
+
+
+class TestFlipDiffusionRecipe:
+    def test_builds_fed_job_with_flip_components(self):
+        """A default recipe should construct a FedJob with the FLIP latent-diffusion wiring."""
+        recipe = FlipDiffusionRecipe()
+        assert recipe.job is not None
+        assert recipe.job.name == "flip_diffusion"
+        assert recipe.job.job.min_clients == 1
+
+    def test_meta_props_carry_model_id_into_custom_props(self):
+        """The FedJob's meta carries the FLIP model_id into custom_props so components resolve it lazily."""
+        recipe = FlipDiffusionRecipe()
+        meta = recipe.job.job.meta_props
+        assert FLIP_CUSTOM_PROPS_KEY in meta
+        assert meta[FLIP_CUSTOM_PROPS_KEY][FLIP_MODEL_ID_KEY] == _DEV_MODEL_ID
+
+    def test_custom_model_id_propagates_to_meta_props(self):
+        custom_id = "abcdef01-2345-6789-abcd-ef0123456789"
+        recipe = FlipDiffusionRecipe(model_id=custom_id)
+        assert recipe.job.job.meta_props[FLIP_CUSTOM_PROPS_KEY][FLIP_MODEL_ID_KEY] == custom_id
+
+    def test_train_script_normalisation(self):
+        """Bare ``trainer.py`` is rewritten to ``custom/trainer.py``; explicit prefix kept."""
+        assert FlipDiffusionRecipe(train_script="trainer.py").train_script == "custom/trainer.py"
+        assert FlipDiffusionRecipe(train_script="custom/my.py").train_script == "custom/my.py"
+
+    def test_overrides_are_applied(self):
+        recipe = FlipDiffusionRecipe(
+            num_rounds_ae=4,
+            num_rounds_dm=6,
+            min_clients=3,
+            train_script="custom/my_trainer.py",
+            validation_timeout=42,
+            percentile_privacy=PercentilePrivacy(gamma=0.5, percentile=25, off=True),
+        )
+        assert recipe.num_rounds_ae == 4
+        assert recipe.num_rounds_dm == 6
+        assert recipe.min_clients == 3
+        assert recipe.train_script == "custom/my_trainer.py"
+        assert recipe.validation_timeout == 42
+        assert recipe.percentile_privacy.gamma == 0.5
+        assert recipe.percentile_privacy.percentile == 25
+        assert recipe.percentile_privacy.off
+
+    def test_default_train_args_have_no_whitespace_values(self):
+        """NVFlare's TaskScriptRunner whitespace-splits task_script_args, so the default keeps only
+        ``--project_id`` (a UUID); the SQL query is plumbed via the client config's top-level ``query``."""
+        recipe = FlipDiffusionRecipe()
+        assert "--query" not in recipe.train_args
+        assert recipe.train_args == "--project_id {project_id}"
+
+    def test_export_writes_fed_job_layout(self, tmp_path: Path):
+        """``recipe.export`` produces the standard NVFLARE FedJob layout with the two-phase wiring."""
+        import torch
+
+        sys.modules["models"].get_model = lambda: torch.nn.Linear(1, 1)
+        try:
+            recipe = FlipDiffusionRecipe()
+            recipe.export(tmp_path)
+
+            job_dir = tmp_path / recipe.job.name
+            assert (job_dir / "meta.json").exists()
+            server_cfg_path = job_dir / "app" / "config" / "config_fed_server.json"
+            client_cfg_path = job_dir / "app" / "config" / "config_fed_client.json"
+            assert server_cfg_path.exists()
+            assert client_cfg_path.exists()
+
+            meta = json.loads((job_dir / "meta.json").read_text())
+            assert meta[FLIP_CUSTOM_PROPS_KEY][FLIP_MODEL_ID_KEY] == _DEV_MODEL_ID
+
+            server_cfg = json.loads(server_cfg_path.read_text())
+            server_blob = json.dumps(server_cfg)
+            assert "InitTraining" in server_blob
+            assert "ClientExceptionReporter" in server_blob
+            assert "PersistToS3AndCleanup" in server_blob
+            assert "ValidationJsonGenerator" in server_blob
+            assert "InitialPTModelLocator" in server_blob
+
+            # Two-phase chain, in order: SAG-LDM(train_ae) → eval(validate_ae) → cleanup →
+            # SAG-LDM(train_dm) → eval(validate_dm) → cleanup.
+            workflow_paths = [w["path"] for w in server_cfg["workflows"]]
+            sag_indices = [i for i, p in enumerate(workflow_paths) if p.endswith("ScatterAndGatherLDM")]
+            eval_indices = [i for i, p in enumerate(workflow_paths) if p.endswith("GlobalModelEval")]
+            broadcast_indices = [i for i, p in enumerate(workflow_paths) if p.endswith("BroadcastTask")]
+            assert len(sag_indices) == 2
+            assert len(eval_indices) == 2
+            assert len(broadcast_indices) == 2
+            assert sag_indices[0] < eval_indices[0] < broadcast_indices[0]
+            assert broadcast_indices[0] < sag_indices[1] < eval_indices[1] < broadcast_indices[1]
+
+            sag_ae, sag_dm = (server_cfg["workflows"][i] for i in sag_indices)
+            assert sag_ae["args"]["train_task_name"] == "train_ae"
+            assert sag_dm["args"]["train_task_name"] == "train_dm"
+            # min_clients MUST be emitted even at its default: the fl-server's deploy-time
+            # configure_server only overrides workflow args that exist in the exported config —
+            # without the key a deployed job silently runs min_clients=1 and closes every round on
+            # the fastest trust's update.
+            assert sag_ae["args"]["min_clients"] == 1
+            assert sag_dm["args"]["min_clients"] == 1
+            assert sag_ae["args"]["num_rounds_ae"] == 1
+            assert sag_ae["args"]["num_rounds_dm"] == 1
+            # Phase-1 → phase-2 handoff: the DM phase seeds itself via the run-dir locator.
+            assert sag_ae["args"]["model_locator_id"] == "model_locator_initial"
+            assert sag_dm["args"]["model_locator_id"] == "model_locator"
+            # The aggregator/persistor/shareable-generator ids are omitted from the SAG args when
+            # they equal the controller defaults — those defaults must resolve against components
+            # the recipe actually wired.
+            component_ids = {c.get("id") for c in server_cfg["components"]}
+            for required_id in ("persistor", "aggregator", "shareable_generator", "model_locator"):
+                assert required_id in component_ids
+
+            eval_ae, eval_dm = (server_cfg["workflows"][i] for i in eval_indices)
+            assert eval_ae["args"]["validation_task_name"] == "validate_ae"
+            assert eval_dm["args"]["validation_task_name"] == "validate_dm"
+
+            client_cfg = json.loads(client_cfg_path.read_text())
+            client_blob = json.dumps(client_cfg)
+            # Client uses ONE stock Client-API executor for all four ML tasks; no RUN_TRAINER /
+            # RUN_VALIDATOR executor pairs.
+            assert "InProcessClientAPIExecutor" in client_blob
+            assert "RUN_TRAINER" not in client_blob
+            assert "RUN_VALIDATOR" not in client_blob
+            executor_tasks = [t for e in client_cfg["executors"] for t in e["tasks"]]
+            for task in ("train_ae", "train_dm", "validate_ae", "validate_dm"):
+                assert task in executor_tasks
+            assert "init_training" in executor_tasks  # CleanupImages init
+            assert "post_validation" in executor_tasks  # CleanupImages post
+
+            # The stage-aware DP filter guards both train tasks' results.
+            privacy_blocks = [
+                block
+                for block in client_cfg.get("task_result_filters", [])
+                if any("StagePercentilePrivacy" in f.get("path", "") for f in block.get("filters", []))
+            ]
+            assert len(privacy_blocks) == 1
+            assert sorted(privacy_blocks[0]["tasks"]) == ["train_ae", "train_dm"]
+
+            # Client event plumbing: FLIP event handler + SummaryWriter analytics relay.
+            assert "ClientEventHandler" in client_blob
+            assert "FlipAnalyticsBridge" in client_blob
+
+            # project_id / query are emitted as top-level client-config placeholders.
+            assert client_cfg["project_id"] == ""
+            assert client_cfg["query"] == "SELECT * FROM Table;"
+        finally:
+            sys.modules["models"].get_model = lambda: object()
+
+    def test_write_client_config_params_is_noop_when_config_absent(self, tmp_path: Path):
+        """If export produced no client config (unexpected layout), the param-write is a safe no-op."""
+        recipe = FlipDiffusionRecipe()
+        recipe._write_client_config_params(tmp_path)


### PR DESCRIPTION
Closes #836.

Migrates the latent diffusion model tutorial from the legacy class-based Executor model to the **NVFLARE Client API + Recipe** model, following the `standard_client_api` (#665/PR #669) and `evaluation_client_api` (#688) ports. This was the last NVFLARE job type with a tutorial but no Client-API path.

## What's new

- **`FlipDiffusionRecipe`** (`flip-utils/flip/nvflare/recipes/`) — the first multi-phase recipe: `InitTraining` → `ScatterAndGatherLDM(train_ae)` → `GlobalModelEval(validate_ae)` → `BroadcastTask` cleanup → `ScatterAndGatherLDM(train_dm)` → `GlobalModelEval(validate_dm)` → cleanup, mirroring the legacy `diffusion_model` template's workflow chain exactly (shared persistor carries the phase-1 → phase-2 autoencoder handoff).
- **`fl-apps/nvflare/diffusion_model_client_api/`** — recipe-generated template + `required_files.json` (`trainer.py`/`validator.py`/`config.json`/`models.py`); aggregate manifest regenerated via `fl-apps/check_required_files.sh`, which registers the job type with flip-api and the UI automatically (no flip-api code change needed).
- **`fl-tutorials/nvflare/image_synthesis/latent_diffusion_model_client_api/`** — sibling tutorial: one `trainer.py` Client-API script serves all four ML task names, `validator.py` becomes a plain module (validation passes + shared latent-geometry helpers), `job.py` with `--export` + SimEnv. The legacy tutorial stays, as with the prior ports.

## Key design decisions

- **One executor, four tasks.** `InProcessClientAPIExecutor.execute()` is task-name agnostic and forwards the real task name to the script, so a single executor maps to `train_ae`/`train_dm`/`validate_ae`/`validate_dm` and the script dispatches on `flare.get_task_name()` — the single-name `is_train()`/`is_evaluate()` predicates cannot distinguish the two train phases.
- **`ScatterAndGatherLDM` gains `_always_serialize_args`** (stock NVFLARE hook): FedJob serialisation omits args equal to their defaults, but deploy-time `configure_server` only overrides workflow args that *exist* in the exported config — without `min_clients` in the template, a deployed job silently runs `min_clients=1` and closes every round on the fastest trust's update.
- **The DP filter goes live.** The client script stamps `FlipMetaKey.STAGE` on outgoing updates (`["autoencoder", "discriminator"]` / `["diffusion_model"]`), which the legacy tutorial never did — `StagePercentilePrivacy` always took its "stage info missing" early-exit and passed every update through unfiltered. Making it live exposed two bugs in the filter, fixed here with regression tests: with multiple stages only the *last* stage's filtering survived (the delta dict was rebuilt per stage), and params outside every stage were left silently divided by `NUM_STEPS_CURRENT_ROUND`.
- **Weight updates return as full-model DIFFs** (like the xray port); FLIP's `ScatterAndGather._accept_train_result` rebuilds full `WEIGHTS` server-side before aggregation (FLIP#684), so the `WEIGHTS` aggregator is satisfied.
- **NaN aborts** surface as raised `RuntimeError`s (→ `EXECUTION_EXCEPTION`, and SAG runs with `ignore_result_error=False`) instead of the legacy client-side `abort_signal.trigger()` — same terminal outcome, clearer logs.

## Behaviour notes (vs legacy)

- Per-epoch training metrics keep the legacy series names and gain an `@epoch` x-axis (FLIP#148 convention).
- The dataset list now takes **every** `input_*.nii.gz` per accession; the legacy code's `{"image": str(i) for i in all_images}` dict-comprehension accidentally kept only the last one. Identical for the common one-series-per-accession case.
- `cross_val_results.json` containing only the `validate_dm` entry is **pre-existing stock behaviour** (`ValidationJsonGenerator` is last-wins per `(client, model)` key — the legacy two-eval job did the same); the AE validation metrics still reach the hub via the metric-event path.

## Verification

- `flip-utils`: ruff clean, **629 unit tests pass** (incl. new recipe-export and stage-privacy regression tests).
- `fl-api`: ruff + mypy clean, **133 tests pass** (incl. new `configure_server` diffusion-workflow test).
- `flip-api`: unit suite green (1318 passed); job-type registration is manifest-driven, no code change.
- `fl-apps/check_required_files.sh` regenerated + stable; template regeneration via `recipe.py` is deterministic (second run produces zero diff).
- **Full NVFLARE simulator run green** (2 sites, spleen CT, RTX 5090): both phases train, the phase-1 → phase-2 checkpoint handoff loads, per-stage DP cutoffs are computed on both phases, both cross-site validations return metrics, results upload, clean END_RUN — zero errors.


## Side-by-side comparison against the legacy app

Ran the legacy Executor tutorial (`latent_diffusion_model`, Docker testing harness, `flare-fl-base:dev`) and the ported tutorial (committed tree, SimEnv) back-to-back on the same spleen data, 2 sites, 1 global round / 1 local epoch per stage, same GPU:

| | Legacy Executor app | Client-API port |
| --- | --- | --- |
| Lifecycle | INITIATED → per-phase PREPARED/RUNNING → RESULTS_UPLOADED, clean END_RUN, 0 errors | identical |
| Metric series | Train loss (G)/(D), Perceptual/KLD/Reconstruction/GAN loss (G), Validation loss (L1), Total loss DM, Validation loss DM, Total loss DM (val), val_l1_loss, val_ssim | identical names (+ `@epoch` x-axis on the per-epoch series) |
| `val_l1_loss` | 0.5299 / 0.5314 | 0.5128 / 0.5114 |
| `val_ssim` | 0.0612 / 0.0554 | 0.0643 / 0.0627 |
| `cross_val_results.json` | `{site: {SRV_server: {metrics_validate_dm: {val_loss: 1.0083 / 1.0059}}}}` | same shape, val_loss 1.0021 / 0.9856 |
| DP filter | inert (no STAGE meta → early-exit) | live, per-stage cutoffs on both phases |

Loss magnitudes match to within run-to-run stochastic variation (different random seeds/augmentations); the results JSON reproduces the legacy shape including the pre-existing last-wins quirk. One operational note from the baseline run: the legacy tutorial fails to parse on a **stale** cached `ghcr.io/…/flare-fl-base:stag` image (its flip-utils predates `ClientExceptionReporter`, which develop's template references) — re-pull `:stag` or build `:dev` locally before running either tutorial.

## Out of scope / follow-ups

- Retiring the legacy `diffusion_model` job type + tutorial (kept, as with the prior ports).
- #813 hub-run recipe builder — this recipe will register with it later.
- A merge-instead-of-replace `ValidationJsonGenerator` so multi-eval jobs keep both eval passes in `cross_val_results.json` (pre-existing, affects legacy too).


## Acceptance Criteria

*Imported from issue #836*

- [x] **New multi-stage recipe** in `flip-utils/flip/nvflare/recipes/` (e.g.
      `FlipDiffusionRecipe`), exported from `recipes/__init__.py`, emitting the two-stage server
      flow (`InitTraining`, 2× SAG + per-phase `GlobalModelEval` + `BroadcastTask` cleanups,
      `PTFileModelPersistor`/locators/`ValidationJsonGenerator`/`ServerEventHandler`/
      `PersistToS3AndCleanup`) and a Client-API client executor for the four ML tasks, with
      `recipe.export()` producing `config_fed_{client,server}.json` + `meta.json`.
- [x] **Rewrite trainer + validator** from `Executor` classes to `nvflare.client` script(s):
      `flare.init()` / `flare.receive()` / `flare.send(...)` with task-name dispatch across
      `train_ae`/`train_dm`/`validate_ae`/`validate_dm`, preserving the AE/GAN and DM training
      semantics, early-stopping (`PATIENCE_STEPS`/`CEILING_NUM_ROUNDS`) and metric outputs.
- [x] **`StagePercentilePrivacy`** task-result filter preserved on both train tasks.
- [x] **New app template** `fl-apps/nvflare/diffusion_model_client_api/` (recipe-generated
      `app/config/*` + `meta.json` + `recipe.py` driver + `required_files.json`), mirroring
      `fl-apps/nvflare/standard_client_api/`.
- [x] **Register the new job type** (`diffusion_model_client_api`) — per-template
      `required_files.json` + regenerate the aggregate via `fl-apps/check_required_files.sh`
      (generated aggregate is never hand-edited; pre-commit `fl-apps-required-files` +
      `check-required-files` CI guard it).
- [x] **Hub wiring:** extend `fl-services/nvflare/fl-api-base/fl_api/utils/prepare_config.py`
      (and its tests) to recognise the new job type, as done for `standard_client_api` /
      `evaluation_client_api`.
- [x] **New sibling tutorial**
      `fl-tutorials/nvflare/image_synthesis/latent_diffusion_model_client_api/` with `job.py`
      (`--export` + `SimEnv`), a `run: sim` Makefile, `.env.app`
      (`JOB_TYPE=diffusion_model_client_api`), and the rewritten `app_files/`. Keep the legacy
      `latent_diffusion_model/` tutorial in place (matches both prior ports).
- [x] **Docs:** add the new job type to `docs/source/components/component-fl-nodes.rst`; update
      the relevant `fl-apps/.../README.md` and tutorial `README.md`.
- [x] **Tests:** recipe unit tests (export layout) + `prepare_config` tests; the new tutorial runs
      green under the NVFLARE simulator (`make -C fl-tutorials run-tutorial TUTORIAL=...`).
