### PR TITLE
feat(models): show created time and default newest-first sort on the Models list

### DIFF
--- a/flip-api/src/flip_api/domain/interfaces/model.py
+++ b/flip-api/src/flip_api/domain/interfaces/model.py
@@ -61,6 +61,7 @@ class IAllModelsResponse(BaseModel):
     project_name: str = Field(..., alias="projectName")
     owner_id: UUID = Field(..., alias="ownerId")
     owner_name: str | None = Field(default=None, alias="ownerName")
+    creation_timestamp: datetime = Field(..., alias="creationTimestamp")
     trusts: list[ITrustSummary] = Field(default_factory=list)
     # The model's 1-based place in the FL training queue (position 1 = next to
     # be picked up); None unless the model has a QUEUED job waiting for a net.

--- a/flip-api/src/flip_api/model_services/services/model_service.py
+++ b/flip-api/src/flip_api/model_services/services/model_service.py
@@ -591,6 +591,7 @@ def get_all_models_service(
             project_name=project_name,
             owner_id=model.owner_id,
             owner_name=owner_name,
+            creation_timestamp=model.creation_timestamp,
             trusts=trusts_by_model.get(model.id, []),
             queue_position=queue_positions.get(model.id),
         )  # type: ignore[call-arg]

--- a/flip-api/tests/integration/test_all_models_endpoint.py
+++ b/flip-api/tests/integration/test_all_models_endpoint.py
@@ -198,6 +198,32 @@ def test_model_without_run_trusts_returns_empty_trusts(
     assert row["trusts"] == []
 
 
+def test_rows_carry_creation_timestamp_and_list_newest_first(
+    client: TestClient, session, project_factory, model_factory
+):
+    """Each row exposes the model's creation timestamp and rows come newest-first."""
+    user_id = uuid4()
+    project = _add_project(session, project_factory, owner_id=user_id, name="Ordered")
+    older = model_factory.build(
+        project_id=project.id, owner_id=user_id, name="older", deleted=False,
+        status=ModelStatus.PREPARED, creation_timestamp=datetime(2026, 1, 1, 12, 0, 0),
+    )
+    newer = model_factory.build(
+        project_id=project.id, owner_id=user_id, name="newer", deleted=False,
+        status=ModelStatus.PREPARED, creation_timestamp=datetime(2026, 6, 1, 12, 0, 0),
+    )
+    session.add(older)
+    session.add(newer)
+    session.commit()
+
+    override_verify_token_as(user_id)
+    rows = [r for r in client.get(MODELS_URL).json()["data"] if r["id"] in {str(older.id), str(newer.id)}]
+
+    assert [r["name"] for r in rows] == ["newer", "older"]
+    assert rows[0]["creationTimestamp"] == "2026-06-01T12:00:00"
+    assert rows[1]["creationTimestamp"] == "2026-01-01T12:00:00"
+
+
 def test_status_filter_narrows_results(client: TestClient, session, project_factory, model_factory):
     """``?status=`` returns only models in that lifecycle state."""
     user_id = uuid4()

--- a/flip-ui/src/pages/__tests__/models.spec.ts
+++ b/flip-ui/src/pages/__tests__/models.spec.ts
@@ -493,6 +493,41 @@ describe("Models Page", () => {
         expect(wrapper.find("[data-test='models-list-item-0']").text()).toContain("—");
     });
 
+    test("the owner sub-line shows the relative created time next to the owner (as on Projects)", async () => {
+        setModels([makeModel({ creationTimestamp: new Date(Date.now() - 2 * 3_600_000).toISOString() })]);
+        const wrapper = mountPage();
+        await wrapper.vm.$nextTick();
+
+        expect(wrapper.find("[data-test='model-owner-meta']").text()).toBe("Dr Ada · created 2h ago");
+    });
+
+    test("the created time falls back to an em-dash when the API omits the timestamp", async () => {
+        setModels([makeModel()]);
+        const wrapper = mountPage();
+        await wrapper.vm.$nextTick();
+
+        expect(wrapper.find("[data-test='model-owner-meta']").text()).toBe("Dr Ada · —");
+    });
+
+    test("rows default-sort by creation date, most recent first", async () => {
+        setModels([
+            makeModel({
+                id: "m1",
+                name: "older",
+                creationTimestamp: "2026-01-01T00:00:00"
+            }),
+            makeModel({
+                id: "m2",
+                name: "newer",
+                creationTimestamp: "2026-06-01T00:00:00"
+            })
+        ]);
+        const wrapper = mountPage();
+        await wrapper.vm.$nextTick();
+
+        expect(wrapper.findAll("[data-test='model-name']").map(n => n.text())).toEqual(["newer", "older"]);
+    });
+
     test("an error/terminal status renders a red pill and a red rail", async () => {
         setModels([makeModel({ status: "STOPPED" })]);
         const wrapper = mountPage();

--- a/flip-ui/src/pages/__tests__/models.spec.ts
+++ b/flip-ui/src/pages/__tests__/models.spec.ts
@@ -490,11 +490,16 @@ describe("Models Page", () => {
         const wrapper = mountPage();
         await wrapper.vm.$nextTick();
 
-        expect(wrapper.find("[data-test='models-list-item-0']").text()).toContain("—");
+        // Exact match: the created half also falls back to an em-dash here, so
+        // a bare toContain("—") could no longer catch an ownerLabel regression.
+        expect(wrapper.find("[data-test='model-owner-meta']").text()).toBe("— · —");
     });
 
     test("the owner sub-line shows the relative created time next to the owner (as on Projects)", async () => {
-        setModels([makeModel({ creationTimestamp: new Date(Date.now() - 2 * 3_600_000).toISOString() })]);
+        // Offset-less naive-UTC string — the wire format the API actually sends
+        // (see test_all_models_endpoint.py) — so local-time parsing regressions
+        // fail here on any non-UTC machine.
+        setModels([makeModel({ creationTimestamp: new Date(Date.now() - 2 * 3_600_000).toISOString().slice(0, 19) })]);
         const wrapper = mountPage();
         await wrapper.vm.$nextTick();
 
@@ -526,6 +531,26 @@ describe("Models Page", () => {
         await wrapper.vm.$nextTick();
 
         expect(wrapper.findAll("[data-test='model-name']").map(n => n.text())).toEqual(["newer", "older"]);
+    });
+
+    test("rows from an older API without timestamps keep the backend order under the default sort", async () => {
+        // The rollout-skew case: a UI deployed ahead of the API gets no
+        // creationTimestamp on ANY row — all tie at 0 and the stable sort must
+        // preserve the backend's newest-first order.
+        setModels([
+            makeModel({
+                id: "m1",
+                name: "backend-first"
+            }),
+            makeModel({
+                id: "m2",
+                name: "backend-second"
+            })
+        ]);
+        const wrapper = mountPage();
+        await wrapper.vm.$nextTick();
+
+        expect(wrapper.findAll("[data-test='model-name']").map(n => n.text())).toEqual(["backend-first", "backend-second"]);
     });
 
     test("an error/terminal status renders a red pill and a red rail", async () => {

--- a/flip-ui/src/pages/__tests__/projects.spec.ts
+++ b/flip-ui/src/pages/__tests__/projects.spec.ts
@@ -273,8 +273,9 @@ describe("Projects Page", () => {
 
     test("renders a relative-time stamp ('Xs / Xm / Xh / Xd ago') for project creation", async () => {
         const project = makeProject("STAGED", [trust("t1", "KCH", true)]);
-        // 2 hours ago — should land in the "h ago" bucket.
-        project.creationtimestamp = new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString();
+        // 2 hours ago — should land in the "h ago" bucket. Offset-less naive-UTC
+        // string: the wire format the API actually sends.
+        project.creationtimestamp = new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString().slice(0, 19);
         setProject(project);
         const wrapper = mountPage();
         await wrapper.vm.$nextTick();
@@ -430,7 +431,7 @@ describe("Projects Page", () => {
 
     test("relativeUpdated renders 'created Xd ago' for older projects", async () => {
         const project = makeProject("STAGED", []);
-        project.creationtimestamp = new Date(Date.now() - 3 * 24 * 60 * 60 * 1000).toISOString();
+        project.creationtimestamp = new Date(Date.now() - 3 * 24 * 60 * 60 * 1000).toISOString().slice(0, 19);
         setProject(project);
         const wrapper = mountPage();
         await wrapper.vm.$nextTick();

--- a/flip-ui/src/pages/models.vue
+++ b/flip-ui/src/pages/models.vue
@@ -132,7 +132,7 @@
                                         {{ model.name }}
                                     </router-link>
                                     <p data-test="model-owner-meta" class="mt-1 text-xs text-gray-500 dark:text-gray-300">
-                                        {{ ownerLabel(model) }} · {{ relativeCreated(model) }}
+                                        {{ ownerLabel(model) }} · {{ relativeCreatedLabel(model.creationTimestamp) }}
                                     </p>
                                 </div>
                                 <!-- Project -->
@@ -289,6 +289,7 @@ import { getAllModels,
     modelStatusDotClass as statusDotClass,
     modelStatusLabelWithQueue,
     modelStatusPillClass as statusPillClass } from "@/services/model-service";
+import { apiTimestampMs, relativeCreatedLabel } from "@/utils/helpers";
 
 const pageSize = 20;
 
@@ -434,8 +435,10 @@ const columns: IColumn[] = [
 ];
 
 // Default: newest first ("created" desc, no column header of its own — the
-// created time sits in the Model column's sub-line). Rows without a timestamp
-// tie at 0, so the stable sort keeps the backend order (also newest-first).
+// created time sits in the Model column's sub-line). When an older deployed
+// API sends no timestamps, every row ties at 0 and the stable sort keeps the
+// backend order (also newest-first); in a mixed page timestamp-less rows
+// would sink to the bottom.
 const sortKey = ref<SortKey>("created");
 const sortDir = ref<SortDir>("desc");
 
@@ -463,8 +466,7 @@ const STATUS_RANK: Record<ModelStatus, number> = {
 };
 const statusRank = (s: ModelStatus | undefined): number => (s ? STATUS_RANK[s] ?? 99 : 99);
 
-const createdMs = (model: IModelSummary): number =>
-    model.creationTimestamp ? new Date(model.creationTimestamp).getTime() : 0;
+const createdMs = (model: IModelSummary): number => apiTimestampMs(model.creationTimestamp) ?? 0;
 
 // "created" deliberately has no tie-break: equal (or absent) timestamps keep
 // the backend order under the stable sort.
@@ -530,18 +532,8 @@ const trustChipLabel = (trust: IModelSummaryTrust): string => {
 // em-dash when the owner has no profile row — the endpoint carries no email.
 const ownerLabel = (model: IModelSummary): string => model.ownerName || "—";
 
-// "created 2h ago" next to the owner — mirrors the Projects list meta line.
-// Em-dash when a deployed API predates the creationTimestamp field.
-const relativeCreated = (model: IModelSummary): string => {
-    if (!model.creationTimestamp) return "—";
-    const created = new Date(model.creationTimestamp).getTime();
-    const sec = (Date.now() - created) / 1000;
-    if (sec < 60) return `created ${Math.max(0, Math.floor(sec))}s ago`;
-    if (sec < 3_600) return `created ${Math.floor(sec / 60)}m ago`;
-    if (sec < 86_400) return `created ${Math.floor(sec / 3_600)}h ago`;
-
-    return `created ${Math.floor(sec / 86_400)}d ago`;
-};
+// The created half of the owner sub-line ("owner · created 2h ago") comes from
+// relativeCreatedLabel in utils/helpers — shared with the Projects list.
 
 // Status pill/dot classes come from model-service (shared with the mobile
 // project-models list), imported under their historical local names.

--- a/flip-ui/src/pages/models.vue
+++ b/flip-ui/src/pages/models.vue
@@ -131,8 +131,8 @@
                                     >
                                         {{ model.name }}
                                     </router-link>
-                                    <p class="mt-1 text-xs text-gray-500 dark:text-gray-300">
-                                        {{ ownerLabel(model) }}
+                                    <p data-test="model-owner-meta" class="mt-1 text-xs text-gray-500 dark:text-gray-300">
+                                        {{ ownerLabel(model) }} · {{ relativeCreated(model) }}
                                     </p>
                                 </div>
                                 <!-- Project -->
@@ -396,7 +396,7 @@ const toggleTile = (key: GroupKey): void => {
     syncStatusFilter();
 };
 
-type SortKey = "name" | "project" | "trusts" | "status";
+type SortKey = "created" | "name" | "project" | "trusts" | "status";
 type SortDir = "asc" | "desc";
 
 interface IColumn {
@@ -433,9 +433,11 @@ const columns: IColumn[] = [
     }
 ];
 
-// Null sortKey keeps the backend order (newest-first) until a header is clicked.
-const sortKey = ref<SortKey | null>(null);
-const sortDir = ref<SortDir>("asc");
+// Default: newest first ("created" desc, no column header of its own — the
+// created time sits in the Model column's sub-line). Rows without a timestamp
+// tie at 0, so the stable sort keeps the backend order (also newest-first).
+const sortKey = ref<SortKey>("created");
+const sortDir = ref<SortDir>("desc");
 
 // First click on a column sorts ascending; subsequent clicks toggle direction.
 const toggleSort = (key: SortKey): void => {
@@ -461,7 +463,13 @@ const STATUS_RANK: Record<ModelStatus, number> = {
 };
 const statusRank = (s: ModelStatus | undefined): number => (s ? STATUS_RANK[s] ?? 99 : 99);
 
+const createdMs = (model: IModelSummary): number =>
+    model.creationTimestamp ? new Date(model.creationTimestamp).getTime() : 0;
+
+// "created" deliberately has no tie-break: equal (or absent) timestamps keep
+// the backend order under the stable sort.
 const SORT_COMPARATORS: Record<SortKey, (a: IModelSummary, b: IModelSummary) => number> = {
+    created: (a, b) => createdMs(a) - createdMs(b),
     name: (a, b) => a.name.localeCompare(b.name),
     project: (a, b) => a.projectName.localeCompare(b.projectName) || a.name.localeCompare(b.name),
     trusts: (a, b) => a.trusts.length - b.trusts.length || a.name.localeCompare(b.name),
@@ -470,7 +478,6 @@ const SORT_COMPARATORS: Record<SortKey, (a: IModelSummary, b: IModelSummary) => 
 
 // Client-side sort of the current page (mirrors the Connection Status trusts table).
 const sortedModels = computed<IModelSummary[]>(() => {
-    if (!sortKey.value) return models.value;
     const cmp = SORT_COMPARATORS[sortKey.value];
 
     return [...models.value].sort(sortDir.value === "asc" ? cmp : (a, b) => cmp(b, a));
@@ -522,6 +529,19 @@ const trustChipLabel = (trust: IModelSummaryTrust): string => {
 // Owner display name (UserProfile.name from the backend). Falls back to an
 // em-dash when the owner has no profile row — the endpoint carries no email.
 const ownerLabel = (model: IModelSummary): string => model.ownerName || "—";
+
+// "created 2h ago" next to the owner — mirrors the Projects list meta line.
+// Em-dash when a deployed API predates the creationTimestamp field.
+const relativeCreated = (model: IModelSummary): string => {
+    if (!model.creationTimestamp) return "—";
+    const created = new Date(model.creationTimestamp).getTime();
+    const sec = (Date.now() - created) / 1000;
+    if (sec < 60) return `created ${Math.max(0, Math.floor(sec))}s ago`;
+    if (sec < 3_600) return `created ${Math.floor(sec / 60)}m ago`;
+    if (sec < 86_400) return `created ${Math.floor(sec / 3_600)}h ago`;
+
+    return `created ${Math.floor(sec / 86_400)}d ago`;
+};
 
 // Status pill/dot classes come from model-service (shared with the mobile
 // project-models list), imported under their historical local names.

--- a/flip-ui/src/pages/projects.vue
+++ b/flip-ui/src/pages/projects.vue
@@ -343,6 +343,7 @@ import CreateProjectModal from "@/partials/projects/CreateProjectModal.vue";
 import { getProjects, IProject, IProjectTrust, ProjectStatus } from "@/services/project-service";
 import { useAuthStore } from "@/store/auth";
 import { useModalsStore } from "@/store/modals";
+import { apiTimestampMs, relativeCreatedLabel } from "@/utils/helpers";
 
 const pageSize = 20;
 const authStore = useAuthStore();
@@ -436,8 +437,8 @@ const sortedProjects = computed<IProject[]>(() => {
     } else {
         // "created" — newest first; rows without a timestamp sink to the bottom.
         arr.sort((a, b) => {
-            const ta = a.creationtimestamp ? new Date(a.creationtimestamp).getTime() : 0;
-            const tb = b.creationtimestamp ? new Date(b.creationtimestamp).getTime() : 0;
+            const ta = apiTimestampMs(a.creationtimestamp) ?? 0;
+            const tb = apiTimestampMs(b.creationtimestamp) ?? 0;
 
             return tb - ta;
         });
@@ -556,15 +557,6 @@ const userCountLabel = (project: IProject): string => {
 
 // IProject has no `lastUpdated` — fall back to creation timestamp as a
 // proxy for the design's "updated 2h ago". Real updated-at tracking is a
-// separate backend change.
-const relativeUpdated = (project: IProject): string => {
-    if (!project.creationtimestamp) return "—";
-    const created = new Date(project.creationtimestamp).getTime();
-    const sec = (Date.now() - created) / 1000;
-    if (sec < 60) return `created ${Math.max(0, Math.floor(sec))}s ago`;
-    if (sec < 3_600) return `created ${Math.floor(sec / 60)}m ago`;
-    if (sec < 86_400) return `created ${Math.floor(sec / 3_600)}h ago`;
-
-    return `created ${Math.floor(sec / 86_400)}d ago`;
-};
+// separate backend change. Formatting is shared with the Models list.
+const relativeUpdated = (project: IProject): string => relativeCreatedLabel(project.creationtimestamp);
 </script>

--- a/flip-ui/src/services/model-service.ts
+++ b/flip-ui/src/services/model-service.ts
@@ -401,6 +401,10 @@ export interface IModelSummary {
     projectName: string;
     ownerId: string;
     ownerName?: string | null;
+    // Optional only until the deployed API ships the field: the owner sub-line
+    // shows an em-dash and the default created-sort keeps the backend order
+    // when it is absent.
+    creationTimestamp?: string;
     trusts: IModelSummaryTrust[];
     // The model's 1-based place in the FL training queue (1 = next to be picked
     // up); null/absent unless the model has a queued job waiting for a net.

--- a/flip-ui/src/utils/__tests__/helpers.spec.ts
+++ b/flip-ui/src/utils/__tests__/helpers.spec.ts
@@ -11,7 +11,7 @@
  * limitations under the License.
  */
 
-import { getRandomId } from "@/utils/helpers";
+import { apiTimestampMs, getRandomId, relativeCreatedLabel } from "@/utils/helpers";
 
 const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
@@ -31,5 +31,61 @@ describe("getRandomId", () => {
         const spy = vi.spyOn(crypto, "randomUUID").mockReturnValueOnce(mockUUID);
         expect(getRandomId()).toBe(mockUUID);
         spy.mockRestore();
+    });
+});
+
+describe("apiTimestampMs", () => {
+    it("parses an offset-less API timestamp as UTC, not browser-local time", () => {
+        expect(apiTimestampMs("2026-06-01T12:00:00")).toBe(Date.UTC(2026, 5, 1, 12, 0, 0));
+    });
+
+    it("leaves an explicit offset alone", () => {
+        expect(apiTimestampMs("2026-06-01T12:00:00Z")).toBe(Date.UTC(2026, 5, 1, 12, 0, 0));
+        expect(apiTimestampMs("2026-06-01T13:00:00+01:00")).toBe(Date.UTC(2026, 5, 1, 12, 0, 0));
+    });
+
+    it("returns null for a missing or empty timestamp", () => {
+        expect(apiTimestampMs(undefined)).toBeNull();
+        expect(apiTimestampMs(null)).toBeNull();
+        expect(apiTimestampMs("")).toBeNull();
+    });
+
+    it("returns null for an unparseable timestamp", () => {
+        expect(apiTimestampMs("not-a-date")).toBeNull();
+    });
+});
+
+describe("relativeCreatedLabel", () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date("2026-06-01T12:00:00Z"));
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    // Offset-less inputs throughout: the API serialises naive UTC, so these
+    // prove the UTC treatment at every bucket boundary.
+    it.each([
+        ["2026-06-01T11:59:01", "created 59s ago"],
+        ["2026-06-01T11:59:00", "created 1m ago"],
+        ["2026-06-01T11:00:01", "created 59m ago"],
+        ["2026-06-01T11:00:00", "created 1h ago"],
+        ["2026-05-31T12:00:01", "created 23h ago"],
+        ["2026-05-31T12:00:00", "created 1d ago"],
+        ["2026-05-29T12:00:00", "created 3d ago"]
+    ])("renders %s as '%s'", (timestamp, label) => {
+        expect(relativeCreatedLabel(timestamp)).toBe(label);
+    });
+
+    it("clamps a future (clock-skewed) timestamp to 0s", () => {
+        expect(relativeCreatedLabel("2026-06-01T12:30:00")).toBe("created 0s ago");
+    });
+
+    it("falls back to an em-dash for missing or unparseable timestamps", () => {
+        expect(relativeCreatedLabel(undefined)).toBe("—");
+        expect(relativeCreatedLabel(null)).toBe("—");
+        expect(relativeCreatedLabel("not-a-date")).toBe("—");
     });
 });

--- a/flip-ui/src/utils/helpers.ts
+++ b/flip-ui/src/utils/helpers.ts
@@ -56,6 +56,40 @@ export const getShortDateFromString = (dateString: string): string => {
     return format(new Date(dateString), "dd/MM/yyyy, HH:mm:ss");
 };
 
+/**
+ * Epoch milliseconds of an API timestamp, or null when missing/unparseable.
+ *
+ * The hub serialises naive-UTC datetimes with no offset suffix
+ * ("2026-06-01T12:00:00"), which `new Date()` would otherwise read as
+ * browser-local time — skewing displayed ages by the viewer's UTC offset.
+ * Offset-less date-times are therefore pinned to UTC before parsing.
+ */
+export const apiTimestampMs = (timestamp?: string | null): number | null => {
+    if (!timestamp) return null;
+    const hasOffset = /(Z|[+-]\d{2}:?\d{2})$/.test(timestamp);
+    const ms = new Date(timestamp.includes("T") && !hasOffset ? `${timestamp}Z` : timestamp).getTime();
+
+    return Number.isFinite(ms) ? ms : null;
+};
+
+/**
+ * "created 2h ago"-style meta label for a list row, from an API timestamp.
+ *
+ * Shared by the Projects and Models lists (owner · created … ago). Falls back
+ * to an em-dash when the timestamp is missing or unparseable; a future
+ * (clock-skewed) timestamp clamps to "created 0s ago".
+ */
+export const relativeCreatedLabel = (timestamp?: string | null): string => {
+    const created = apiTimestampMs(timestamp);
+    if (created === null) return "—";
+    const sec = (Date.now() - created) / 1000;
+    if (sec < 60) return `created ${Math.max(0, Math.floor(sec))}s ago`;
+    if (sec < 3_600) return `created ${Math.floor(sec / 60)}m ago`;
+    if (sec < 86_400) return `created ${Math.floor(sec / 3_600)}h ago`;
+
+    return `created ${Math.floor(sec / 86_400)}d ago`;
+};
+
 export const getOrderedLogs = (logs: ILog[] | undefined, reverse = false): ILog[] => {
     if (!logs) {
         return [];


### PR DESCRIPTION
## What

- The estate-wide **Models** list now shows the model's relative creation time next to the owner in the Model column sub-line (`Dr Ada · created 2h ago`) — the same meta-line treatment the Projects list already has.
- The table **default-sorts by creation date, most recent first**, as an explicit client-side sort rather than merely inheriting the backend order.

## How

- `GET /api/models` rows carry a new `creationTimestamp` field (the query was already ordered `creation_timestamp DESC`, so no ordering change server-side; no DB schema change, hence no migration).
- `models.vue` gains a `created` sort key (default, descending) with no column header of its own — the created time lives in the Model column's sub-line. Equal/absent timestamps tie at 0, so the stable sort preserves the backend (newest-first) order, which keeps behaviour sane against an older deployed API that doesn't send the field yet; the sub-line then falls back to an em-dash, mirroring the Projects page.
- **Timezone fix (second commit, found in review):** the hub serialises creation timestamps as naive UTC with no offset suffix, which `new Date()` parses as browser-local time — so relative labels were skewed by the viewer's UTC offset (pinned at "0s ago" west of UTC). The duplicated relative-time formatter is now a shared util (`apiTimestampMs` + `relativeCreatedLabel` in `utils/helpers.ts`) that pins offset-less date-times to UTC, used by **both** the Models and Projects lists — fixing the same pre-existing skew on the Projects page. (`ConnectionStatus.vue`'s `heartbeatText` has a similar-but-different local copy — left for a follow-up.)

## Testing

- flip-api: new integration test asserting each row carries `creationTimestamp` (pinning the offset-less wire format) and rows come newest-first — the first regression guard on the list's ordering. Full suite green: ruff, mypy, 1335 unit, 100 integration.
- flip-ui: 16 new util tests for the shared helpers (UTC pinning, every bucket boundary, future-clock clamp, em-dash fallbacks) plus Models-page cases: created time next to owner (fixture uses the **real offset-less wire format**, so local-time parsing regressions fail on any non-UTC machine — the earlier `toISOString()` fixture masked the bug), em-dash fallback asserted as the exact `— · —` meta line, default newest-first ordering, and the all-timestamps-absent rollout case preserving backend order. Suite verified under `TZ=Europe/London`, `TZ=America/New_York` and `TZ=UTC`. Lint + 1097 unit tests green.