### PR TITLE
chore: pin dcmqi conversion image to v1.5.6

### DIFF
--- a/flip-api/tests/xnat_seg_upload.py
+++ b/flip-api/tests/xnat_seg_upload.py
@@ -48,7 +48,7 @@ import requests
 # Both dev trust XNATs. IPv4 literals on purpose: the XNAT ports are published by Docker
 # Swarm ingress, which accepts but never answers ::1, and localhost resolves there first.
 DEFAULT_XNAT_URLS = ("http://127.0.0.1:8104", "http://127.0.0.1:8106")
-DCMQI_IMAGE = "qiicr/dcmqi:latest"
+DCMQI_IMAGE = "qiicr/dcmqi:v1.5.6"
 ROI_COLLECTION_TYPE = "icr:roiCollectionData"
 
 


### PR DESCRIPTION
One-line follow-up to the post-approval review note on #817 ([thread](https://github.com/londonaicentre/FLIP/pull/817#discussion_r3694795309)): the demo DICOM-SEG conversion image `DCMQI_IMAGE` in `flip-api/tests/xnat_seg_upload.py` was `qiicr/dcmqi:latest` — inconsistent with the pinned `CYPRESS_IMAGE` in the same PR, and an unpinned conversion image could silently change DICOM-SEG output between recordings.

Pins the default to the current stable release `qiicr/dcmqi:v1.5.6`. Per-run override remains available via `--dcmqi-image`.

**Verification of the pinned image:** `v1.5.6` was exercised through the module's own `_run_dcmqi` invocation (same entrypoint + `--user uid:gid` shape) on dcmqi's upstream matched test data (`data/segmentations/ct-3slice` + liver SEG re-extracted to NIfTI via `segimage2itkimage -t nii`): it produced a valid DICOM-SEG (DICM preamble, 102 KB). Note the previously-cached `latest` the recordings ran was `v1.5.6-2-gb6137d9` (two commits past the tag), so the pin is a no-op in practice today — it just stops future silent drift.

The other item in that note (zip-slip on `zf.extractall`) was verified n/a: CPython's `ZipFile.extract`/`extractall` strips absolute paths and removes `..` components from member names, so no guard is needed — see the thread for the empirical check.