### PR TITLE
[Task]: Move the Helm chart toolchain to Helm 4

### DIFF
--- a/.github/workflows/test_helm_chart.yml
+++ b/.github/workflows/test_helm_chart.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@v4
         with:
-          version: "v3.16.0"
+          version: "v4.2.3"
 
       - name: Lint chart
         run: helm lint deploy/providers/kubernetes/
@@ -71,7 +71,7 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@v4
         with:
-          version: "v3.16.0"
+          version: "v4.2.3"
 
       - name: Render template (default/nvflare)
         run: helm template trust-release deploy/providers/kubernetes/ > /dev/null
@@ -112,7 +112,7 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@v4
         with:
-          version: "v3.16.0"
+          version: "v4.2.3"
 
       - name: Create kind cluster
         uses: helm/kind-action@v1

--- a/deploy/providers/kubernetes/README.md
+++ b/deploy/providers/kubernetes/README.md
@@ -50,6 +50,15 @@ server; no inbound ports are exposed from the K8s cluster.
 - **External Secrets Operator** or **Secrets Store CSI Driver** (recommended for
   production secrets management)
 
+> **Helm 4 readiness semantics.** Helm 4 reimplemented `--wait` on top of
+> [kstatus](https://github.com/kubernetes-sigs/cli-utils/tree/master/pkg/kstatus),
+> which is stricter than Helm 3's readiness check — an install that Helm 3 called
+> ready can now block until the workloads genuinely settle, and time out if they
+> never do. `make deploy` does **not** pass `--wait` (it relies on `--timeout 20m`
+> alone), so this only bites if you add `--wait` to your own `helm upgrade`
+> invocation; if you do, size `--timeout` for the slowest service to become ready
+> rather than for the API call to return.
+
 ## Quickstart
 
 A K8s trust is registered with the hub **exactly like any other trust** — by a

--- a/deploy/providers/kubernetes/README.md
+++ b/deploy/providers/kubernetes/README.md
@@ -44,7 +44,7 @@ server; no inbound ports are exposed from the K8s cluster.
 ## Prerequisites
 
 - **Kubernetes cluster** 1.28+ (EKS, AKS, or on-prem)
-- **Helm** 3.16+
+- **Helm** 4.x (the CI-tested version; 3.16+ also works)
 - **kubectl** configured with cluster access
 - **NVIDIA GPU Operator** (if GPU workloads are enabled)
 - **External Secrets Operator** or **Secrets Store CSI Driver** (recommended for

--- a/deploy/providers/kubernetes/scripts/preflight.sh
+++ b/deploy/providers/kubernetes/scripts/preflight.sh
@@ -85,7 +85,7 @@ HELM_OK=false
 if ! command -v "$HELM_BIN" >/dev/null 2>&1; then
     fail "helm not found in PATH"
     hint "macOS:  brew install helm"
-    hint "Linux:  curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash"
+    hint "Linux:  curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-4 | bash"
     hint "Docs:   https://helm.sh/docs/intro/install/"
 else
     HELM_VER="$("$HELM_BIN" version 2>/dev/null | extract_semver)"


### PR DESCRIPTION
Closes #860.

## What

Moves the Helm chart toolchain to Helm 4 (current major) while keeping the chart itself compatible with 3.16+:

- `.github/workflows/test_helm_chart.yml` — the three Helm jobs (lint, template, kind E2E) now set up **v4.2.3** instead of v3.16.0.
- `deploy/providers/kubernetes/README.md` — prerequisites name Helm 4.x as the CI-tested version (3.16+ still works).
- `deploy/providers/kubernetes/scripts/preflight.sh` — the Linux install hint now points at the upstream `get-helm-4` script (verified it exists). The `>= 3.16` version floor is unchanged — it already accepts 4.x, so operators on either major pass preflight.

No chart template, values, or Python changes.

## Verification

Local, with the real binaries (helm v4.2.3 vs v3.21.3):

- `helm lint`: identical result on both majors — 0 failures, same single `[INFO] Chart.yaml: icon is recommended`.
- `helm template` diffed v3 vs v4 for the default (nvflare) and `flBackend=flower` variants: **semantically identical** — the only differences are trailing blank lines Helm 4 preserves where Helm 3 trimmed them.
- All four CI template variants (default, flower, all-services-disabled, external-service override) render cleanly under v4.2.3.
- `bash -n` on `preflight.sh`; workflow YAML parses.

The one thing not testable locally is install-time behaviour (Helm 4's `--wait` uses stricter kstatus readiness) — that is exactly what the kind E2E job in this PR's CI run exercises under the new pin.


## Acceptance Criteria

*Imported from issue #860*

- [x] `.github/workflows/test_helm_chart.yml` installs Helm v4.x in all three Helm jobs (lint, template, kind E2E)
- [x] The kind E2E install job passes under Helm 4 in CI (this validates install-time behaviour, e.g. Helm 4's stricter kstatus-based `--wait`)
- [x] `deploy/providers/kubernetes/README.md` prerequisites name Helm 4 as the CI-tested version, with 3.16+ still accepted
- [x] `scripts/preflight.sh` install hint points at the Helm 4 install script (`get-helm-4`); the >= 3.16 version floor stays unchanged
