### PR TITLE
Harden XNAT configuration on both deployments: fail loud on config API errors (Compose + Kubernetes), drop PACS_DICOM_PORT indirection

### DIFF
--- a/deploy/providers/kubernetes/TROUBLESHOOTING.md
+++ b/deploy/providers/kubernetes/TROUBLESHOOTING.md
@@ -12,6 +12,7 @@ services, with a focus on the XNAT DICOM import pipeline.
    - [2.1 PacsNotStorableException — destination AE/port mismatch](#21-pacsnotstorableexception--destination-aeport-mismatch)
    - [2.2 Studies Received but Land in the Unassigned Prearchive](#22-studies-received-but-land-in-the-unassigned-prearchive)
    - [2.3 imaging-api Gets 401 from XNAT (flipServiceAccount)](#23-imaging-api-gets-401-from-xnat-flipserviceaccount)
+   - [2.3a dcm2niix Never Registered (admin missing ContainerManager)](#23a-dcm2niix-never-registered-admin-missing-containermanager)
    - [2.4 Forcing a Re-pull (status stuck on "Processing")](#24-forcing-a-re-pull-status-stuck-on-processing)
    - [2.5 Running the Imaging Import Worker Manually](#25-running-the-imaging-import-worker-manually)
    - [2.6 C-MOVE Testing from the DCMTK Pod](#26-c-move-testing-from-the-dcmtk-pod)
@@ -237,6 +238,38 @@ kubectl exec -n flip-trust "$XNAT_POD" -- \
 
 Verify: `curl -u flipServiceAccount:<pass> http://localhost:8080/xapi/users/flipServiceAccount`
 from inside the pod should return 200.
+
+### 2.3a dcm2niix Never Registered (admin missing ContainerManager)
+
+**Symptom:** Studies pull and archive fine, but no NIfTI is ever produced, so
+FL training sees `num_samples=0`. `GET /xapi/commands?name=dcm2niix` returns
+`[]` and `GET /xapi/docker/server` 500s — yet the `xnat-init` Job reported
+**success**.
+
+**Root Cause:** Container Service >= 3.7.0 requires the `ContainerManager` role
+for `/xapi/docker/server` and `/xapi/commands`. The Compose deploy's
+`trust/xnat/xnat/config/configure-xnat.sh` grants it to the admin account; the
+chart's init job did not, so those two calls returned 401/403. Because every
+call in the `configure-dcm2niix` container was `|| true` (or warn-only), the
+Job still exited 0 with dcm2niix silently unregistered — the same
+silent-failure class as FLIP#822 / FLIP#862.
+
+**Fix:** Both are now handled by `xnat-init-job.yaml`: `configure-xnat-web`
+grants the role, and `configure-dcm2niix` waits for it and then fails loudly
+rather than swallowing the error. To repair a cluster configured by an older
+chart:
+
+```bash
+kubectl exec -n flip-trust "$XNAT_POD" -- \
+  curl -s -X PUT -u admin:<admin-pass> -H "accept: application/json" \
+  http://localhost:8080/xapi/users/admin/roles/ContainerManager
+```
+
+Then re-run the init job (`helm upgrade` re-fires the post-install hook).
+Verify: `curl -s -u admin:<pass> http://localhost:8080/xapi/users/admin/roles/`
+must include `ContainerManager`, and
+`curl -s -u admin:<pass> "http://localhost:8080/xapi/commands?name=dcm2niix"`
+must return a command with a `dcm2niix-scan` wrapper.
 
 ### 2.4 Forcing a Re-pull (status stuck on "Processing")
 

--- a/deploy/providers/kubernetes/templates/xnat-init-job.yaml
+++ b/deploy/providers/kubernetes/templates/xnat-init-job.yaml
@@ -95,15 +95,91 @@ spec:
               XNAT_URL="http://xnat-web:8080"
               ADMIN_USER="{{ .Values.xnat.web.adminUser }}"
               ADMIN_PASS="${XNAT_ADMIN_PASS}"
+
+              # Scrub secrets out of anything echoed on failure: the value
+              # following -u (credentials) or -d/--data-binary (payloads carry
+              # the admin and service passwords) must never reach the pod log,
+              # and neither must a live JSESSIONID.
+              scrub_args() {
+                local redact_next=""
+                local arg
+                local out=""
+                for arg in "$@"; do
+                  if [ -n "$redact_next" ]; then
+                    out="$out <redacted>"
+                    redact_next=""
+                  elif [ "$arg" = "-u" ] || [ "$arg" = "-d" ] || [ "$arg" = "--data-binary" ]; then
+                    out="$out $arg"
+                    redact_next=1
+                  else
+                    out="$out $arg"
+                  fi
+                done
+                printf '%s' "${out# }" | sed 's/JSESSIONID=[^ ]*/JSESSIONID=<redacted>/g'
+              }
+
+              # Fail-loud wrapper for XNAT's REST API — the Kubernetes
+              # counterpart of xnat_curl in trust/xnat/xnat/config/configure-xnat.sh
+              # (FLIP#862). Bare `curl -s` exits 0 on HTTP errors, so every
+              # configuration call below used to be swallowed by `|| true` and
+              # this Job reported success on a half-configured XNAT — the same
+              # silent-failure class as the unregistered-PACS bug (FLIP#822).
+              # On 2xx, emits the response body on stdout. On anything else —
+              # or a curl transport failure — reports the (scrubbed) request and
+              # the response body on stderr and returns non-zero, which `set -e`
+              # turns into an abort at the call site.
+              xnat_curl() {
+                local response
+                local status
+                local body
+                local curl_exit=0
+                response=$(curl -sS --connect-timeout 10 --max-time 120 -w '\n%{http_code}' "$@") || curl_exit=$?
+                if [ "$curl_exit" -ne 0 ]; then
+                  echo "ERROR: curl transport failure (exit $curl_exit)" >&2
+                  echo "  args: $(scrub_args "$@")" >&2
+                  return 1
+                fi
+                # Strip CRs so a middlebox emitting \r\n line endings cannot
+                # make the status guard fail on an invisible character.
+                status=$(printf '%s' "$response" | tail -n1 | tr -d '\r')
+                body=$(printf '%s' "$response" | sed '$d' | tr -d '\r')
+                # Fail closed: anything other than a literal 2xx status line
+                # (including an empty or non-numeric one) is an error.
+                case "$status" in
+                  2[0-9][0-9]) ;;
+                  *)
+                    echo "ERROR: XNAT request failed with HTTP $status" >&2
+                    echo "  args: $(scrub_args "$@")" >&2
+                    echo "  body: $body" >&2
+                    return 1
+                    ;;
+                esac
+                if [ -n "$body" ]; then
+                  printf '%s\n' "$body"
+                fi
+              }
+
               echo "Waiting for XNAT to be ready..."
+              XNAT_READY=false
+              HTTP_CODE=000
               for i in $(seq 1 60); do
-                HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" "${XNAT_URL}/xapi/siteConfig" 2>/dev/null)
+                # `|| HTTP_CODE=000` is load-bearing: `set -e` aborts on a
+                # failing command substitution, so without it the first probe
+                # against a still-booting Tomcat (curl exit 7) kills this
+                # container and the loop can never wait.
+                HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
+                  --connect-timeout 5 --max-time 10 "${XNAT_URL}/xapi/siteConfig" 2>/dev/null) || HTTP_CODE=000
                 if [ "$HTTP_CODE" = "200" ] || [ "$HTTP_CODE" = "401" ]; then
                   echo "XNAT is ready (HTTP ${HTTP_CODE})!"
+                  XNAT_READY=true
                   break
                 fi
                 sleep 10
               done
+              if [ "$XNAT_READY" != "true" ]; then
+                echo "ERROR: XNAT did not become ready within 600s (last HTTP ${HTTP_CODE})" >&2
+                exit 1
+              fi
 
               # Login: try configured password first, fall back to XNAT default (admin:admin pre-init)
               _xnat_login() {
@@ -130,17 +206,29 @@ spec:
 
               # Activate XNAT site (idempotent — safe to call even if already initialized)
               echo "Activating XNAT site..."
-              curl -s -X POST "${XNAT_URL}/xapi/siteConfig" \
+              xnat_curl -X POST "${XNAT_URL}/xapi/siteConfig" \
                 -H "Cookie: JSESSIONID=${JSESSION}" \
                 -H "Content-Type: application/json" \
-                -d '{"initialized": true}' -o /dev/null -w "siteConfig HTTP:%{http_code}\n" || true
+                -d '{"initialized": true}' >/dev/null
 
               # Set admin password to configured value if it differs from default
               echo "Setting admin password..."
-              curl -s -X PUT "${XNAT_URL}/xapi/users/${ADMIN_USER}" \
+              xnat_curl -X PUT "${XNAT_URL}/xapi/users/${ADMIN_USER}" \
                 -H "Cookie: JSESSIONID=${JSESSION}" \
                 -H "Content-Type: application/json" \
-                -d "{\"password\": \"${ADMIN_PASS}\"}" -o /dev/null -w "setPassword HTTP:%{http_code}\n" || true
+                -d "{\"password\": \"${ADMIN_PASS}\"}" >/dev/null
+
+              # Grant the admin account the ContainerManager role. Mirrors
+              # trust/xnat/xnat/config/configure-xnat.sh — the sibling
+              # configure-dcm2niix container authenticates as admin, and since
+              # Container Service 3.7.0 both /xapi/docker/server and
+              # /xapi/commands require this role. Without it those calls fail
+              # with 401/403 and, because they were `|| true`, the Job still
+              # reported success with dcm2niix silently unregistered.
+              echo "Assigning role 'ContainerManager' to ${ADMIN_USER}..."
+              xnat_curl -X PUT "${XNAT_URL}/xapi/users/${ADMIN_USER}/roles/ContainerManager" \
+                -H "Cookie: JSESSIONID=${JSESSION}" \
+                -H "accept: application/json" >/dev/null
 
               # Assign roles to service account
               SERVICE_USER="${XNAT_SERVICE_USER:-flipServiceAccount}"
@@ -149,32 +237,31 @@ spec:
               # matches XNAT_SERVICE_PASSWORD in imaging-api, even after a backup
               # restore (the DB-layer user creation above uses a fixed hash).
               echo "Setting ${SERVICE_USER} password..."
-              curl -s -X PUT "${XNAT_URL}/xapi/users/${SERVICE_USER}" \
+              xnat_curl -X PUT "${XNAT_URL}/xapi/users/${SERVICE_USER}" \
                 -H "Cookie: JSESSIONID=${JSESSION}" \
                 -H "Content-Type: application/json" \
-                -d "{\"password\": \"${SERVICE_PASS}\"}" -o /dev/null -w "setServicePassword HTTP:%{http_code}\n" || true
+                -d "{\"password\": \"${SERVICE_PASS}\"}" >/dev/null
               echo "Assigning roles to ${SERVICE_USER}..."
-              curl -sf -X PUT "${XNAT_URL}/xapi/users/${SERVICE_USER}/groups/" \
+              xnat_curl -X PUT "${XNAT_URL}/xapi/users/${SERVICE_USER}/groups/" \
                 -H "Cookie: JSESSIONID=${JSESSION}" \
                 -H "Content-Type: application/json" \
-                -d '["ALL_DATA_ADMIN"]' || true
-              curl -sf -X PUT "${XNAT_URL}/xapi/users/${SERVICE_USER}/roles/" \
+                -d '["ALL_DATA_ADMIN"]' >/dev/null
+              xnat_curl -X PUT "${XNAT_URL}/xapi/users/${SERVICE_USER}/roles/" \
                 -H "Cookie: JSESSIONID=${JSESSION}" \
                 -H "Content-Type: application/json" \
-                -d '["ContainerManager","DataManager","SiteUser","Administrator","Dqr","non_expiring"]' || true
+                -d '["ContainerManager","DataManager","SiteUser","Administrator","Dqr","non_expiring"]' >/dev/null
 
               # Apply + enable the site-wide anonymization script (mirrors
               # trust/xnat/xnat/config/configure-xnat.sh in the Compose deploy).
               echo "Applying site-wide anonymization script..."
-              curl -s -X PUT "${XNAT_URL}/xapi/anonymize/site" \
+              xnat_curl -X PUT "${XNAT_URL}/xapi/anonymize/site" \
                 -H "Cookie: JSESSIONID=${JSESSION}" \
                 -H "Content-Type: text/plain" \
-                --data-binary @/cs-config/anon_script.das \
-                -o /dev/null -w "anonScript HTTP:%{http_code}\n" || true
-              curl -s -X PUT "${XNAT_URL}/xapi/anonymize/site/enabled" \
+                --data-binary @/cs-config/anon_script.das >/dev/null
+              xnat_curl -X PUT "${XNAT_URL}/xapi/anonymize/site/enabled" \
                 -H "Cookie: JSESSIONID=${JSESSION}" \
                 -H "Content-Type: application/json" \
-                -d 'true' -o /dev/null -w "anonEnable HTTP:%{http_code}\n" || true
+                -d 'true' >/dev/null
 
               # Replace the default DICOM SCP receiver with the DQR-aware one.
               # The stock receiver uses identifier=dicomObjectIdentifier with
@@ -185,14 +272,14 @@ spec:
               # requesting project and the relabel map (Subject UUID /
               # Session=accession) is applied.
               echo "Replacing DICOM SCP receiver with DQR-aware config..."
-              for SCP_ID in $(curl -s "${XNAT_URL}/xapi/dicomscp" \
-                  -H "Cookie: JSESSIONID=${JSESSION}" \
-                  | jq -r '.[] | select(.aeTitle == "XNAT") | .id'); do
-                curl -s -X DELETE "${XNAT_URL}/xapi/dicomscp/${SCP_ID}" \
-                  -H "Cookie: JSESSIONID=${JSESSION}" \
-                  -o /dev/null -w "deleteScp(${SCP_ID}) HTTP:%{http_code}\n" || true
+              scp_list=$(xnat_curl "${XNAT_URL}/xapi/dicomscp" \
+                -H "Cookie: JSESSIONID=${JSESSION}")
+              for SCP_ID in $(printf '%s' "$scp_list" | jq -r '.[] | select(.aeTitle == "XNAT") | .id'); do
+                echo "  Removing existing SCP receiver id=${SCP_ID}..."
+                xnat_curl -X DELETE "${XNAT_URL}/xapi/dicomscp/${SCP_ID}" \
+                  -H "Cookie: JSESSIONID=${JSESSION}" >/dev/null
               done
-              curl -s -X POST "${XNAT_URL}/xapi/dicomscp" \
+              xnat_curl -X POST "${XNAT_URL}/xapi/dicomscp" \
                 -H "Cookie: JSESSIONID=${JSESSION}" \
                 -H "Content-Type: application/json" \
                 -d '{
@@ -209,29 +296,38 @@ spec:
                   "projectRoutingExpression": "",
                   "subjectRoutingExpression": "",
                   "sessionRoutingExpression": ""
-                }' -o /dev/null -w "createScp HTTP:%{http_code}\n" || true
+                }' >/dev/null
 
-              # Register PACS
-              echo "Registering PACS..."
-              curl -sf -X POST "${XNAT_URL}/xapi/pacs" \
-                -H "Cookie: JSESSIONID=${JSESSION}" \
-                -H "Content-Type: application/json" \
-                -d '{
-                  "aeTitle": "ORTHANC",
-                  "defaultQueryRetrievePacs": true,
-                  "defaultStoragePacs": true,
-                  "host": "orthanc",
-                  "label": "Orthanc PACS",
-                  "ormStrategySpringBeanId": "dicomOrmStrategy",
-                  "queryRetrievePort": 4242,
-                  "queryable": true,
-                  "storable": true,
-                  "supportsExtendedNegotiations": true
-                }' || echo "PACS may already be registered"
+              # Register PACS. Check-then-create by aeTitle: a duplicate
+              # registration surfaces as an unspecific 500 (DB unique-constraint
+              # violation), so re-run idempotency has to be a lookup rather than
+              # a tolerated status code (FLIP#862).
+              existing_pacs=$(xnat_curl "${XNAT_URL}/xapi/pacs" \
+                -H "Cookie: JSESSIONID=${JSESSION}")
+              if printf '%s' "$existing_pacs" | grep -q '"aeTitle":"ORTHANC"'; then
+                echo "PACS 'ORTHANC' already registered — leaving as-is."
+              else
+                echo "Registering PACS..."
+                xnat_curl -X POST "${XNAT_URL}/xapi/pacs" \
+                  -H "Cookie: JSESSIONID=${JSESSION}" \
+                  -H "Content-Type: application/json" \
+                  -d '{
+                    "aeTitle": "ORTHANC",
+                    "defaultQueryRetrievePacs": true,
+                    "defaultStoragePacs": true,
+                    "host": "orthanc",
+                    "label": "Orthanc PACS",
+                    "ormStrategySpringBeanId": "dicomOrmStrategy",
+                    "queryRetrievePort": 4242,
+                    "queryable": true,
+                    "storable": true,
+                    "supportsExtendedNegotiations": true
+                  }' >/dev/null
+              fi
 
               # Configure DQR settings
               echo "Configuring DQR settings..."
-              curl -sf -X POST "${XNAT_URL}/xapi/dqr/settings" \
+              xnat_curl -X POST "${XNAT_URL}/xapi/dqr/settings" \
                 -H "Cookie: JSESSIONID=${JSESSION}" \
                 -H "Content-Type: application/json" \
                 -d '{
@@ -244,15 +340,32 @@ spec:
                   "allowAllProjectsToUseDqr": true,
                   "leavePacsAuditTrail": false,
                   "dqrMaxPacsRequestAttempts": "100"
-                }' || echo "DQR settings may already be configured"
+                }' >/dev/null
 
-              # Configure PACS availability for all days
+              # Configure PACS availability for all days. DQR pre-creates
+              # availability intervals when the PACS is registered, so this POST
+              # returns 400 "probable overlap with existing interval" for an
+              # already-scheduled day — treated as "already configured" rather
+              # than a failure. Anything else non-2xx is a real error.
               echo "Configuring PACS availability..."
               for DAY in MONDAY TUESDAY WEDNESDAY THURSDAY FRIDAY SATURDAY SUNDAY; do
-                curl -sf -X POST "${XNAT_URL}/xapi/pacs/1/availability" \
+                avail_status=$(curl -s -o /tmp/pacs-availability-response.json \
+                  --connect-timeout 10 --max-time 120 -w '%{http_code}' \
+                  -X POST "${XNAT_URL}/xapi/pacs/1/availability" \
                   -H "Cookie: JSESSIONID=${JSESSION}" \
                   -H "Content-Type: application/json" \
-                  -d "{\"availabilityEnd\":\"23:59\",\"availabilityStart\":\"00:00\",\"availableNow\":true,\"dayOfWeek\":\"$DAY\",\"enabled\":true,\"pacsId\":1,\"threads\":4,\"utilizationPercent\":100}" || true
+                  -d "{\"availabilityEnd\":\"23:59\",\"availabilityStart\":\"00:00\",\"availableNow\":true,\"dayOfWeek\":\"$DAY\",\"enabled\":true,\"pacsId\":1,\"threads\":4,\"utilizationPercent\":100}") || avail_status="000"
+                case "$avail_status" in
+                  2[0-9][0-9]) ;;
+                  400)
+                    echo "  Availability interval for $DAY already exists (HTTP 400 overlap) — leaving as-is."
+                    ;;
+                  *)
+                    echo "ERROR: setting PACS availability for $DAY failed (HTTP $avail_status)" >&2
+                    cat /tmp/pacs-availability-response.json >&2 || true
+                    exit 1
+                    ;;
+                esac
               done
 
               echo "XNAT web configuration complete."
@@ -300,79 +413,168 @@ spec:
               CREDS="${XNAT_ADMIN_USER}:${XNAT_ADMIN_PASS}"
               DCM2NIIX_NAME="dcm2niix"
 
+              # Same fail-loud helper as the configure-xnat-web container (each
+              # container runs its own script, so it is defined twice). Mirrors
+              # xnat_curl in trust/xnat/xnat/config/configure-dcm2niix.sh, which
+              # is already fail-loud on the Compose side — this brings K8s to
+              # parity (FLIP#862).
+              scrub_args() {
+                local redact_next=""
+                local arg
+                local out=""
+                for arg in "$@"; do
+                  if [ -n "$redact_next" ]; then
+                    out="$out <redacted>"
+                    redact_next=""
+                  elif [ "$arg" = "-u" ] || [ "$arg" = "-d" ] || [ "$arg" = "--data-binary" ]; then
+                    out="$out $arg"
+                    redact_next=1
+                  else
+                    out="$out $arg"
+                  fi
+                done
+                printf '%s' "${out# }" | sed 's/JSESSIONID=[^ ]*/JSESSIONID=<redacted>/g'
+              }
+
+              xnat_curl() {
+                local response
+                local status
+                local body
+                local curl_exit=0
+                response=$(curl -sS --connect-timeout 10 --max-time 120 -w '\n%{http_code}' "$@") || curl_exit=$?
+                if [ "$curl_exit" -ne 0 ]; then
+                  echo "ERROR: curl transport failure (exit $curl_exit)" >&2
+                  echo "  args: $(scrub_args "$@")" >&2
+                  return 1
+                fi
+                status=$(printf '%s' "$response" | tail -n1 | tr -d '\r')
+                body=$(printf '%s' "$response" | sed '$d' | tr -d '\r')
+                case "$status" in
+                  2[0-9][0-9]) ;;
+                  *)
+                    echo "ERROR: XNAT request failed with HTTP $status" >&2
+                    echo "  args: $(scrub_args "$@")" >&2
+                    echo "  body: $body" >&2
+                    return 1
+                    ;;
+                esac
+                if [ -n "$body" ]; then
+                  printf '%s\n' "$body"
+                fi
+              }
+
               echo "Waiting for XNAT to be ready..."
+              XNAT_READY=false
+              HTTP_CODE=000
               for i in $(seq 1 60); do
-                HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" "${XNAT_URL}/xapi/siteConfig" 2>/dev/null)
+                # `|| HTTP_CODE=000` is load-bearing: `set -e` aborts on a
+                # failing command substitution, so without it the first probe
+                # against a still-booting Tomcat (curl exit 7) kills this
+                # container and the loop can never wait.
+                HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
+                  --connect-timeout 5 --max-time 10 "${XNAT_URL}/xapi/siteConfig" 2>/dev/null) || HTTP_CODE=000
                 if [ "$HTTP_CODE" = "200" ] || [ "$HTTP_CODE" = "401" ]; then
                   echo "XNAT is ready (HTTP ${HTTP_CODE})!"
+                  XNAT_READY=true
                   break
                 fi
                 sleep 10
               done
+              if [ "$XNAT_READY" != "true" ]; then
+                echo "ERROR: XNAT did not become ready within 600s (last HTTP ${HTTP_CODE})" >&2
+                exit 1
+              fi
 
               # The sibling configure-xnat-web container activates the site
               # ({"initialized": true} on /xapi/siteConfig). Wait for that before
               # touching the Container Service plugin so we don't race it.
               echo "Waiting for XNAT site activation..."
+              SITE_ACTIVATED=false
               for i in $(seq 1 60); do
-                INIT=$(curl -sf -u "${CREDS}" "${XNAT_URL}/xapi/siteConfig" 2>/dev/null \
-                  | jq -r '.initialized // false')
+                INIT=$(curl -sf -u "${CREDS}" --connect-timeout 5 --max-time 10 \
+                  "${XNAT_URL}/xapi/siteConfig" 2>/dev/null \
+                  | jq -r '.initialized // false') || INIT=false
                 if [ "${INIT}" = "true" ]; then
                   echo "XNAT site is activated."
+                  SITE_ACTIVATED=true
                   break
                 fi
                 sleep 5
               done
+              if [ "$SITE_ACTIVATED" != "true" ]; then
+                echo "ERROR: XNAT site was not activated within 300s — the sibling configure-xnat-web container likely failed" >&2
+                exit 1
+              fi
+
+              # The sibling configure-xnat-web container grants ${XNAT_ADMIN_USER}
+              # the ContainerManager role, which every Container Service call
+              # below requires (CS >= 3.7.0). Wait for it to land rather than
+              # racing it — an unauthorised call here used to be swallowed by
+              # `|| true` and left dcm2niix unregistered on a "successful" Job.
+              echo "Waiting for the ContainerManager role on ${XNAT_ADMIN_USER}..."
+              HAS_CM=false
+              for i in $(seq 1 60); do
+                ROLES=$(curl -sf -u "${CREDS}" --connect-timeout 5 --max-time 10 \
+                  "${XNAT_URL}/xapi/users/${XNAT_ADMIN_USER}/roles/" 2>/dev/null) || ROLES=""
+                if printf '%s' "$ROLES" | jq -e 'index("ContainerManager")' >/dev/null 2>&1; then
+                  echo "${XNAT_ADMIN_USER} holds ContainerManager."
+                  HAS_CM=true
+                  break
+                fi
+                sleep 5
+              done
+              if [ "$HAS_CM" != "true" ]; then
+                echo "ERROR: ${XNAT_ADMIN_USER} never gained the ContainerManager role within 300s — Container Service calls would fail 401/403" >&2
+                exit 1
+              fi
 
               echo "Registering Kubernetes backend with the Container Service plugin..."
               CS_HTTP=$(curl -s -o /tmp/cs_resp.txt -w "%{http_code}" \
+                --connect-timeout 10 --max-time 120 \
                 -X POST "${XNAT_URL}/xapi/docker/server" \
                 -u "${CREDS}" \
                 -H "Content-Type: application/json" \
-                -d @/cs-config/container-service-backend-configuration.kubernetes.json)
+                -d @/cs-config/container-service-backend-configuration.kubernetes.json) || CS_HTTP="000"
               if [ "${CS_HTTP}" = "200" ] || [ "${CS_HTTP}" = "201" ]; then
                 echo "Container Service backend registered (HTTP ${CS_HTTP})."
               else
-                echo "Warning: Container Service backend registration returned HTTP ${CS_HTTP} — may not be supported on this XNAT build."
-                echo "Response: $(cat /tmp/cs_resp.txt)"
+                echo "ERROR: Container Service backend registration failed (HTTP ${CS_HTTP})" >&2
+                cat /tmp/cs_resp.txt >&2 || true
+                exit 1
               fi
 
               echo "Checking for an existing ${DCM2NIIX_NAME} command..."
-              EXISTING_ID=$(curl -s "${XNAT_URL}/xapi/commands?name=${DCM2NIIX_NAME}" \
-                -u "${CREDS}" | jq -r '.[0].id // empty')
+              EXISTING=$(xnat_curl -u "${CREDS}" "${XNAT_URL}/xapi/commands?name=${DCM2NIIX_NAME}")
+              EXISTING_ID=$(printf '%s' "$EXISTING" | jq -r '.[0].id // empty')
               if [ -n "${EXISTING_ID}" ]; then
                 echo "Deleting existing command id=${EXISTING_ID}..."
-                curl -s -X DELETE "${XNAT_URL}/xapi/commands/${EXISTING_ID}" -u "${CREDS}" -o /dev/null || true
+                xnat_curl -X DELETE "${XNAT_URL}/xapi/commands/${EXISTING_ID}" -u "${CREDS}" >/dev/null
               fi
 
               echo "Registering ${DCM2NIIX_NAME} command..."
-              DCM_HTTP=$(curl -s -o /tmp/dcm_resp.txt -w "%{http_code}" \
-                -X POST "${XNAT_URL}/xapi/commands" \
+              xnat_curl -X POST "${XNAT_URL}/xapi/commands" \
                 -u "${CREDS}" \
                 -H "Content-Type: application/json" \
-                -d @/cs-config/dcm2niix_command.json)
-              echo "dcm2niix command registration: HTTP ${DCM_HTTP}"
+                -d @/cs-config/dcm2niix_command.json >/dev/null
 
               echo "Looking up registered command id and wrapper name..."
-              RESPONSE=$(curl -s "${XNAT_URL}/xapi/commands?name=${DCM2NIIX_NAME}" -u "${CREDS}")
-              CMD_ID=$(echo "${RESPONSE}" | jq -r '.[0].id // empty')
-              WRAPPER_NAME=$(echo "${RESPONSE}" | jq -r '.[0].xnat[0].name // empty')
-              if [ -n "${CMD_ID}" ] && [ -n "${WRAPPER_NAME}" ]; then
-                echo "Command id=${CMD_ID}, wrapper=${WRAPPER_NAME}"
-                echo "Enabling ${DCM2NIIX_NAME} command site-wide..."
-                curl -s -o /dev/null -w "enableCommand HTTP:%{http_code}\n" \
-                  -X PUT "${XNAT_URL}/xapi/commands/${CMD_ID}/wrappers/${WRAPPER_NAME}/enabled" \
-                  -u "${CREDS}" || true
-              else
-                echo "Warning: ${DCM2NIIX_NAME} command not found after registration — skipping enable step."
+              RESPONSE=$(xnat_curl -u "${CREDS}" "${XNAT_URL}/xapi/commands?name=${DCM2NIIX_NAME}")
+              CMD_ID=$(printf '%s' "${RESPONSE}" | jq -r '.[0].id // empty')
+              WRAPPER_NAME=$(printf '%s' "${RESPONSE}" | jq -r '.[0].xnat[0].name // empty')
+              if [ -z "${CMD_ID}" ] || [ -z "${WRAPPER_NAME}" ]; then
+                echo "ERROR: ${DCM2NIIX_NAME} command not found after registration (id='${CMD_ID}' wrapper='${WRAPPER_NAME}')" >&2
+                exit 1
               fi
+              echo "Command id=${CMD_ID}, wrapper=${WRAPPER_NAME}"
+              echo "Enabling ${DCM2NIIX_NAME} command site-wide..."
+              xnat_curl -X PUT "${XNAT_URL}/xapi/commands/${CMD_ID}/wrappers/${WRAPPER_NAME}/enabled" \
+                -u "${CREDS}" >/dev/null
 
               echo "Enabling the Event Service..."
-              curl -s -o /dev/null -w "eventService HTTP:%{http_code}\n" \
-                -X PUT "${XNAT_URL}/xapi/events/prefs" \
+              xnat_curl -X PUT "${XNAT_URL}/xapi/events/prefs" \
                 -u "${CREDS}" \
                 -H "Content-Type: application/json" \
-                -d '{"enabled": true}' || true
+                -d '{"enabled": true}' >/dev/null
 
               echo "Container Service + dcm2niix configuration complete."
           env:

--- a/trust/xnat/README.md
+++ b/trust/xnat/README.md
@@ -61,6 +61,11 @@ make up
 
 `make up` will create the required data directories, deploy the XNAT stack via Docker Swarm, and automatically configure both XNAT instances (service account, admin password, SCP receiver, PACS registration, dcm2niix command).
 
+Every configuration call is checked: a rejected XNAT API call (non-2xx) aborts the deploy with the failing request's
+HTTP status and response body (see `configure-xnat-<stack>.log` inside the container), instead of silently skipping
+that step. Re-running against an already-configured instance is tolerated — the existing service account, PACS
+registration, and availability intervals are detected and left as-is.
+
 In development (when `PROD` is not set), `make up` also mounts the local `xnat/plugins` and `xnat/config` directories into the container for hot-reload. In production, these are baked into the Docker image.
 
 > **Important — XNAT data volumes must be bind-mounted.**

--- a/trust/xnat/xnat/config/configure-xnat.sh
+++ b/trust/xnat/xnat/config/configure-xnat.sh
@@ -21,24 +21,110 @@
 
 set -euo pipefail
 
+# Required, non-empty (":?" also rejects set-but-empty, which `set -u` does
+# not): an empty value interpolated into a JSON payload produces invalid JSON
+# that XNAT rejects — the failure mode behind the silent PACS registration
+# bug (FLIP#822 / FLIP#862).
+: "${XNAT_ADMIN_USER:?}" "${XNAT_ADMIN_INITIAL_PASSWORD:?}" "${XNAT_ADMIN_PASSWORD:?}"
+: "${XNAT_SERVICE_USER:?}" "${XNAT_SERVICE_PASSWORD:?}" "${XNAT_PORT:?}"
+
 # The below are fixed values for now
 XNAT_URL="http://xnat-web:8080" # internal to Docker network
 ORTHANC_HOST="orthanc" # name of the service (container) in docker-compose
 ORTHANC_AETITLE="ORTHANC"
 
-# Wait for XNAT to be available
+# Wait for XNAT to be available (wall-clock bounded, and each probe carries
+# its own timeout, so a dead or wedged XNAT fails the deploy loudly instead
+# of printing dots forever — same shape as configure-dcm2niix.sh).
 echo "Waiting for XNAT to be available..."
-until $(curl --output /dev/null --silent --head --fail $XNAT_URL/app/template/Login.vm); do
+wait_start=$SECONDS
+deadline=$((wait_start + 900))
+until curl --output /dev/null --silent --head --fail \
+  --connect-timeout 5 --max-time 10 "$XNAT_URL/app/template/Login.vm"; do
+  if [[ "$SECONDS" -ge "$deadline" ]]; then
+    echo "ERROR: XNAT did not become available within $((SECONDS - wait_start))s" >&2
+    exit 1
+  fi
   printf '.'
   sleep 1
 done
 echo "XNAT is up!"
+
+# Helper: curl wrapper for XNAT's REST API — same contract as xnat_curl in
+# configure-dcm2niix.sh, except credentials are passed by the caller: this
+# script authenticates its first two calls with the *initial* admin password
+# and everything after the rotation with the new one. On 2xx, emits the
+# response body on stdout. On any other status — or a curl transport failure —
+# reports the request (and, for HTTP failures, the response body) on stderr
+# and returns non-zero, which `set -e` turns into an abort at the call site.
+# Bare `curl -s` exits 0 on HTTP errors, so a rejected configuration call
+# used to skip that step invisibly — silently-unregistered PACS was how the
+# empty-PACS_DICOM_PORT bug stayed hidden (FLIP#822 / FLIP#862).
+# Unlike the dcm2niix variant, credentials and payloads travel through "$@"
+# here, so the args echoed on failure are scrubbed first: the value following
+# -u (credentials) or -d/--data-binary (payloads carry the admin and service
+# passwords) must never reach the tee'd configure log.
+scrub_args() {
+  local redact_next=""
+  local arg
+  local out=""
+  for arg in "$@"; do
+    if [[ -n "$redact_next" ]]; then
+      out+=" <redacted>"
+      redact_next=""
+    elif [[ "$arg" == "-u" || "$arg" == "-d" || "$arg" == "--data-binary" ]]; then
+      out+=" $arg"
+      redact_next=1
+    else
+      out+=" $arg"
+    fi
+  done
+  printf '%s' "${out# }"
+}
+
+xnat_curl() {
+  local response
+  local status
+  local body
+  local curl_exit=0
+  response=$(curl -sS --connect-timeout 10 --max-time 120 -w '\n%{http_code}' "$@") || curl_exit=$?
+  if [[ "$curl_exit" -ne 0 ]]; then
+    echo "ERROR: curl transport failure (exit $curl_exit)" >&2
+    echo "  args: $(scrub_args "$@")" >&2
+    return 1
+  fi
+  status=$(printf '%s' "$response" | tail -n1)
+  body=$(printf '%s' "$response" | sed '$d')
+  # Strip CRs so a middlebox emitting \r\n line endings can't make the
+  # callers' guards fail on an invisible character (a raw CR is not valid
+  # inside JSON strings, so this is lossless).
+  status=${status//$'\r'/}
+  body=${body//$'\r'/}
+  # Fail closed: anything other than a literal 2xx status line (including
+  # an empty or non-numeric one) is an error.
+  if ! [[ "$status" =~ ^2[0-9]{2}$ ]]; then
+    echo "ERROR: XNAT request failed with HTTP $status" >&2
+    echo "  args: $(scrub_args "$@")" >&2
+    echo "  body: $body" >&2
+    return 1
+  fi
+  if [[ -n "$body" ]]; then
+    printf '%s\n' "$body"
+  fi
+}
 
 # Idempotency short-circuit: if XNAT is already initialized AND the initial
 # admin password no longer authenticates, this instance was fully configured
 # by a prior run. Re-running the rest of the script would silently 401 on the
 # initial-password curls and then produce duplicate-key errors for the service
 # account, PACS registration, and PACS availability intervals — so skip it.
+# NOTE: when the configured admin password equals the initial one (the dev
+# kits do this), this can never fire and the whole script re-runs on every
+# `make up-trust` — so the conflict-prone calls below (service account, PACS
+# registration, availability intervals) carry their own already-configured
+# guards instead of relying on this short-circuit.
+# (These probes check status codes explicitly — a non-200 here is a signal,
+# not an error, so they intentionally stay bare curl rather than xnat_curl.)
 init_pw_status=$(curl -s -o /dev/null -w '%{http_code}' \
   -u "${XNAT_ADMIN_USER}:${XNAT_ADMIN_INITIAL_PASSWORD}" \
   "$XNAT_URL/xapi/siteConfig/initialized")
@@ -56,21 +142,24 @@ sleep 10 # Additional wait to ensure XNAT is fully up before proceeding
 
 # Activate XNAT instance
 echo "Activating XNAT instance..."
-curl -s -X POST "$XNAT_URL/xapi/siteConfig" \
+xnat_curl -X POST "$XNAT_URL/xapi/siteConfig" \
   -u "${XNAT_ADMIN_USER}:${XNAT_ADMIN_INITIAL_PASSWORD}" \
   -H "Content-Type: application/json" \
   -d '{"initialized": true}'
 
 # Change admin password
 echo "Changing admin password..."
-curl -s -X PUT "$XNAT_URL/xapi/users/admin" \
+xnat_curl -X PUT "$XNAT_URL/xapi/users/admin" \
   -u "${XNAT_ADMIN_USER}:${XNAT_ADMIN_INITIAL_PASSWORD}" \
   -H "Content-Type: application/json" \
   -d "{\"username\": \"${XNAT_ADMIN_USER}\", \"password\": \"${XNAT_ADMIN_PASSWORD}\"}"
 
-# Create service account
+# Create service account. Tolerates the 409 XNAT returns when the account
+# already exists (re-run on an already-configured instance — see the
+# idempotency note above); anything else non-2xx fails the deploy.
 echo "Creating service account..."
-curl -s -X POST "$XNAT_URL/xapi/users" \
+create_user_status=$(curl -s -o /tmp/create-user-response.json --connect-timeout 10 --max-time 120 \
+  -w '%{http_code}' -X POST "$XNAT_URL/xapi/users" \
   -u "${XNAT_ADMIN_USER}:${XNAT_ADMIN_PASSWORD}" \
   -H "Content-Type: application/json" \
   -d "{
@@ -79,7 +168,16 @@ curl -s -X POST "$XNAT_URL/xapi/users" \
     \"firstName\": \"flip Service Account\",
     \"lastName\": \"flip Service Account\",
     \"email\": \"xnat@example.com\"
-  }"
+  }") || create_user_status="000"
+if [[ "$create_user_status" == 2* ]]; then
+  echo "Service account created."
+elif [[ "$create_user_status" == "409" ]]; then
+  echo "Service account already exists (HTTP 409) — leaving as-is."
+else
+  echo "ERROR: creating service account failed (HTTP $create_user_status)" >&2
+  cat /tmp/create-user-response.json >&2 || true
+  exit 1
+fi
 
 # Add ContainerManager role to admin user
 # NOTE This was added when the ContainerManager role was introduced in Container Service 3.7.0 (see
@@ -87,21 +185,21 @@ curl -s -X POST "$XNAT_URL/xapi/users" \
 # https://wiki.xnat.org/container-service/container-service-administration#ContainerServiceAdministration-EnablingaContainerManager
 echo " "
 echo "Assigning role 'ContainerManager' to admin account..."
-curl -s -X PUT "$XNAT_URL/xapi/users/${XNAT_ADMIN_USER}/roles/ContainerManager" \
+xnat_curl -X PUT "$XNAT_URL/xapi/users/${XNAT_ADMIN_USER}/roles/ContainerManager" \
   -u "${XNAT_ADMIN_USER}:${XNAT_ADMIN_PASSWORD}" \
   -H "accept: application/json"
 
 # Assign roles to service account (including 'ContainerManager' role)
 echo " "
 echo "Assigning roles to service account..."
-curl -s -X PUT "$XNAT_URL/xapi/users/${XNAT_SERVICE_USER}/groups/" \
+xnat_curl -X PUT "$XNAT_URL/xapi/users/${XNAT_SERVICE_USER}/groups/" \
   -u "${XNAT_ADMIN_USER}:${XNAT_ADMIN_PASSWORD}" \
   -H "Content-Type: application/json" \
   -d '[
     "ALL_DATA_ADMIN"
   ]'
 
-curl -s -X PUT "$XNAT_URL/xapi/users/${XNAT_SERVICE_USER}/roles/" \
+xnat_curl -X PUT "$XNAT_URL/xapi/users/${XNAT_SERVICE_USER}/roles/" \
   -u "${XNAT_ADMIN_USER}:${XNAT_ADMIN_PASSWORD}" \
   -H "Content-Type: application/json" \
   -d '[
@@ -116,12 +214,12 @@ curl -s -X PUT "$XNAT_URL/xapi/users/${XNAT_SERVICE_USER}/roles/" \
 # Disable guest account
 echo " "
 echo "Disabling guest account..."
-curl -s -X PUT "$XNAT_URL/xapi/users/guest/enabled/false" \
+xnat_curl -X PUT "$XNAT_URL/xapi/users/guest/enabled/false" \
   -u "${XNAT_ADMIN_USER}:${XNAT_ADMIN_PASSWORD}"
 
 # Configure DQR plugin
 echo "Configuring DQR plugin..."
-curl -s -X POST "$XNAT_URL/xapi/dqr/settings" \
+xnat_curl -X POST "$XNAT_URL/xapi/dqr/settings" \
   -u "${XNAT_ADMIN_USER}:${XNAT_ADMIN_PASSWORD}" \
   -H "Content-Type: application/json" \
   -d '{
@@ -138,20 +236,20 @@ curl -s -X POST "$XNAT_URL/xapi/dqr/settings" \
 
 # Configure site-wide anonymization script
 echo "Configuring site-wide anonymization script..."
-curl -s -X PUT "$XNAT_URL/xapi/anonymize/site" \
+xnat_curl -X PUT "$XNAT_URL/xapi/anonymize/site" \
   -u "${XNAT_ADMIN_USER}:${XNAT_ADMIN_PASSWORD}" \
   -H "Content-Type: text/plain" \
   --data-binary @anon_script.das
 
 # Enable site-wide anonymization
 echo "Enabling site-wide anonymization..."
-curl -s -X PUT "$XNAT_URL/xapi/anonymize/site/enabled" \
+xnat_curl -X PUT "$XNAT_URL/xapi/anonymize/site/enabled" \
   -u "${XNAT_ADMIN_USER}:${XNAT_ADMIN_PASSWORD}" \
   -H "Content-Type: application/json" \
   -d 'true'
 
 # Get SCP receivers
-response=$(curl -s -u "$XNAT_ADMIN_USER:$XNAT_ADMIN_PASSWORD" "$XNAT_URL/xapi/dicomscp")
+response=$(xnat_curl -u "$XNAT_ADMIN_USER:$XNAT_ADMIN_PASSWORD" "$XNAT_URL/xapi/dicomscp")
 
 # Debug: Print Raw Response
 echo "Raw API Response: $response"
@@ -172,7 +270,7 @@ else
             echo "Removing SCP Receiver with ID: $scp_receiver_id..."
 
             # Send DELETE request to remove the SCP receiver
-            delete_response=$(curl -s -u "$XNAT_ADMIN_USER:$XNAT_ADMIN_PASSWORD" -X DELETE "$XNAT_URL/xapi/dicomscp/$scp_receiver_id")
+            delete_response=$(xnat_curl -u "$XNAT_ADMIN_USER:$XNAT_ADMIN_PASSWORD" -X DELETE "$XNAT_URL/xapi/dicomscp/$scp_receiver_id")
 
             echo "Delete Response: $delete_response"
             echo "SCP Receiver removed successfully."
@@ -186,7 +284,7 @@ fi
 
 # Configure SCP receiver to have dqrObjectIdentifier as the identifier (the default is not)
 echo "Configuring SCP receiver..."
-curl -s -X POST "$XNAT_URL/xapi/dicomscp" \
+xnat_curl -X POST "$XNAT_URL/xapi/dicomscp" \
   -u "${XNAT_ADMIN_USER}:${XNAT_ADMIN_PASSWORD}" \
   -H "Content-Type: application/json" \
   -d "{
@@ -207,34 +305,53 @@ curl -s -X POST "$XNAT_URL/xapi/dicomscp" \
 
 # Configure OHIF viewer
 echo "Configuring OHIF viewer..."
-curl -s -X POST "$XNAT_URL/xapi/siteConfig" \
+xnat_curl -X POST "$XNAT_URL/xapi/siteConfig" \
   -u "${XNAT_ADMIN_USER}:${XNAT_ADMIN_PASSWORD}" \
   -H "Content-Type: application/json" \
   -d '{"addOhifViewLinkToProjectListingDefaults": true }'
 
 # Register PACS
-echo "Registering PACS..."
-curl -s -X POST "$XNAT_URL/xapi/pacs" \
-  -u "${XNAT_ADMIN_USER}:${XNAT_ADMIN_PASSWORD}" \
-  -H "Content-Type: application/json" \
-  -d "{
-    \"aeTitle\": \"${ORTHANC_AETITLE}\",
-    \"defaultQueryRetrievePacs\": true,
-    \"defaultStoragePacs\": true,
-    \"host\": \"${ORTHANC_HOST}\",
-    \"label\": \"Test PACS instance\",
-    \"ormStrategySpringBeanId\": \"dicomOrmStrategy\",
-    \"queryRetrievePort\": ${PACS_DICOM_PORT},
-    \"queryable\": true,
-    \"storable\": true,
-    \"supportsExtendedNegotiations\": true
-  }"
+# queryRetrievePort is the port XNAT dials Orthanc on over the Docker network
+# (the "host" below is the orthanc service name), so Orthanc's fixed container
+# port 4242 is the only correct value. The old ${PACS_DICOM_PORT} indirection
+# was nominally the *host-published* DICOM port — its "${PACS_DICOM_PORT}:4242"
+# mappings are commented out in every compose file — so a kit setting it to
+# anything but 4242 silently broke registration (FLIP#822 / FLIP#862).
+# Check-then-create: a duplicate registration surfaces as an unspecific 500
+# (DB unique-constraint violation), so re-run idempotency is a lookup by
+# aeTitle rather than a tolerated status code.
+existing_pacs=$(xnat_curl -u "${XNAT_ADMIN_USER}:${XNAT_ADMIN_PASSWORD}" "$XNAT_URL/xapi/pacs")
+if printf '%s' "$existing_pacs" | grep -q "\"aeTitle\":\"${ORTHANC_AETITLE}\""; then
+  echo "PACS '${ORTHANC_AETITLE}' already registered — leaving as-is."
+else
+  echo "Registering PACS..."
+  xnat_curl -X POST "$XNAT_URL/xapi/pacs" \
+    -u "${XNAT_ADMIN_USER}:${XNAT_ADMIN_PASSWORD}" \
+    -H "Content-Type: application/json" \
+    -d "{
+      \"aeTitle\": \"${ORTHANC_AETITLE}\",
+      \"defaultQueryRetrievePacs\": true,
+      \"defaultStoragePacs\": true,
+      \"host\": \"${ORTHANC_HOST}\",
+      \"label\": \"Test PACS instance\",
+      \"ormStrategySpringBeanId\": \"dicomOrmStrategy\",
+      \"queryRetrievePort\": 4242,
+      \"queryable\": true,
+      \"storable\": true,
+      \"supportsExtendedNegotiations\": true
+    }"
+fi
 
-# Configure PACS availability schedule (all days)
-# Not sure if the below is working or is just returning the default configuration
+# Configure PACS availability schedule (all days). DQR appears to pre-create
+# availability intervals when the PACS is registered: on XNAT 1.10 + DQR 3.0.0
+# this POST returns 400 "probable overlap with existing interval" for an
+# already-scheduled day, so 400 is treated as "already configured" rather than
+# a failure. Anything else non-2xx is a real error and fails the deploy.
 for DAY in MONDAY TUESDAY WEDNESDAY THURSDAY FRIDAY SATURDAY SUNDAY; do
   echo "Setting PACS availability for $DAY..."
-  curl -s -X POST "$XNAT_URL/xapi/pacs/1/availability" \
+  avail_body=/tmp/pacs-availability-response.json
+  avail_status=$(curl -s -o "$avail_body" --connect-timeout 10 --max-time 120 -w '%{http_code}' \
+    -X POST "$XNAT_URL/xapi/pacs/1/availability" \
     -u "${XNAT_ADMIN_USER}:${XNAT_ADMIN_PASSWORD}" \
     -H "Content-Type: application/json" \
     -d "{
@@ -246,7 +363,16 @@ for DAY in MONDAY TUESDAY WEDNESDAY THURSDAY FRIDAY SATURDAY SUNDAY; do
       \"pacsId\": 1,
       \"threads\": 1,
       \"utilizationPercent\": 100
-    }"
+    }") || avail_status="000"
+  if [[ "$avail_status" == 2* ]]; then
+    continue
+  elif [[ "$avail_status" == "400" ]]; then
+    echo "  Availability interval for $DAY already exists (HTTP 400 overlap) — leaving as-is."
+  else
+    echo "ERROR: setting PACS availability for $DAY failed (HTTP $avail_status)" >&2
+    cat "$avail_body" >&2 || true
+    exit 1
+  fi
 done
 
 echo "XNAT configuration complete!"


### PR DESCRIPTION
# Description

Follow-up to the PR #822 review round, which fixed one trigger of a silent XNAT PACS registration failure but left the silence itself in place. Hardens **both** deployments that configure XNAT — the Compose/Swarm `configure-xnat.sh` and the Kubernetes chart's `xnat-init-job.yaml`.

## Compose / Swarm — `configure-xnat.sh`

Every XNAT configuration call in `configure-xnat.sh` was a bare `curl -s`, which exits 0 on HTTP errors — a rejected call silently skipped that configuration step. This PR ports the `xnat_curl()` fail-loud helper from the sibling `configure-dcm2niix.sh` (2xx-or-abort, transport-failure handling, bounded wait-for-XNAT) and applies it to every configuration call, so a rejected call now aborts the deploy with the HTTP status and response body. Failure output scrubs the values following `-u`/`-d`/`--data-binary`, so credentials and password-bearing payloads never reach the tee'd configure log.

It also removes the `PACS_DICOM_PORT` trap: the `/xapi/pacs` registration now uses Orthanc's fixed container port `4242` directly. XNAT dials Orthanc by Docker-network service name, so the container port is the only correct value — the variable was nominally the *host-published* DICOM port (its `"${PACS_DICOM_PORT}:4242"` mappings are commented out in every compose file), and any kit setting it to anything else silently broke registration. Required env vars are also guarded with `:?` (empty-var-into-JSON is the #822 failure mode generalised).

Making the script strict surfaced a real behaviour: the idempotency short-circuit never fires when the admin password equals the initial one (the dev kits do this), so the script fully re-runs on every `make up-trust` and previously "worked" only because duplicate-key errors were silent. The conflict-prone calls now carry explicit already-configured guards:

- service-account creation tolerates XNAT's specific 409 ("resource … already exists");
- PACS registration is check-then-create by aeTitle (a duplicate registration surfaces as an unspecific 500 DB-constraint error, so a status-code tolerance would mask real failures);
- availability intervals tolerate the 400 "probable overlap with existing interval" that DQR returns for already-scheduled days (observed on XNAT 1.10 + DQR 3.0.0 — DQR appears to pre-create intervals at PACS registration, which also explains the old "not sure if this is working" comment).

## Kubernetes — `xnat-init-job.yaml`

Originally left as a follow-up. Testing showed the gap was not cosmetic: **the chart does not use `configure-xnat.sh` at all** — it configures XNAT from its own inline scripts, where every call was `curl … || true` — so the Compose-side fix reached none of the Kubernetes deployment. (The chart also ships a second, unused copy of a `configure-xnat.sh` in an `-xnat-scripts` ConfigMap that no pod mounts.) This PR brings it to parity:

- the same `xnat_curl` wrapper (2xx-or-abort, secrets/JSESSIONID scrubbed) in the `configure-xnat-web` and `configure-dcm2niix` containers;
- both readiness loops now actually wait. `set -e` aborts on a failing command substitution, so the first probe against a still-booting Tomcat killed the container — **no cold `helm install` with `xnat.enabled=true` could succeed**. Each loop now also fails loudly on timeout instead of falling through into an opaque downstream error;
- the same idempotency guards as the Compose script (PACS check-then-create, 400-overlap tolerated).

**This surfaced a real bug the silence was hiding.** The chart never granted the admin account the `ContainerManager` role, which Container Service ≥ 3.7.0 requires for `/xapi/docker/server` and `/xapi/commands` (the Compose script has always granted it). Both calls returned 401/403 and, being `|| true`, the Job still exited **0 with dcm2niix silently unregistered** — i.e. a "successfully configured" Kubernetes trust with no DICOM→NIfTI conversion, which would surface much later as `num_samples=0` at training. Verified it was authorization and not a race: `/xapi/siteConfig` returned 200 with the same credentials while `/xapi/docker/server` failed. The role is now granted, `configure-dcm2niix` waits for it, and the failure modes are loud. Documented in `deploy/providers/kubernetes/TROUBLESHOOTING.md` §2.3a with a repair recipe for clusters configured by an older chart.

## Linked Issues

Closes #862. Sibling follow-up from the same review round: #863 (drop the orthanc compat caps once all trusts run the non-root image).

## Checklist

- [x] Follows the project's coding conventions and style guide
- [x] Updates documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Type of Change

- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [x] In-line docstrings updated.
- [x] Documentation updated (`trust/xnat/README.md`, `deploy/providers/kubernetes/TROUBLESHOOTING.md`).

## Testing

### Compose / Swarm — fresh bring-up (the former draft blocker) ✅

Both dev trusts torn down, data dirs wiped and rebuilt from this branch, so `configure-xnat.sh` ran **first-configuration against a virgin XNAT** (not just re-run mode):

- `make up-xnat KIT=GSTT` — exit 0. Site activated, admin password rotated, service account created, PACS registered with `queryRetrievePort: 4242`, DQR-aware `dqrObjectIdentifier` SCP receiver installed, site anonymisation enabled, all 7 availability days accepted, dcm2niix registered and validated.
- `make up-xnat KIT=KCH` — exit 0, same result.
- **Re-run** on the already-configured GSTT instance — exit 0 with every idempotency guard firing: `Service account already exists (HTTP 409)`, `PACS 'ORTHANC' already registered`, and `Availability interval for <DAY> already exists (HTTP 400 overlap)` ×7.

The strictness caught a genuine fault during this run: with an empty bind-mounted `plugins/` directory shadowing the image's baked plugins, XNAT came up with **no DQR plugin** and the script aborted on `POST /xapi/dqr/settings` → 404. The old `curl -s` would have reported "XNAT configuration complete!" on an XNAT that cannot pull DICOM at all — exactly the failure class this PR is about.

### End-to-end smoke through the freshly configured XNATs ✅

`make e2e_smoke` run on **both FL backends** against both trusts, through the XNATs configured by this branch's script:

| Backend | Result | Model | Final status |
| --- | --- | --- | --- |
| Flower | **PASS** (exit 0) | `0c070b3a` | `RESULTS_UPLOADED` + artefact downloaded |
| NVFLARE | **PASS** (exit 0) | `38dc76b3` | `RESULTS_UPLOADED` + artefact downloaded |

Both ran on project `b6ee092c`: cohort returned from GSTT + KCH, model uploaded and scanned, DICOM pull completed **300/300 studies on both trusts**, federated training converged, results uploaded and downloaded. The NVFLARE leg reused the same project via `--project-id`, so the pull was not repeated (backend switched with `make restart-fl FL_BACKEND=nvflare`).

The pull is the part that depends on this PR: it exercises the PACS registration on port 4242, the DQR-aware `dqrObjectIdentifier` receiver and `directArchive`, all written by this script onto a wiped XNAT.

### Kubernetes — verified live on kind ✅

Chart installed with `xnat.enabled=true` (which CI does not exercise — `ci/test-values.yaml` sets it `false`):

- **cold `helm install`** succeeds with the init job as a real post-install hook (impossible before the readiness-loop fix);
- **`helm upgrade`** re-fires the hook idempotently (REVISION 2, "Upgrade complete");
- resulting XNAT probed directly rather than trusting the Job's exit code: admin roles include `ContainerManager`, PACS `ORTHANC` on host `orthanc` port `4242`, SCP receiver `dqrObjectIdentifier` with `customProcessing`/`directArchive`/anon, `dcm2niix` command registered with the `dcm2niix-scan` wrapper, Container Service backend registered, site initialised, anonymisation enabled, DQR settings applied;
- `helm lint` clean, chart tests pass (11 passed).

### Static ✅

`bash -n` + `shellcheck -S warning` clean on `configure-xnat.sh`. `shellcheck -s sh` clean on both rendered init-job scripts (only pre-existing `local`/`pipefail` POSIX-strictness notes, both supported by busybox ash). Helper semantics proven in `alpine:3.20`/busybox ash: 2xx returns the body, non-2xx and transport failures return non-zero and abort at the call site under `set -e`, and credentials, payloads and JSESSIONIDs are redacted from error output.

## Additional Notes

- Deliberately **not** touching `trust/xnat/docker-compose-stack.yml` (the now-inert `PACS_DICOM_PORT` env plumbing) — #822 edits that exact line, and changing it here would conflict. Once #822 merges, the env entry and the commented-out host port mappings can be dropped in a tiny cleanup (noted on #862).
- **Conflict warning:** this branch's activation `POST /xapi/siteConfig` sends only `{"initialized": true}`. PR #849 edits that exact call to also set `siteUrl` (its XNAT 1.10 regression fix). Whichever lands second will need a manual merge of that hunk.
- The re-run path still deletes + recreates the XNAT SCP receiver each time — pre-existing behaviour, unchanged.
- Unrelated pre-existing issue seen while testing on kind: the chart's `imaging-import-worker` crashloops (exit 100) with every diagnostic sent to `/dev/null`, so the cause is unobservable. Not touched here; worth its own issue.

## Acceptance Criteria

*Imported from issue #862*

- [x] `configure-xnat.sh` fails loudly (non-zero exit, status + response body on stderr) when an XNAT configuration call returns a non-2xx response, instead of continuing silently.
- [x] The `/xapi/pacs` registration uses Orthanc's fixed container port 4242 directly, removing the `PACS_DICOM_PORT` indirection from the script.
- [x] The wait-for-XNAT loop is wall-clock bounded (matching `configure-dcm2niix.sh`) instead of printing dots forever against a dead XNAT.
- [x] The PACS availability-interval loop tolerates XNAT's 400 "probable overlap with existing interval" response (observed on XNAT 1.10 + DQR 3.0.0 — DQR appears to pre-create intervals) without failing the deploy.
- [x] A fresh XNAT bring-up (`make -C trust/xnat up`) completes with the hardened script.
