### PR TITLE
fix(tests): stop alembic's fileConfig disabling the application logger

### DIFF
--- a/flip-api/src/flip_api/db/migrations/env.py
+++ b/flip-api/src/flip_api/db/migrations/env.py
@@ -42,7 +42,13 @@ import flip_api.db.models.user_models  # noqa: F401
 config = context.config
 
 if config.config_file_name is not None:
-    fileConfig(config.config_file_name)
+    # disable_existing_loggers=False is load-bearing: the default (True) disables
+    # every logger not declared in alembic.ini, including the app's own "uvicorn"
+    # logger. Harmless for the entrypoint's `alembic upgrade head`, which is its
+    # own process, but the integration tests run Alembic in-process — so the
+    # default silently muted application logging for the rest of the session and
+    # every later caplog assertion saw an empty log.
+    fileConfig(config.config_file_name, disable_existing_loggers=False)
 
 target_metadata = SQLModel.metadata
 

--- a/flip-api/tests/integration/test_migrations.py
+++ b/flip-api/tests/integration/test_migrations.py
@@ -86,6 +86,26 @@ def test_upgrade_head_on_empty_db_reaches_head(empty_db_engine: Engine) -> None:
         assert current == _script_head(connection)
 
 
+def test_running_migrations_does_not_disable_application_logging(empty_db_engine: Engine) -> None:
+    """Running Alembic in-process must leave the app's logger enabled.
+
+    ``migrations/env.py`` calls ``logging.config.fileConfig``, whose default
+    ``disable_existing_loggers=True`` sets ``disabled = True`` on every logger
+    absent from ``alembic.ini`` — including the "uvicorn" logger the app logs
+    through. Production is unaffected (the entrypoint runs ``alembic upgrade
+    head`` as its own process), but in-process runs poison logging for the rest
+    of the interpreter: the logger emits nothing, so every later ``caplog``
+    assertion sees an empty log and fails for reasons unrelated to its subject.
+    """
+    from flip_api.utils.logger import logger
+
+    with empty_db_engine.connect() as connection:
+        command.upgrade(make_alembic_config(connection), "head")
+
+    assert logger.disabled is False, "alembic's fileConfig disabled the application logger"
+    assert logger.propagate is True, "the application logger no longer propagates to root (caplog cannot see it)"
+
+
 def test_no_drift_between_models_and_migrations(empty_db_engine: Engine) -> None:
     """Drift guard: the migrations reproduce ``SQLModel.metadata`` with no diff.
 

--- a/flip-api/tests/integration/test_migrations.py
+++ b/flip-api/tests/integration/test_migrations.py
@@ -96,6 +96,13 @@ def test_running_migrations_does_not_disable_application_logging(empty_db_engine
     head`` as its own process), but in-process runs poison logging for the rest
     of the interpreter: the logger emits nothing, so every later ``caplog``
     assertion sees an empty log and fails for reasons unrelated to its subject.
+
+    The regression pinned here is ``logger.disabled`` — that flag alone is what
+    ``disable_existing_loggers`` moves, and reverting the fix fails on it. The
+    ``logger.propagate`` assertion is a general safety check, not part of this
+    regression: ``fileConfig`` never touches ``propagate``, but detaching the
+    logger from root would blind ``caplog`` just as completely, so both routes
+    to an empty ``caplog`` are covered rather than only the one we hit.
     """
     from flip_api.utils.logger import logger
 


### PR DESCRIPTION
# Description

`make -C flip-api local_test` (and `make test`) fail **24 tests on a clean `develop`**, every one of which passes when run on its own. All 24 assert on `caplog`, and in each the captured log is empty.

## Cause

`src/flip_api/db/migrations/env.py` calls `logging.config.fileConfig(config.config_file_name)`. `fileConfig` defaults to **`disable_existing_loggers=True`**, which sets `disabled = True` on every logger not declared in `alembic.ini` — including `"uvicorn"`, the logger the entire app logs through (`flip_api/utils/logger.py`).

The integration tests run Alembic **in-process** (`command.upgrade(...)` from `tests/integration/conftest.py`), so from the first integration test onward the application logger is silently muted for the rest of the interpreter, and every later `caplog` assertion sees `''`.

Reduced to two lines:

```python
>>> from flip_api.utils.logger import logger; from logging.config import fileConfig
>>> logger.disabled
False
>>> fileConfig('alembic.ini'); logger.disabled
True
```

This is why it looks like flakiness but is not: `pytest tests/unit` alone never touches Alembic and passes 1440/1440, while the full run is *deterministically* red. The failing tests are innocent — bisecting showed every file under `tests/integration/` triggers it, i.e. the shared conftest, not any one test.

## Production impact: none

`entrypoint.sh:45` runs `uv run alembic upgrade head` as its **own process** before uvicorn starts, so the muted logger dies with that process. Nothing runs Alembic inside the API process, so application logging in dev/stag/prod was never affected. This is a test-environment defect only — but a corrosive one, since it makes any `caplog`-based test unreliable and trains people to ignore a red suite.

## Change

- `disable_existing_loggers=False` in `migrations/env.py`, with a comment explaining why it is load-bearing.
- A regression test in `tests/integration/test_migrations.py` asserting that after a real `upgrade head` the application logger is neither `disabled` nor detached from root propagation — the two ways `caplog` can be blinded.

## Linked Issues

**No pre-existing issue.** This was found opportunistically while verifying an unrelated PR (#444) — the red suite there turned out to be pre-existing on `develop` and unrelated to that change. Rather than file a tracker for a two-file fix that was already diagnosed and fixed in the same sitting, the diagnosis is written up in full above so it is searchable from the PR.

## Checklist

- [x] Follows the project's coding conventions and style guide
- [ ] Updates documentation — n/a, no user- or operator-facing behaviour changes (test-environment defect; no env vars, endpoints, or workflows touched)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published — none; this is self-contained

## Type of Change

- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [x] In-line docstrings updated.
- [ ] Documentation updated, tested `make -C docs/ docs`. — n/a, see above

## Testing

I did the following tests to verify my changes:

- [x] Quick tests passed locally by running `make -C flip-api unit_test` (covered by the `local_test` run below).
- [x] Integration tests pass by running `make -C flip-api integration_test` (covered by the `local_test` run below).

Detail:

- [x] `make -C flip-api local_test` — **1553 passed**, ruff + mypy clean (clean `develop` collects 1552: 24 failed, 1528 passed; this PR adds one test, hence 1553)
- [x] `uv run pytest tests/integration/test_migrations.py` — 5 passed
- [x] Mutation-checked: reverting the one-argument fix fails the new regression test, confirming it actually pins the behaviour rather than passing vacuously
- [x] Root cause reproduced directly in a REPL (above), not inferred from the failure pattern

## Additional Notes

Reviewers can reproduce the original failure on `develop` with `make -C flip-api local_test` (24 failures, all `caplog`-based), then confirm each of those tests passes in isolation — the ordering dependence is the tell.

Review round (@garciadias): the regression test's docstring is now explicit that `logger.disabled` is the pinned regression and `logger.propagate` is a general safety check — `fileConfig` never touches `propagate`, and the old wording implied otherwise. Docstring-only; no behaviour change.
