### PR TITLE
[Docs]: Stop the FL app docs restating what the repository already declares

### DIFF
--- a/docs/source/components/component-fl-nodes.rst
+++ b/docs/source/components/component-fl-nodes.rst
@@ -29,13 +29,16 @@ Due to security restrictions, FLIP users are not allowed to control what happens
 Although most adjustable aspects of machine learning training happen on the client side 
 (e.g. dataloading, training loop, model architecture), FLIP provides different job types
 that the user can choose based on their needs.
-Currently, these job types include federated averaging (job type `standard`),
-evaluation task (job type `evaluation`), federated optimisation (job type `fed_opt`)
-and diffusion model training (job type `diffusion_model`), which covers multi-stage federated training.
-For NVFLARE, three further job types drive the client code through the modern **NVFLARE Client API**
+Which job types are available depends on the backend.
+**Both backends** offer federated averaging (job type `standard`) and an evaluation task
+(job type `evaluation`) — for a Flower app, those two are the whole set.
+**NVFLARE** adds federated optimisation (job type `fed_opt`) and diffusion model training
+(job type `diffusion_model`), which covers multi-stage federated training, along with three further
+job types that drive the client code through the modern **NVFLARE Client API**
 (a plain training/evaluation script using ``nvflare.client`` instead of a class-based ``Executor``):
 federated averaging (job type `standard_client_api`), model evaluation (job type `evaluation_client_api`)
 and two-stage diffusion model training (job type `diffusion_model_client_api`).
+The manifests under :ref:`fl-required-files` are the authoritative list for each backend.
 More job types will be added in the future, adjusting to the community's needs.
 
 **How to choose a job type?**
@@ -56,9 +59,7 @@ Then, the Central Hub API will take care of bundling together:
 - The static (non-modifiable) files that are required for the specific job type.
 
 For more information about currently supported apps, see the per-job-type implementations under
-`fl-apps/ <https://github.com/londonaicentre/FLIP/tree/develop/fl-apps/nvflare>`_ (``standard``, ``evaluation``,
-``diffusion_model``, ``fed_opt``, ``standard_client_api``, ``evaluation_client_api``,
-``diffusion_model_client_api``).
+`fl-apps/ <https://github.com/londonaicentre/FLIP/tree/develop/fl-apps>`_.
 
 Examples of how the same job type (standard -> federated averaging) can run different user-uploaded applications are:
 

--- a/docs/source/components/component-fl-nodes.rst
+++ b/docs/source/components/component-fl-nodes.rst
@@ -94,54 +94,29 @@ Required files per job type
 Each job type declares its own set of required files. A submission missing any of them is rejected
 before anything is shipped to a Trust, with a message naming the missing files.
 
-The lists below are reproduced from the manifests in the repository
-(``fl-apps/<backend>/<job_type>/required_files.json``, aggregated into
-``fl-apps/<backend>/required_files.json``), which are the source of truth. The FLIP UI reads the
-same manifests through the ``/model/job-types`` endpoint and shows the applicable list on the model
-page — so the UI, not this table, is what to trust if the two ever disagree.
+The manifests that decide this are included below **directly from the repository** rather than
+transcribed, so this page cannot fall out of step with the platform. Each key is a job type and its
+array is the exact set of files that job type requires.
 
-**NVFLARE job types**
+Each backend's manifest is generated from the per-template
+``fl-apps/<backend>/<job_type>/required_files.json`` files by ``fl-apps/check_required_files.sh``,
+which runs as a pre-commit hook and is enforced in CI — so adding a job type or changing its
+required set updates this page as a side effect of the change itself. The FLIP UI reads the same
+manifests through the ``/model/job-types`` endpoint and shows the applicable list on the model page.
 
-.. list-table::
-   :header-rows: 1
-   :widths: 32 68
+.. literalinclude:: ../../../fl-apps/nvflare/required_files.json
+   :language: json
+   :caption: ``fl-apps/nvflare/required_files.json`` — required files per NVFLARE job type
 
-   * - Job type
-     - Required files
-   * - ``standard``
-     - ``trainer.py``, ``validator.py``, ``models.py``, ``config.json``
-   * - ``standard_client_api``
-     - ``trainer.py``, ``models.py``, ``config.json`` (no ``validator.py`` — the Client API script
-       does its own validation)
-   * - ``fed_opt``
-     - ``trainer.py``, ``validator.py``, ``models.py``, ``config.json``
-   * - ``diffusion_model``
-     - ``trainer.py``, ``validator.py``, ``models.py``, ``config.json``
-   * - ``diffusion_model_client_api``
-     - ``trainer.py``, ``validator.py``, ``models.py``, ``config.json``
-   * - ``evaluation``
-     - ``evaluator.py``, ``config.json``
-   * - ``evaluation_client_api``
-     - ``evaluator.py``, ``models.py``, ``config.json``
-
-**Flower job types**
-
-.. list-table::
-   :header-rows: 1
-   :widths: 32 68
-
-   * - Job type
-     - Required files
-   * - ``standard``
-     - ``client_app.py``, ``models.py``
-   * - ``evaluation``
-     - ``client_app.py``, ``models.py``
+.. literalinclude:: ../../../fl-apps/flower/required_files.json
+   :language: json
+   :caption: ``fl-apps/flower/required_files.json`` — required files per Flower job type
 
 .. note::
 
-   ``config.json`` is a required file for every NVFLARE job type, because it carries ``job_type``
-   along with the training configuration below. It is *not* required for Flower job types, but
-   uploading one is still how a Flower app selects a job type other than ``standard``.
+   Every NVFLARE job type lists ``config.json``, which carries ``job_type`` along with the training
+   configuration below. The Flower job types do not require it, but uploading one is still how a
+   Flower app selects a job type other than ``standard``.
 
    ``pyproject.toml`` is **not** a file the researcher supplies for a Flower app. It is part of the
    platform's base template for the job type and is bundled automatically; a ``pyproject.toml``

--- a/docs/source/working-with-flip-apps/package-model-as-map.rst
+++ b/docs/source/working-with-flip-apps/package-model-as-map.rst
@@ -669,32 +669,50 @@ What FLIP actually validates in ``config.json``
 ================================================
 
 It is worth being explicit about this, because it is easy to assume more checking happens than
-does.
+does — and because the checking that *does* happen is split across two services, at two different
+moments.
 
-**FLIP reads exactly one key out of** ``config.json`` **:** ``job_type``. The Central Hub API
-opens the uploaded ``config.json`` solely to determine which base application template to bundle
-(``flip-api/src/flip_api/fl_services/services/fl_service.py:466-486``), and validates that value
-against the per-backend manifest of known job types
-(``fl_service.py:483-484``). An unrecognised ``job_type`` is rejected; a missing one falls back to
-``standard``.
+**The Central Hub API reads exactly one key:** ``job_type``. It opens the uploaded ``config.json``
+solely to decide which base application template to bundle, and validates that value against the
+per-backend manifest of known job types (``bundle_nvflare_application`` /
+``bundle_flower_application`` in ``flip-api/src/flip_api/fl_services/services/fl_service.py``). An
+unrecognised ``job_type`` is rejected; a missing one falls back to ``standard`` — as does a missing
+``config.json``, which is a valid submission for a Flower app.
 
-**Everything else in** ``config.json`` **is unvalidated.** ``LOCAL_ROUNDS``, ``LEARNING_RATE``,
-``VAL_SPLIT``, ``net_config`` and any other key are read only by your own trainer, validator and
-``models.py`` at runtime. There is no schema, no type checking and no required-key check. In the
-shipped NVFLARE tutorials only three of six declare ``LOCAL_ROUNDS`` and only two declare
-``LEARNING_RATE`` — both are conventions of particular apps, not platform requirements.
+**For NVFLARE, the FL API then validates a fixed set of platform keys** when it assembles the job
+(``validate_config`` in ``fl-services/nvflare/fl-api-base/fl_api/utils/prepare_config.py``). Several
+of those failures are hard rejections that stop the job rather than silent fallbacks: an unknown
+``AGGREGATOR``, an ``AGGREGATION_WEIGHTS`` weight outside 0–1, an uncompilable
+``AGGREGATE_ONLY_REGEX``, or ``BEST_MODEL_METRIC`` on a job that runs a single round. The full set,
+with accepted values and defaults, is documented under :ref:`fl-training-configuration`.
 
-**What *is* enforced is file presence.** Each job type declares a required file list in
-``fl-apps/<backend>/<job_type>/required_files.json``, and a submission missing any of them fails
-fast with ``FileNotFoundError`` before anything is uploaded
-(``fl_service.py:517-523``). The required set differs per job type — ``standard`` requires
-``trainer.py``, ``validator.py``, ``config.json`` and ``models.py``, while
-``standard_client_api`` does not require ``validator.py``.
+**Everything outside that set is passed through untouched**, for your own trainer, validator and
+``models.py`` to read at runtime. ``LEARNING_RATE``, ``VAL_SPLIT``, ``net_config`` and any key you
+invent are neither validated nor defaulted — some shipped tutorials declare them and some do not,
+because they are conventions of particular apps rather than platform requirements.
 
-The practical consequence for packaging: **a typo in an export-related key would fail silently
-today.** If a key is misspelled, nothing rejects the submission — the value is simply absent at
-runtime and your code falls back to whatever default it defines. Any export configuration added to
-``config.json`` in future should come with validation, or it will inherit this behaviour.
+**What *is* enforced is file presence.** Each job type declares a required file list, and a
+submission missing any of them fails fast with ``FileNotFoundError`` before anything is uploaded.
+The required set differs per job type — see :ref:`fl-required-files` for the manifests.
+
+The practical consequence for packaging is unchanged, and it is why this section exists: **a typo in
+an export-related key would fail silently today.** An invented key sits outside the validated set by
+definition, so nothing rejects the submission — the value is simply absent at runtime and your code
+falls back to whatever default it defines. Any export configuration added to ``config.json`` in
+future should come with validation, or it will inherit this behaviour.
+
+.. note::
+
+   Two traps hide in the gap between *validated* and *enforced*.
+
+   ``LOCAL_ROUNDS`` **is** read by ``validate_config``, but rejecting it changes nothing you would
+   notice. The default is written only when the key is *absent*, so a present-but-out-of-range value
+   survives into the deployed ``config.json`` and reaches your trainer verbatim —
+   ``"LOCAL_ROUNDS": 5000`` really does run 5000 local iterations.
+
+   On the Flower path, the silent-typo behaviour inverts. Run-config overrides live in
+   ``config.toml``, and ``flwr`` **rejects** any key the app's ``pyproject.toml`` does not already
+   declare, failing the run at submission rather than ignoring it.
 
 .. _map-open-questions:
 


### PR DESCRIPTION
# Description

Follow-up to #869, clearing both items left open in its review thread. Three changes across two files, all the same defect: documentation restating something the repository already declares, and drifting from it.

## 1. Include the required-files manifests instead of transcribing them (`029c20f2`)

#869 added per-job-type required-files tables. They were hand-copied from `fl-apps/<backend>/required_files.json`, so they stayed correct only by someone remembering to update them — the same failure mode that made the tables necessary in the first place. (The section they replaced had claimed the NVFLARE minimum was `trainer.py` + `validator.py`, which had been wrong for as long as `models.py` had been required.)

Both `list-table`s are replaced by `literalinclude` of the two generated aggregate manifests. Those are produced from the per-template `required_files.json` arrays by `fl-apps/check_required_files.sh`, which runs as a pre-commit hook and is enforced by the `fl-apps-check-required-files` workflow (it regenerates and fails on stale output). A change to any job type's required set now updates this page as a side effect of the change itself. The manifests are already `linguist-generated` in `.gitattributes`.

**One judgement call worth review.** The per-row annotations went with the tables — e.g. `standard_client_api` carried "*no `validator.py` — the Client API script does its own validation*". They restated manifest content and would drift with it. The obvious move is to keep the insight as a generalisation across the Client API job types, and **that generalisation would be wrong**: `diffusion_model_client_api` does require `validator.py`. The tables were accurate only because each row had been checked individually, which is the property this PR removes the need for. If you want that annotation back it can return scoped to `standard_client_api`, at the cost of one hand-maintained assertion.

## 2. Fix the backend scoping of the job-type list, and drop its duplicate (`b2054b42`)

Found while assessing whether the job type *names* could be drift-proofed the same way. They can't — each name is paired with editorial content ("federated averaging", the `nvflare.client`-vs-`Executor` explanation) that exists nowhere in the manifests. But the paragraph carried a substantive error:

> Currently, these job types include federated averaging (job type `standard`), evaluation task (job type `evaluation`), federated optimisation (job type `fed_opt`) and diffusion model training (job type `diffusion_model`) […] **For NVFLARE**, three further job types […]

That reads as *the first four work on both backends, plus three NVFLARE-only extras*. Flower offers only `standard` and `evaluation` — so the page told Flower users they could run `fed_opt` and `diffusion_model`. This predates #869, but that PR's manifests, now included a few paragraphs below, contradict it directly on the same page.

The sentence is now scoped per backend. The list of seven NVFLARE names after the `fl-apps/` link is gone — it duplicated the manifest keys shown just above — and that link now targets the `fl-apps/` tree root rather than `fl-apps/nvflare`, since the sentence covers both backends.

## 3. Scope the `config.json` validation section to the layer that does each check (`c7546f6c`)

`package-model-as-map.rst`'s "What FLIP actually validates in `config.json`" described the Central Hub bundler but spoke for the platform: *"There is no schema, no type checking and no required-key check."* The NVFLARE FL API's `validate_config` reads eight keys, and several failures are hard rejections that stop the job — an unknown `AGGREGATOR`, an `AGGREGATION_WEIGHTS` weight outside 0–1, an uncompilable `AGGREGATE_ONLY_REGEX`, `BEST_MODEL_METRIC` on a single-round job, `BEST_MODEL_METRIC_MINIMIZE` without `BEST_MODEL_METRIC`. So all three of "no schema", "no type checking" and "no required-key check" are false at that layer. It read as accurate until #869 documented those keys on the FL nodes page; now the two pages contradict each other.

The claim is now split by service, and the section's warning restated on the basis that actually holds: **an invented key sits outside the validated set by definition**, so it is passed through unchecked. That conclusion is what the section exists for and it survives intact — only the supporting argument was wrong.

`LOCAL_ROUNDS` was the weakest example it could have picked and now gets a note: `validate_config` *does* read it, but the default is written only when the key is **absent**, so an out-of-range value survives into the deployed `config.json` and reaches the trainer verbatim — `"LOCAL_ROUNDS": 5000` really runs 5000 local iterations. The note also records that the silent-typo conclusion **inverts on the Flower path**, where `flwr` rejects any run-config key the app's `pyproject.toml` does not declare, failing the run at submission.

Its three line-number citations had all drifted, one misleadingly — `fl_service.py:517-523` now lands on the `job_type` block, real code that isn't what the sentence describes. They are replaced with the function names they meant (`bundle_nvflare_application`, `bundle_flower_application`, `validate_config`), which don't drift with line numbers. The hand-copied required-file list and the "three of six tutorials" tally are gone too — there are now ten tutorials, four declaring `LOCAL_ROUNDS` — replaced by a cross-reference and a claim that carries no count.

## Linked Issues

Follow-up to #869. No issue filed — happy to open one if you'd prefer it tracked.

## Checklist

- [x] Follows the project's coding conventions and style guide
- [x] Updates documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Type of Change

- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] In-line docstrings updated.
- [x] Documentation updated, tested `make -C docs/ docs`.

## Testing

Documentation-only change — two files, no source files.

- [x] `make -C docs/ docs` after `make clean`: build succeeds with **zero warnings**, on every commit.
- [x] Both manifests verified as actually rendered in the built HTML — captions and JSON highlighting present in `build/html/components/component-fl-nodes.html` — rather than trusting the build log.
- [x] Include path verified against the ReadTheDocs layout: RTD builds `docs/source/conf.py` from a full-repo checkout, so `../../../fl-apps/…` resolves to the repo root. `literalinclude` is built in, so no `conf.py` change is needed.
- [x] `bash fl-apps/check_required_files.sh` — no diff against the checked-in manifests, confirming the "correct by construction" claim holds as of this commit rather than only in principle.
- [x] Per-backend job-type sentence checked against the manifest keys directly: Flower is exactly `{standard, evaluation}`, NVFLARE has all seven.
- [x] Every validation claim in change 3 traced to `validate_config` — including which failures raise and which silently fall back to a default — and the `LOCAL_ROUNDS` behaviour traced through `configure_config`'s absent-key-only override.
- [x] All three replacement citations verified to exist as named symbols (`fl_service.py:411`, `:643`, `prepare_config.py:601`).
- [x] Tutorial-count claim re-derived before removing it: 10 NVFLARE tutorial `config.json` files, 4 with `LOCAL_ROUNDS`, 2 with `LEARNING_RATE`.
- [x] Cross-references resolve: no hand-copied required-file list survives anywhere in `docs/source/`, and all inbound `:ref:`fl-required-files`` / `:ref:`fl-training-configuration`` links render.

## Additional Notes

The remaining job-type *names* on the FL nodes page stay as reviewed prose. They can't be included from a manifest — the descriptions attached to them exist nowhere in the repository — and the residual risk is much lower-grade than the file lists: a stale name list means a new job type missing from a sentence, not a failed upload.

Change 3 is a rhetorical rewrite of a different page from changes 1 and 2. It is here because it is the page #869 made contradictory, so shipping them together means `develop` never carries the contradiction unexplained — but it is cleanly separable if you would rather it went on its own.
