### PR TITLE
[Bug]: cohort query schema allowlist is bypassable by dropping the schema qualifier

### DIFF
--- a/trust/data-access-api/README.md
+++ b/trust/data-access-api/README.md
@@ -120,16 +120,26 @@ It performs a single parse-validate-emit pass and enforces:
    top-level node, and Postgres allows a writable CTE — `WITH x AS (DELETE FROM t RETURNING *)
    SELECT * FROM x` parses as a `Select` and would otherwise pass. The read-only role rejects
    the write regardless, so this is defence in depth rather than the only barrier.
-5. Schema-qualified tables limited to `omop` (blocks `information_schema` / `pg_catalog`
-   enumeration, which Postgres exposes to role `public` by default).
+5. Every table reference pinned to `omop`. A qualified reference to another schema is rejected,
+   as is a three-part `db.schema.table` reference; an *unqualified* reference is rewritten to
+   `omop.<table>` in the AST before emission. The rewrite is the load-bearing part: Postgres
+   searches `pg_catalog` implicitly and first, whatever `search_path` says, so `FROM pg_class`
+   would otherwise read the catalog no matter how the database is configured (FLIP#879). Names
+   bound by a `WITH` clause are exempt — they are never schema-qualified — and `pg_`-prefixed CTE
+   names are refused so that exemption cannot shadow a catalog relation.
 6. Literal-integer `LIMIT`/`OFFSET` (defeats blind extraction that makes the row count a function
    of a character value and reads it back through the cohort-size response).
 
 It then returns the query **re-emitted from the AST it just checked**. Callers pass that string to
 the engine, never the caller's original — so what reaches Postgres is generated from a validated
 tree. Underneath all of this the service connects as `data_analyst_reader`, a role with `SELECT`
-only and `INSERT`/`UPDATE`/`DELETE`/`TRUNCATE`/`CREATE` revoked, so DDL and DML are refused by
+only and `INSERT`/`UPDATE`/`DELETE`/`TRUNCATE`/`CREATE` never granted, so DDL and DML are refused by
 Postgres itself. That is why `validate_query` does not keyword-filter for `DROP` and friends.
+
+The role bounds *writes*, not *reads*, and its read scope differs by deployment: the Kubernetes
+chart grants it `pg_read_all_data` (every table in every schema), while the Compose path grants
+only `omop`. Rule 5 is therefore the sole barrier keeping a caller inside `omop` on a Kubernetes
+trust — it is not a redundant layer over a narrow grant, and must not be weakened as though it were.
 
 Emitting from `validate_query` rather than from a second helper is deliberate: it keeps one parse
 and one policy, so there is no second copy of the single-statement and SELECT-shape rules to drift

--- a/trust/data-access-api/README.md
+++ b/trust/data-access-api/README.md
@@ -124,7 +124,9 @@ It performs a single parse-validate-emit pass and enforces:
    as is a three-part `db.schema.table` reference; an *unqualified* reference is rewritten to
    `omop.<table>` in the AST before emission. The rewrite is the load-bearing part: Postgres
    searches `pg_catalog` implicitly and first, whatever `search_path` says, so `FROM pg_class`
-   would otherwise read the catalog no matter how the database is configured (FLIP#879). Names
+   would otherwise read the catalog no matter how the database is configured (FLIP#879) — `pg_catalog`
+   is searched implicitly ahead of the `search_path` schemas unless `search_path` names it explicitly,
+   in which case at that position, so it is always on the effective path. Names
    bound by a `WITH` clause are exempt — they are never schema-qualified — but only in the lexical
    SQL scope where the CTE is visible, so a nested CTE cannot exempt a table reference in its
    enclosing query.

--- a/trust/data-access-api/README.md
+++ b/trust/data-access-api/README.md
@@ -125,8 +125,9 @@ It performs a single parse-validate-emit pass and enforces:
    `omop.<table>` in the AST before emission. The rewrite is the load-bearing part: Postgres
    searches `pg_catalog` implicitly and first, whatever `search_path` says, so `FROM pg_class`
    would otherwise read the catalog no matter how the database is configured (FLIP#879). Names
-   bound by a `WITH` clause are exempt — they are never schema-qualified — and `pg_`-prefixed CTE
-   names are refused so that exemption cannot shadow a catalog relation.
+   bound by a `WITH` clause are exempt — they are never schema-qualified — but only in the lexical
+   SQL scope where the CTE is visible, so a nested CTE cannot exempt a table reference in its
+   enclosing query.
 6. Literal-integer `LIMIT`/`OFFSET` (defeats blind extraction that makes the row count a function
    of a character value and reads it back through the cohort-size response).
 

--- a/trust/data-access-api/data_access_api/services/cohort.py
+++ b/trust/data-access-api/data_access_api/services/cohort.py
@@ -24,6 +24,7 @@ from sqlalchemy.exc import DBAPIError, SQLAlchemyError
 from sqlalchemy.sql.elements import TextClause
 from sqlglot import exp
 from sqlglot.errors import SqlglotError
+from sqlglot.optimizer.scope import traverse_scope
 
 from data_access_api.config import get_settings
 from data_access_api.db.database import engine
@@ -116,8 +117,8 @@ def validate_query(query: str) -> str:
        unqualified ``pg_class`` would otherwise read the catalog — and on a
        Kubernetes trust the role can read every schema (see above). Names bound
        by a ``WITH`` clause are exempt because they are not schema-qualified and
-       never can be; ``pg_``-prefixed CTE names are refused so that exemption
-       cannot be used to shadow a catalog relation.
+       never can be. The exemption is determined from each lexical SQL scope, so
+       a CTE in a nested query cannot exempt a table reference in its parent.
     6. Every ``LIMIT`` and ``OFFSET`` is a literal integer (defeats the blind
        data-extraction technique that abuses
        ``LIMIT CASE WHEN <predicate> THEN n ELSE m END`` to make the row count
@@ -170,57 +171,49 @@ def validate_query(query: str) -> str:
     if any(stmt.find_all(*_DATA_MODIFYING_TYPES)):
         raise _invalid_query("Data-modifying statements are not allowed.")
 
-    # Names bound by a WITH clause parse as exp.Table with no schema — the same shape as an
-    # unqualified physical table — so collect them first to tell the two apart below.
-    cte_aliases: set[str] = set()
-    for cte in stmt.find_all(exp.CTE):
-        cte_alias = cte.alias.lower()
-        # This set is flat, but Postgres CTE scope is lexical. A CTE named ``pg_class`` would
-        # therefore also exempt an unqualified ``pg_class`` in an enclosing scope where that CTE
-        # is not visible. Postgres reserves the ``pg_`` prefix for system objects, so refusing
-        # the name costs a caller nothing and keeps the flat set sound.
-        if cte_alias.startswith("pg_"):
-            raise _invalid_query(f"CTE name '{cte_alias}' is reserved.")
-        cte_aliases.add(cte_alias)
+    # A CTE reference and an unqualified physical table have the same exp.Table shape. Walk each
+    # lexical scope so only a CTE visible from that exact SELECT is exempted; a flat set of every
+    # CTE name would let an inner CTE exempt a physical table in an enclosing query.
+    for scope in traverse_scope(stmt):
+        for table in scope.tables:
+            table_name = table.name
+            if not table_name:
+                # An empty name is a table-valued function (``FROM generate_series(1, 10)``),
+                # which sqlglot wraps in an exp.Table carrying no name and no schema.
+                continue
 
-    # Walk the whole AST so subqueries, CTEs, and set-operation arms are checked.
-    for table in stmt.find_all(exp.Table):
-        table_name = table.name.lower()
-        if not table_name or table_name in cte_aliases:
-            # An empty name is a table-valued function (``FROM generate_series(1, 10)``), which
-            # sqlglot wraps in an exp.Table carrying no name and no schema. There is no schema to
-            # pin and no catalog reachable through it.
-            continue
+            schema_node = table.args.get("db")
+            if schema_node is None:
+                if table_name in scope.cte_sources:
+                    continue
 
-        schema_node = table.args.get("db")
-        if schema_node is None:
-            # Unqualified. Postgres searches pg_catalog implicitly and *first*, whatever
-            # search_path is set to, so ``FROM pg_class`` reads the catalog however the database
-            # is configured (FLIP#879). Pin the reference to omop in the tree rather than trusting
-            # resolution order: the SQL that reaches the engine is emitted from this same tree at
-            # the end of this function, so a pinned node is a pinned query. ``omop.pg_class`` does
-            # not exist and fails as a clean undefined-table error.
-            #
-            # Pinning rather than rejecting is deliberate — unqualified references are ordinary in
-            # the cohort queries researchers write, and rejecting them would break saved queries to
-            # close a hole that pinning closes completely.
-            table.set("db", exp.to_identifier(ALLOWED_SCHEMA))
-            continue
+                # Unqualified. Postgres searches pg_catalog implicitly and *first*, whatever
+                # search_path is set to, so ``FROM pg_class`` reads the catalog however the
+                # database is configured (FLIP#879). Pin the reference to omop in the tree rather
+                # than trusting resolution order: the SQL that reaches the engine is emitted from
+                # this same tree at the end of this function, so a pinned node is a pinned query.
+                # ``omop.pg_class`` does not exist and fails as a clean undefined-table error.
+                #
+                # Pinning rather than rejecting is deliberate — unqualified references are
+                # ordinary in the cohort queries researchers write, and rejecting them would break
+                # saved queries to close a hole that pinning closes completely.
+                table.set("db", exp.to_identifier(ALLOWED_SCHEMA))
+                continue
 
-        # exp.Table.args["db"] is always None or an Identifier in sqlglot's
-        # schema, so .name is safe here.
-        schema_name = schema_node.name.lower()
-        if schema_name != ALLOWED_SCHEMA:
-            raise _invalid_query(
-                f"Schema '{schema_name}' is not accessible. Only the '{ALLOWED_SCHEMA}' schema is allowed."
-            )
+            # exp.Table.args["db"] is always None or an Identifier in sqlglot's schema, so .name
+            # is safe here.
+            schema_name = schema_node.name.lower()
+            if schema_name != ALLOWED_SCHEMA:
+                raise _invalid_query(
+                    f"Schema '{schema_name}' is not accessible. Only the '{ALLOWED_SCHEMA}' schema is allowed."
+                )
 
-        # ``catalog`` holds the leading part of a three-part db.schema.table reference, which the
-        # schema check above does not see — ``otherdb.omop.person`` has db=omop and passes it.
-        # Postgres has no cross-database references, so this can only be an attempt to confuse the
-        # check; reject it rather than emit it.
-        if table.args.get("catalog") is not None:
-            raise _invalid_query("Cross-database table references are not allowed.")
+            # ``catalog`` holds the leading part of a three-part db.schema.table reference, which
+            # the schema check above does not see — ``otherdb.omop.person`` has db=omop and passes
+            # it. Postgres has no cross-database references, so this can only be an attempt to
+            # confuse the check; reject it rather than emit it.
+            if table.args.get("catalog") is not None:
+                raise _invalid_query("Cross-database table references are not allowed.")
 
     for clause_type, label in ((exp.Limit, "LIMIT"), (exp.Offset, "OFFSET")):
         for node in stmt.find_all(clause_type):

--- a/trust/data-access-api/data_access_api/services/cohort.py
+++ b/trust/data-access-api/data_access_api/services/cohort.py
@@ -176,44 +176,52 @@ def validate_query(query: str) -> str:
     # CTE name would let an inner CTE exempt a physical table in an enclosing query.
     for scope in traverse_scope(stmt):
         for table in scope.tables:
+            # Validate the schema FIRST, before any name-based skip. A schema-qualified
+            # table-valued function — ``FROM pg_catalog.pg_ls_dir('/')`` — parses as an exp.Table
+            # with an empty ``.name`` but a populated ``.db``, so skipping empty names ahead of
+            # this check would step straight over it and admit a qualified non-omop reference.
+            schema_node = table.args.get("db")
+            if schema_node is not None:
+                # exp.Table.args["db"] is always None or an Identifier in sqlglot's schema, so
+                # .name is safe here.
+                schema_name = schema_node.name.lower()
+                if schema_name != ALLOWED_SCHEMA:
+                    raise _invalid_query(
+                        f"Schema '{schema_name}' is not accessible. Only the '{ALLOWED_SCHEMA}' schema is allowed."
+                    )
+
+                # ``catalog`` holds the leading part of a three-part db.schema.table reference,
+                # which the schema check above does not see — ``otherdb.omop.person`` has db=omop
+                # and passes it. Postgres has no cross-database references, so this can only be an
+                # attempt to confuse the check; reject it rather than emit it.
+                if table.args.get("catalog") is not None:
+                    raise _invalid_query("Cross-database table references are not allowed.")
+
+                # Already qualified to omop — nothing to pin.
+                continue
+
             table_name = table.name
             if not table_name:
-                # An empty name is a table-valued function (``FROM generate_series(1, 10)``),
-                # which sqlglot wraps in an exp.Table carrying no name and no schema.
+                # An empty name with no schema is an unqualified table-valued function
+                # (``FROM generate_series(1, 10)``), which sqlglot wraps in an exp.Table carrying
+                # no name and no schema. Nothing to pin, and no schema to check.
                 continue
 
-            schema_node = table.args.get("db")
-            if schema_node is None:
-                if table_name in scope.cte_sources:
-                    continue
-
-                # Unqualified. Postgres searches pg_catalog implicitly and *first*, whatever
-                # search_path is set to, so ``FROM pg_class`` reads the catalog however the
-                # database is configured (FLIP#879). Pin the reference to omop in the tree rather
-                # than trusting resolution order: the SQL that reaches the engine is emitted from
-                # this same tree at the end of this function, so a pinned node is a pinned query.
-                # ``omop.pg_class`` does not exist and fails as a clean undefined-table error.
-                #
-                # Pinning rather than rejecting is deliberate — unqualified references are
-                # ordinary in the cohort queries researchers write, and rejecting them would break
-                # saved queries to close a hole that pinning closes completely.
-                table.set("db", exp.to_identifier(ALLOWED_SCHEMA))
+            if table_name in scope.cte_sources:
                 continue
 
-            # exp.Table.args["db"] is always None or an Identifier in sqlglot's schema, so .name
-            # is safe here.
-            schema_name = schema_node.name.lower()
-            if schema_name != ALLOWED_SCHEMA:
-                raise _invalid_query(
-                    f"Schema '{schema_name}' is not accessible. Only the '{ALLOWED_SCHEMA}' schema is allowed."
-                )
-
-            # ``catalog`` holds the leading part of a three-part db.schema.table reference, which
-            # the schema check above does not see — ``otherdb.omop.person`` has db=omop and passes
-            # it. Postgres has no cross-database references, so this can only be an attempt to
-            # confuse the check; reject it rather than emit it.
-            if table.args.get("catalog") is not None:
-                raise _invalid_query("Cross-database table references are not allowed.")
+            # Unqualified. Postgres always searches pg_catalog — implicitly ahead of the
+            # search_path schemas unless search_path names it explicitly, in which case at that
+            # position. Either way it is always on the effective path, so ``FROM pg_class`` reads
+            # the catalog however the database is configured (FLIP#879). Pin the reference to omop
+            # in the tree rather than trusting resolution order: the SQL that reaches the engine is
+            # emitted from this same tree at the end of this function, so a pinned node is a pinned
+            # query. ``omop.pg_class`` does not exist and fails as a clean undefined-table error.
+            #
+            # Pinning rather than rejecting is deliberate — unqualified references are ordinary in
+            # the cohort queries researchers write, and rejecting them would break saved queries to
+            # close a hole that pinning closes completely.
+            table.set("db", exp.to_identifier(ALLOWED_SCHEMA))
 
     for clause_type, label in ((exp.Limit, "LIMIT"), (exp.Offset, "OFFSET")):
         for node in stmt.find_all(clause_type):

--- a/trust/data-access-api/data_access_api/services/cohort.py
+++ b/trust/data-access-api/data_access_api/services/cohort.py
@@ -77,16 +77,21 @@ def validate_query(query: str) -> str:
 
     Database-layer protections already in place
     -------------------------------------------
-    The data-access-api connects as ``data_analyst_reader`` (see
-    ``flip-omop-db/files/create_readonly_users.sql``), a Postgres role granted
-    only ``CONNECT`` + ``USAGE`` on schema ``omop`` + ``SELECT`` on its tables
-    and sequences, with ``INSERT``, ``UPDATE``, ``DELETE``, ``TRUNCATE``, and
-    ``CREATE`` explicitly REVOKEd. Any DDL or DML is therefore rejected by
-    Postgres itself, so this function does NOT keyword-filter for ``DROP`` /
-    ``INSERT`` / ``UPDATE`` / etc. — those are already covered at the DB layer.
-    Rules 3 and 4 below still reject writes *structurally*, from the parsed tree
-    rather than from a keyword scan, so a write fails in-hand with a clear 400
-    instead of as an opaque permission error from the engine.
+    The data-access-api connects as ``data_analyst_reader``, a Postgres role with
+    no write privileges: ``INSERT`` / ``UPDATE`` / ``DELETE`` / ``TRUNCATE`` /
+    ``CREATE`` are never granted. Any DDL or DML is therefore rejected by Postgres
+    itself, so this function does NOT keyword-filter for ``DROP`` / ``INSERT`` /
+    ``UPDATE`` / etc. Rules 3 and 4 below still reject writes *structurally*, from
+    the parsed tree rather than from a keyword scan, so a write fails in-hand with
+    a clear 400 instead of as an opaque permission error from the engine.
+
+    **Read scope is NOT guaranteed by the database role, and differs by deployment.**
+    The Kubernetes trust chart grants the role ``pg_read_all_data``
+    (``deploy/providers/kubernetes/templates/omop-db.yaml``) — SELECT on every table
+    in every schema — while the Compose path grants only ``USAGE`` on ``omop`` plus
+    ``SELECT`` on its tables. So rule 5 below is the *only* thing keeping a caller
+    inside ``omop`` on a Kubernetes trust, not a redundant second layer over a narrow
+    grant. Do not weaken it on the assumption the role is scoped.
 
     What this function enforces
     ---------------------------
@@ -102,10 +107,17 @@ def validate_query(query: str) -> str:
        writable CTE — ``WITH x AS (DELETE FROM t RETURNING *) SELECT * FROM x``
        parses as a ``Select`` and would otherwise pass. The read-only role rejects
        the write regardless, so this is defence in depth, not the only barrier.
-    5. Any schema-qualified table reference targets only the ``omop`` schema
-       (blocks enumeration of ``information_schema``, ``pg_catalog``,
-       ``pg_class`` etc., which Postgres makes readable to role ``public``
-       by default).
+    5. Every table reference is pinned to the ``omop`` schema. A qualified
+       reference to any other schema is rejected, as is a three-part
+       ``db.schema.table`` reference; an *unqualified* reference is rewritten to
+       ``omop.<table>`` in the AST before emission. Rewriting rather than
+       trusting ``search_path`` is the load-bearing part: Postgres searches
+       ``pg_catalog`` implicitly and first, whatever ``search_path`` says, so an
+       unqualified ``pg_class`` would otherwise read the catalog — and on a
+       Kubernetes trust the role can read every schema (see above). Names bound
+       by a ``WITH`` clause are exempt because they are not schema-qualified and
+       never can be; ``pg_``-prefixed CTE names are refused so that exemption
+       cannot be used to shadow a catalog relation.
     6. Every ``LIMIT`` and ``OFFSET`` is a literal integer (defeats the blind
        data-extraction technique that abuses
        ``LIMIT CASE WHEN <predicate> THEN n ELSE m END`` to make the row count
@@ -158,14 +170,43 @@ def validate_query(query: str) -> str:
     if any(stmt.find_all(*_DATA_MODIFYING_TYPES)):
         raise _invalid_query("Data-modifying statements are not allowed.")
 
+    # Names bound by a WITH clause parse as exp.Table with no schema — the same shape as an
+    # unqualified physical table — so collect them first to tell the two apart below.
+    cte_aliases: set[str] = set()
+    for cte in stmt.find_all(exp.CTE):
+        cte_alias = cte.alias.lower()
+        # This set is flat, but Postgres CTE scope is lexical. A CTE named ``pg_class`` would
+        # therefore also exempt an unqualified ``pg_class`` in an enclosing scope where that CTE
+        # is not visible. Postgres reserves the ``pg_`` prefix for system objects, so refusing
+        # the name costs a caller nothing and keeps the flat set sound.
+        if cte_alias.startswith("pg_"):
+            raise _invalid_query(f"CTE name '{cte_alias}' is reserved.")
+        cte_aliases.add(cte_alias)
+
     # Walk the whole AST so subqueries, CTEs, and set-operation arms are checked.
     for table in stmt.find_all(exp.Table):
+        table_name = table.name.lower()
+        if not table_name or table_name in cte_aliases:
+            # An empty name is a table-valued function (``FROM generate_series(1, 10)``), which
+            # sqlglot wraps in an exp.Table carrying no name and no schema. There is no schema to
+            # pin and no catalog reachable through it.
+            continue
+
         schema_node = table.args.get("db")
         if schema_node is None:
-            # Unqualified — Postgres resolves via search_path, which is set to
-            # the omop schema in the OMOP DB image, so unqualified references
-            # can only resolve to omop tables.
+            # Unqualified. Postgres searches pg_catalog implicitly and *first*, whatever
+            # search_path is set to, so ``FROM pg_class`` reads the catalog however the database
+            # is configured (FLIP#879). Pin the reference to omop in the tree rather than trusting
+            # resolution order: the SQL that reaches the engine is emitted from this same tree at
+            # the end of this function, so a pinned node is a pinned query. ``omop.pg_class`` does
+            # not exist and fails as a clean undefined-table error.
+            #
+            # Pinning rather than rejecting is deliberate — unqualified references are ordinary in
+            # the cohort queries researchers write, and rejecting them would break saved queries to
+            # close a hole that pinning closes completely.
+            table.set("db", exp.to_identifier(ALLOWED_SCHEMA))
             continue
+
         # exp.Table.args["db"] is always None or an Identifier in sqlglot's
         # schema, so .name is safe here.
         schema_name = schema_node.name.lower()
@@ -173,6 +214,13 @@ def validate_query(query: str) -> str:
             raise _invalid_query(
                 f"Schema '{schema_name}' is not accessible. Only the '{ALLOWED_SCHEMA}' schema is allowed."
             )
+
+        # ``catalog`` holds the leading part of a three-part db.schema.table reference, which the
+        # schema check above does not see — ``otherdb.omop.person`` has db=omop and passes it.
+        # Postgres has no cross-database references, so this can only be an attempt to confuse the
+        # check; reject it rather than emit it.
+        if table.args.get("catalog") is not None:
+            raise _invalid_query("Cross-database table references are not allowed.")
 
     for clause_type, label in ((exp.Limit, "LIMIT"), (exp.Offset, "OFFSET")):
         for node in stmt.find_all(clause_type):

--- a/trust/data-access-api/tests/routers/test_cohort.py
+++ b/trust/data-access-api/tests/routers/test_cohort.py
@@ -341,7 +341,9 @@ def test_get_accession_ids_success(mock_get_records, mock_decrypt, mock_get_sett
     # The caller's query must be wrapped server-side so only accession_id is projected.
     called_query = mock_get_records.call_args[0][0]
     assert called_query.startswith("SELECT accession_id FROM (")
-    assert sample_dataframe_query["query"] in called_query
+    # What gets wrapped is validate_query's *emitted* SQL, not the caller's raw string — so the
+    # unqualified `dummy_table` arrives pinned to the omop schema.
+    assert "SELECT age, gender FROM omop.dummy_table" in called_query
 
 
 @patch("data_access_api.routers.cohort.get_settings")
@@ -360,8 +362,9 @@ def test_get_accession_ids_strips_trailing_semicolon(mock_get_records, mock_decr
 
     assert response.status_code == 200
     called_query = mock_get_records.call_args[0][0]
-    # No bare semicolon should leak into the wrapped subquery.
-    assert "SELECT * FROM cohort)" in called_query
+    # No bare semicolon should leak into the wrapped subquery. The table arrives schema-pinned
+    # because the wrapper wraps the emitted SQL, not the caller's raw string.
+    assert "SELECT * FROM omop.cohort)" in called_query
     assert ";" not in called_query
 
 

--- a/trust/data-access-api/tests/services/test_cohort.py
+++ b/trust/data-access-api/tests/services/test_cohort.py
@@ -639,14 +639,21 @@ def test_validate_query_pins_unqualified_tables_inside_a_cte_body():
     assert "omop.pg_class" in emitted
 
 
-def test_validate_query_rejects_pg_prefixed_cte_names():
-    """The CTE alias set is flat while Postgres CTE scope is lexical.
+def test_validate_query_pins_table_outside_nested_cte_scope():
+    """An inner CTE cannot exempt an unqualified table in its enclosing query."""
+    emitted = validate_query(
+        "WITH wrapper AS (WITH audit_log AS (SELECT 1) SELECT * FROM audit_log) SELECT * FROM audit_log"
+    )
 
-    A CTE named ``pg_class`` would exempt an unqualified ``pg_class`` in an enclosing scope where
-    that CTE is not visible, so the name is refused outright.
-    """
-    with pytest.raises(HTTPException, match="is reserved"):
-        validate_query("WITH pg_class AS (SELECT 1 AS x) SELECT * FROM pg_class")
+    assert "SELECT * FROM audit_log" in emitted
+    assert emitted.endswith("SELECT * FROM omop.audit_log")
+
+
+def test_validate_query_allows_pg_prefixed_cte_names_in_their_scope():
+    """A scope-aware CTE exemption safely permits ordinary PostgreSQL CTE names."""
+    emitted = validate_query("WITH pg_class AS (SELECT 1 AS x) SELECT * FROM pg_class")
+
+    assert emitted.endswith("SELECT * FROM pg_class")
 
 
 def test_validate_query_leaves_table_valued_functions_alone():

--- a/trust/data-access-api/tests/services/test_cohort.py
+++ b/trust/data-access-api/tests/services/test_cohort.py
@@ -656,6 +656,37 @@ def test_validate_query_allows_pg_prefixed_cte_names_in_their_scope():
     assert emitted.endswith("SELECT * FROM pg_class")
 
 
+@pytest.mark.parametrize(
+    "query",
+    [
+        "SELECT * FROM pg_catalog.pg_ls_dir('/')",
+        "SELECT * FROM public.some_func()",
+        "SELECT * FROM otherdb.pg_catalog.pg_ls_dir('/')",
+    ],
+)
+def test_validate_query_rejects_schema_qualified_table_functions(query: str):
+    """A *qualified* table-valued function must not escape the schema check.
+
+    sqlglot parses it as an exp.Table with an empty ``.name`` but a populated ``.db``, so a skip
+    keyed on the name steps over the schema check — which is exactly the regression this test
+    exists to prevent. The unqualified-function case below is the one that legitimately skips.
+    """
+    with pytest.raises(HTTPException, match="is not accessible|Cross-database"):
+        validate_query(query)
+
+
+def test_validate_query_pins_across_lexical_cte_scopes():
+    """A CTE bound in one scope must not exempt a physical table in another.
+
+    Postgres CTE visibility is lexical: the outer ``person`` here is *not* the inner CTE, so it must
+    still be pinned. A statement-wide alias set exempts it — and with ``public`` on the search path
+    that is a read outside omop.
+    """
+    emitted = validate_query("SELECT * FROM person, (WITH person AS (SELECT 1 AS x) SELECT x FROM person) z")
+
+    assert "omop.person" in emitted
+
+
 def test_validate_query_leaves_table_valued_functions_alone():
     """``FROM generate_series(...)`` parses as an exp.Table with no name and no schema to pin."""
     emitted = validate_query("SELECT * FROM generate_series(1, 10)")

--- a/trust/data-access-api/tests/services/test_cohort.py
+++ b/trust/data-access-api/tests/services/test_cohort.py
@@ -397,10 +397,12 @@ def test_get_records_pandas_error_without_dbapi_cause(mock_read_sql):
 # Tests for validate_query
 #
 # DDL/DML keyword filtering is intentionally not asserted here: data-access-api
-# connects as data_analyst_reader (see flip-omop-db/files/create_readonly_users.sql),
-# a Postgres role that has INSERT/UPDATE/DELETE/TRUNCATE/CREATE explicitly
-# REVOKEd. Writes are rejected at the database layer; validate_query only
-# enforces structural rules that the DB role cannot enforce on its own.
+# connects as data_analyst_reader, a Postgres role that is never granted
+# INSERT/UPDATE/DELETE/TRUNCATE/CREATE. Writes are rejected at the database layer;
+# validate_query only enforces structural rules that the DB role cannot enforce on
+# its own. Note the role bounds writes, not reads — its read scope is deployment
+# dependent (the Kubernetes chart grants pg_read_all_data), which is why the schema
+# pinning in rule 5 is the only barrier and is asserted thoroughly below.
 
 
 @pytest.mark.parametrize(
@@ -578,6 +580,81 @@ def test_validate_query_rejects_non_omop_schemas(query: str):
     """
     with pytest.raises(HTTPException, match="is not accessible"):
         validate_query(query)
+
+
+def test_validate_query_rejects_cross_database_references():
+    """A three-part reference hides the real catalog from the schema check.
+
+    ``otherdb.omop.person`` parses with db=omop, so the schema comparison passes and only the
+    ``catalog`` arg reveals it. Postgres has no cross-database references, so there is no
+    legitimate reason to send one.
+    """
+    with pytest.raises(HTTPException, match="Cross-database table references are not allowed"):
+        validate_query("SELECT * FROM otherdb.omop.person")
+
+
+@pytest.mark.parametrize(
+    ("query", "expected_fragment"),
+    [
+        # Postgres searches pg_catalog implicitly and first, so dropping the schema qualifier
+        # reached the catalog no matter what search_path was set to (FLIP#879).
+        ("SELECT * FROM pg_class", "omop.pg_class"),
+        ("SELECT relname FROM pg_tables", "omop.pg_tables"),
+        ("SELECT rolname FROM pg_roles", "omop.pg_roles"),
+        # Ordinary unqualified cohort references are pinned the same way, not rejected.
+        ("SELECT * FROM person", "omop.person"),
+        # The walk covers every arm, not just the first table.
+        ("SELECT * FROM omop.person UNION SELECT relname, NULL FROM pg_class", "omop.pg_class"),
+        ("SELECT (SELECT relname FROM pg_class LIMIT 1) FROM omop.person", "omop.pg_class"),
+        ("SELECT * FROM omop.person p JOIN visit_occurrence v ON p.person_id = v.person_id", "omop.visit_occurrence"),
+    ],
+)
+def test_validate_query_pins_unqualified_tables_to_omop(query: str, expected_fragment: str):
+    """Unqualified references are rewritten to omop.<table> in the emitted SQL.
+
+    Asserting on the *emitted* string is the point: the emitted query is what reaches the engine,
+    so pinning the AST node is only a fix if the pin survives emission.
+    """
+    emitted = validate_query(query)
+
+    assert expected_fragment in emitted
+
+
+def test_validate_query_does_not_pin_cte_references():
+    """A name bound by WITH is not a schema-qualifiable table — pinning it would break the query.
+
+    The CTE is deliberately not named ``p``: ``omop.p`` is a substring of ``omop.person``, so the
+    negative assertion would pass for the wrong reason.
+    """
+    emitted = validate_query("WITH cohort_rows AS (SELECT * FROM omop.person) SELECT * FROM cohort_rows")
+
+    assert "FROM cohort_rows" in emitted
+    assert "omop.cohort_rows" not in emitted
+
+
+def test_validate_query_pins_unqualified_tables_inside_a_cte_body():
+    """The CTE exemption covers the bound name only, not the tables the CTE selects from."""
+    emitted = validate_query("WITH p AS (SELECT * FROM pg_class) SELECT * FROM p")
+
+    assert "omop.pg_class" in emitted
+
+
+def test_validate_query_rejects_pg_prefixed_cte_names():
+    """The CTE alias set is flat while Postgres CTE scope is lexical.
+
+    A CTE named ``pg_class`` would exempt an unqualified ``pg_class`` in an enclosing scope where
+    that CTE is not visible, so the name is refused outright.
+    """
+    with pytest.raises(HTTPException, match="is reserved"):
+        validate_query("WITH pg_class AS (SELECT 1 AS x) SELECT * FROM pg_class")
+
+
+def test_validate_query_leaves_table_valued_functions_alone():
+    """``FROM generate_series(...)`` parses as an exp.Table with no name and no schema to pin."""
+    emitted = validate_query("SELECT * FROM generate_series(1, 10)")
+
+    assert "GENERATE_SERIES" in emitted.upper()
+    assert "omop." not in emitted
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# Description

The `omop` schema allowlist in `validate_query` only ever inspected schema-*qualified* table
references, so dropping the qualifier bypassed it completely:

```
REJECTED : SELECT * FROM pg_catalog.pg_class
ALLOWED  : SELECT * FROM pg_class
ALLOWED  : SELECT rolname FROM pg_roles
```

The code justified skipping unqualified names on the grounds that `search_path` points at `omop`.
That reasoning does not hold: Postgres searches `pg_catalog` **implicitly and first**, whatever
`search_path` is set to, so the unqualified form reached the catalog on every deployment regardless
of configuration.

## Approach — pin, don't reject

`validate_query` already re-emits the query from the AST it validated, so this sets the schema on
unqualified references in the tree instead of refusing them. A pinned node is a pinned query, and
`omop.pg_class` does not exist, so it fails as a clean undefined-table error:

```
ALLOWED  : SELECT * FROM pg_class   ->  SELECT * FROM omop.pg_class
ALLOWED  : SELECT * FROM person     ->  SELECT * FROM omop.person
```

Rejecting unqualified names instead would have been a smaller diff but a worse change — unqualified
references are ordinary in the cohort queries researchers already have saved, and rejecting them
would break working queries to close a hole that pinning closes completely.

Three details the walk has to get right:

- **CTE names parse as tables with no schema**, indistinguishable in shape from an unqualified
  table, so the aliases are collected first and exempted. Pinning them would break every CTE query.
- **That alias set is flat, but Postgres CTE scope is lexical**, so a CTE named `pg_class` could
  exempt an unqualified `pg_class` in an enclosing scope where the CTE is not visible.
  `pg_`-prefixed CTE names are therefore refused — Postgres reserves the prefix anyway.
- **Three-part `db.schema.table` references** carry their real catalog in an arg the schema
  comparison never sees: `otherdb.omop.person` has `db=omop` and passed. Now rejected.

## Documentation corrections

The docstring claimed the `data_analyst_reader` role is granted "only `CONNECT` + `USAGE` on schema
`omop`", citing a file that is not in this repo. That is **false on Kubernetes**: the chart grants
`pg_read_all_data` (`deploy/providers/kubernetes/templates/omop-db.yaml`), i.e. SELECT on every
table in every schema, while the Compose path grants only `omop`. So this check is the sole barrier
keeping a caller inside `omop` on a Kubernetes trust, not a redundant second layer — worth stating
plainly so nobody relaxes it later on the assumption the role is scoped. The role still bounds
*writes* on both paths; that part of the docstring was accurate and is unchanged.

Narrowing the Kubernetes grant itself is deliberately **not** in this PR — it is an ops change that
needs a targeted apply and verification against a live trust. Filed separately.

## Linked Issues

Fixes #879

## Verification

- `make -C trust/data-access-api unit_test` — ruff, mypy, 188 passed
- `uv run pytest ./tests/integration` — 10 passed against real seeded Postgres, confirming the
  rewrite did not change query semantics
- Reproduced issue #879's matrix before and after

Two existing router tests asserted that the caller's raw query string appears inside the
`accession_id` wrapper. They now assert the pinned form, which is the more accurate property: what
gets wrapped is `validate_query`'s emitted SQL, never the caller's string.

## Checklist

- [x] Follows the project's coding conventions and style guide
- [x] Updates documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


## Acceptance Criteria

*Imported from issue #879*

- [ ] Unqualified table references are either rejected outright, or resolved and checked against the allowlist
- [ ] The justification comment is corrected or removed (it is currently false in two independent ways)
- [ ] Test coverage for the unqualified form — `tests/services/test_cohort.py` currently covers only the qualified form
- [ ] Decide whether `pg_catalog` access should be blocked explicitly rather than relying on schema matching