### PR TITLE
Sanitise error details so internal URLs cannot leak in 500 responses

### DIFF
--- a/flip-api/src/flip_api/cohort_services/save_cohort_query.py
+++ b/flip-api/src/flip_api/cohort_services/save_cohort_query.py
@@ -105,5 +105,5 @@ def save_cohort_query(
         # Re-raise HTTP exceptions
         raise
     except Exception as e:
-        logger.error(f"Error saving cohort query: {str(e)}")
-        raise HTTPException(status_code=500, detail=f"Internal server error: {str(e)}")
+        logger.exception("Error saving cohort query")
+        raise HTTPException(status_code=500, detail="Internal server error") from e

--- a/flip-api/src/flip_api/cohort_services/submit_cohort_query.py
+++ b/flip-api/src/flip_api/cohort_services/submit_cohort_query.py
@@ -242,5 +242,5 @@ def submit_cohort_query(
         raise
     except Exception as e:
         db.rollback()
-        logger.error(f"Error submitting cohort query: {str(e)}")
-        raise HTTPException(status_code=500, detail=f"Internal server error: {str(e)}")
+        logger.exception("Error submitting cohort query")
+        raise HTTPException(status_code=500, detail="Internal server error") from e

--- a/flip-api/src/flip_api/fl_services/initiate_training.py
+++ b/flip-api/src/flip_api/fl_services/initiate_training.py
@@ -94,7 +94,8 @@ def initiate_training(
     except HTTPException:
         raise  # re-raise known errors
     except Exception as e:
+        logger.exception("Error during training initiation")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"An error occurred during training initiation: {str(e)}",
-        )
+            detail="Internal server error",
+        ) from e

--- a/flip-api/src/flip_api/model_services/retrieve_model_status_from_logs.py
+++ b/flip-api/src/flip_api/model_services/retrieve_model_status_from_logs.py
@@ -79,8 +79,14 @@ def retrieve_model_status_from_logs(
     except httpx.HTTPStatusError as exc:
         if exc.response.status_code == 404:
             logger.debug("Could not find model status from logs.")
-            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Logs not found.")
-        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(exc))
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Logs not found.") from exc
+        # str() on an HTTPStatusError embeds the full request URL, and elastic_url is a Secrets
+        # Manager value — keep it in the log, never in a response body reachable by any user with
+        # model access.
+        logger.exception("Elasticsearch query for model status failed")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Internal server error"
+        ) from exc
 
     logs = response.json().get("hits", {}).get("hits", [])
     if not logs:

--- a/flip-api/tests/unit/cohort_services/test_save_cohort_query.py
+++ b/flip-api/tests/unit/cohort_services/test_save_cohort_query.py
@@ -118,8 +118,12 @@ def test_save_cohort_query_internal_error(mock_has_project_status, mock_can_modi
     request = MagicMock()
     request.headers.get.return_value = mock_auth_token
 
-    # Expect an HTTPException or a general Exception with a message
-    with pytest.raises(HTTPException, match="Internal server error") as exc_info:
+    with pytest.raises(HTTPException) as exc_info:
         save_cohort_query(request=request, cohort_query=cohort_query_input, db=mock_db_session)
 
     assert exc_info.value.status_code == 500
+    # Equality, not `match=`: that is re.search, so it matches
+    # "Internal server error: Unexpected DB failure" just as happily and would pass against the
+    # leaking version. The point of the assertion is that the exception text is *absent*.
+    assert exc_info.value.detail == "Internal server error"
+    assert "Unexpected DB failure" not in exc_info.value.detail

--- a/flip-api/tests/unit/fl_services/test_initiate_training.py
+++ b/flip-api/tests/unit/fl_services/test_initiate_training.py
@@ -162,7 +162,11 @@ def test_initiate_training_failure(model_id, fake_request, mock_db, client1, moc
         with pytest.raises(HTTPException) as exc_info:
             initiate_training(model_id, payload, fake_request, mock_db, user_id="user123")
         assert exc_info.value.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
-        assert "Unexpected error" in exc_info.value.detail
+        # The underlying exception text must stay in the log, not the response body — it can carry
+        # connection strings and other internals, and this endpoint is reachable by any researcher
+        # who owns the model.
+        assert exc_info.value.detail == "Internal server error"
+        assert "Unexpected error" not in exc_info.value.detail
 
 
 def test_initiate_training_unavailable_in_deployment_mode(

--- a/flip-api/tests/unit/model_services/test_retrieve_model_status_from_logs.py
+++ b/flip-api/tests/unit/model_services/test_retrieve_model_status_from_logs.py
@@ -1,0 +1,104 @@
+# Copyright (c) Guy's and St Thomas' NHS Foundation Trust & King's College London
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+import httpx
+import pytest
+from fastapi import status
+from fastapi.testclient import TestClient
+
+from flip_api.auth.dependencies import verify_token
+from flip_api.db.database import get_session
+from flip_api.main import app
+
+client = TestClient(app)
+
+test_model_id = uuid4()
+test_user_id = uuid4()
+
+# Stands in for the Elasticsearch base URL, which is a Secrets Manager value in every deployed
+# environment. Asserting on a sentinel rather than on the exact message keeps the test about the
+# property (the host must not reach the caller) rather than about the wording.
+SECRET_ES_HOST = "vpc-flip-internal-es.eu-west-2.es.amazonaws.example"
+SECRET_ES_URL = f"https://{SECRET_ES_HOST}:9200"
+
+MODULE = "flip_api.model_services.retrieve_model_status_from_logs"
+
+
+@pytest.fixture(autouse=True)
+def override_dependencies():
+    mock_session = MagicMock()
+    app.dependency_overrides[get_session] = lambda: mock_session
+    app.dependency_overrides[verify_token] = lambda: test_user_id
+    yield mock_session
+    app.dependency_overrides.clear()
+
+
+def _elastic_status_error(status_code: int) -> httpx.HTTPStatusError:
+    """Build the error httpx raises for a non-2xx, carrying the real request URL.
+
+    ``str()`` on this exception embeds that URL — which is the whole point of the test.
+    """
+    request = httpx.Request("POST", f"{SECRET_ES_URL}/centralhub-eks/_search")
+    response = httpx.Response(status_code=status_code, request=request)
+
+    return httpx.HTTPStatusError("upstream failed", request=request, response=response)
+
+
+@patch(f"{MODULE}.httpx.post")
+@patch(f"{MODULE}.get_secret", return_value=SECRET_ES_URL)
+@patch(f"{MODULE}.get_model_status")
+@patch(f"{MODULE}.can_access_model", return_value=True)
+def test_upstream_error_does_not_leak_the_elasticsearch_url(
+    mock_can_access, mock_get_model_status, mock_get_secret, mock_post
+):
+    """A non-404 upstream failure must not put the internal Elasticsearch URL in the response.
+
+    The endpoint is reachable by any authenticated user with access to the model, so anything in
+    ``detail`` is disclosed to a non-privileged caller.
+    """
+    mock_get_model_status.return_value = MagicMock(deleted=False)
+    mock_post.return_value.raise_for_status.side_effect = _elastic_status_error(500)
+
+    response = client.get(f"/api/model/{test_model_id}/training/log")
+
+    assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+    detail = response.json()["detail"]
+    assert SECRET_ES_HOST not in detail
+    assert "centralhub-eks" not in detail
+    assert detail == "Internal server error"
+
+
+@patch(f"{MODULE}.httpx.post")
+@patch(f"{MODULE}.get_secret", return_value=SECRET_ES_URL)
+@patch(f"{MODULE}.get_model_status")
+@patch(f"{MODULE}.can_access_model", return_value=True)
+def test_upstream_404_still_reports_logs_not_found(
+    mock_can_access, mock_get_model_status, mock_get_secret, mock_post
+):
+    """The 404 branch was already sanitised — keep it distinguishable from the 500 branch."""
+    mock_get_model_status.return_value = MagicMock(deleted=False)
+    mock_post.return_value.raise_for_status.side_effect = _elastic_status_error(404)
+
+    response = client.get(f"/api/model/{test_model_id}/training/log")
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+    assert response.json()["detail"] == "Logs not found."
+
+
+@patch(f"{MODULE}.can_access_model", return_value=False)
+def test_access_denied_for_unrelated_model(mock_can_access):
+    response = client.get(f"/api/model/{test_model_id}/training/log")
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN

--- a/flip-api/tests/unit/model_services/test_retrieve_model_status_from_logs.py
+++ b/flip-api/tests/unit/model_services/test_retrieve_model_status_from_logs.py
@@ -46,14 +46,21 @@ def override_dependencies():
 
 
 def _elastic_status_error(status_code: int) -> httpx.HTTPStatusError:
-    """Build the error httpx raises for a non-2xx, carrying the real request URL.
+    """Build the error httpx raises for a non-2xx, with the message httpx itself would construct.
 
-    ``str()`` on this exception embeds that URL — which is the whole point of the test.
+    Raising it via ``raise_for_status()`` rather than instantiating it directly is load-bearing:
+    ``HTTPStatusError`` carries whatever message it is given, so a hand-written one stringifies to
+    just that string and the URL assertions below would pass against the leaky code too. Only
+    ``raise_for_status`` builds the "... for url '<url>'" form that actually contains the secret.
     """
     request = httpx.Request("POST", f"{SECRET_ES_URL}/centralhub-eks/_search")
     response = httpx.Response(status_code=status_code, request=request)
+    try:
+        response.raise_for_status()
+    except httpx.HTTPStatusError as exc:
+        return exc
 
-    return httpx.HTTPStatusError("upstream failed", request=request, response=response)
+    raise AssertionError(f"status {status_code} did not raise")  # pragma: no cover
 
 
 @patch(f"{MODULE}.httpx.post")


### PR DESCRIPTION
# Description

`flip-api/src/flip_api/model_services/retrieve_model_status_from_logs.py` returned the raw
exception string as the HTTP `detail` when the Elasticsearch call failed:

```python
raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(exc))
```

`str()` on an `httpx.HTTPStatusError` embeds the full request URL, and `elastic_url` is read from
Secrets Manager a few lines above — so provoking any non-404 upstream error disclosed the internal
Elasticsearch scheme, host, port and index:

```
Server error '500 Internal Server Error' for url 'https://<internal-es-host>:9200/centralhub-eks/_search'
```

The route is gated by `verify_token` + `can_access_model`, so this is reachable by any authenticated
user with access to a model — no elevated role needed. The adjacent 404 branch was already sanitised
to `"Logs not found."`, which is what makes this look like an oversight rather than a decision.

Three sibling handlers leak `str(e)` in the same shape and are swept here too: `save_cohort_query`,
`submit_cohort_query`, and `initiate_training`. All four now follow the convention already
established in `user_services/delete_user.py:121-124` — log the exception, return a generic detail,
chain with `from e`.

## Scope

There are roughly twenty more handlers across flip-api that interpolate exception text into
`detail`. They are **not** in this PR: none carries a secret the way the Elasticsearch URL does, and
sweeping them means touching ~20 files and rewriting ~15 tests that currently assert on the leaked
string. Mixing that refactor into a security fix would make both harder to review. Inventoried as a
follow-up instead.

## Linked Issues

Fixes #888

## Verification

- `make -C flip-api unit_test` — ruff, mypy, **1465 passed**
- The new leak test was run against the pre-fix code to confirm it fails there:
  `AssertionError: assert 'upstream failed' == 'Internal server error'` — so it is a real regression
  lock, not a test that would pass either way

`retrieve_model_status_from_logs` had **no test file at all**, so this adds one covering the leak,
the still-distinct 404 branch, and the 403 authorization path. `test_initiate_training_failure`
asserted on the leaked string and now asserts the opposite.

## Checklist

- [x] Follows the project's coding conventions and style guide
- [ ] Updates documentation — n/a, no documented behaviour changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


## Acceptance Criteria

*Imported from issue #888*

- [ ] All four sites log the exception and return a generic `detail`
- [ ] `retrieve_model_status_from_logs` gains a test asserting a sentinel host in the upstream error does not appear in the response detail
- [ ] `test_initiate_training.py` updated (it currently asserts on the leaked string)
- [ ] `make -C flip-api unit_test` green