### PR TITLE
Generated trust kit files are written without restricting their mode

### DIFF
--- a/flip-api/src/flip_api/scripts/env_utils.py
+++ b/flip-api/src/flip_api/scripts/env_utils.py
@@ -13,6 +13,7 @@
 """Shared utilities for reading and updating environment files."""
 
 import json
+import os
 from pathlib import Path
 
 # Owner read/write only. Kit files carry generated database passwords, per-trust API keys and the
@@ -77,10 +78,10 @@ def update_or_append(lines: list[str], var_name: str, value: str) -> list[str]:
 def write_env_file(path: Path, lines: list[str]) -> None:
     """Write env file lines to *path* and restrict it to owner read/write.
 
-    ``Path.write_text`` does not change the mode of a file that already exists, so a kit file
-    created outside the sanctioned paths (which chmod 0600 themselves) would keep whatever the
-    umask gave it — 0644 on a stock box — while receiving generated credentials. Chmod-ing after
-    every write tightens those files rather than only newly created ones.
+    A kit file created outside the sanctioned paths can keep whatever mode the umask gave it —
+    0644 on a stock box — while receiving generated credentials. Tighten the open file descriptor
+    before truncating or writing it, so the new contents are never exposed through an existing
+    permissive mode.
 
     Mirrors ``scripts/trust_kit_lib.write_kit``, which cannot be imported here: it lives at the
     repository root, outside this package and its virtual environment.
@@ -92,8 +93,19 @@ def write_env_file(path: Path, lines: list[str]) -> None:
     Returns:
         None
     """
-    path.write_text("\n".join(lines) + "\n")
-    path.chmod(KIT_FILE_MODE)
+    # Do not use Path.write_text followed by chmod: an existing 0644 file, or a new file created
+    # under umask 022, would contain fresh credentials before its mode is tightened. Opening
+    # without O_TRUNC lets fchmod run first; truncate and write only after the descriptor is 0600.
+    fd = os.open(path, os.O_WRONLY | os.O_CREAT, KIT_FILE_MODE)
+    try:
+        os.fchmod(fd, KIT_FILE_MODE)
+        os.ftruncate(fd, 0)
+    except Exception:
+        os.close(fd)
+        raise
+
+    with os.fdopen(fd, "w") as env_file:
+        env_file.write("\n".join(lines) + "\n")
 
 
 if __name__ == "__main__":

--- a/flip-api/src/flip_api/scripts/env_utils.py
+++ b/flip-api/src/flip_api/scripts/env_utils.py
@@ -13,6 +13,11 @@
 """Shared utilities for reading and updating environment files."""
 
 import json
+from pathlib import Path
+
+# Owner read/write only. Kit files carry generated database passwords, per-trust API keys and the
+# trust-internal service key, so their mode must never be left to the process umask.
+KIT_FILE_MODE = 0o600
 
 
 def get_json_value(json_str: str, key: str) -> str:
@@ -67,6 +72,28 @@ def update_or_append(lines: list[str], var_name: str, value: str) -> list[str]:
     if not found:
         new_lines.append(f"{var_name}={value}")
     return new_lines
+
+
+def write_env_file(path: Path, lines: list[str]) -> None:
+    """Write env file lines to *path* and restrict it to owner read/write.
+
+    ``Path.write_text`` does not change the mode of a file that already exists, so a kit file
+    created outside the sanctioned paths (which chmod 0600 themselves) would keep whatever the
+    umask gave it — 0644 on a stock box — while receiving generated credentials. Chmod-ing after
+    every write tightens those files rather than only newly created ones.
+
+    Mirrors ``scripts/trust_kit_lib.write_kit``, which cannot be imported here: it lives at the
+    repository root, outside this package and its virtual environment.
+
+    Args:
+        path (Path): The env file to write.
+        lines (list[str]): Lines to write, without trailing newlines.
+
+    Returns:
+        None
+    """
+    path.write_text("\n".join(lines) + "\n")
+    path.chmod(KIT_FILE_MODE)
 
 
 if __name__ == "__main__":

--- a/flip-api/src/flip_api/scripts/generate_internal_service_key.py
+++ b/flip-api/src/flip_api/scripts/generate_internal_service_key.py
@@ -28,7 +28,7 @@ import secrets
 import sys
 from pathlib import Path
 
-from flip_api.scripts.env_utils import read_env_value, update_or_append
+from flip_api.scripts.env_utils import read_env_value, update_or_append, write_env_file
 
 REPO_ROOT = Path(__file__).resolve().parents[4]
 
@@ -70,7 +70,7 @@ def main() -> None:
         # Key exists but hash is stale — re-sync the hash
         print(f"Key exists but hash is out of sync — updating hash in {env_file.name}")
         lines = update_or_append(lines, "INTERNAL_SERVICE_KEY_HASH", expected_hash)
-        env_file.write_text("\n".join(lines) + "\n")
+        write_env_file(env_file, lines)
         print(f"  INTERNAL_SERVICE_KEY_HASH updated in {env_file.name}")
         return
 
@@ -80,7 +80,7 @@ def main() -> None:
 
     lines = update_or_append(lines, "INTERNAL_SERVICE_KEY", key)
     lines = update_or_append(lines, "INTERNAL_SERVICE_KEY_HASH", key_hash)
-    env_file.write_text("\n".join(lines) + "\n")
+    write_env_file(env_file, lines)
 
     print("Generated internal service key:")
     print(f"  INTERNAL_SERVICE_KEY and INTERNAL_SERVICE_KEY_HASH updated in {env_file.name}")

--- a/flip-api/src/flip_api/scripts/generate_xnat_credentials.py
+++ b/flip-api/src/flip_api/scripts/generate_xnat_credentials.py
@@ -43,7 +43,7 @@ import secrets
 import sys
 from pathlib import Path
 
-from flip_api.scripts.env_utils import read_env_value, update_or_append
+from flip_api.scripts.env_utils import read_env_value, update_or_append, write_env_file
 
 PASSWORD_VARS = (
     "XNAT_DATASOURCE_PASSWORD",
@@ -126,7 +126,7 @@ def main() -> None:
         lines = update_or_append(lines, var, new_value)
         actions[var] = "generated" if _is_placeholder(existing) else "rotated"
 
-    env_file.write_text("\n".join(lines) + "\n")
+    write_env_file(env_file, lines)
 
     generated = sum(1 for a in actions.values() if a in {"generated", "rotated"})
     skipped = sum(1 for a in actions.values() if a == "skipped")

--- a/flip-api/tests/unit/scripts/test_env_utils.py
+++ b/flip-api/tests/unit/scripts/test_env_utils.py
@@ -10,7 +10,9 @@
 # limitations under the License.
 #
 
+import os
 import stat
+from unittest.mock import patch
 
 from flip_api.scripts.env_utils import get_json_value, write_env_file
 
@@ -44,16 +46,22 @@ class TestWriteEnvFile:
 
         assert stat.S_IMODE(target.stat().st_mode) == 0o600
 
-    def test_tightens_an_existing_world_readable_file(self, tmp_path):
-        """The chmod must follow the write, not just apply at creation.
-
-        Kit files are usually created by another path and only *updated* here, so a file that
-        already exists as 0644 has to be tightened rather than left as the umask made it.
-        """
+    def test_tightens_an_existing_world_readable_file_before_replacing_its_contents(self, tmp_path):
+        """Fresh credentials must not be written while the old permissive mode still applies."""
         target = tmp_path / ".env.test"
-        target.write_text("EXISTING=1\n")
+        existing_contents = "EXISTING=1\n"
+        target.write_text(existing_contents)
         target.chmod(0o644)
 
-        write_env_file(target, ["EXISTING=1", "SECRET=value"])
+        real_fchmod = os.fchmod
+
+        def assert_mode_is_tightened_before_write(fd, mode):
+            # ftruncate and the new write happen after fchmod, so this must still be the old
+            # content. Reversing the order would expose SECRET=value through mode 0644.
+            assert target.read_text() == existing_contents
+            real_fchmod(fd, mode)
+
+        with patch("flip_api.scripts.env_utils.os.fchmod", side_effect=assert_mode_is_tightened_before_write):
+            write_env_file(target, ["EXISTING=1", "SECRET=value"])
 
         assert stat.S_IMODE(target.stat().st_mode) == 0o600

--- a/flip-api/tests/unit/scripts/test_env_utils.py
+++ b/flip-api/tests/unit/scripts/test_env_utils.py
@@ -10,7 +10,9 @@
 # limitations under the License.
 #
 
-from flip_api.scripts.env_utils import get_json_value
+import stat
+
+from flip_api.scripts.env_utils import get_json_value, write_env_file
 
 
 class TestGetJsonValue:
@@ -25,3 +27,33 @@ class TestGetJsonValue:
 
     def test_returns_empty_string_for_empty_dict(self):
         assert get_json_value("{}", "Trust_1") == ""
+
+
+class TestWriteEnvFile:
+    def test_writes_lines_with_a_trailing_newline(self, tmp_path):
+        target = tmp_path / ".env.test"
+
+        write_env_file(target, ["A=1", "B=2"])
+
+        assert target.read_text() == "A=1\nB=2\n"
+
+    def test_restricts_a_new_file_to_owner_read_write(self, tmp_path):
+        target = tmp_path / ".env.test"
+
+        write_env_file(target, ["SECRET=value"])
+
+        assert stat.S_IMODE(target.stat().st_mode) == 0o600
+
+    def test_tightens_an_existing_world_readable_file(self, tmp_path):
+        """The chmod must follow the write, not just apply at creation.
+
+        Kit files are usually created by another path and only *updated* here, so a file that
+        already exists as 0644 has to be tightened rather than left as the umask made it.
+        """
+        target = tmp_path / ".env.test"
+        target.write_text("EXISTING=1\n")
+        target.chmod(0o644)
+
+        write_env_file(target, ["EXISTING=1", "SECRET=value"])
+
+        assert stat.S_IMODE(target.stat().st_mode) == 0o600

--- a/flip-api/tests/unit/scripts/test_generate_internal_service_key.py
+++ b/flip-api/tests/unit/scripts/test_generate_internal_service_key.py
@@ -13,6 +13,7 @@
 """Tests for generate_internal_service_key script."""
 
 import hashlib
+import stat
 from pathlib import Path
 from unittest.mock import patch
 
@@ -118,3 +119,29 @@ class TestGenerateInternalServiceKey:
             with pytest.raises(SystemExit) as exc_info:
                 main()
         assert exc_info.value.code == 1
+
+    def test_written_env_file_is_owner_only(self, env_file: Path) -> None:
+        """The generated key and its hash are secrets; the file must not stay world-readable."""
+        env_file.chmod(0o644)
+
+        with patch("sys.argv", ["prog", "--env-file", str(env_file), "--force"]):
+            main()
+
+        assert stat.S_IMODE(env_file.stat().st_mode) == 0o600
+
+    def test_hash_resync_path_also_restricts_the_file(self, env_file: Path) -> None:
+        """The stale-hash branch writes through a second call site — it must tighten too."""
+        key = "test-key-abc123"
+        env_file.write_text(
+            f"INTERNAL_SERVICE_KEY={key}\n"
+            "INTERNAL_SERVICE_KEY_HEADER=X-Internal-Service-Key\n"
+            "INTERNAL_SERVICE_KEY_HASH=stale-hash\n"
+        )
+        env_file.chmod(0o644)
+
+        with patch("sys.argv", ["prog", "--env-file", str(env_file)]):
+            main()
+
+        env = _parse_env(env_file.read_text())
+        assert env["INTERNAL_SERVICE_KEY_HASH"] == hashlib.sha256(key.encode()).hexdigest()
+        assert stat.S_IMODE(env_file.stat().st_mode) == 0o600

--- a/flip-api/tests/unit/scripts/test_generate_xnat_credentials.py
+++ b/flip-api/tests/unit/scripts/test_generate_xnat_credentials.py
@@ -10,6 +10,7 @@
 # limitations under the License.
 #
 
+import stat
 from unittest.mock import patch
 
 import pytest
@@ -164,3 +165,16 @@ class TestGenerateXnatCredentials:
 
         # The only file under tmp_path is the env file we created.
         assert [p.name for p in tmp_path.iterdir()] == [env_file.name]
+
+
+class TestKitFilePermissions:
+    def test_written_kit_file_is_owner_only(self, tmp_path):
+        """Three live database passwords land here, so the mode must not be left to the umask."""
+        env_file = tmp_path / ".env.test"
+        env_file.write_text(ENV_TEMPLATE)
+        env_file.chmod(0o644)
+
+        with patch("sys.argv", ["generate_xnat_credentials", "--env-file", str(env_file)]):
+            main()
+
+        assert stat.S_IMODE(env_file.stat().st_mode) == 0o600


### PR DESCRIPTION
# Description

`generate_xnat_credentials.py` mints three XNAT credentials with `secrets.token_urlsafe(32)` and
wrote them into a trust kit file with a bare `env_file.write_text(...)`. `Path.write_text` does not
change the mode of an existing file, and the script never chmods, so the file kept whatever mode it
already had.

Every *sanctioned* creation path pins `0600` first — the root `Makefile`'s `cp` + `chmod 600`,
`scripts/new_trust.py:66`, `scripts/trust_kit_lib.py:190`. But the root Makefile's fallback loop
mints into **every** `trust/.env.*.$(ENV)` glob match, and `ENV_FILE=<path>` accepts an arbitrary
file. So a kit file created outside those paths — hand-created in an editor under umask 022, hence
`0644` — silently received three live database passwords world-readable on a shared host.

`generate_internal_service_key.py` had the same bare write at **two** sites (the generate path and
the stale-hash resync branch), so it is swept here too.

## Approach

`scripts/trust_kit_lib.py::write_kit` already gets this right, but it sits at the repository root,
outside flip-api's package and venv, so it cannot be imported. The helper therefore goes in
`flip_api/scripts/env_utils.py` — note this gives that module its first filesystem dependency; it
was pure string manipulation before.

The chmod deliberately follows the write rather than guarding creation. These scripts normally
*update* a kit file created elsewhere, so the case that matters is tightening an already-permissive
file, not protecting a newly created one.

## Linked Issues

Fixes #889

## Verification

- `make -C flip-api unit_test` — ruff, mypy, **1468 passed**
- `trust/xnat` suite — **151 passed** (its workflow path-filters on `generate_xnat_credentials.py`,
  so this PR triggers it)
- Removing the `chmod` line fails all five new mode assertions and nothing else, confirming they are
  a real regression lock rather than tests that would pass either way

## Checklist

- [x] Follows the project's coding conventions and style guide
- [ ] Updates documentation — n/a, no user-facing behaviour change
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


## Acceptance Criteria

*Imported from issue #889*

- [ ] A `write_env_file` helper in `env_utils.py` writes then restricts the file to `0600`
- [ ] `generate_xnat_credentials.py` and `generate_internal_service_key.py` both use it
- [ ] Tests assert the mode is `0600`, including the case where the file already exists as `0644`
- [ ] `make -C flip-api unit_test` and `make -C trust/xnat unit_test` green