### PR TITLE
XNAT username sanitisation is discarded when a username collides

### DIFF
--- a/trust/imaging-api/imaging_api/services/users.py
+++ b/trust/imaging-api/imaging_api/services/users.py
@@ -68,7 +68,8 @@ def to_create_imaging_user(user: CentralHubUser, headers: dict[str, str]) -> Cre
     base_username = user.email.split("@")[0]
 
     # Replace all non-alphanumeric characters as they're not supported
-    username = re.sub(r"[^a-zA-Z0-9 \-]", "", base_username)
+    sanitised_stem = re.sub(r"[^a-zA-Z0-9 \-]", "", base_username)
+    username = sanitised_stem
 
     # Get existing users to check for uniqueness
     try:
@@ -76,12 +77,15 @@ def to_create_imaging_user(user: CentralHubUser, headers: dict[str, str]) -> Cre
     except Exception as e:
         raise Exception(f"Error: XNAT error when fetching users: {str(e)}")
 
-    # Keep adding a suffix until we find a unique username
+    # Keep adding a suffix until we find a unique username. The suffix builds on the *sanitised*
+    # stem, never on the raw local part: this value is sent to an admin-authenticated
+    # POST /xapi/users and interpolated into an XNAT URL path, so a collision must not be the one
+    # route that reintroduces the characters stripped above.
     if existing_users:
         existing_usernames = {u.username for u in existing_users}
         suffix = 1
         while username in existing_usernames:
-            username = f"{base_username}{suffix}"
+            username = f"{sanitised_stem}{suffix}"
             suffix += 1
 
     # Create and return the user profile

--- a/trust/imaging-api/tests/services/test_users.py
+++ b/trust/imaging-api/tests/services/test_users.py
@@ -10,6 +10,7 @@
 # limitations under the License.
 #
 
+import re
 from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
@@ -183,8 +184,53 @@ def test_to_create_imaging_user_with_conflict(mock_get_users, mock_pwd, headers)
     hub_user = CentralHubUser(id=uuid4(), email="john.doe@hospital.nhs.uk")
 
     create_user_req = to_create_imaging_user(hub_user, headers)
-    # Should append suffix to avoid collision
-    assert create_user_req.username == "john.doe1"
+    # Should append a suffix to the *sanitised* stem to avoid collision — the dot from the email
+    # local part must not come back.
+    assert create_user_req.username == "johndoe1"
+
+
+@pytest.mark.parametrize(
+    "email",
+    [
+        "john.doe@hospital.nhs.uk",
+        "jo+hn.doe@hospital.nhs.uk",
+        "j'ohn.d%oe@hospital.nhs.uk",
+        "john=doe!@hospital.nhs.uk",
+    ],
+)
+@patch("imaging_api.services.users.generate_complex_password", return_value="P@ssw0rd123456!")
+@patch("imaging_api.services.users.get_xnat_users")
+def test_to_create_imaging_user_collision_keeps_sanitisation(mock_get_users, mock_pwd, headers, email):
+    """The generated username must stay within the safe charset even after a collision.
+
+    This is the property that matters, not the literal value: the username is sent to an
+    admin-authenticated POST /xapi/users and interpolated into an XNAT URL path, so characters like
+    ``%``, ``+``, ``'`` and ``!`` must never reach it. Asserting the charset rather than the exact
+    string keeps the test meaningful if the suffix scheme ever changes.
+    """
+    existing_user = MagicMock()
+    existing_user.username = "johndoe"
+    mock_get_users.return_value = [existing_user]
+    hub_user = CentralHubUser(id=uuid4(), email=email)
+
+    create_user_req = to_create_imaging_user(hub_user, headers)
+
+    assert re.fullmatch(r"[a-zA-Z0-9 \-]+", create_user_req.username), create_user_req.username
+
+
+@patch("imaging_api.services.users.generate_complex_password", return_value="P@ssw0rd123456!")
+@patch("imaging_api.services.users.get_xnat_users")
+def test_to_create_imaging_user_suffix_increments_past_repeated_collisions(mock_get_users, mock_pwd, headers):
+    """Successive collisions keep incrementing rather than sticking on the first suffix."""
+    taken = [MagicMock(), MagicMock()]
+    taken[0].username = "johndoe"
+    taken[1].username = "johndoe1"
+    mock_get_users.return_value = taken
+    hub_user = CentralHubUser(id=uuid4(), email="john.doe@hospital.nhs.uk")
+
+    create_user_req = to_create_imaging_user(hub_user, headers)
+
+    assert create_user_req.username == "johndoe2"
 
 
 @patch("imaging_api.services.users.generate_complex_password", return_value="P@ssw0rd123456!")


### PR DESCRIPTION
# Description

`to_create_imaging_user` sanitises the XNAT username derived from a user's email, then throws that
work away the moment there is a collision:

```python
username = re.sub(r"[^a-zA-Z0-9 \-]", "", base_username)   # sanitised
...
while username in existing_usernames:
    username = f"{base_username}{suffix}"                  # raw again
```

So `john.doe@…` yields `johndoe` normally, but `john.doe1` when `johndoe` is already taken.

That value is sent to an admin-authenticated `POST /xapi/users` and interpolated into an XNAT URL
path (`/data/projects/{p}/users/Members/{username}`). `EmailStr` rejects quoted local parts, so `/`
and `..` cannot appear and traversal is not possible — but `%`, `+`, `!`, `#`, `$`, `&`, `'`, `*`,
`=`, `?`, `^` and `` ` `` all can. Whether XNAT/Tomcat percent-decoding makes any of those
exploitable is genuinely untested, so I would not claim more than "the collision path should not be
the one route that reintroduces the characters the sanitiser exists to strip".

## Linked Issues

Fixes #890

## Note on the existing test

`test_to_create_imaging_user_with_conflict` asserted `"john.doe1"` — it locked in the bug. It now
expects `"johndoe1"`.

The new tests assert the **charset property** (`^[a-zA-Z0-9 \-]+$`) across several awkward local
parts rather than a literal string, so they stay meaningful if the suffix scheme changes. A second
test covers repeated collisions, since that path was previously untested.

One correction to the issue text: the loop does terminate — `suffix` increments each iteration. The
defect is solely the loss of sanitisation.

## Verification

- `make -C trust/imaging-api unit_test` — ruff, mypy, **275 passed**
- Restoring the buggy line fails all six new/updated assertions and nothing else

## Checklist

- [x] Follows the project's coding conventions and style guide
- [ ] Updates documentation — n/a
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


## Acceptance Criteria

*Imported from issue #890*

- [ ] The collision suffix builds on the sanitised stem
- [ ] `test_to_create_imaging_user_with_conflict` updated to expect `johndoe1`
- [ ] A test asserts the generated username always matches `^[a-zA-Z0-9 \-]+$`, including on collision
- [ ] `make -C trust/imaging-api unit_test` green