### PR TITLE
Site banner link is rendered into an href without allow-listing the scheme

### DIFF
--- a/flip-api/src/flip_api/domain/interfaces/site.py
+++ b/flip-api/src/flip_api/domain/interfaces/site.py
@@ -11,13 +11,33 @@
 #
 
 
-from pydantic import BaseModel
+from typing import Any
+
+from pydantic import BaseModel, HttpUrl, field_validator
 
 
 class ISiteBanner(BaseModel):
     message: str
-    link: str | None = None
+    # HttpUrl restricts the scheme to http/https, which is what matters here: this value is
+    # rendered into an href that every user sees, so a `javascript:` (or `data:`) URL would
+    # execute in the visitor's session. Defence in depth behind the frontend's own guard — the
+    # API is reachable directly, so the UI check alone protects nothing.
+    link: HttpUrl | None = None
     enabled: bool
+
+    @field_validator("link", mode="before")
+    @classmethod
+    def _empty_string_is_no_link(cls, v: Any) -> Any:
+        """Treat an empty or whitespace-only link as absent.
+
+        ``update_site_details`` persists ``""`` rather than NULL when a banner has no link, so
+        every such row would otherwise fail ``HttpUrl`` validation on read. Coercing here keeps
+        those rows valid instead of routing them through the read path's error fallback.
+        """
+        if isinstance(v, str) and v.strip() == "":
+            return None
+
+        return v
 
 
 class ISiteDetails(BaseModel):

--- a/flip-api/src/flip_api/site_services/services/details_service.py
+++ b/flip-api/src/flip_api/site_services/services/details_service.py
@@ -11,6 +11,7 @@
 #
 
 from fastapi import HTTPException, status
+from pydantic import ValidationError
 from sqlmodel import Session, select
 
 from flip_api.config import get_settings
@@ -42,12 +43,23 @@ def get_site_details(db: Session) -> ISiteDetails:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Deployment mode not found")
 
     if banner:
-        validated_banner = ISiteBanner.model_validate(banner.model_dump())
+        stored = banner.model_dump()
+        try:
+            validated_banner = ISiteBanner.model_validate(stored)
+        except ValidationError:
+            # A row stored before the link-scheme validator existed (or written by some other
+            # path) must not take the whole site down: every page load reads this, so raising
+            # here would turn a bad banner link into a site-wide 500. Drop the link and serve
+            # the rest of the banner.
+            logger.warning("Stored site banner failed validation; serving it without its link")
+            validated_banner = ISiteBanner.model_validate({**stored, "link": None})
 
         return ISiteDetails(
             banner=ISiteBanner(
                 message=validated_banner.message,
-                link=validated_banner.link if banner.link and banner.link.strip() != "" else None,
+                # The empty-string sentinel is already normalised to None by ISiteBanner's
+                # validator, so no second emptiness check is needed here.
+                link=validated_banner.link,
                 enabled=validated_banner.enabled,
             ),
             deploymentMode=config.value,

--- a/flip-api/tests/unit/domain/interfaces/test_site.py
+++ b/flip-api/tests/unit/domain/interfaces/test_site.py
@@ -1,0 +1,52 @@
+# Copyright (c) Guy's and St Thomas' NHS Foundation Trust & King's College London
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import pytest
+from pydantic import ValidationError
+
+from flip_api.domain.interfaces.site import ISiteBanner
+
+
+class TestISiteBannerLinkValidation:
+    """The banner link is rendered into an href every user sees, so the scheme is allow-listed."""
+
+    @pytest.mark.parametrize(
+        "link",
+        [
+            "javascript:alert(1)",
+            "JaVaScRiPt:alert(1)",
+            "\tjavascript:alert(1)",
+            " javascript:alert(1)",
+            "data:text/html,<script>alert(1)</script>",
+            "ftp://example.com/x",
+            "/relative/path",
+        ],
+    )
+    def test_rejects_non_http_schemes(self, link: str):
+        with pytest.raises(ValidationError):
+            ISiteBanner.model_validate({"message": "m", "link": link, "enabled": True})
+
+    @pytest.mark.parametrize("link", ["https://example.nhs.uk/guidance", "http://example.nhs.uk/guidance"])
+    def test_accepts_http_schemes(self, link: str):
+        banner = ISiteBanner.model_validate({"message": "m", "link": link, "enabled": True})
+
+        assert str(banner.link) == link
+
+    @pytest.mark.parametrize("link", ["", "   ", None])
+    def test_treats_blank_as_no_link(self, link: str | None):
+        """update_site_details persists "" rather than NULL, so blank must validate as absent.
+
+        Without this every existing link-less banner would fail validation on read.
+        """
+        banner = ISiteBanner.model_validate({"message": "m", "link": link, "enabled": True})
+
+        assert banner.link is None

--- a/flip-api/tests/unit/site_services/services/test_details_service.py
+++ b/flip-api/tests/unit/site_services/services/test_details_service.py
@@ -47,7 +47,9 @@ def test_get_site_details_with_banner():
     assert isinstance(result, ISiteDetails)
     assert result.banner is not None
     assert result.banner.message == "Welcome!"
-    assert result.banner.link == "https://example.com"
+    # HttpUrl normalises a bare authority by appending the root path, so the round-tripped value
+    # gains a trailing slash. Equivalent URL, deliberate consequence of validating the scheme.
+    assert str(result.banner.link) == "https://example.com/"
     assert result.banner.enabled is True
     assert result.deploymentMode is True
 
@@ -87,7 +89,7 @@ def test_update_site_details_success(mock_db):
     # Assert
     assert result is None
     assert existing_banner.message == "New Message"
-    assert existing_banner.link == "https://example.com"
+    assert existing_banner.link == "https://example.com/"
     assert existing_banner.enabled is True
     assert existing_config.value is False
 
@@ -174,7 +176,7 @@ def test_update_site_details_creates_new_banner(mock_db):
     added_banner = mock_db.add.call_args[0][0]
     assert isinstance(added_banner, SiteBanner)
     assert added_banner.message == "Brand New"
-    assert added_banner.link == "https://new.com"
+    assert added_banner.link == "https://new.com/"
     assert added_banner.enabled is True
 
 

--- a/flip-ui/src/components/AiBanner/AiBanner.vue
+++ b/flip-ui/src/components/AiBanner/AiBanner.vue
@@ -23,8 +23,8 @@
                     </div>
                     <div class="flex items-center flex-shrink-0 order-3 w-full mt-2 sm:order-2 sm:mt-0 sm:w-auto">
                         <a
-                            v-if="link"
-                            :href="link"
+                            v-if="safeLink"
+                            :href="safeLink"
                             target="_blank"
                             data-test="banner-link"
                             class="flex items-center justify-center px-4 py-2 text-white hover:text-primary-200 grow"
@@ -42,18 +42,24 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from "vue";
+import { computed, ref } from "vue";
 import { directive as vTippy } from "vue-tippy";
+
+import { safeExternalUrl } from "@/utils/helpers";
 
 interface IBannerProps {
     message: string;
     link?: string;
 }
 
-withDefaults(
+const props = withDefaults(
     defineProps<IBannerProps>(),
     { link: undefined }
 );
+
+// Gate the anchor itself, not just its href: a link with a rejected scheme should drop the
+// "Learn more" affordance entirely rather than render as an anchor that silently does nothing.
+const safeLink = computed(() => safeExternalUrl(props.link));
 
 const showBanner = ref(true);
 

--- a/flip-ui/src/components/AiBanner/__tests__/AiBanner.spec.ts
+++ b/flip-ui/src/components/AiBanner/__tests__/AiBanner.spec.ts
@@ -25,4 +25,28 @@ describe("AiBanner", () => {
 
         expect(comp.element).toMatchSnapshot();
     });
+
+    test("renders the link when the scheme is http(s)", () => {
+        const comp = mountComponent(AiBanner, {
+            props: {
+                message: "Some cool message",
+                link: "https://example.nhs.uk"
+            }
+        });
+
+        expect(comp.find("[data-test=\"banner-link\"]").attributes("href")).toBe("https://example.nhs.uk");
+    });
+
+    test("drops the link entirely when the scheme is not http(s)", () => {
+        // A javascript: href would execute in every user's session. The affordance should
+        // disappear rather than render as an anchor that silently does nothing.
+        const comp = mountComponent(AiBanner, {
+            props: {
+                message: "Some cool message",
+                link: "javascript:alert(1)"
+            }
+        });
+
+        expect(comp.find("[data-test=\"banner-link\"]").exists()).toBe(false);
+    });
 });

--- a/flip-ui/src/partials/admin/banner/SiteBanner.vue
+++ b/flip-ui/src/partials/admin/banner/SiteBanner.vue
@@ -61,11 +61,11 @@
                                             <p class="ml-3 font-medium text-white" v-text="values.message" />
                                         </div>
                                         <div
-                                            v-if="values.link"
+                                            v-if="safeExternalUrl(values.link)"
                                             class="flex-shrink-0 order-3 w-full mt-2 sm:order-2 sm:mt-0 sm:w-auto"
                                         >
                                             <a
-                                                :href="values.link"
+                                                :href="safeExternalUrl(values.link)"
                                                 target="_blank"
                                                 class="flex items-center justify-center px-4 py-2 text-white group"
                                             >
@@ -156,6 +156,7 @@ import AiLoader from "@/components/AiLoader/AiLoader.vue";
 import AiSkeleton from "@/components/AiSkeleton/AiSkeleton.vue";
 import AiTextArea from "@/components/AiTextArea/AiTextArea.vue";
 import { ISiteBanner, useSiteDetailsStore } from "@/store/siteDetailsStore";
+import { safeExternalUrl } from "@/utils/helpers";
 
 const details = useSiteDetailsStore();
 const loadingButton = ref(false);

--- a/flip-ui/src/utils/__tests__/helpers.spec.ts
+++ b/flip-ui/src/utils/__tests__/helpers.spec.ts
@@ -11,7 +11,7 @@
  * limitations under the License.
  */
 
-import { apiTimestampMs, getRandomId, relativeCreatedLabel } from "@/utils/helpers";
+import { apiTimestampMs, getRandomId, relativeCreatedLabel, safeExternalUrl } from "@/utils/helpers";
 
 const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
@@ -87,5 +87,36 @@ describe("relativeCreatedLabel", () => {
         expect(relativeCreatedLabel(undefined)).toBe("—");
         expect(relativeCreatedLabel(null)).toBe("—");
         expect(relativeCreatedLabel("not-a-date")).toBe("—");
+    });
+});
+
+describe("safeExternalUrl", () => {
+    it.each([
+        "javascript:alert(1)",
+        "JaVaScRiPt:alert(1)",
+        "\tjavascript:alert(1)",
+        " javascript:alert(1)",
+        "data:text/html,<script>alert(1)</script>",
+        "vbscript:msgbox(1)"
+    ])("rejects %s", (url) => {
+        expect(safeExternalUrl(url)).toBeUndefined();
+    });
+
+    it.each([
+        "https://example.nhs.uk/guidance",
+        "http://example.nhs.uk/guidance",
+        "HTTPS://example.nhs.uk/guidance"
+    ])("allows %s", (url) => {
+        expect(safeExternalUrl(url)).toBe(url);
+    });
+
+    it("returns undefined for empty and nullish input", () => {
+        expect(safeExternalUrl("")).toBeUndefined();
+        expect(safeExternalUrl(undefined)).toBeUndefined();
+        expect(safeExternalUrl(null)).toBeUndefined();
+    });
+
+    it("accepts a relative path, which resolves against the app origin", () => {
+        expect(safeExternalUrl("/projects")).toBe("/projects");
     });
 });

--- a/flip-ui/src/utils/helpers.ts
+++ b/flip-ui/src/utils/helpers.ts
@@ -124,6 +124,29 @@ export const capatilizeString = (value: string): string => {
 export const getRandomId = (): string => crypto.randomUUID();
 
 
+/**
+ * Return `url` only when it is an absolute http(s) URL, otherwise `undefined`.
+ *
+ * The site banner's link is admin-supplied and rendered into an `href` that every user sees, so a
+ * `javascript:` URL would execute in the visitor's session. The scheme is allow-listed rather than
+ * denied: a prefix check is defeated by leading whitespace (`\tjavascript:`) and by case
+ * (`JaVaScRiPt:`), whereas neither parses to an allowed protocol.
+ *
+ * Parsing against `window.location.origin` means a relative path resolves and is accepted; the
+ * banner is expected to hold absolute links, but a relative one is harmless.
+ */
+export const safeExternalUrl = (url?: string | null): string | undefined => {
+    if (!url) return undefined;
+
+    try {
+        const parsed = new URL(url, window.location.origin);
+
+        return ["http:", "https:"].includes(parsed.protocol) ? url : undefined;
+    } catch {
+        return undefined;
+    }
+};
+
 export const getInitials = (name: string): string => {
     const rgx = /(\p{L}{1})\p{L}+/gu;
 


### PR DESCRIPTION
# Description

The site banner's link is admin-set and rendered directly into an `href` that every user sees, with
no restriction on the scheme — so a `javascript:` URL executes in the session of every user who
clicks it. The only guard was client-side yup validation on the admin form, bypassed by calling the
API directly, and the backend accepted a bare `str`.

Requires an admin holding `CAN_MANAGE_SITE_BANNER`, so this is escalation-from-admin rather than a
route in from outside — but the fix is small.

## Backend — `HttpUrl` rather than a hand-rolled validator

`ISiteBanner.link` is now `pydantic.HttpUrl`, which restricts the scheme to http/https. Verified it
rejects `javascript:`, mixed-case `JaVaScRiPt:`, leading-whitespace `\tjavascript:`, `data:`,
`ftp:` and relative paths.

Two consequences of the typed field, both handled:

- **`HttpUrl` rejects `""`, and that is exactly what this codebase stores for "no link"** —
  `update_site_details` persists `""` rather than NULL. A `mode="before"` validator coerces blank to
  `None`, so every existing link-less banner stays valid instead of failing validation on read.
- **`HttpUrl` normalises a bare authority**: `https://example.com` is stored as
  `https://example.com/`. Equivalent URL, but it is a visible change to the stored value — three
  existing assertions were updated to match.

One ergonomic note for reviewers: because the field is typed, mypy rejects
`ISiteBanner(link="https://…")` with a plain `str`. The new tests use `model_validate` instead,
which is also how the read path actually constructs these (from `model_dump()`).

## Frontend — the load-bearing half

The backend validator only protects *new* writes. The store can still hold a value written before
this change, so the render sites need their own guard. `safeExternalUrl` parses with `URL()` and
allow-lists `http:`/`https:` — a prefix check would be defeated by leading whitespace and by case.

Both render sites gate the `v-if` on the sanitised value, so a rejected link removes the "Learn
more" affordance entirely rather than rendering an anchor that silently does nothing.

## The read-path trap

`details_service` validates the stored banner on **every** page load. A raising validator alone
would turn a row poisoned before this change into a site-wide 500 — trading a stored XSS for an
outage. The read path therefore falls back to `link=None` and logs, rather than propagating.

## Linked Issues

Fixes #891

## Verification

- `make -C flip-api unit_test` — ruff, mypy, **1474 passed**
- `npm run test:unit` — **1127 passed**, `npm run lint` clean (3 remaining warnings are pre-existing
  in `EditProjectDrawer.vue`, untouched here)
- Reverting the `v-if`/`href` guard fails the `javascript:` component test and nothing else

## Checklist

- [x] Follows the project's coding conventions and style guide
- [ ] Updates documentation — n/a
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


## Acceptance Criteria

*Imported from issue #891*

- [ ] A shared helper allow-lists `http:`/`https:` and is used at both render sites
- [ ] A rejected link removes the link affordance rather than rendering an inert anchor
- [ ] Backend rejects non-http(s) links on write, and degrades to `link=None` on read rather than erroring
- [ ] Tests cover `javascript:`, mixed case, and leading-whitespace variants
- [ ] `make -C flip-ui unit_test` and `make -C flip-api unit_test` green