### PR TITLE
XNAT init job prints the live admin session token to the pod log

### DIFF
--- a/.github/workflows/test_helm_chart.yml
+++ b/.github/workflows/test_helm_chart.yml
@@ -119,15 +119,19 @@ jobs:
 
       # The init Job must never print the live XNAT admin JSESSIONID. It is reused as a Cookie
       # header on ~20 subsequent calls, and the chart ships Loki/Alloy, so a logged session is
-      # both replayable and retained beyond the Job. The pattern deliberately matches the shell
-      # *interpolation* rather than the literal string "JSESSIONID", which appears legitimately
-      # in every Cookie header and in scrub_args' own sed.
+      # both replayable and retained beyond the Job.
+      #
+      # The pattern matches an `echo` of the $JSESSION *interpolation* in any wording — not just
+      # the exact line removed in FLIP#892 — so `echo "session: ${JSESSION}"` and `echo "$JSESSION"`
+      # are caught too, which is the likelier shape of a future regression than a verbatim re-add.
+      # It deliberately does not key on the literal string "JSESSIONID", which appears legitimately
+      # ~25 times in Cookie headers (passed via -H, never echoed) and in scrub_args' own sed.
       - name: XNAT init job does not log the session token
         run: |
           helm template trust-release deploy/providers/kubernetes/ \
             --set xnat.enabled=true \
             --show-only templates/xnat-init-job.yaml > xnat-init.rendered.yaml
-          if grep -nE 'echo[^|]*JSESSIONID[^|]*\$\{?JSESSION\}?' xnat-init.rendered.yaml; then
+          if grep -nE 'echo[^|]*\$\{?JSESSION\}?' xnat-init.rendered.yaml; then
             echo "::error::the XNAT init job echoes the live JSESSIONID into the pod log"
             exit 1
           fi

--- a/.github/workflows/test_helm_chart.yml
+++ b/.github/workflows/test_helm_chart.yml
@@ -117,6 +117,21 @@ jobs:
             exit 1
           fi
 
+      # The init Job must never print the live XNAT admin JSESSIONID. It is reused as a Cookie
+      # header on ~20 subsequent calls, and the chart ships Loki/Alloy, so a logged session is
+      # both replayable and retained beyond the Job. The pattern deliberately matches the shell
+      # *interpolation* rather than the literal string "JSESSIONID", which appears legitimately
+      # in every Cookie header and in scrub_args' own sed.
+      - name: XNAT init job does not log the session token
+        run: |
+          helm template trust-release deploy/providers/kubernetes/ \
+            --set xnat.enabled=true \
+            --show-only templates/xnat-init-job.yaml > xnat-init.rendered.yaml
+          if grep -nE 'echo[^|]*JSESSIONID[^|]*\$\{?JSESSION\}?' xnat-init.rendered.yaml; then
+            echo "::error::the XNAT init job echoes the live JSESSIONID into the pod log"
+            exit 1
+          fi
+
   kind-e2e:
     name: kind E2E
     runs-on: ubuntu-latest

--- a/deploy/providers/kubernetes/templates/xnat-init-job.yaml
+++ b/deploy/providers/kubernetes/templates/xnat-init-job.yaml
@@ -153,11 +153,14 @@ spec:
                 echo "Configured password failed, trying XNAT default (admin:admin)..."
                 JSESSION=$(_xnat_login "admin")
               fi
-              echo "JSESSIONID: ${JSESSION}"
               if [ -z "$JSESSION" ]; then
                 echo "Failed to login to XNAT with any credential"
                 exit 1
               fi
+              # Never print the session id itself. It is a live XNAT admin session, reused as a
+              # Cookie header on every call below, and pod logs are shipped to Loki and outlive
+              # the Job — which is the same reason scrub_args() redacts it from failure output.
+              echo "XNAT login succeeded (admin session acquired)."
 
               # Activate XNAT site (idempotent — safe to call even if already initialized).
               # siteUrl must be non-empty on XNAT >= 1.10.0: the Restlet create paths NPE on a
@@ -852,6 +855,11 @@ data:
     }
 
     wait_for_xnat
+
+    # The session id is written to disk on the way through, so remove it whenever this script
+    # exits. It is a live XNAT admin session and the file would otherwise outlive its use inside
+    # the container's filesystem.
+    trap 'rm -f /tmp/jsession.txt' EXIT
 
     # Login and get JSESSIONID
     login() {


### PR DESCRIPTION
# Description

`deploy/providers/kubernetes/templates/xnat-init-job.yaml` printed the live XNAT admin session
token to the pod log on every run:

```sh
echo "JSESSIONID: ${JSESSION}"
```

That token is reused as `-H "Cookie: JSESSIONID=..."` on roughly twenty subsequent calls, so it is
a working admin session for its lifetime — user management, PACS configuration, imaging data.
Anyone with `kubectl logs` on the namespace can replay it, and the chart deploys Loki/Alloy/Grafana,
so pod logs are shipped and retained beyond the Job's own lifetime.

The line sat **three lines below** the `scrub_args()` helper added by #862, whose comment states
that "neither must a live JSESSIONID" reach the pod log. The new redaction control was being
defeated by a pre-existing line directly beneath it.

## Changes

- Replace the echo with a presence-only message, **moved after** the empty-session guard so it is
  not printed on the failure path.
- The third embedded script (the `wget` variant) does not log the token but writes it to
  `/tmp/jsession.txt` and never removes it — added a `trap ... EXIT`.
- Added a rendered-manifest assertion to `test_helm_chart.yml`, following the FLIP-PT-091
  `--show-only` + grep precedent already in that workflow.

**Not touched**, deliberately: the second embedded script (`configure-dcm2niix`) carries a verbatim
`scrub_args` copy but never echoes the token, so there is nothing to fix there. The third script's
`|| true` error-swallowing is the separate #862 fail-loud class and would widen this PR's scope.

## Linked Issues

Fixes #892

## Verification

Coverage here was previously nil — `test_helm_chart.yml` only renders the chart, and the kind e2e
sets `xnat: enabled: false`. So the new guard is the only thing standing between this and a
regression, which makes proving it can *fail* the important part:

```
PRE-FIX render:   524:  echo "JSESSIONID: ${JSESSION}"   -> guard fires
POST-FIX render:  no match                               -> guard silent
```

The pattern matches the shell **interpolation** (`${JSESSION}`) rather than the literal string
`JSESSIONID`, which appears ~25 times legitimately in Cookie headers and in `scrub_args`' own `sed`.

- `helm lint` — 1 chart linted, 0 failed
- `make -C deploy/providers/kubernetes test` — lint + template + validate clean
- chart python tests — 18 passed

## Checklist

- [x] Follows the project's coding conventions and style guide
- [ ] Updates documentation — n/a
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


## Acceptance Criteria

*Imported from issue #892*

- [ ] The init job no longer prints the session token; a presence-only message replaces it, after the empty-session guard
- [ ] Script 3 removes `/tmp/jsession.txt` on exit
- [ ] A rendered-manifest assertion in `test_helm_chart.yml` fails if the echo returns, verified to fire against the pre-fix render
- [ ] `helm lint` and the chart render green