### PR TITLE
Numeric-encoded IP hosts bypass the bundle URL private-range guard

### DIFF
--- a/.github/workflows/fl-api-test-flower.yml
+++ b/.github/workflows/fl-api-test-flower.yml
@@ -22,11 +22,17 @@ on:
     paths:
       - "fl-services/flower/fl-api-flower/fl_api/**"
       - ".github/workflows/fl-api-test-flower.yml"
+      # The sibling copy and the sync check, so drift in either direction runs the guard.
+      - "fl-services/nvflare/fl-api-base/fl_api/utils/validation.py"
+      - "scripts/check_fl_api_validation_sync.sh"
   pull_request:
     branches: [main, develop]
     paths:
       - "fl-services/flower/fl-api-flower/fl_api/**"
       - ".github/workflows/fl-api-test-flower.yml"
+      # The sibling copy and the sync check, so drift in either direction runs the guard.
+      - "fl-services/nvflare/fl-api-base/fl_api/utils/validation.py"
+      - "scripts/check_fl_api_validation_sync.sh"
 jobs:
   flip-fl-api:
     runs-on: ubuntu-latest
@@ -47,6 +53,10 @@ jobs:
 
       - name: Install uv (if used for dependency management)
         run: pip install uv
+
+      - name: Check fl-api validation guards are in sync
+        working-directory: ./
+        run: ./scripts/check_fl_api_validation_sync.sh
 
       - name: Run tests with pytest (example)
         run: |

--- a/.github/workflows/fl-api-test-nvflare.yml
+++ b/.github/workflows/fl-api-test-nvflare.yml
@@ -22,11 +22,17 @@ on:
     paths:
       - "fl-services/nvflare/fl-api-base/fl_api/**"
       - ".github/workflows/fl-api-test-nvflare.yml"
+      # The sibling copy and the sync check, so drift in either direction runs the guard.
+      - "fl-services/flower/fl-api-flower/fl_api/utils/validation.py"
+      - "scripts/check_fl_api_validation_sync.sh"
   pull_request:
     branches: [main, develop]
     paths:
       - "fl-services/nvflare/fl-api-base/fl_api/**"
       - ".github/workflows/fl-api-test-nvflare.yml"
+      # The sibling copy and the sync check, so drift in either direction runs the guard.
+      - "fl-services/flower/fl-api-flower/fl_api/utils/validation.py"
+      - "scripts/check_fl_api_validation_sync.sh"
 jobs:
   flip-fl-api:
     runs-on: ubuntu-latest
@@ -47,6 +53,10 @@ jobs:
 
       - name: Install uv (if used for dependency management)
         run: pip install uv
+
+      - name: Check fl-api validation guards are in sync
+        working-directory: ./
+        run: ./scripts/check_fl_api_validation_sync.sh
 
       - name: Run tests with pytest (example)
         run: |

--- a/fl-services/flower/fl-api-flower/fl_api/utils/validation.py
+++ b/fl-services/flower/fl-api-flower/fl_api/utils/validation.py
@@ -23,6 +23,7 @@ that becomes a filesystem path or an outbound fetch is validated here first.
 import ipaddress
 import os
 import re
+import socket
 from pathlib import Path
 from urllib.parse import urlparse
 
@@ -135,12 +136,23 @@ def validate_bundle_url(url: str) -> str:
             detail=f"Bundle URL port not allowed: {port}.",
         )
 
-    # Block IP-literal hosts in non-public ranges. A host that is not an IP literal raises
-    # ValueError and is left to the https + optional allow-list checks (we do not resolve DNS).
+    # Block IP-literal hosts in non-public ranges. Two parsers, because they disagree:
+    # ipaddress.ip_address accepts only the canonical dotted-quad form, while the resolver behind
+    # the actual fetch (getaddrinfo -> inet_aton) also accepts packed decimal, hex and octal
+    # spellings — "2130706433", "0x7f000001", "017700000001", "127.1" and "0" all reach loopback.
+    # Parsing with ip_address alone therefore left the checks below unrun for exactly the
+    # spellings an attacker would pick. inet_aton raises OSError on a real DNS name, so a host
+    # neither parser accepts is left to the https + optional allow-list checks — we still do not
+    # resolve DNS here, which would make this function network-dependent without closing the
+    # rebinding window anyway.
+    ip: ipaddress.IPv4Address | ipaddress.IPv6Address | None
     try:
-        ip: ipaddress.IPv4Address | ipaddress.IPv6Address | None = ipaddress.ip_address(hostname)
+        ip = ipaddress.ip_address(hostname)
     except ValueError:
-        ip = None
+        try:
+            ip = ipaddress.IPv4Address(socket.inet_aton(hostname))
+        except (OSError, ipaddress.AddressValueError):
+            ip = None
     if ip is not None and (
         ip.is_private
         or ip.is_loopback

--- a/fl-services/flower/fl-api-flower/fl_api/utils/validation.py
+++ b/fl-services/flower/fl-api-flower/fl_api/utils/validation.py
@@ -136,6 +136,18 @@ def validate_bundle_url(url: str) -> str:
             detail=f"Bundle URL port not allowed: {port}.",
         )
 
+    # Refuse a host carrying a NUL or other control character before either parser sees it.
+    # urlparse passes NUL straight through to .hostname, and resolvers that truncate at NUL would
+    # then reach a different host than the one checked here — "127.0.0.1\x00" is the loopback
+    # bypass that shape buys. Neither parser rejects it usefully on its own: inet_aton raises a
+    # plain ValueError (not the AddressValueError subclass), which would either escape as a 500 or,
+    # if swallowed, leave the range checks below unrun. No legitimate host contains these.
+    if any(ch < " " or ch == "\x7f" for ch in hostname):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Bundle URL host not allowed: {hostname!r}.",
+        )
+
     # Block IP-literal hosts in non-public ranges. Two parsers, because they disagree:
     # ipaddress.ip_address accepts only the canonical dotted-quad form, while the resolver behind
     # the actual fetch (getaddrinfo -> inet_aton) also accepts packed decimal, hex and octal
@@ -151,7 +163,7 @@ def validate_bundle_url(url: str) -> str:
     except ValueError:
         try:
             ip = ipaddress.IPv4Address(socket.inet_aton(hostname))
-        except (OSError, ipaddress.AddressValueError):
+        except OSError:
             ip = None
     if ip is not None and (
         ip.is_private

--- a/fl-services/flower/fl-api-flower/tests/test_validation.py
+++ b/fl-services/flower/fl-api-flower/tests/test_validation.py
@@ -94,3 +94,35 @@ def test_validate_bundle_url_rejects_unsafe_hosts(bad):
 def test_validate_bundle_url_accepts_explicit_443():
     url = "https://s3.eu-west-2.amazonaws.com:443/bucket/key"
     assert validate_bundle_url(url) == url
+
+
+# FLIP#893: ipaddress.ip_address only accepts the canonical dotted-quad form, so every other
+# numeric spelling used to fall into the "not an IP literal" branch and skip the range checks
+# entirely — while glibc's resolver resolves all of them to loopback or a private address.
+@pytest.mark.parametrize(
+    ("host", "resolves_to"),
+    [
+        ("2130706433", "127.0.0.1"),      # packed decimal
+        ("0x7f000001", "127.0.0.1"),      # hex
+        ("017700000001", "127.0.0.1"),    # octal
+        ("127.1", "127.0.0.1"),           # short form
+        ("0", "0.0.0.0"),                 # unspecified
+        ("167772165", "10.0.0.5"),        # packed decimal, private range
+    ],
+)
+def test_validate_bundle_url_rejects_numeric_encoded_private_hosts(host, resolves_to):
+    with pytest.raises(HTTPException) as exc:
+        validate_bundle_url(f"https://{host}/bundle/app/custom/train.py")
+    assert exc.value.status_code == 400
+
+
+@pytest.mark.parametrize("host", ["test.local", "s3.eu-west-2.amazonaws.com", "1.1.1.1"])
+def test_validate_bundle_url_still_accepts_public_hosts(host):
+    """The second parser must not turn a DNS name into a rejection, or resolve anything.
+
+    ``test.local`` deliberately does not resolve: if this function ever starts calling
+    getaddrinfo, this case fails and the network dependency is caught here rather than in
+    production.
+    """
+    url = f"https://{host}/bundle/app/custom/train.py"
+    assert validate_bundle_url(url) == url

--- a/fl-services/flower/fl-api-flower/tests/test_validation.py
+++ b/fl-services/flower/fl-api-flower/tests/test_validation.py
@@ -126,3 +126,15 @@ def test_validate_bundle_url_still_accepts_public_hosts(host):
     """
     url = f"https://{host}/bundle/app/custom/train.py"
     assert validate_bundle_url(url) == url
+
+
+@pytest.mark.parametrize("host", ["127.0.0.1\x00", "example.com\x00", "2130706433\x00"])
+def test_validate_bundle_url_rejects_hosts_with_embedded_nul(host):
+    """An embedded NUL must stay a 400, not escape as an uncaught ValueError.
+
+    urlparse passes NUL through to .hostname and socket.inet_aton raises a plain ValueError on it —
+    which ipaddress.AddressValueError does not cover, since it is a subclass rather than a parent.
+    """
+    with pytest.raises(HTTPException) as exc:
+        validate_bundle_url(f"https://{host}/bundle/app/custom/train.py")
+    assert exc.value.status_code == 400

--- a/fl-services/nvflare/fl-api-base/fl_api/utils/validation.py
+++ b/fl-services/nvflare/fl-api-base/fl_api/utils/validation.py
@@ -21,6 +21,7 @@ that becomes a filesystem path or an outbound fetch is validated here first.
 
 import ipaddress
 import os
+import socket
 from pathlib import Path
 from urllib.parse import urlparse
 
@@ -105,12 +106,23 @@ def validate_bundle_url(url: str) -> str:
             detail=f"Bundle URL port not allowed: {port}.",
         )
 
-    # Block IP-literal hosts in non-public ranges. A host that is not an IP literal raises
-    # ValueError and is left to the https + optional allow-list checks (we do not resolve DNS).
+    # Block IP-literal hosts in non-public ranges. Two parsers, because they disagree:
+    # ipaddress.ip_address accepts only the canonical dotted-quad form, while the resolver behind
+    # the actual fetch (getaddrinfo -> inet_aton) also accepts packed decimal, hex and octal
+    # spellings — "2130706433", "0x7f000001", "017700000001", "127.1" and "0" all reach loopback.
+    # Parsing with ip_address alone therefore left the checks below unrun for exactly the
+    # spellings an attacker would pick. inet_aton raises OSError on a real DNS name, so a host
+    # neither parser accepts is left to the https + optional allow-list checks — we still do not
+    # resolve DNS here, which would make this function network-dependent without closing the
+    # rebinding window anyway.
+    ip: ipaddress.IPv4Address | ipaddress.IPv6Address | None
     try:
-        ip: ipaddress.IPv4Address | ipaddress.IPv6Address | None = ipaddress.ip_address(hostname)
+        ip = ipaddress.ip_address(hostname)
     except ValueError:
-        ip = None
+        try:
+            ip = ipaddress.IPv4Address(socket.inet_aton(hostname))
+        except (OSError, ipaddress.AddressValueError):
+            ip = None
     if ip is not None and (
         ip.is_private
         or ip.is_loopback

--- a/fl-services/nvflare/fl-api-base/fl_api/utils/validation.py
+++ b/fl-services/nvflare/fl-api-base/fl_api/utils/validation.py
@@ -106,6 +106,18 @@ def validate_bundle_url(url: str) -> str:
             detail=f"Bundle URL port not allowed: {port}.",
         )
 
+    # Refuse a host carrying a NUL or other control character before either parser sees it.
+    # urlparse passes NUL straight through to .hostname, and resolvers that truncate at NUL would
+    # then reach a different host than the one checked here — "127.0.0.1\x00" is the loopback
+    # bypass that shape buys. Neither parser rejects it usefully on its own: inet_aton raises a
+    # plain ValueError (not the AddressValueError subclass), which would either escape as a 500 or,
+    # if swallowed, leave the range checks below unrun. No legitimate host contains these.
+    if any(ch < " " or ch == "\x7f" for ch in hostname):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Bundle URL host not allowed: {hostname!r}.",
+        )
+
     # Block IP-literal hosts in non-public ranges. Two parsers, because they disagree:
     # ipaddress.ip_address accepts only the canonical dotted-quad form, while the resolver behind
     # the actual fetch (getaddrinfo -> inet_aton) also accepts packed decimal, hex and octal
@@ -121,7 +133,7 @@ def validate_bundle_url(url: str) -> str:
     except ValueError:
         try:
             ip = ipaddress.IPv4Address(socket.inet_aton(hostname))
-        except (OSError, ipaddress.AddressValueError):
+        except OSError:
             ip = None
     if ip is not None and (
         ip.is_private

--- a/fl-services/nvflare/fl-api-base/tests/utils/test_validation.py
+++ b/fl-services/nvflare/fl-api-base/tests/utils/test_validation.py
@@ -110,3 +110,15 @@ def test_validate_bundle_url_still_accepts_public_hosts(host):
     """
     url = f"https://{host}/bundle/app/custom/train.py"
     assert validate_bundle_url(url) == url
+
+
+@pytest.mark.parametrize("host", ["127.0.0.1\x00", "example.com\x00", "2130706433\x00"])
+def test_validate_bundle_url_rejects_hosts_with_embedded_nul(host):
+    """An embedded NUL must stay a 400, not escape as an uncaught ValueError.
+
+    urlparse passes NUL through to .hostname and socket.inet_aton raises a plain ValueError on it —
+    which ipaddress.AddressValueError does not cover, since it is a subclass rather than a parent.
+    """
+    with pytest.raises(HTTPException) as exc:
+        validate_bundle_url(f"https://{host}/bundle/app/custom/train.py")
+    assert exc.value.status_code == 400

--- a/fl-services/nvflare/fl-api-base/tests/utils/test_validation.py
+++ b/fl-services/nvflare/fl-api-base/tests/utils/test_validation.py
@@ -78,3 +78,35 @@ def test_validate_bundle_url_rejects_unsafe_hosts(bad):
 def test_validate_bundle_url_accepts_explicit_443():
     url = "https://s3.eu-west-2.amazonaws.com:443/bucket/key"
     assert validate_bundle_url(url) == url
+
+
+# FLIP#893: ipaddress.ip_address only accepts the canonical dotted-quad form, so every other
+# numeric spelling used to fall into the "not an IP literal" branch and skip the range checks
+# entirely — while glibc's resolver resolves all of them to loopback or a private address.
+@pytest.mark.parametrize(
+    ("host", "resolves_to"),
+    [
+        ("2130706433", "127.0.0.1"),      # packed decimal
+        ("0x7f000001", "127.0.0.1"),      # hex
+        ("017700000001", "127.0.0.1"),    # octal
+        ("127.1", "127.0.0.1"),           # short form
+        ("0", "0.0.0.0"),                 # unspecified
+        ("167772165", "10.0.0.5"),        # packed decimal, private range
+    ],
+)
+def test_validate_bundle_url_rejects_numeric_encoded_private_hosts(host, resolves_to):
+    with pytest.raises(HTTPException) as exc:
+        validate_bundle_url(f"https://{host}/bundle/app/custom/train.py")
+    assert exc.value.status_code == 400
+
+
+@pytest.mark.parametrize("host", ["test.local", "s3.eu-west-2.amazonaws.com", "1.1.1.1"])
+def test_validate_bundle_url_still_accepts_public_hosts(host):
+    """The second parser must not turn a DNS name into a rejection, or resolve anything.
+
+    ``test.local`` deliberately does not resolve: if this function ever starts calling
+    getaddrinfo, this case fails and the network dependency is caught here rather than in
+    production.
+    """
+    url = f"https://{host}/bundle/app/custom/train.py"
+    assert validate_bundle_url(url) == url

--- a/scripts/check_fl_api_validation_sync.sh
+++ b/scripts/check_fl_api_validation_sync.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+# Copyright (c) 2026 Guy's and St Thomas' NHS Foundation Trust & King's College London
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Verify that the shared URL/path guards in the two fl-api services have not drifted.
+#
+# `safe_join` and `validate_bundle_url` are byte-identical copies in the NVFLARE and Flower
+# fl-api services. They are the only SSRF and path-traversal guards in front of the server-side
+# bundle fetch, so a fix applied to one copy and not the other silently leaves the second service
+# vulnerable -- which is exactly what happened with the numeric-IP bypass in FLIP#893.
+#
+# They are copies rather than a shared module on purpose: the two services live in separate Docker
+# build contexts, separate uv projects and separate published images, so extracting a shared
+# distributable costs far more than it protects. This check is the cheaper guarantee.
+#
+# The whole files are NOT compared -- they legitimately differ (copyright header, and the Flower
+# copy carries a flower-only validate_tutorial_folder_name plus its _SAFE_NAME constant). Only the
+# shared function bodies are compared.
+#
+# Paths are relative to the repo root (this script lives in scripts/, so cd up one).
+cd "$(dirname "$0")/.." || exit 1
+
+NVFLARE_FILE="fl-services/nvflare/fl-api-base/fl_api/utils/validation.py"
+FLOWER_FILE="fl-services/flower/fl-api-flower/fl_api/utils/validation.py"
+
+# Functions that must stay identical between the two copies.
+SHARED_FUNCTIONS=("safe_join" "validate_bundle_url")
+
+status=0
+
+for file in "$NVFLARE_FILE" "$FLOWER_FILE"; do
+    if [ ! -f "$file" ]; then
+        echo "ERROR: $file not found"
+        exit 1
+    fi
+done
+
+# Extract a single top-level function definition (def <name> ... up to the next top-level
+# statement). Emitted to stdout so the caller can diff two extractions.
+extract_function() {
+    local file="$1" func="$2"
+    awk -v func="$func" '
+        $0 ~ "^def " func "\\(" { inside = 1 }
+        inside && NR > 1 && /^[^ \t#)]/ && $0 !~ "^def " func "\\(" && started { inside = 0 }
+        inside { print; started = 1 }
+    ' "$file"
+}
+
+for func in "${SHARED_FUNCTIONS[@]}"; do
+    nvflare_body=$(extract_function "$NVFLARE_FILE" "$func")
+    flower_body=$(extract_function "$FLOWER_FILE" "$func")
+
+    if [ -z "$nvflare_body" ]; then
+        echo "ERROR: could not find '$func' in $NVFLARE_FILE"
+        status=1
+        continue
+    fi
+    if [ -z "$flower_body" ]; then
+        echo "ERROR: could not find '$func' in $FLOWER_FILE"
+        status=1
+        continue
+    fi
+
+    if [ "$nvflare_body" != "$flower_body" ]; then
+        echo "ERROR: '$func' has drifted between the two fl-api copies."
+        echo "  $NVFLARE_FILE"
+        echo "  $FLOWER_FILE"
+        echo "Diff (nvflare vs flower):"
+        diff <(printf '%s\n' "$nvflare_body") <(printf '%s\n' "$flower_body") | sed 's/^/    /'
+        echo "Resync by copying the corrected function into the other file."
+        status=1
+    fi
+done
+
+if [ "$status" -eq 0 ]; then
+    echo "fl-api validation guards are in sync (${SHARED_FUNCTIONS[*]})."
+fi
+
+exit "$status"

--- a/scripts/check_fl_api_validation_sync.sh
+++ b/scripts/check_fl_api_validation_sync.sh
@@ -46,10 +46,12 @@ done
 # Extract a single top-level function definition (def <name> ... up to the next top-level
 # statement). Emitted to stdout so the caller can diff two extractions.
 extract_function() {
-    local file="$1" func="$2"
-    awk -v func="$func" '
-        $0 ~ "^def " func "\\(" { inside = 1 }
-        inside && NR > 1 && /^[^ \t#)]/ && $0 !~ "^def " func "\\(" && started { inside = 0 }
+    local file="$1" fname="$2"
+    # `fname`, not `func`: gawk reserves `func` as a builtin and dies on -v func=...,
+    # while mawk accepts it — so the obvious name passes locally and fails in CI.
+    awk -v fname="$fname" '
+        $0 ~ "^def " fname "\\(" { inside = 1 }
+        inside && NR > 1 && /^[^ \t#)]/ && $0 !~ "^def " fname "\\(" && started { inside = 0 }
         inside { print; started = 1 }
     ' "$file"
 }


### PR DESCRIPTION
# Description

`validate_bundle_url` blocks IP-literal hosts in non-public ranges — but only for spellings
`ipaddress.ip_address` accepts. Every other numeric form raises `ValueError`, which the guard read
as "this is a DNS name" and skipped the private/loopback/reserved/multicast checks entirely. The
resolver behind the actual fetch is not so fussy:

| Host | `ipaddress.ip_address` | resolves to |
|---|---|---|
| `2130706433` | ValueError → checks skipped | `127.0.0.1` |
| `0x7f000001` | ValueError → checks skipped | `127.0.0.1` |
| `017700000001` | ValueError → checks skipped | `127.0.0.1` |
| `127.1` | ValueError → checks skipped | `127.0.0.1` |
| `0` | ValueError → checks skipped | `0.0.0.0` |
| `167772165` | ValueError → checks skipped | `10.0.0.5` |

So `https://2130706433/...` passed the only SSRF control in front of the server-side fetch and then
connected to loopback. `BUNDLE_URL_ALLOWED_HOSTS` would have caught it, but it defaults to empty and
is set **nowhere** outside code and tests, so that branch is inert in every shipped environment.

## Approach — a second parser, not DNS

`socket.inet_aton` is glibc's permissive IPv4 parser: it accepts exactly the spellings
`ip_address` rejects, and raises `OSError` on a genuine hostname. So the range checks now run for
all six vectors **without** introducing name resolution.

Not resolving is deliberate and load-bearing: `test_validate_bundle_url_accepts_https` uses the
non-resolving `https://test.local/…`, the docstring promises DNS names are not resolved, and
resolving here would make the function network-dependent without closing the rebinding window
anyway. There is a test asserting `test.local` still passes, so a future change that adds
`getaddrinfo` fails here rather than in production.

## Drift check

The two `validate_bundle_url` copies are byte-identical by necessity — separate Docker build
contexts, separate uv projects, separate images — with no shared module and, until now, nothing
checking they stay in step. That is exactly how one copy gets fixed and the other left vulnerable.

`scripts/check_fl_api_validation_sync.sh` compares only the **shared function bodies**
(`safe_join`, `validate_bundle_url`); a whole-file diff would fail on the legitimate differences
(copyright header, and the Flower copy's `validate_tutorial_folder_name` + `_SAFE_NAME`).

Both workflows run it, and **each path filter now includes the sibling copy** — otherwise editing
only the Flower file would never trigger the NVFLARE workflow, which is the drift case the check
exists for.

A shared module would be the textbook answer and the wrong call here: it means a new distributable,
two Dockerfile changes, two pyproject changes and a versioning story — several times the size of
the fix it protects.

## Not in this PR

Populating `BUNDLE_URL_ALLOWED_HOSTS` per environment is the more robust control, but it needs the
real per-environment object-store hostname; setting it wrongly breaks every bundle download, turning
a LOW security finding into an outage. Filed separately.

## Linked Issues

Fixes #893

## Verification

- nvflare `make local_test` — ruff, mypy, **158 passed**
- flower `make local_test` — ruff, mypy, **106 passed**
- Reverting the fix in one copy fails the 6 new bypass tests **and** trips the drift check
- Introducing a one-line difference between the copies produces a readable diff and exit 1

## Checklist

- [x] Follows the project's coding conventions and style guide
- [ ] Updates documentation — n/a
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


## Acceptance Criteria

*Imported from issue #893*

- [ ] All five numeric spellings above are rejected, in both copies
- [ ] No DNS resolution is introduced; `https://test.local/...` still passes
- [ ] A CI check fails if the two `validate_bundle_url` bodies drift apart
- [ ] Both FL API test suites green