### PR TITLE
One unapproved trust id permanently wedges the FL job queue platform-wide

### DIFF
--- a/flip-api/src/flip_api/fl_services/initiate_training.py
+++ b/flip-api/src/flip_api/fl_services/initiate_training.py
@@ -23,7 +23,7 @@ from flip_api.domain.interfaces.fl import IInitiateTrainingInputPayload
 from flip_api.domain.schemas.status import ModelStatus
 from flip_api.fl_services.services.fl_scheduler_service import log_queue_positions
 from flip_api.fl_services.services.fl_service import add_fl_job
-from flip_api.model_services.services.model_service import add_log, update_model_status
+from flip_api.model_services.services.model_service import add_log, update_model_status, validate_trust_ids
 from flip_api.utils.constants import SERVICE_UNAVAILABLE_MESSAGE
 from flip_api.utils.logger import logger
 from flip_api.utils.site_manager import is_deployment_mode_enabled
@@ -77,6 +77,16 @@ def initiate_training(
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=f"Unknown trust(s): {missing}",
+        )
+
+    # Existing is not the same as approved. Without this the request is accepted and the job only
+    # fails later, in the scheduler — where it used to sit at the head of a shared queue and block
+    # FL training for every project on every net (FLIP#894). Reject at the boundary so the caller
+    # gets a 400 in hand and nothing is enqueued.
+    if not validate_trust_ids(model_id, list(payload.trust_ids), db):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="One or more of the selected trusts are not approved for this model",
         )
 
     try:

--- a/flip-api/src/flip_api/fl_services/services/fl_scheduler_service.py
+++ b/flip-api/src/flip_api/fl_services/services/fl_scheduler_service.py
@@ -569,7 +569,20 @@ def check_for_queued_jobs(scheduler_id: UUID, session: Session) -> IJobResponse 
                 "retiring it so it cannot block the queue"
             )
             job.status = JobStatus.DELETED
-            update_model_status(job.model_id, ModelStatus.ERROR, session)
+
+            # A model can have been retried while this older job was waiting in the queue. Do not
+            # transition the model to ERROR in that case: update_model_status(ERROR) releases the
+            # latest non-deleted job for the model, which would silently complete the valid retry.
+            active_job = session.exec(
+                select(FLJob.id)
+                .where(
+                    FLJob.model_id == job.model_id,
+                    col(FLJob.status).in_((JobStatus.QUEUED, JobStatus.IN_PROGRESS)),
+                )
+                .limit(1)
+            ).first()
+            if not active_job:
+                update_model_status(job.model_id, ModelStatus.ERROR, session)
             add_log(
                 job.model_id,
                 "Training could not start: the selected trusts are not approved for this model.",

--- a/flip-api/src/flip_api/fl_services/services/fl_scheduler_service.py
+++ b/flip-api/src/flip_api/fl_services/services/fl_scheduler_service.py
@@ -556,9 +556,29 @@ def check_for_queued_jobs(scheduler_id: UUID, session: Session) -> IJobResponse 
         job.started = datetime.utcnow()
 
         job_trust_ids = [t.id for t in job.trusts]
-        # Validate trusts
+        # Validate trusts. A job that references trusts not approved for its model can never run,
+        # so retire it here rather than raising: the raise left the job QUEUED (the status write
+        # above rolls back with the transaction), and because this query always picks the
+        # globally-earliest queued job, the same unrunnable job was re-selected on every tick and
+        # blocked every job behind it, on every net, indefinitely (FLIP#894). initiate_training now
+        # rejects these at the boundary, so reaching this branch means a job predating that check
+        # or one whose model approvals changed after it was queued.
         if not validate_trust_ids(job.model_id, job_trust_ids, session):
-            raise Exception(f"Job {job.id} references trust ids not approved for model {job.model_id}")
+            logger.error(
+                f"Job {job.id} references trust ids not approved for model {job.model_id}; "
+                "retiring it so it cannot block the queue"
+            )
+            job.status = JobStatus.DELETED
+            update_model_status(job.model_id, ModelStatus.ERROR, session)
+            add_log(
+                job.model_id,
+                "Training could not start: the selected trusts are not approved for this model.",
+                session,
+                success=False,
+            )
+            session.commit()
+            revert_scheduler_pickup(scheduler_id, session)
+            return None
 
         # Assign job to scheduler
         scheduler = session.get(FLScheduler, scheduler_id)

--- a/flip-api/tests/unit/fl_services/services/test_fl_scheduler_service.py
+++ b/flip-api/tests/unit/fl_services/services/test_fl_scheduler_service.py
@@ -460,6 +460,44 @@ def test_check_for_queued_jobs_success(fake_session, scheduler_id, model_id):
     fake_session.commit.assert_called()
 
 
+def test_check_for_queued_jobs_retires_a_job_with_unapproved_trusts(fake_session, scheduler_id, model_id):
+    """A job that can never run must be retired, not re-raised.
+
+    It previously raised a bare Exception, which check_for_queued_jobs does not catch (its only
+    handler is SQLAlchemyError). The status write above the raise rolled back with the
+    transaction, so the job went back to QUEUED — and because the dequeue always picks the
+    globally-earliest queued job, the same unrunnable job was re-selected on every tick and
+    blocked FL training on every net indefinitely (FLIP#894).
+    """
+    trust = MagicMock(id=uuid4())
+    job = MagicMock()
+    job.id = uuid4()
+    job.model_id = model_id
+    job.trusts = [trust]
+
+    fake_session.exec.side_effect = [MagicMock(first=MagicMock(return_value=job))]
+
+    with (
+        patch("flip_api.fl_services.services.fl_scheduler_service.validate_trust_ids", return_value=False),
+        patch("flip_api.fl_services.services.fl_scheduler_service.update_model_status") as mock_status,
+        patch("flip_api.fl_services.services.fl_scheduler_service.add_log") as mock_add_log,
+        patch("flip_api.fl_services.services.fl_scheduler_service.revert_scheduler_pickup") as mock_revert,
+    ):
+        result = fl_scheduler_service.check_for_queued_jobs(scheduler_id, fake_session)
+
+    # No job dispatched, and the tick ends cleanly rather than propagating.
+    assert result is None
+    # Retired, so the next tick reaches the job behind it.
+    assert job.status == JobStatus.DELETED
+    # The retirement is committed — an uncommitted status change would roll back and the job
+    # would be picked again, which is the whole bug.
+    fake_session.commit.assert_called()
+    mock_status.assert_called_once_with(model_id, ModelStatus.ERROR, fake_session)
+    # The researcher needs to know why their training never started.
+    assert mock_add_log.call_args.kwargs["success"] is False
+    mock_revert.assert_called_once()
+
+
 def test_check_for_queued_jobs_none(fake_session, scheduler_id):
     fake_session.exec.return_value.first.return_value = None
 

--- a/flip-api/tests/unit/fl_services/services/test_fl_scheduler_service.py
+++ b/flip-api/tests/unit/fl_services/services/test_fl_scheduler_service.py
@@ -475,7 +475,10 @@ def test_check_for_queued_jobs_retires_a_job_with_unapproved_trusts(fake_session
     job.model_id = model_id
     job.trusts = [trust]
 
-    fake_session.exec.side_effect = [MagicMock(first=MagicMock(return_value=job))]
+    fake_session.exec.side_effect = [
+        MagicMock(first=MagicMock(return_value=job)),
+        MagicMock(first=MagicMock(return_value=None)),
+    ]
 
     with (
         patch("flip_api.fl_services.services.fl_scheduler_service.validate_trust_ids", return_value=False),
@@ -495,6 +498,34 @@ def test_check_for_queued_jobs_retires_a_job_with_unapproved_trusts(fake_session
     mock_status.assert_called_once_with(model_id, ModelStatus.ERROR, fake_session)
     # The researcher needs to know why their training never started.
     assert mock_add_log.call_args.kwargs["success"] is False
+    mock_revert.assert_called_once()
+
+
+def test_check_for_queued_jobs_preserves_a_newer_valid_retry_when_retiring_an_invalid_job(
+    fake_session, scheduler_id, model_id
+):
+    """Retiring an old invalid job must not complete a later valid retry for the same model."""
+    invalid_trust = MagicMock(id=uuid4())
+    invalid_job = MagicMock(id=uuid4(), model_id=model_id, trusts=[invalid_trust])
+    valid_retry = MagicMock(id=uuid4(), model_id=model_id, status=JobStatus.QUEUED)
+
+    fake_session.exec.side_effect = [
+        MagicMock(first=MagicMock(return_value=invalid_job)),
+        MagicMock(first=MagicMock(return_value=valid_retry)),
+    ]
+
+    with (
+        patch("flip_api.fl_services.services.fl_scheduler_service.validate_trust_ids", return_value=False),
+        patch("flip_api.fl_services.services.fl_scheduler_service.update_model_status") as mock_status,
+        patch("flip_api.fl_services.services.fl_scheduler_service.add_log"),
+        patch("flip_api.fl_services.services.fl_scheduler_service.revert_scheduler_pickup") as mock_revert,
+    ):
+        result = fl_scheduler_service.check_for_queued_jobs(scheduler_id, fake_session)
+
+    assert result is None
+    assert invalid_job.status == JobStatus.DELETED
+    assert valid_retry.status == JobStatus.QUEUED
+    mock_status.assert_not_called()
     mock_revert.assert_called_once()
 
 

--- a/flip-api/tests/unit/fl_services/test_initiate_training.py
+++ b/flip-api/tests/unit/fl_services/test_initiate_training.py
@@ -65,6 +65,15 @@ def deployment_mode_disabled():
         yield mock_enabled
 
 
+@pytest.fixture(autouse=True)
+def mock_validate_trust_ids():
+    # With a MagicMock session the real validate_trust_ids compares ModelTrustIntersect rows
+    # against the submitted ids and always fails, so default it to approved here; the
+    # unapproved-trust test below overrides the return value.
+    with patch("flip_api.fl_services.initiate_training.validate_trust_ids", return_value=True) as mock:
+        yield mock
+
+
 @pytest.fixture
 def mock_can_modify_model():
     with patch("flip_api.fl_services.initiate_training.can_modify_model") as mock:
@@ -192,6 +201,26 @@ def test_initiate_training_rejects_unknown_trusts(
 
     assert exc_info.value.status_code == status.HTTP_400_BAD_REQUEST
     assert str(ghost_id) in exc_info.value.detail
+    mock_add_fl_job.assert_not_called()
+
+
+def test_initiate_training_rejects_trusts_not_approved_for_the_model(
+    model_id, fake_request, mock_db, client1, mock_can_modify_model, mock_add_fl_job, mock_validate_trust_ids
+):
+    """A trust that exists but is not approved for this model must be refused at the boundary.
+
+    Accepting it here used to enqueue a job that could never run, and because the scheduler picks
+    the globally-earliest queued job it then blocked FL training on every net indefinitely
+    (FLIP#894).
+    """
+    mock_validate_trust_ids.return_value = False
+    payload = IInitiateTrainingInputPayload(trust_ids=[client1.id])
+
+    with pytest.raises(HTTPException) as exc_info:
+        initiate_training(model_id, payload, fake_request, mock_db, user_id="user123")
+
+    assert exc_info.value.status_code == status.HTTP_400_BAD_REQUEST
+    assert "not approved" in exc_info.value.detail
     mock_add_fl_job.assert_not_called()
 
 


### PR DESCRIPTION
# Description

`POST /api/fl/initiate/{model_id}` checked only that each submitted trust id **existed**, never that
it was **approved for the model**. The approval check lived solely in the scheduler dequeue, where
it raised a bare `Exception`. Four properties combine to turn that into a platform-wide outage:

1. `check_for_queued_jobs` catches only `SQLAlchemyError`, so the bare `Exception` propagates.
2. `job.status = IN_PROGRESS` is set before the raise but `session.commit()` comes after it — so the
   status change rolls back and the job returns to `QUEUED`.
3. The dequeue selects the **globally-earliest** `QUEUED` job with no per-net filter, so the same
   unrunnable job is re-selected on every tick.
4. `_recover_stale_busy_schedulers` returns the net to `AVAILABLE` each tick, so it keeps retrying.

**One request from any researcher who owns a model halts FL training for every project on every net,
indefinitely**, until that `FLJob` row is removed by hand. Trust ids are easy to obtain —
`GET /api/trusts` is authenticated but deliberately not admin-gated and returns every trust's id.
Diagnosis is nasty: the symptom is "no training runs anywhere" plus one log line naming a job id.

## Both halves

**Boundary** — `initiate_training` now calls `validate_trust_ids` and returns 400, so the shared
queue cannot be poisoned in the first place.

**Self-healing scheduler** — a job that fails the approval check is *retired* rather than re-raised:
marked `DELETED`, model set to `ERROR`, reason logged against the model, committed, scheduler
released, clean return. The commit is the load-bearing part — an uncommitted status change rolls
back and the job gets picked again, which is the bug. This matters beyond the boundary fix: a job
queued before this change, or one whose model approvals changed after it was queued, still reaches
that branch.

`JobStatus` has no `ERRORED` member and adding one needs a native-PG-enum migration, so retirement
reuses `DELETED`; the model status and model log carry the reason the researcher needs.

## Test note

Every existing test in `test_initiate_training.py` needed a new autouse fixture. With a MagicMock
session the real `validate_trust_ids` compares `ModelTrustIntersect` rows against the submitted ids
and always fails, so without it the new check would 400 all of them — the same shape as the existing
`deployment_mode_disabled` fixture.

## Linked Issues

Fixes #894

## Verification

- `make -C flip-api unit_test` — ruff, mypy, **1464 passed**
- Restoring the bare `raise` fails the new scheduler test and nothing else

## Merge order

Touches `initiate_training.py`, which #896 also touches. **Land #896 first**, then this needs a
rebase — a PR that conflicts with `develop` gets no CI at all, silently.

## Checklist

- [x] Follows the project's coding conventions and style guide
- [ ] Updates documentation — n/a
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


## Acceptance Criteria

*Imported from issue #894*

- [ ] `initiate_training` returns 400 when any submitted trust is not approved for the model
- [ ] A job that fails the scheduler's approval check is marked errored and committed, and the loop continues
- [ ] A test covers the boundary rejection, and a scheduler test covers the self-healing path
- [ ] `make -C flip-api unit_test` green