### PR TITLE
submit_cohort_query trusts an unscoped query_id and dispatches the request-body SQL

### DIFF
--- a/flip-api/src/flip_api/cohort_services/submit_cohort_query.py
+++ b/flip-api/src/flip_api/cohort_services/submit_cohort_query.py
@@ -29,9 +29,10 @@ from flip_api.domain.schemas.cohort import (
     SubmitCohortQueryOutput,
     TrustDetails,
 )
-from flip_api.domain.schemas.status import TaskType
+from flip_api.domain.schemas.status import ProjectStatus, TaskType
 from flip_api.utils.encryption import encrypt
 from flip_api.utils.logger import logger
+from flip_api.utils.project_manager import has_project_status
 
 router = APIRouter(prefix="/cohort", tags=["cohort_services"])
 
@@ -147,11 +148,49 @@ def submit_cohort_query(
                 detail=f"User with ID: {user_id} is not allowed to modify this project",
             )
 
+        # The client-supplied query_id is only trusted once it is proven to belong to the project
+        # the caller was just authorised on. Scoping the lookup by project_id is what stops a
+        # caller authorised on project A from dispatching — and overwriting the queried-trust set
+        # of — a Queries row owned by project B, whose members then read the resulting stats.
+        query_row = db.exec(
+            select(Queries)
+            .where(Queries.id == cohort_query.query_id)
+            .where(Queries.project_id == cohort_query.project_id)
+        ).first()
+        if query_row is None:
+            logger.warning(
+                "Cohort submit refused: query_id %s is not a query of project %s (user %s).",
+                cohort_query.query_id,
+                cohort_query.project_id,
+                user_id,
+            )
+            raise HTTPException(status_code=404, detail="Cohort query not found for this project.")
+
+        # The same gate save_cohort_query enforces: once a project is staged or approved its cohort
+        # of record is frozen, so it must not be re-dispatched to the trusts either.
+        if not has_project_status(cohort_query.project_id, ProjectStatus.UNSTAGED, db):
+            raise HTTPException(
+                status_code=400,
+                detail="Unable to run the cohort query as the project has been staged/approved",
+            )
+
+        # Dispatch the SQL of record rather than the request body. Queries.query is what the UI
+        # renders, what project approval is granted against, and what the audit trail says was
+        # asked of patient data — shipping the body lets those diverge silently. Substituting
+        # rather than rejecting on mismatch keeps a client that round-trips the text with
+        # incidental whitespace working; the divergence is logged either way.
+        if cohort_query.query != query_row.query:
+            logger.info(
+                "Cohort submit: request body query differs from the persisted query for %s; "
+                "dispatching the persisted query.",
+                cohort_query.query_id,
+            )
+
         # Fast-feedback validity pre-check only — the trust is the authority on
         # query safety. See validate_query's docstring for why this is
         # deliberately weaker than the trust-side check.
         try:
-            validate_query(cohort_query.query)
+            validate_query(query_row.query)
         except ValueError as e:
             raise HTTPException(status_code=400, detail=str(e))
 
@@ -176,17 +215,17 @@ def submit_cohort_query(
         for trust in trusts:
             try:
                 task_payload = SubmitCohortQueryBody(
-                    query_name=cohort_query.name,
-                    query=cohort_query.query,
+                    query_name=query_row.name,
+                    query=query_row.query,
                     encrypted_project_id=encrypted_project_id,
-                    query_id=cohort_query.query_id,
+                    query_id=query_row.id,
                     trust_id=str(trust.id),
                 )
 
                 task = TrustTask(
                     trust_id=trust.id,
                     task_type=TaskType.COHORT_QUERY,
-                    query_id=cohort_query.query_id,
+                    query_id=query_row.id,
                     payload=json.dumps(task_payload.model_dump(mode="json")),
                 )
                 db.add(task)
@@ -216,23 +255,12 @@ def submit_cohort_query(
         # can surface trusts that never responded — without this, a trust that
         # was sent the query but failed to post any result (offline, hub
         # rejected the error report) would silently vanish from the panel.
-        query_row = db.exec(select(Queries).where(Queries.id == cohort_query.query_id)).first()
-        if query_row is not None:
-            query_row.queried_trust_ids = queried_trust_ids
-        else:
-            # No Queries row means save_cohort_query never persisted (or was rolled back). The
-            # per-trust tasks are still queued, but queried_trust_ids stays empty, so the
-            # cohort-results UI can't surface trusts that never responded. Surface the upstream
-            # gap instead of committing silently.
-            logger.warning(
-                "No Queries row for query_id %s; cohort tasks were queued but queried_trust_ids was not persisted.",
-                cohort_query.query_id,
-            )
+        query_row.queried_trust_ids = queried_trust_ids
 
         db.commit()
 
         # Prepare response
-        data_to_return = SubmitCohortQueryOutput(trust=result, query_id=cohort_query.query_id)  # type: ignore[call-arg]
+        data_to_return = SubmitCohortQueryOutput(trust=result, query_id=query_row.id)  # type: ignore[call-arg]
 
         logger.info("Successfully queued cohort query tasks for all trusts")
 

--- a/flip-api/tests/integration/test_cohort_submit_db_flow.py
+++ b/flip-api/tests/integration/test_cohort_submit_db_flow.py
@@ -1,0 +1,109 @@
+# Copyright (c) Guy's and St Thomas' NHS Foundation Trust & King's College London
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Integration coverage of ``submit_cohort_query``'s project scoping, against real Postgres.
+
+The security property is that a caller authorised on project A cannot dispatch — or mutate — a
+``Queries`` row belonging to project B. A mocked session cannot prove that: it returns whatever the
+test stubs regardless of whether the statement filters on ``project_id``. Only a real database shows
+that B's row is untouched and that no ``TrustTask`` rows were created.
+"""
+
+from uuid import uuid4
+
+import pytest
+from fastapi import HTTPException
+from sqlmodel import Session, select
+
+from flip_api.cohort_services.submit_cohort_query import submit_cohort_query
+from flip_api.db.models.main_models import Queries, TrustTask
+from flip_api.domain.schemas.cohort import SubmitCohortQuery
+from flip_api.domain.schemas.status import ProjectStatus
+from tests.fixtures.user_fixtures import mock_request
+
+__all__ = ["mock_request"]
+
+ATTACKER_SQL = "SELECT person_id FROM omop.person"
+VICTIM_SQL = "SELECT person_id FROM omop.observation"
+
+
+@pytest.fixture
+def attacker(session: Session, project_factory):
+    """A project the caller owns — ``can_modify_project`` passes on ownership alone."""
+    owner_id = uuid4()
+    project = project_factory.build(owner_id=owner_id, deleted=False, status=ProjectStatus.UNSTAGED)
+    session.add(project)
+    session.commit()
+    query = Queries(
+        id=uuid4(), project_id=project.id, name="mine", query=ATTACKER_SQL,
+        created_by=owner_id, queried_trust_ids=[],
+    )
+    session.add(query)
+    session.commit()
+
+    return owner_id, project, query
+
+
+@pytest.fixture
+def victim_query(session: Session, project_factory):
+    """A ``Queries`` row belonging to a project the caller has nothing to do with."""
+    project = project_factory.build(owner_id=uuid4(), deleted=False, status=ProjectStatus.UNSTAGED)
+    session.add(project)
+    session.commit()
+    query = Queries(
+        id=uuid4(), project_id=project.id, name="theirs", query=VICTIM_SQL,
+        created_by=project.owner_id, queried_trust_ids=[],
+    )
+    session.add(query)
+    session.commit()
+
+    return query
+
+
+def test_cannot_dispatch_another_projects_query(
+    session: Session, mock_request, attacker, victim_query, trust_factory
+):
+    """Authorised on project A, supplying project B's query_id → refused, and B is untouched.
+
+    The 404 alone is not the property worth pinning. What matters is that nothing was dispatched
+    and B's row was not mutated — previously the fan-out ran and B's ``queried_trust_ids`` was
+    overwritten, which is what corrupted the results B's members then read.
+    """
+    owner_id, project, _ = attacker
+    # A Trust must exist, otherwise submit 404s at the trust listing instead of at the scoped
+    # lookup — and every assertion below would then hold for the wrong reason. `trust` is in
+    # conftest's _PRESERVED_TABLES, so relying on rows left by other test files would also make
+    # this order-dependent.
+    session.add(trust_factory.build())
+    session.commit()
+
+    payload = SubmitCohortQuery(
+        name="poison",
+        query=ATTACKER_SQL,
+        project_id=project.id,
+        query_id=victim_query.id,
+        authenticationToken="Bearer test-token",
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        submit_cohort_query(mock_request, payload, session, owner_id)
+
+    assert exc_info.value.status_code == 404
+    # Pin the *reason*: "No trusts found" is also a 404 from this endpoint.
+    assert exc_info.value.detail == "Cohort query not found for this project."
+
+    session.expire_all()
+    untouched = session.get(Queries, victim_query.id)
+    assert untouched is not None
+    assert untouched.queried_trust_ids == []
+    assert untouched.query == VICTIM_SQL
+    assert session.exec(select(TrustTask)).all() == []

--- a/flip-api/tests/unit/cohort_services/test_submit_cohort_query.py
+++ b/flip-api/tests/unit/cohort_services/test_submit_cohort_query.py
@@ -63,12 +63,50 @@ def mock_can_modify():
         yield
 
 
-def test_submit_cohort_query_queues_task(mock_request, sample_query, mock_encrypt, mock_can_modify):
+def _persisted_row(sql: str = "SELECT * FROM patients", name: str = "Test Query") -> MagicMock:
+    """Stand-in for the Queries row submit now re-reads.
+
+    Submit dispatches the *persisted* SQL rather than the request body, so tests must supply a row
+    whose ``query``/``name``/``id`` are the values expected to reach the trusts.
+    """
+    row = MagicMock()
+    row.id = query_id
+    row.name = name
+    row.query = sql
+    return row
+
+
+def _db(row: MagicMock | None = None, trusts: list | None = None) -> MagicMock:
+    """MagicMock session wired for submit's two exec() calls, in order.
+
+    1. the project-scoped Queries lookup (``.first()``)
+    2. the Trust listing (``.all()``)
+
+    The order matters: the Queries lookup moved ahead of the trust listing so an unauthorised
+    query_id fails before any work is done.
+    """
+    db = MagicMock()
+    db.exec.side_effect = [
+        MagicMock(first=MagicMock(return_value=row if row is not None else _persisted_row())),
+        MagicMock(all=MagicMock(return_value=list(trusts or []))),
+    ]
+    return db
+
+
+@pytest.fixture
+def mock_unstaged():
+    """Default the project to UNSTAGED — submit now enforces the same gate save does."""
+    with patch("flip_api.cohort_services.submit_cohort_query.has_project_status", return_value=True) as mock:
+        yield mock
+
+
+def test_submit_cohort_query_queues_task(
+    mock_request, sample_query, mock_encrypt, mock_can_modify, mock_unstaged
+):
     """Submitting a cohort query should create a TrustTask for each trust."""
-    mock_db = MagicMock()
     mock_trust = MagicMock(id="trust_1", name="Trust A", endpoint="http://trust-a.com")
     mock_trust.name = "Trust A"
-    mock_db.exec.return_value.all.return_value = [mock_trust]
+    mock_db = _db(trusts=[mock_trust])
 
     response = submit_cohort_query(mock_request, sample_query, mock_db, user_id)
 
@@ -90,14 +128,15 @@ def test_submit_cohort_query_queues_task(mock_request, sample_query, mock_encryp
     assert response.trust[0].message == "Task queued"
 
 
-def test_submit_cohort_query_multiple_trusts(mock_request, sample_query, mock_encrypt, mock_can_modify):
+def test_submit_cohort_query_multiple_trusts(
+    mock_request, sample_query, mock_encrypt, mock_can_modify, mock_unstaged
+):
     """Should create one task per trust."""
-    mock_db = MagicMock()
     mock_trust_a = MagicMock(id="trust_1", name="Trust A", endpoint="http://trust-a.com")
     mock_trust_a.name = "Trust A"
     mock_trust_b = MagicMock(id="trust_2", name="Trust B", endpoint="http://trust-b.com")
     mock_trust_b.name = "Trust B"
-    mock_db.exec.return_value.all.return_value = [mock_trust_a, mock_trust_b]
+    mock_db = _db(trusts=[mock_trust_a, mock_trust_b])
 
     response = submit_cohort_query(mock_request, sample_query, mock_db, user_id)
 
@@ -108,7 +147,7 @@ def test_submit_cohort_query_multiple_trusts(mock_request, sample_query, mock_en
 
 
 def test_submit_cohort_query_persists_queried_trust_ids(
-    mock_request, sample_query, mock_encrypt, mock_can_modify
+    mock_request, sample_query, mock_encrypt, mock_can_modify, mock_unstaged
 ):
     """The dispatched trust IDs must land on Queries.queried_trust_ids so the
     per-trust UI can render trusts that errored or never responded — otherwise
@@ -121,13 +160,8 @@ def test_submit_cohort_query_persists_queried_trust_ids(
     mock_trust_b = MagicMock(id=trust_b)
     mock_trust_b.name = "Trust B"
 
-    mock_db = MagicMock()
-    mock_query_row = MagicMock()
-    # Two exec calls: first returns the trust list, second returns the Queries row.
-    mock_db.exec.side_effect = [
-        MagicMock(all=MagicMock(return_value=[mock_trust_a, mock_trust_b])),
-        MagicMock(first=MagicMock(return_value=mock_query_row)),
-    ]
+    mock_query_row = _persisted_row()
+    mock_db = _db(row=mock_query_row, trusts=[mock_trust_a, mock_trust_b])
 
     submit_cohort_query(mock_request, sample_query, mock_db, user_id)
 
@@ -135,28 +169,79 @@ def test_submit_cohort_query_persists_queried_trust_ids(
     assert mock_db.commit.called
 
 
-def test_submit_cohort_query_warns_when_query_row_missing(
-    mock_request, sample_query, mock_encrypt, mock_can_modify, caplog
+def test_submit_cohort_query_404s_when_query_row_missing(
+    mock_request, sample_query, mock_encrypt, mock_can_modify, mock_unstaged
 ):
-    """If the Queries row is missing (save_cohort_query never persisted), the tasks are still
-    queued and committed, but a warning is logged so the upstream gap is visible instead of
-    silently dropping queried_trust_ids."""
+    """A query_id that resolves to no row of this project is refused before any work.
+
+    Previously this warned and carried on, which was tenable when the row only supplied
+    queried_trust_ids. It is not tenable now the row supplies the SQL that gets dispatched.
+    """
+    mock_db = _db(row=None)
+
+    with pytest.raises(HTTPException) as exc_info:
+        submit_cohort_query(mock_request, sample_query, mock_db, user_id)
+
+    assert exc_info.value.status_code == 404
+    mock_db.add.assert_not_called()
+    mock_db.commit.assert_not_called()
+
+
+def test_submit_cohort_query_scopes_the_query_lookup_to_the_project(
+    mock_request, sample_query, mock_encrypt, mock_can_modify, mock_unstaged
+):
+    """The Queries lookup must filter on project_id, not just id.
+
+    Asserting on the statement is white-box, but a mock session cannot otherwise distinguish a
+    scoped lookup from an unscoped one — and the scoping *is* the security property.
+
+    It must be the WHERE clause specifically: ``select(Queries)`` puts every column in the SELECT
+    list, so the string "queries.project_id" appears in the compiled statement whether or not the
+    lookup is scoped. Asserting on the full statement passes against the unscoped version.
+    """
+    mock_db = _db(trusts=[])
+
+    with pytest.raises(HTTPException):
+        submit_cohort_query(mock_request, sample_query, mock_db, user_id)
+
+    where = str(mock_db.exec.call_args_list[0][0][0].whereclause)
+    assert "queries.project_id" in where
+
+
+def test_submit_cohort_query_rejected_once_the_project_is_staged(
+    mock_request, sample_query, mock_encrypt, mock_can_modify, mock_unstaged
+):
+    """save_cohort_query freezes the cohort at staging; submit must not re-dispatch past it."""
+    mock_unstaged.return_value = False
+    mock_db = _db(trusts=[])
+
+    with pytest.raises(HTTPException) as exc_info:
+        submit_cohort_query(mock_request, sample_query, mock_db, user_id)
+
+    assert exc_info.value.status_code == 400
+    assert "staged/approved" in exc_info.value.detail
+    mock_db.add.assert_not_called()
+
+
+def test_submit_cohort_query_dispatches_the_persisted_query_not_the_body(
+    mock_request, sample_query, mock_encrypt, mock_can_modify, mock_unstaged
+):
+    """The SQL sent to the trusts is the SQL of record, even when the body disagrees.
+
+    Queries.query is what the UI renders and what approval is granted against, so allowing the
+    body to differ means the audit record and what actually ran against patient data can diverge.
+    """
+    persisted_sql = "SELECT person_id FROM omop.person"
     mock_trust = MagicMock(id=uuid.uuid4())
     mock_trust.name = "Trust A"
+    mock_db = _db(row=_persisted_row(sql=persisted_sql), trusts=[mock_trust])
 
-    mock_db = MagicMock()
-    # First exec → trust list; second exec → Queries lookup returns None (row absent).
-    mock_db.exec.side_effect = [
-        MagicMock(all=MagicMock(return_value=[mock_trust])),
-        MagicMock(first=MagicMock(return_value=None)),
-    ]
+    # sample_query carries "SELECT * FROM patients" — deliberately different.
+    submit_cohort_query(mock_request, sample_query, mock_db, user_id)
 
-    response = submit_cohort_query(mock_request, sample_query, mock_db, user_id)
-
-    assert mock_db.add.called
-    assert mock_db.commit.called
-    assert len(response.trust) == 1
-    assert "queried_trust_ids was not persisted" in caplog.text
+    added_task = mock_db.add.call_args[0][0]
+    assert persisted_sql in added_task.payload
+    assert sample_query.query not in added_task.payload
 
 
 def _query(sql: str) -> SubmitCohortQuery:
@@ -171,46 +256,56 @@ def _query(sql: str) -> SubmitCohortQuery:
 
 
 @patch("flip_api.cohort_services.submit_cohort_query.can_modify_project", return_value=True)
-def test_submit_cohort_query_rejects_non_select(mock_can_modify, mock_auth_request):
+def test_submit_cohort_query_rejects_non_select(mock_can_modify, mock_auth_request, mock_unstaged):
     """Statements that are not SELECT-shaped are rejected by the hub pre-check."""
     with pytest.raises(HTTPException) as exc_info:
-        submit_cohort_query(mock_auth_request, _query("DROP TABLE patients;"), MagicMock(), user_id)
+        submit_cohort_query(
+            mock_auth_request, _query("DROP TABLE patients;"), _db(row=_persisted_row("DROP TABLE patients;")), user_id
+        )
 
     assert exc_info.value.status_code == 400
     assert "SELECT" in str(exc_info.value.detail)
 
 
 @patch("flip_api.cohort_services.submit_cohort_query.can_modify_project", return_value=True)
-def test_submit_cohort_query_rejects_unparseable_sql(mock_can_modify, mock_auth_request):
+def test_submit_cohort_query_rejects_unparseable_sql(mock_can_modify, mock_auth_request, mock_unstaged):
     """Input that is not SQL at all is rejected.
 
     The previous sqlparse-based check accepted this: ``sqlparse.parse`` is a
     non-validating tokenizer and returns a truthy result for arbitrary text.
     """
     with pytest.raises(HTTPException) as exc_info:
-        submit_cohort_query(mock_auth_request, _query("$$$$ not sql at all !!!"), MagicMock(), user_id)
-
-    assert exc_info.value.status_code == 400
-
-
-@patch("flip_api.cohort_services.submit_cohort_query.can_modify_project", return_value=True)
-def test_submit_cohort_query_rejects_stacked_statements(mock_can_modify, mock_auth_request):
-    """Query stacking is rejected — only one statement may be submitted."""
-    with pytest.raises(HTTPException) as exc_info:
         submit_cohort_query(
-            mock_auth_request, _query("SELECT 1; DROP TABLE patients"), MagicMock(), user_id
+            mock_auth_request,
+            _query("$$$$ not sql at all !!!"),
+            _db(row=_persisted_row("$$$$ not sql at all !!!")),
+            user_id,
         )
 
     assert exc_info.value.status_code == 400
 
 
 @patch("flip_api.cohort_services.submit_cohort_query.can_modify_project", return_value=True)
-def test_submit_cohort_query_rejects_oversized_query(mock_can_modify, mock_auth_request):
+def test_submit_cohort_query_rejects_stacked_statements(mock_can_modify, mock_auth_request, mock_unstaged):
+    """Query stacking is rejected — only one statement may be submitted."""
+    with pytest.raises(HTTPException) as exc_info:
+        submit_cohort_query(
+            mock_auth_request,
+            _query("SELECT 1; DROP TABLE patients"),
+            _db(row=_persisted_row("SELECT 1; DROP TABLE patients")),
+            user_id,
+        )
+
+    assert exc_info.value.status_code == 400
+
+
+@patch("flip_api.cohort_services.submit_cohort_query.can_modify_project", return_value=True)
+def test_submit_cohort_query_rejects_oversized_query(mock_can_modify, mock_auth_request, mock_unstaged):
     """Pathologically large queries are rejected before the parser allocates an AST."""
     oversized = f"SELECT {'a' * (MAX_QUERY_LENGTH + 1)} FROM omop.person"
 
     with pytest.raises(HTTPException) as exc_info:
-        submit_cohort_query(mock_auth_request, _query(oversized), MagicMock(), user_id)
+        submit_cohort_query(mock_auth_request, _query(oversized), _db(row=_persisted_row(oversized)), user_id)
 
     assert exc_info.value.status_code == 400
     assert "length" in str(exc_info.value.detail).lower()
@@ -236,7 +331,7 @@ def test_validate_query_accepts_cte_with_set_operation():
 
 
 @patch("flip_api.cohort_services.submit_cohort_query.can_modify_project", return_value=True)
-def test_submit_cohort_query_invalid_sql(mock_can_modify, monkeypatch, mock_request, sample_query):
+def test_submit_cohort_query_invalid_sql(mock_can_modify, monkeypatch, mock_request, sample_query, mock_unstaged):
     """Invalid SQL should be rejected."""
     monkeypatch.setattr(
         "flip_api.cohort_services.submit_cohort_query.validate_query",
@@ -244,17 +339,16 @@ def test_submit_cohort_query_invalid_sql(mock_can_modify, monkeypatch, mock_requ
     )
 
     with pytest.raises(HTTPException) as exc_info:
-        submit_cohort_query(mock_request, sample_query, MagicMock(), user_id)
+        submit_cohort_query(mock_request, sample_query, _db(), user_id)
 
     assert exc_info.value.status_code == 400
     assert "Invalid SQL" in str(exc_info.value.detail)
 
 
 @patch("flip_api.cohort_services.submit_cohort_query.can_modify_project", return_value=True)
-def test_submit_cohort_query_no_trusts(mock_can_modify, mock_request, sample_query):
+def test_submit_cohort_query_no_trusts(mock_can_modify, mock_request, sample_query, mock_unstaged):
     """No trusts in the database should return 404."""
-    mock_db = MagicMock()
-    mock_db.exec.return_value.all.return_value = []
+    mock_db = _db(trusts=[])
 
     with pytest.raises(HTTPException) as exc_info:
         submit_cohort_query(mock_request, sample_query, mock_db, user_id)
@@ -263,12 +357,13 @@ def test_submit_cohort_query_no_trusts(mock_can_modify, mock_request, sample_que
     assert "No trusts found" in str(exc_info.value.detail)
 
 
-def test_submit_cohort_query_task_payload_contains_query(mock_request, sample_query, mock_encrypt, mock_can_modify):
+def test_submit_cohort_query_task_payload_contains_query(
+    mock_request, sample_query, mock_encrypt, mock_can_modify, mock_unstaged
+):
     """The task payload should contain the query details."""
-    mock_db = MagicMock()
     mock_trust = MagicMock(id="trust_1", name="Trust A", endpoint="http://trust-a.com")
     mock_trust.name = "Trust A"
-    mock_db.exec.return_value.all.return_value = [mock_trust]
+    mock_db = _db(trusts=[mock_trust])
 
     submit_cohort_query(mock_request, sample_query, mock_db, user_id)
 


### PR DESCRIPTION
# Description

Two related defects in `submit_cohort_query`, both from trusting the client-supplied `query_id`
without reference to the project the caller was authorised on.

**Unscoped lookup.** Authorisation checks `can_modify_project` against the body's `project_id`, but
`query_id` was then used independently — tagging the `TrustTask`s fanned out to every trust and
selecting/overwriting a `Queries` row by id alone. `receive_cohort_results` also keys `QueryResult`
and `QueryStats` purely on `query_id`, so a caller authorised on project A could have the trusts'
results written against project B. Reads stay scoped by `can_access_cohort_query`, so this is
integrity, not disclosure.

**Body SQL dispatched instead of the stored SQL.** The task was built from `cohort_query.query`,
never re-reading the persisted row — so what ran at the trusts could differ from `Queries.query`,
which is what the UI renders and what approval is granted against. There was also no `UNSTAGED`
gate, so a cohort could be re-dispatched after trusts approved the project, overwriting the results
the approval rested on.

## Changes

- Scope the `Queries` lookup by `project_id`; 404 on a miss; move it ahead of the trust listing.
- Source the task payload (`query`, `name`, `query_id`) from the persisted row.
- Apply the same `UNSTAGED` gate `save_cohort_query` enforces.

On a body-vs-stored mismatch I chose **substitution with an INFO log** rather than rejection —
rejecting can break a client on incidental whitespace drift, and the log still surfaces divergence.

The second `db.exec` for the `Queries` row and its warn-and-continue branch are gone: the row is
already in hand, and "warn and carry on" was tenable when it only supplied `queried_trust_ids` but
not now that it supplies the SQL being dispatched.

## Test note — both scoping tests were initially vacuous

Worth calling out, because the first versions of these tests passed against the broken code:

- The unit test asserted `"queries.project_id" in str(statement)`. `select(Queries)` puts **every**
  column in the SELECT list, so that string is present whether or not the WHERE clause is scoped. It
  now asserts on `statement.whereclause`.
- The integration test 404'd at the **trust listing** — neither fixture created a `Trust` row — so
  all four assertions held for the wrong reason. Worse, `trust` is in conftest's `_PRESERVED_TABLES`,
  so whether it was red depended on collection order. It now creates a trust and pins the 404's
  *reason*, since "No trusts found" is also a 404 from this endpoint.

Both are now verified red against the unscoped lookup and green with it.

## Linked Issues

Fixes #913

## Behaviour changes

| Change | Risk |
|---|---|
| Missing/foreign query row → 404 instead of warn-and-continue | Every in-repo caller saves before submitting; `/step/cohort` passes the id straight from the save response |
| Staged/approved project → 400 | No in-repo caller submits post-stage; the UI reaches submit only via `/step/cohort`, whose first step already 400s on non-UNSTAGED |
| Body `query`/`name` become advisory | Both stay required in the schema, so no request shape changes |

**Open question:** does any operational runbook re-submit a cohort query to a staged/approved project
— to recover from a trust that never responded, say? No such path exists in code, but a manual
procedure would break under the UNSTAGED gate.

## Verification

- `make -C flip-api unit_test` — ruff, mypy, **1465 passed**
- `uv run pytest tests/integration/test_cohort_submit_db_flow.py` — **1 passed**, red without the scoping

Nine existing unit tests needed rewiring for the new `db.exec` call order, behind a
`_db()`/`_persisted_row()` helper pair.

## Checklist

- [x] Follows the project's coding conventions and style guide
- [ ] Updates documentation — n/a
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


## Acceptance Criteria

*Imported from issue #913*

- [ ] A `query_id` belonging to another project is refused, and that project's row and results are provably untouched
- [ ] The SQL dispatched to trusts comes from the persisted row
- [ ] Submitting against a staged/approved project is refused
- [ ] The scoping test is verified to fail without the fix — note a mocked session cannot distinguish a scoped lookup from an unscoped one, so this needs real Postgres
- [ ] `make -C flip-api unit_test` and `make -C flip-api integration_test` green