### PR TITLE
Release v0.4.0

### DIFF
--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -85,7 +85,7 @@ jobs:
 
       - name: Run unit tests
         if: steps.check_tag.outputs.skip == 'false'
-        run: uv run pytest -s -vv
+        run: uv run pytest -vv
 
       - name: Build package
         if: steps.check_tag.outputs.skip == 'false'

--- a/flip-api/pyproject.toml
+++ b/flip-api/pyproject.toml
@@ -12,7 +12,7 @@
 
 [project]
 name = "flip-api"
-version = "0.3.0"
+version = "0.4.0"
 description = ""
 readme = "README.md"
 authors = [

--- a/flip-api/uv.lock
+++ b/flip-api/uv.lock
@@ -798,7 +798,7 @@ wheels = [
 
 [[package]]
 name = "flip-api"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },

--- a/flip-ui/package-lock.json
+++ b/flip-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "flip-ui",
-    "version": "0.3.0",
+    "version": "0.4.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "flip-ui",
-            "version": "0.3.0",
+            "version": "0.4.0",
             "dependencies": {
                 "echarts": "^6.1.0",
                 "highlight.js": "^10.7.3",

--- a/flip-ui/package.json
+++ b/flip-ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "flip-ui",
-    "version": "0.3.0",
+    "version": "0.4.0",
     "engines": {
         "node": "^20.19.0 || >=22.12.0"
     },

--- a/flip-utils/flip/__init__.py
+++ b/flip-utils/flip/__init__.py
@@ -37,4 +37,4 @@ from flip.exceptions import ResultsUploadError
 
 __all__ = ["FLIP", "FLIPBase", "ResultsUploadError"]
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@
 #
 [project]
 name = "flip"
-version = "0.3.0"
+version = "0.4.0"
 description = ""
 readme = "README.md"
 authors = [

--- a/trust/data-access-api/pyproject.toml
+++ b/trust/data-access-api/pyproject.toml
@@ -12,7 +12,7 @@
 
 [project]
 name = "data-access-api"
-version = "0.3.0"
+version = "0.4.0"
 description = "flip Trust Data Access API"
 readme = "README.md"
 authors = [

--- a/trust/data-access-api/uv.lock
+++ b/trust/data-access-api/uv.lock
@@ -393,7 +393,7 @@ wheels = [
 
 [[package]]
 name = "data-access-api"
-version = "0.3.0"
+version = "0.4.0"
 source = { virtual = "." }
 dependencies = [
     { name = "cryptography" },

--- a/trust/imaging-api/pyproject.toml
+++ b/trust/imaging-api/pyproject.toml
@@ -12,7 +12,7 @@
 
 [project]
 name = "imaging-api"
-version = "0.3.0"
+version = "0.4.0"
 description = "flip Trust Imaging API"
 readme = "README.md"
 authors = [

--- a/trust/imaging-api/uv.lock
+++ b/trust/imaging-api/uv.lock
@@ -784,7 +784,7 @@ wheels = [
 
 [[package]]
 name = "imaging-api"
-version = "0.3.0"
+version = "0.4.0"
 source = { virtual = "." }
 dependencies = [
     { name = "asyncpg" },

--- a/trust/trust-api/pyproject.toml
+++ b/trust/trust-api/pyproject.toml
@@ -12,7 +12,7 @@
 
 [project]
 name = "trust-api"
-version = "0.3.1"
+version = "0.4.0"
 description = "flip Trust API"
 readme = "README.md"
 authors = [

--- a/trust/trust-api/pyproject.toml
+++ b/trust/trust-api/pyproject.toml
@@ -12,7 +12,7 @@
 
 [project]
 name = "trust-api"
-version = "0.3.0"
+version = "0.3.1"
 description = "flip Trust API"
 readme = "README.md"
 authors = [

--- a/trust/trust-api/uv.lock
+++ b/trust/trust-api/uv.lock
@@ -1368,7 +1368,7 @@ wheels = [
 
 [[package]]
 name = "trust-api"
-version = "0.3.1"
+version = "0.4.0"
 source = { virtual = "." }
 dependencies = [
     { name = "cryptography" },

--- a/trust/trust-api/uv.lock
+++ b/trust/trust-api/uv.lock
@@ -1368,7 +1368,7 @@ wheels = [
 
 [[package]]
 name = "trust-api"
-version = "0.3.0"
+version = "0.3.1"
 source = { virtual = "." }
 dependencies = [
     { name = "cryptography" },

--- a/uv.lock
+++ b/uv.lock
@@ -8,5 +8,5 @@ exclude-newer-span = "P3D"
 
 [[package]]
 name = "flip"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }


### PR DESCRIPTION
Version-bump PR per CONTRIBUTING ["Cutting a release"](../blob/develop/CONTRIBUTING.md#cutting-a-release): merge into `develop`, then open `develop` → `main` to cut the release.

## Version bumps

| Component | Version |
|---|---|
| FLIP (root — becomes the `v0.4.0` release tag) | 0.3.0 → 0.4.0 |
| flip-api | 0.3.0 → 0.4.0 |
| flip-ui | 0.3.0 → 0.4.0 |
| imaging-api | 0.3.0 → 0.4.0 |
| data-access-api | 0.3.0 → 0.4.0 |
| trust-api | 0.3.0 → 0.4.0 |
| flip-utils (`flip` on PyPI) | 0.4.0 → 0.4.1 (see below) |

**trust-api tracks the platform version.** Only its dependencies changed since v0.3.0, so a strict semver read would make it 0.3.1 — but holding one service back means image tags, deployed services and support requests no longer line up without a per-service lookup. It moves to 0.4.0 with everything else. flip-utils is the deliberate exception: it is published to PyPI as `flip` and has its own consumers, so its version stays independent (see below).

## Release-pipeline fixes bundled in

- **Drop `-s` from the release-pypi pytest invocation.** The latest run on `main` (after #808 merged) crashed at interpreter exit with `OSError: [Errno 9] Bad file descriptor` on `sys.stdout.flush` (exit code 120) *after every test passed*, killing the release job before publish. With default capture the suite is clean — verified locally on uv-synced deps: 653 passed.
- **flip-utils to 0.4.1, not 0.4.0.** `release.yml` (reads the root version) and `release-pypi.yml` (reads flip `__version__`) mint tags in the same `v*` namespace, and both run on every push to `main`. flip 0.4.0 was never published or tagged (release-pypi has failed on every run), so once this release merges, `release.yml` claims `v0.4.0` and release-pypi's tag-exists check would then skip publishing flip 0.4.0 permanently. Bumping flip-utils to 0.4.1 sidesteps the collision for this release; separating the tag namespaces (e.g. a `flip-utils-v*` tag prefix) is the proper long-term fix.

## ⚠️ Known blocker for the PyPI leg (not fixable in-repo)

The June release-pypi run got past tests and failed at publish with `422 invalid-publisher` — PyPI trusted publishing for the `flip` project does not match this repo/workflow/environment (workflow `release-pypi.yml`, environment `flip`). Until that is configured on pypi.org, the PyPI leg will keep failing. The platform release (`release.yml` tag + GitHub Release + `:prod` images) is independent and unaffected.

## Verification

- `uv lock --check` (uv 0.11.16 — CI's pinned version) passes on all five re-locked projects.
- flip-utils: `ruff check` clean; `pytest -vv` without `-s`: **653 passed**.
- Version-string-only changes otherwise; full suite runs in PR CI.