### PR TITLE
fix(flip-ui): scope VITE_E2E to its own .env.e2e / --mode e2e

### DIFF
--- a/.github/workflows/regenerate_docs_gifs.yml
+++ b/.github/workflows/regenerate_docs_gifs.yml
@@ -63,10 +63,11 @@ jobs:
       - name: Install ffmpeg
         run: sudo apt-get update && sudo apt-get install -y ffmpeg
 
-      - name: Stub flip-ui/.env.development for Cypress
+      - name: Stub flip-ui/.env.e2e for Cypress
+        # `.env.e2e`, not `.env.development` — see flip-ui/README.md → Testing.
         working-directory: ./flip-ui
         run: |
-          cat > .env.development <<'EOF'
+          cat > .env.e2e <<'EOF'
           VITE_LOCAL=false
           VITE_E2E=true
           CENTRAL_HUB_API_URL=http://localhost:8080

--- a/.github/workflows/test_flip_ui.yml
+++ b/.github/workflows/test_flip_ui.yml
@@ -129,13 +129,15 @@ jobs:
           cache: npm
           cache-dependency-path: flip-ui/package-lock.json
 
-      - name: Stub flip-ui/.env.development for Cypress
+      - name: Stub flip-ui/.env.e2e for Cypress
         # Vite's `loadEnv` and the cypress plugin (dotenv) both read this
         # file at process start. The values mirror the job-level `env:`
         # block above — they're stubs because the suite mocks Cognito and
         # the API at the network layer, so nothing here ever hits AWS.
+        #
+        # `.env.e2e`, not `.env.development` — see flip-ui/README.md → Testing.
         run: |
-          cat > .env.development <<'EOF'
+          cat > .env.e2e <<'EOF'
           VITE_LOCAL=false
           VITE_E2E=true
           CENTRAL_HUB_API_URL=http://localhost:8080

--- a/.gitignore
+++ b/.gitignore
@@ -260,6 +260,7 @@ web_modules/
 # dotenv environment variable files
 .env.development
 .env.development.local
+.env.e2e
 .env.test.local
 .env.production.local
 .env.local

--- a/flip-ui/Makefile
+++ b/flip-ui/Makefile
@@ -39,11 +39,11 @@ npm-install:
 # needs to be available locally. Requires Node >=20.19 and `npm install` to have
 # been run on the host.
 e2e_test:
-	@test -f .env.development || { \
-		echo "ERROR: flip-ui/.env.development is missing." >&2; \
+	@test -f .env.e2e || { \
+		echo "ERROR: flip-ui/.env.e2e is missing." >&2; \
 		echo "Cypress needs it for Vite + dotenv. See flip-ui/README.md → Testing → End-to-end tests for the dummy values to use locally." >&2; \
 		exit 1; \
 	}
 	@# `pretest:start` runs scripts/generate-window-js.sh which reads VITE_*
 	@# from the shell env (NOT the .env file). Source the file to export them.
-	set -a && . ./.env.development && set +a && npm run test:ci:docker
+	set -a && . ./.env.e2e && set +a && npm run test:ci:docker

--- a/flip-ui/README.md
+++ b/flip-ui/README.md
@@ -130,7 +130,16 @@ cd flip-ui
 npm install
 # One-shot env file. Values are dummies — the suite mocks Cognito + the API,
 # so nothing here ever leaves the box. Match the values used in CI.
-cat > .env.development <<'EOF'
+#
+# It MUST be `.env.e2e`, never `.env.development`: VITE_E2E arms the Cypress
+# auth seam (src/utils/auth.ts), which takes the signed-in user from a
+# `cypress.auth.user` localStorage key instead of Cognito. Vite loads
+# `.env.development` for `npm run dev` / `make ui` too, so putting the flag
+# there makes the interactive dev server bounce every page refresh to
+# /auth/login while your real Cognito tokens sit unused in localStorage.
+# `vite.config.mts` now refuses to start in any mode but `e2e` with the flag
+# set, so a misplaced file fails loudly instead of wasting an afternoon.
+cat > .env.e2e <<'EOF'
 VITE_LOCAL=false
 VITE_E2E=true
 CENTRAL_HUB_API_URL=http://localhost:8080
@@ -143,8 +152,9 @@ npm run test:ci            # boots the dev server on :4173 and runs cypress
 ```
 
 `test:ci` uses `start-server-and-test` to start the Vite dev server (`npm run test:start`, plain HTTP on
-`http://localhost:4173`) and then runs `cypress run --browser chrome` against it. The non-privileged port `4173`
-avoids the need to run with `sudo` on Linux/macOS and matches the port used in CI.
+`http://localhost:4173`, `--mode e2e` so it reads `.env.e2e`) and then runs `cypress run --browser chrome`
+against it. The non-privileged port `4173` avoids the need to run with `sudo` on Linux/macOS and matches the
+port used in CI.
 
 To open the Cypress GUI for interactive debugging:
 
@@ -202,7 +212,7 @@ The Cypress suite runs on every PR and on push to `develop` / `main` via the `cy
 
 - Uses `cypress-io/github-action@v6`, which caches the Cypress binary and `node_modules` between runs.
 - Fans out across the six spec groups via a `strategy.matrix.group` so wall-clock time stays short.
-- Boots the Vite dev server with the same `.env.development` stub shown above.
+- Boots the Vite dev server with the same `.env.e2e` stub shown above.
 - On failure, uploads `test/cypress/screenshots` as an artefact (`cypress-screenshots-<group>`, retained 7 days).
 
 Running the suite against the **real** backend stack is out of scope for the in-repo CI — that's the nightly E2E job

--- a/flip-ui/package.json
+++ b/flip-ui/package.json
@@ -23,7 +23,7 @@
         "test:ui": "cypress run --browser chrome",
         "test:ui:docker": "docker run --rm --network host -v \"$PWD\":/e2e -w /e2e --entrypoint cypress cypress/included:14.5.2 run --browser electron",
         "pretest:start": "npm run generate-window-js",
-        "test:start": "vite --port 4173 --mode development",
+        "test:start": "vite --port 4173 --mode e2e",
         "test:ci": "start-server-and-test test:start http-get://localhost:4173 test:ui",
         "test:ci:docker": "start-server-and-test test:start http-get://localhost:4173 test:ui:docker",
         "docs:record": "start-server-and-test test:start http-get://localhost:4173 'cypress run --config-file cypress.docs.config.ts --browser chrome'",

--- a/flip-ui/scripts/__tests__/check-build-flags.spec.ts
+++ b/flip-ui/scripts/__tests__/check-build-flags.spec.ts
@@ -14,7 +14,7 @@
 import { execFileSync } from "node:child_process";
 import path from "node:path";
 
-import { checkViteLocal, runCli } from "../check-build-flags.mjs";
+import { checkViteE2e, checkViteLocal, runCli } from "../check-build-flags.mjs";
 
 // Resolved once because every spec runs the script as a child process,
 // and resolving relative to __dirname keeps the test order-independent
@@ -64,6 +64,31 @@ describe("checkViteLocal", () => {
     });
 });
 
+describe("checkViteE2e", () => {
+    it("names the Cypress auth seam so the stake is visible", () => {
+        // A generic "bad config" message would invite an operator to paper
+        // over it; the refusal has to say what the flag actually does.
+        const reason = checkViteE2e();
+        expect(reason).toContain("VITE_E2E");
+        expect(reason).toContain("cypress.auth.user");
+        expect(reason).toContain("/auth/login");
+    });
+
+    it("names .env.e2e as the one legitimate home", () => {
+        expect(checkViteE2e()).toContain(".env.e2e");
+    });
+
+    it("reports mode and command when the caller knows them", () => {
+        const reason = checkViteE2e("development", "serve");
+        expect(reason).toContain("development");
+        expect(reason).toContain("serve");
+    });
+
+    it("falls back to build phrasing when mode is unknown", () => {
+        expect(checkViteE2e()).toContain("Refusing to build");
+    });
+});
+
 describe("runCli", () => {
     // runCli is the exported CLI entry. We drive it directly (rather
     // than spawning the script as a child process) so vitest's
@@ -88,6 +113,24 @@ describe("runCli", () => {
         expect(code).toBe(0);
         expect(io.exit).not.toHaveBeenCalled();
         expect(io.error).not.toHaveBeenCalled();
+    });
+
+    it("returns 1 when VITE_E2E='true' — the prebuild hooks have no mode, so it can only be a shipping build", () => {
+        const io = makeIo();
+
+        const code = runCli({ VITE_E2E: "true" }, io);
+
+        expect(code).toBe(1);
+        expect(io.exit).toHaveBeenCalledWith(1);
+        expect(io.error.mock.calls[0][0]).toContain("VITE_E2E");
+    });
+
+    it("returns 0 when VITE_E2E is not exactly 'true'", () => {
+        const io = makeIo();
+
+        expect(runCli({ VITE_E2E: "false" }, io)).toBe(0);
+        expect(runCli({ VITE_E2E: "1" }, io)).toBe(0);
+        expect(io.exit).not.toHaveBeenCalled();
     });
 
     it("returns 1 and forwards the reason to error+exit when VITE_LOCAL='true'", () => {

--- a/flip-ui/scripts/check-build-flags.mjs
+++ b/flip-ui/scripts/check-build-flags.mjs
@@ -49,6 +49,42 @@ export function checkViteLocal(env) {
 }
 
 /**
+ * Message for a VITE_E2E misuse. Unlike VITE_LOCAL this flag has one
+ * legitimate home — the Cypress dev server (`vite --mode e2e`, reading
+ * .env.e2e) — so the caller decides legality from (mode, command) and
+ * this only phrases the refusal.
+ *
+ * VITE_E2E arms the Cypress auth seam in src/utils/auth.ts, which takes
+ * the signed-in user from a `cypress.auth.user` localStorage key instead
+ * of Cognito. In a browser without that fixture nobody is ever signed in,
+ * so every guarded navigation redirects to /auth/login — an interactive
+ * dev server with the flag set silently logs you out on each refresh, and
+ * a build with it ships an auth seam to users.
+ *
+ * @param {string} [mode] Vite mode, when known (config-time callers).
+ * @param {string} [command] "build" | "serve", when known.
+ * @returns {string} multi-line refusal message
+ */
+export function checkViteE2e(mode, command) {
+    const where = mode === undefined
+        ? "Refusing to build flip-ui: VITE_E2E=true is set."
+        : `Refusing to run flip-ui (mode '${mode}', command '${command}') with VITE_E2E=true.`;
+
+    return [
+        where,
+        "",
+        "VITE_E2E arms the Cypress auth seam in src/utils/auth.ts, which",
+        "reads the signed-in user from a 'cypress.auth.user' localStorage",
+        "key instead of Cognito. A browser without that fixture is never",
+        "signed in, so every page refresh redirects to /auth/login.",
+        "",
+        "The flag is valid only for the Cypress dev server, which loads",
+        "flip-ui/.env.e2e via 'npm run test:start' (vite --mode e2e).",
+        "It must never appear in .env.development or in a built bundle."
+    ].join("\n");
+}
+
+/**
  * CLI driver. Takes the side-effecting bits as parameters so a unit
  * test can drive it without forking a real process — child-process
  * spawns don't count for vitest's coverage instrumentation, and we
@@ -59,7 +95,10 @@ export function checkViteLocal(env) {
  * @returns {0 | 1} exit code; the caller forwards it to process.exit.
  */
 export function runCli(env, io) {
-    const reason = checkViteLocal(env);
+    // The prebuild hooks have no Vite mode, so an exported VITE_E2E here is
+    // unambiguously a shipping build — refuse it on the same axis as
+    // VITE_LOCAL. The mode-aware check lives in vite.config.mts.
+    const reason = checkViteLocal(env) ?? (env.VITE_E2E === "true" ? checkViteE2e() : null);
     if (reason) {
         io.error(reason);
         io.exit(1);

--- a/flip-ui/test/cypress/plugins/index.ts
+++ b/flip-ui/test/cypress/plugins/index.ts
@@ -26,7 +26,7 @@ export default function (
     config: Cypress.PluginConfigOptions
 ): void | Cypress.ConfigOptions | Promise<Cypress.ConfigOptions> {
 
-    dotenv.config({ path: "./.env.development" });
+    dotenv.config({ path: "./.env.e2e" });
     config.env = process.env;
 
     on("dev-server:start", async (options: Cypress.DevServerConfig) => {

--- a/flip-ui/vite.config.mts
+++ b/flip-ui/vite.config.mts
@@ -12,12 +12,22 @@ import Inspector from "vite-plugin-vue-inspector";
 import Layouts from "vite-plugin-vue-layouts-next";
 import svgLoader from "vite-svg-loader";
 
+import { checkViteE2e } from "./scripts/check-build-flags.mjs";
 import iconStubPlugin from "./test/iconStubPlugin";
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode, command }) => {
 
     const env = loadEnv(mode, process.cwd());
+
+    // VITE_E2E is legal only for the Cypress dev server (`vite --mode e2e`,
+    // reading .env.e2e); checkViteE2e explains the stake. Refusing on
+    // `command === "build"` as well as on a mode mismatch matters — the mode
+    // check alone still lets `vite build --mode e2e` inline the Cypress auth
+    // seam into a shippable dist/.
+    if (env.VITE_E2E === "true" && (command === "build" || mode !== "e2e")) {
+        throw new Error(checkViteE2e(mode, command));
+    }
 
     // Belt-and-braces guard for `vite build` invoked directly (bypassing
     // the npm prebuild hook in package.json). Vite inlines VITE_LOCAL at


### PR DESCRIPTION
## Problem

`VITE_E2E` arms the Cypress auth seam in `src/utils/auth.ts`, which takes the signed-in user from a `cypress.auth.user` localStorage key instead of Cognito:

```ts
if (isCypressMode()) {
    const stored = window.localStorage.getItem("cypress.auth.user");
    if (stored && !auth.user) { … }
    if (!auth.user) return next("/auth/login");   // ← synchronous, silent
    return next();
}
```

The flag lived in `flip-ui/.env.development` — which `README.md` told you to create in order to run the E2E suite locally, and which Vite **also** loads for `npm run dev` / `make ui`. So creating that file armed the seam in your own browser. With no `cypress.auth.user` fixture present, `auth.user` is null on every cold load, and the guard redirects to `/auth/login` before ever reaching the real session check.

Symptom: the interactive dev server silently signs you out on **every page refresh**, while your real Cognito tokens sit untouched in localStorage. It is silent (this path shows no snackbar) and it never reads the tokens, so it looks nothing like a session-expiry bug.

## Change

- `VITE_E2E` now lives in **`flip-ui/.env.e2e`**, read only by `npm run test:start` (`vite --mode e2e`). `npm run dev` can no longer load it.
- `vite.config.mts` refuses to start with the flag set in any other mode **or in a build**. Both halves matter: a mode-only check still allows `vite build --mode e2e` to inline the Cypress seam into a shippable `dist/`.
- The refusal message moves to `scripts/check-build-flags.mjs` next to the existing `checkViteLocal` guard, and is wired into `runCli` so the `prebuild` / `prebuild:deploy` hooks catch an exported `VITE_E2E=true`. Unit-tested alongside its sibling.
- Both CI workflows write `.env.e2e` instead of `.env.development`.
- The Cypress dotenv plugin (`test/cypress/plugins/index.ts`) is repointed at `.env.e2e` — it was still reading `.env.development`, which CI no longer writes and which dotenv skips silently.

## Verification

Guard fires in all three paths, and the legitimate Cypress path still works:

| Invocation | Result |
|---|---|
| `vite build --mode e2e` with flag | refused (**was allowed before this PR**) |
| `vite --mode development` with flag | refused |
| `node scripts/check-build-flags.mjs` with flag exported | refused, exit 1 |
| `vite --mode e2e` (serve — the Cypress path) | starts normally, flag active |

`npm run lint` clean (3 pre-existing warnings in `EditProjectDrawer.vue`, untouched). Unit suite green: 107 files, 1120 passed / 1 skipped — +6 new tests for the guard.

## Notes for the reviewer

- No runtime/application behaviour changes — this is build/dev-tooling scoping only. The Cypress seam itself is unchanged and still build-time gated (verified previously to dead-code-eliminate to a literal `false` in production bundles).
- `.env.e2e` is gitignored, like `.env.development`. `flip-ui/README.md` documents the new file and why it must not be `.env.development`.
- `lighthouse_flip_ui.yml` is deliberately untouched: it never sets `VITE_E2E` and uses `vite preview`, not `test:start`.