### PR TITLE
develop -> main

### DIFF
--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -85,7 +85,7 @@ jobs:
 
       - name: Run unit tests
         if: steps.check_tag.outputs.skip == 'false'
-        run: uv run pytest -s -vv
+        run: uv run pytest -vv
 
       - name: Build package
         if: steps.check_tag.outputs.skip == 'false'

--- a/flip-api/pyproject.toml
+++ b/flip-api/pyproject.toml
@@ -12,7 +12,7 @@
 
 [project]
 name = "flip-api"
-version = "0.3.0"
+version = "0.4.0"
 description = ""
 readme = "README.md"
 authors = [

--- a/flip-api/uv.lock
+++ b/flip-api/uv.lock
@@ -798,7 +798,7 @@ wheels = [
 
 [[package]]
 name = "flip-api"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },

--- a/flip-ui/package-lock.json
+++ b/flip-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "flip-ui",
-    "version": "0.3.0",
+    "version": "0.4.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "flip-ui",
-            "version": "0.3.0",
+            "version": "0.4.0",
             "dependencies": {
                 "echarts": "^6.1.0",
                 "highlight.js": "^10.7.3",

--- a/flip-ui/package.json
+++ b/flip-ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "flip-ui",
-    "version": "0.3.0",
+    "version": "0.4.0",
     "engines": {
         "node": "^20.19.0 || >=22.12.0"
     },

--- a/flip-utils/flip/__init__.py
+++ b/flip-utils/flip/__init__.py
@@ -37,4 +37,4 @@ from flip.exceptions import ResultsUploadError
 
 __all__ = ["FLIP", "FLIPBase", "ResultsUploadError"]
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@
 #
 [project]
 name = "flip"
-version = "0.3.0"
+version = "0.4.0"
 description = ""
 readme = "README.md"
 authors = [

--- a/trust/data-access-api/pyproject.toml
+++ b/trust/data-access-api/pyproject.toml
@@ -12,7 +12,7 @@
 
 [project]
 name = "data-access-api"
-version = "0.3.0"
+version = "0.4.0"
 description = "flip Trust Data Access API"
 readme = "README.md"
 authors = [

--- a/trust/data-access-api/uv.lock
+++ b/trust/data-access-api/uv.lock
@@ -393,7 +393,7 @@ wheels = [
 
 [[package]]
 name = "data-access-api"
-version = "0.3.0"
+version = "0.4.0"
 source = { virtual = "." }
 dependencies = [
     { name = "cryptography" },

--- a/trust/imaging-api/pyproject.toml
+++ b/trust/imaging-api/pyproject.toml
@@ -12,7 +12,7 @@
 
 [project]
 name = "imaging-api"
-version = "0.3.0"
+version = "0.4.0"
 description = "flip Trust Imaging API"
 readme = "README.md"
 authors = [

--- a/trust/imaging-api/uv.lock
+++ b/trust/imaging-api/uv.lock
@@ -784,7 +784,7 @@ wheels = [
 
 [[package]]
 name = "imaging-api"
-version = "0.3.0"
+version = "0.4.0"
 source = { virtual = "." }
 dependencies = [
     { name = "asyncpg" },

--- a/trust/trust-api/pyproject.toml
+++ b/trust/trust-api/pyproject.toml
@@ -12,7 +12,7 @@
 
 [project]
 name = "trust-api"
-version = "0.3.1"
+version = "0.4.0"
 description = "flip Trust API"
 readme = "README.md"
 authors = [

--- a/trust/trust-api/pyproject.toml
+++ b/trust/trust-api/pyproject.toml
@@ -12,7 +12,7 @@
 
 [project]
 name = "trust-api"
-version = "0.3.0"
+version = "0.3.1"
 description = "flip Trust API"
 readme = "README.md"
 authors = [

--- a/trust/trust-api/uv.lock
+++ b/trust/trust-api/uv.lock
@@ -1368,7 +1368,7 @@ wheels = [
 
 [[package]]
 name = "trust-api"
-version = "0.3.1"
+version = "0.4.0"
 source = { virtual = "." }
 dependencies = [
     { name = "cryptography" },

--- a/trust/trust-api/uv.lock
+++ b/trust/trust-api/uv.lock
@@ -1368,7 +1368,7 @@ wheels = [
 
 [[package]]
 name = "trust-api"
-version = "0.3.0"
+version = "0.3.1"
 source = { virtual = "." }
 dependencies = [
     { name = "cryptography" },

--- a/uv.lock
+++ b/uv.lock
@@ -8,5 +8,5 @@ exclude-newer-span = "P3D"
 
 [[package]]
 name = "flip"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }


### PR DESCRIPTION
<!--
Copyright (c) 2026 Guy's and St Thomas' NHS Foundation Trust & King's College London
Licensed under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at
    http://www.apache.org/licenses/LICENSE-2.0
Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
-->

# Description

Cuts the **v0.4.0** release: promotes `develop` into `main` per CONTRIBUTING
["Cutting a release"](../blob/develop/CONTRIBUTING.md#cutting-a-release).

This is a deliberately small diff — **14 files, +15/-15**. The feature work for this release was already
promoted by #808 (merged 2026-08-06); everything here is the version bump (#917) plus one release-pipeline
fix bundled with it. Nothing else has landed on `develop` since.

Commits: `20a4072f`, `0f57d781`, `181dd447`, merged via `fcd964c5` (#917).

## Version bumps

| Component | Version |
|---|---|
| FLIP (root — becomes the `v0.4.0` release tag) | 0.3.0 → 0.4.0 |
| flip-api | 0.3.0 → 0.4.0 |
| flip-ui | 0.3.0 → 0.4.0 |
| imaging-api | 0.3.0 → 0.4.0 |
| data-access-api | 0.3.0 → 0.4.0 |
| trust-api | 0.3.0 → 0.4.0 |
| flip-utils (`flip` on PyPI) | 0.4.0 → 0.4.1 |

**trust-api tracks the platform version.** Only its dependencies changed since v0.3.0, so a strict semver
read would make it 0.3.1 — but holding one service back means image tags, deployed services and support
requests no longer line up without a per-service lookup. It moves to 0.4.0 with everything else.

**flip-utils is the deliberate exception** and goes to 0.4.1, not 0.4.0. It is published to PyPI as `flip`
and has its own consumers, so its version stays independent. `release.yml` (reads the root version) and
`release-pypi.yml` (reads `flip.__version__`) mint tags into the *same* `v*` namespace and both fire on every
push to `main`. flip 0.4.0 was never published or tagged (release-pypi has failed on every run since June),
so once this merges `release.yml` would claim `v0.4.0` and release-pypi's tag-exists check would then skip
publishing flip 0.4.0 permanently. 0.4.1 sidesteps the collision for this release; separating the tag
namespaces (e.g. a `flip-utils-v*` prefix) is the proper long-term fix.

## Release-pipeline fix bundled in

**Drop `-s` from the release-pypi pytest invocation** (`20a4072f`). The run on `main` after #808 merged
crashed at interpreter exit with `OSError: [Errno 9] Bad file descriptor` on `sys.stdout.flush` (exit code
120) *after every test had passed*, killing the release job before publish. With default capture the suite is
clean — verified locally on uv-synced deps: **653 passed**.

## What merging this triggers

- `release.yml` — reads the root `pyproject.toml` version, creates the `v0.4.0` tag and a GitHub Release with
  auto-generated notes.
- `docker_build_*.yml` — rebuilds every service and pushes the `:prod` image tag (alongside `:<sha>`) to GHCR.
- `release-pypi.yml` — attempts to publish `flip` 0.4.1 to PyPI.

### ⚠️ Known blocker on the PyPI leg (not fixable in-repo)

The June release-pypi run got past tests and failed at publish with `422 invalid-publisher`: PyPI trusted
publishing for the `flip` project does not match this repo/workflow/environment (workflow `release-pypi.yml`,
environment `flip`). Until that is configured on pypi.org the PyPI leg will keep failing. The platform release
(`release.yml` tag + GitHub Release + `:prod` images) is independent and unaffected.

## Linked Issues

None — this is a release cut. Issue links live on the individual PRs promoted by #808 and on #917.

## Checklist

- [x] Follows the project's coding conventions and style guide
- [ ] Updates documentation — n/a, no behaviour change
- [ ] I have added tests that prove my fix is effective or that my feature works — n/a, version strings + a CI flag
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Type of Change

- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make -C docs/ docs`.

## Testing

Verification carried out on #917 before it merged to `develop`:

- `uv lock --check` passes on all five re-locked projects (uv 0.11.16 — CI's pinned version).
- flip-utils: `ruff check` clean; `pytest -vv` without `-s`: **653 passed**.
- Changes are version-string-only otherwise; the full suite runs on this PR (every PR runs the whole roster,
  no path filtering).

## Additional Notes

`develop` shows as 3 commits *behind* `main` — those are the `main`-only merge commits from PRs #531, #654 and
#808. That is the normal shape of this repo's release flow (`main` is never merged back into `develop`) and
does not conflict; GitHub reports the PR as mergeable.

**Ignore the version in the release-notes preview comment below — it says `v0.4.1`, which is wrong.**
`pr-release-notes-preview.yml` reads `flip-utils/flip/__init__.py` (the PyPI package version) instead of the
root `pyproject.toml` that `release.yml` actually tags from, so it is previewing flip-utils, not the platform
release. **The release this PR cuts is `v0.4.0`.** The same comment's empty changelog is a second, separate
fault: the workflow grants itself `contents: read`, but `releases/generate-notes` needs `contents: write`, so
the API call fails with `Resource not accessible by integration` and the template renders unpopulated. Both
faults pre-date this PR — the preview on #808 likewise announced `0.4.0` for what was cut as `v0.3.0`.
