### PR TITLE
[Bug]: platform and flip-utils releases share one v* tag namespace and will silently suppress each other

### DIFF
--- a/.github/RELEASE_NOTES_TEMPLATE.md
+++ b/.github/RELEASE_NOTES_TEMPLATE.md
@@ -11,7 +11,7 @@
     limitations under the License.
 -->
 
-# :package: FLIP {{VERSION}} Release Notes
+# :package: {{PROJECT}} {{VERSION}} Release Notes
 
 ## :sparkles: Highlights
 

--- a/.github/workflows/pr-release-notes-preview.yml
+++ b/.github/workflows/pr-release-notes-preview.yml
@@ -84,6 +84,7 @@ jobs:
 
             // Substitute placeholders
             header = header
+              .replace(/\{\{PROJECT\}\}/g, 'FLIP')
               .replace(/\{\{VERSION\}\}/g, version)
               .replace(/\{\{TAG\}\}/g,     tag)
               .replace(/\{\{PREV_TAG\}\}/g, prevTag || 'initial release');

--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -49,8 +49,12 @@ jobs:
             exit 1
           fi
 
-          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
-          echo "tag=v${VERSION}"    >> "$GITHUB_OUTPUT"
+          # flip-utils tags carry their own prefix. The platform release (release.yml) owns the
+          # bare `v*` namespace; sharing it meant a version number used by one artefact silently
+          # suppressed the other's release — see the tag-existence check below, which skips the
+          # PyPI publish outright when it finds a tag it does not own.
+          echo "version=${VERSION}"            >> "$GITHUB_OUTPUT"
+          echo "tag=flip-utils-v${VERSION}"    >> "$GITHUB_OUTPUT"
           echo "Detected version: ${VERSION}"
 
       - name: Check if tag already exists
@@ -117,10 +121,17 @@ jobs:
           set -euo pipefail
           VERSION="${{ steps.version.outputs.version }}"
           TAG="${{ steps.version.outputs.tag }}"
-          PREV_TAG=$(git tag --list 'v*.*.*' | sort -V | grep -v "^${TAG}$" | tail -n1)
+          # Match only this artefact's tags, so the changelog spans flip-utils history rather than
+          # whatever the platform released most recently. The `|| true` is load-bearing under
+          # `set -o pipefail`: the tag for THIS release already exists by now (created above), so on
+          # the first prefixed release grep filters the only match away and exits 1 — which would
+          # kill the step immediately after an irreversible PyPI publish. Empty is a valid answer
+          # here and is handled by the ${PREV_TAG:-initial release} default below.
+          PREV_TAG=$(git tag --list 'flip-utils-v*.*.*' | sort -V | grep -v "^${TAG}$" | tail -n1 || true)
 
           # Strip the license comment block and substitute placeholders
           HEADER=$(sed '/^<!--/,/-->/d' "$GITHUB_WORKSPACE/.github/RELEASE_NOTES_TEMPLATE.md" \
+            | sed "s/{{PROJECT}}/flip-utils/g" \
             | sed "s/{{VERSION}}/${VERSION}/g" \
             | sed "s/{{TAG}}/${TAG}/g" \
             | sed "s/{{PREV_TAG}}/${PREV_TAG:-initial release}/g")
@@ -146,6 +157,6 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh release create "${{ steps.version.outputs.tag }}" \
-            --title "flip ${{ steps.version.outputs.tag }}" \
+            --title "flip-utils v${{ steps.version.outputs.version }}" \
             --notes-file "${{ steps.notes.outputs.notes_file }}" \
             dist/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,10 +60,42 @@ jobs:
                   git tag "${{ steps.version.outputs.tag }}"
                   git push origin "${{ steps.version.outputs.tag }}"
 
+            # generate_release_notes lets GitHub choose the previous release itself, which is
+            # whatever was published most recently — including a flip-utils release cut seconds
+            # after ours on the same push. Pin the range to the previous *platform* tag instead,
+            # the way release-pypi.yml already does for its own artefact.
+            - name: Prepare release notes
+              if: steps.tag_check.outputs.exists == 'false'
+              id: notes
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              run: |
+                  set -euo pipefail
+                  TAG="${{ steps.version.outputs.tag }}"
+                  # `|| true` is load-bearing under `set -o pipefail` — the tag for THIS release
+                  # was created by the step above, so when it is the only match grep exits 1.
+                  # Empty is a valid answer and is handled below.
+                  PREV_TAG=$(git tag --list 'v*.*.*' | sort -V | grep -v "^${TAG}$" | tail -n1 || true)
+
+                  API_ARGS=(-X POST
+                    -f "tag_name=${TAG}"
+                    -f "target_commitish=${{ github.sha }}")
+                  if [[ -n "$PREV_TAG" ]]; then
+                    API_ARGS+=(-f "previous_tag_name=${PREV_TAG}")
+                    echo "Generating notes for ${PREV_TAG}...${TAG}"
+                  else
+                    echo "No previous platform tag found — generating notes from the start."
+                  fi
+
+                  gh api "repos/${{ github.repository }}/releases/generate-notes" \
+                    "${API_ARGS[@]}" --jq '.body' > /tmp/release_notes.md
+
+                  echo "notes_file=/tmp/release_notes.md" >> "$GITHUB_OUTPUT"
+
             - name: Create GitHub Release
               if: steps.tag_check.outputs.exists == 'false'
               uses: softprops/action-gh-release@v2
               with:
                   tag_name: ${{ steps.version.outputs.tag }}
                   name: "Release ${{ steps.version.outputs.tag }}"
-                  generate_release_notes: true
+                  body_path: ${{ steps.notes.outputs.notes_file }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -528,7 +528,7 @@ A push to `main` cuts **two independent releases**, from two independently-versi
 
 The `flip-utils-` prefix is what keeps them apart: every `git tag --list 'v*.*.*'` lookup in the release and preview workflows matches platform tags only, so each train's changelog spans its own history. **Do not drop the prefix or widen those globs** — the two version sequences advance independently and will overlap.
 
-> **Note:** `v0.4.1` is a flip-utils tag that predates this split and still sits in the platform namespace. The platform must not use version 0.4.1.
+> **Historical note:** flip-utils 0.4.1 was released just before this split and originally tagged `v0.4.1`, in the platform namespace. It was retro-tagged as `flip-utils-v0.4.1` (same commit, `c55f79e8`) and the old tag deleted, so the two namespaces are clean from `v0.4.0` / `flip-utils-v0.4.1` onwards. The published PyPI artefact was never affected.
 
 ### Versioning
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -517,6 +517,19 @@ The new branch should be based on the latest `develop` branch.
 
 Releases are cut from `main`. The version is set in the root `pyproject.toml`, and merging to `main` triggers [`.github/workflows/release.yml`](.github/workflows/release.yml), which reads that version, creates a `v<MAJOR.MINOR.PATCH>` git tag, and publishes a GitHub Release with auto-generated notes. On the same merge, the per-service `.github/workflows/docker_build_*.yml` workflows rebuild every service and push the `:prod` image tag (alongside `:<sha>`) to GHCR. There is no separate release-publishing step beyond merging to `main`.
 
+### Two release trains, two tag namespaces
+
+A push to `main` cuts **two independent releases**, from two independently-versioned artefacts. They must never share a tag namespace: each workflow skips its own release when it finds its tag already present, so a version number claimed by one artefact would silently suppress the other's release — or, for flip-utils, its PyPI publish.
+
+| Artefact | Version source | Workflow | Tag | Release title |
+| --- | --- | --- | --- | --- |
+| FLIP platform | root [`pyproject.toml`](pyproject.toml) | [`release.yml`](.github/workflows/release.yml) | `v<X.Y.Z>` | `Release v<X.Y.Z>` |
+| flip-utils (PyPI `flip-utils`) | [`flip-utils/flip/__init__.py`](flip-utils/flip/__init__.py) | [`release-pypi.yml`](.github/workflows/release-pypi.yml) | `flip-utils-v<X.Y.Z>` | `flip-utils v<X.Y.Z>` |
+
+The `flip-utils-` prefix is what keeps them apart: every `git tag --list 'v*.*.*'` lookup in the release and preview workflows matches platform tags only, so each train's changelog spans its own history. **Do not drop the prefix or widen those globs** — the two version sequences advance independently and will overlap.
+
+> **Note:** `v0.4.1` is a flip-utils tag that predates this split and still sits in the platform namespace. The platform must not use version 0.4.1.
+
 ### Versioning
 
 FLIP follows [Semantic Versioning](https://semver.org/). The version in the **root** [`pyproject.toml`](pyproject.toml) is the FLIP release version — it is what `release.yml` reads to create the git tag.


### PR DESCRIPTION
<!--
Copyright (c) 2026 Guy's and St Thomas' NHS Foundation Trust & King's College London
Licensed under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at
    http://www.apache.org/licenses/LICENSE-2.0
Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
-->

# Description

A push to `main` cuts **two releases from two independently-versioned artefacts**, and both minted `v<version>`
tags into one namespace. Each workflow's tag-existence check asks only *"does `v<my version>` exist?"* — never
*whose* tag it is — so a version number claimed by one artefact silently suppresses the other's release, or,
for flip-utils, its PyPI publish.

**This stopped being hypothetical on the v0.4.0 cut.** Both trains tagged on the same push:

```
v0.4.0   "Release v0.4.0"   10:47:53   ← platform      (release.yml)
v0.4.1   "flip v0.4.1"      10:49:11   ← flip-utils    (release-pypi.yml)
```

`release-pypi.yml` went green end to end for the first time ever on that push — the `-s` removal in #917 was
its last in-repo blocker — publishing **flip-utils 0.4.1** to PyPI and tagging `v0.4.1` 78 seconds after the
platform tagged `v0.4.0`.

## The fix: one prefix

flip-utils tags become `flip-utils-v<version>`. Every `git tag --list 'v*.*.*'` lookup across the release and
preview workflows then matches platform tags only — no glob needed special-casing, and
`pr-release-notes-preview.yml`'s `PREV_TAG` self-corrects with no change to that line at all.

| | Before | After |
|---|---|---|
| Platform tag | `v0.4.0` | `v0.4.0` *(unchanged)* |
| flip-utils tag | `v0.4.1` | `flip-utils-v0.4.1` |
| flip-utils Release title | `flip v0.4.1` | `flip-utils v0.4.1` |
| Notes header | `FLIP 0.4.1 Release Notes` | `flip-utils 0.4.1 Release Notes` |

## Also fixed: the changelog range in `release.yml`

`release.yml` used `generate_release_notes: true`, which lets GitHub pick the previous release **itself** — now
the flip-utils release cut 78 seconds after v0.4.0. The next platform release would have generated its
changelog against that, producing a **near-empty release notes body**.

This is the failure that fires next, on any platform version number, regardless of the tag collision. Fixed by
generating notes against the previous *platform* tag explicitly, the way `release-pypi.yml` already did for its
own artefact. The body content is unchanged in shape — both paths call `releases/generate-notes`; this one just
controls the range.

## The `|| true` is load-bearing

Both `PREV_TAG` lookups run under `set -euo pipefail`, and the tag for the release in progress **already
exists** by then (it is created by an earlier step). On the first prefixed flip-utils release, `grep -v`
filters away its only match and exits 1 — killing the step **immediately after the irreversible PyPI publish**,
between `uv publish` and the GitHub Release.

Verified before and after:

```console
$ # first prefixed release, no prior flip-utils tag — WITHOUT || true
$ bash -c 'set -euo pipefail; TAG=flip-utils-v0.4.2; PREV_TAG=$(git tag --list "flip-utils-v*.*.*" | sort -V | grep -v "^${TAG}$" | tail -n1); echo ok'
exit=1                        # step dies

$ # same, WITH || true
PREV=[] (empty is correct)
exit=0
```

Empty is a valid answer and both call sites already handle it (`${PREV_TAG:-initial release}` /
`if [[ -n "$PREV_TAG" ]]`).

## Linked Issues

Fixes #927

## Checklist

- [x] Follows the project's coding conventions and style guide
- [x] Updates documentation — CONTRIBUTING "Cutting a release" gains a two-namespaces section
- [ ] I have added tests that prove my fix is effective or that my feature works — n/a, see Testing below
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Type of Change

- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make -C docs/ docs`.

## Testing

These workflows only run on push to `main`, so they cannot execute on this PR. Verified by simulating the tag
globs against a scratch repo seeded with the **real** tag set:

| Scenario | Result |
|---|---|
| Platform `PREV_TAG` for a future `v0.5.0`, **after** the stray is re-tagged | `v0.4.0` ✓ |
| flip-utils `PREV_TAG` for 0.4.2 | `flip-utils-v0.4.1` ✓ |
| Version ordering — `flip-utils-v0.4.10` vs `flip-utils-v0.10.0` | `v0.10.0` ✓ (`sort -V` correct across the prefix) |
| Platform wants `v0.4.2` — blocked by a flip-utils tag? | no → release proceeds ✓ |
| flip-utils wants 0.4.0 — blocked by the platform's `v0.4.0`? | no → publish proceeds ✓ |
| Does `v*.*.*` match any `flip-utils-*` tag? | no ✓ |
| First prefixed release / fresh repo, no prior tag | empty, exit 0 ✓ |
| Platform `PREV_TAG` against the **live repo**, after the stray was re-tagged | `v0.4.0` ✓ |

All three workflows parse as valid YAML; the embedded `github-script` passes `node --check`.

## The stray `v0.4.1` has been resolved

flip-utils 0.4.1 shipped just before this split and was tagged `v0.4.1`, in the platform namespace, with a
public GitHub Release attached. Workflows cannot retroactively rename a tag, so this was done by hand
(2026-08-07), before merge:

1. Created annotated tag `flip-utils-v0.4.1` on commit `c55f79e8` — **not** `ba2b36d6`, which is the *annotated
   tag object*, not the commit. `refs/tags/v0.4.1` was created by `git tag -a`, so its `object.sha`
   dereferences one level further than it appears to.
2. Retargeted GitHub Release `366684601` onto the new tag — new tag first, so the Release was never orphaned
   or auto-drafted.
3. Deleted `refs/tags/v0.4.1`.

Verified against the live repo afterwards:

```console
platform next release compares against:    v0.4.0
flip-utils next release compares against:  flip-utils-v0.4.1
v* glob picks up flip-utils tags?          no
```

The Release kept both PyPI artefacts (`flip_utils-0.4.1-py3-none-any.whl`, `flip_utils-0.4.1.tar.gz`) and is
still published, not draft. The PyPI package itself was never touched — this was git/GitHub metadata only.

The Release title was also corrected to `flip-utils v0.4.1`, matching the convention this PR introduces. The
releases list now distinguishes the two trains at a glance:

```
v0.4.0              Release v0.4.0       assets=0
flip-utils-v0.4.1   flip-utils v0.4.1    assets=2
v0.3.0              Release v0.3.0       assets=0
```

One cosmetic leftover, deliberately unchanged: that Release's *body* still opens `FLIP 0.4.1 Release Notes`.
The `{{PROJECT}}` placeholder in this PR fixes that for future releases, but an already-published body is
static text and would need a manual rewrite.


## Acceptance Criteria

*Imported from issue #927*

- [x] flip-utils releases tag under a distinct prefix (`flip-utils-v*`); platform releases keep `v*`.
- [x] Each workflow's tag-existence check can only be satisfied by a tag of its own artefact — a version
      number used by one artefact never suppresses the other's release or publish.
- [x] Each workflow's `PREV_TAG` resolves to the previous tag **of the same artefact**. Covers `release.yml`,
      `release-pypi.yml`, and `pr-release-notes-preview.yml`.
- [x] The existing `v0.1.1` … `v0.4.0` platform tags and their GitHub Releases are unchanged.
- [x] CONTRIBUTING ["Cutting a release"](../blob/develop/CONTRIBUTING.md#cutting-a-release) documents the two
      tag namespaces and which workflow owns each.
- [x] The stray `v0.4.1` tag is resolved (done by hand — see above).