### PR TITLE
Release pipeline fixes: preview version, tag namespace split (develop → main)

### DIFF
--- a/.github/RELEASE_NOTES_TEMPLATE.md
+++ b/.github/RELEASE_NOTES_TEMPLATE.md
@@ -11,7 +11,7 @@
     limitations under the License.
 -->
 
-# :package: FLIP {{VERSION}} Release Notes
+# :package: {{PROJECT}} {{VERSION}} Release Notes
 
 ## :sparkles: Highlights
 

--- a/.github/workflows/pr-release-notes-preview.yml
+++ b/.github/workflows/pr-release-notes-preview.yml
@@ -84,6 +84,7 @@ jobs:
 
             // Substitute placeholders
             header = header
+              .replace(/\{\{PROJECT\}\}/g, 'FLIP')
               .replace(/\{\{VERSION\}\}/g, version)
               .replace(/\{\{TAG\}\}/g,     tag)
               .replace(/\{\{PREV_TAG\}\}/g, prevTag || 'initial release');

--- a/.github/workflows/pr-release-notes-preview.yml
+++ b/.github/workflows/pr-release-notes-preview.yml
@@ -26,6 +26,9 @@ jobs:
   preview:
     if: github.event.pull_request.head.ref == 'develop'
     runs-on: ubuntu-latest
+    permissions: # override the workflow default: releases/generate-notes needs contents:write
+      contents: write
+      pull-requests: write
 
     steps:
       - name: Checkout repository
@@ -37,8 +40,17 @@ jobs:
       - name: Extract version and previous tag
         id: meta
         run: |
-          VERSION=$(grep -m1 '__version__' flip-utils/flip/__init__.py | sed 's/.*= *"\(.*\)"/\1/')
+          # Read the ROOT pyproject.toml, exactly as release.yml does — that is the FLIP release
+          # version this PR will tag. Do NOT read flip-utils/flip/__init__.py: flip-utils ships to
+          # PyPI as `flip` and is versioned independently of the platform, so it describes a
+          # different artefact than the one being released.
+          VERSION=$(grep -m1 '^version' pyproject.toml | sed 's/version = "\(.*\)"/\1/')
           PREV_TAG=$(git tag --list 'v*.*.*' | sort -V | tail -n1)
+
+          if [[ -z "$VERSION" ]]; then
+            echo "ERROR: Could not extract version from the root pyproject.toml."
+            exit 1
+          fi
 
           echo "version=${VERSION}"           >> "$GITHUB_OUTPUT"
           echo "tag=v${VERSION}"              >> "$GITHUB_OUTPUT"
@@ -91,13 +103,22 @@ jobs:
               const resp = await github.rest.repos.generateReleaseNotes(params);
               generatedNotes = resp.data.body;
             } catch (err) {
-              console.log(`generateReleaseNotes API error: ${err.message}`);
-              generatedNotes = '_Could not generate changelog preview at this time._';
+              // Surface the reason in both the run annotations and the comment itself. A bare
+              // "could not generate" hid a permissions misconfiguration across two releases: the
+              // preview looked merely empty rather than broken.
+              core.warning(`generateReleaseNotes API error: ${err.message}`);
+              generatedNotes = [
+                '> [!WARNING]',
+                `> Could not generate the changelog preview: \`${err.message}\``,
+                '>',
+                '> The sections below are the unpopulated template. This is a fault in',
+                '> `pr-release-notes-preview.yml`, not a sign that the release is empty.',
+              ].join('\n');
             }
 
             // ── Compose the full comment body ───────────────────────────────
             const marker  = '<!-- release-notes-preview -->';
-            const heading = `## :clipboard: Release Notes Preview — flip ${tag}`;
+            const heading = `## :clipboard: Release Notes Preview — FLIP ${tag}`;
             const footer  = [
               '---',
               `> **Version:** \`${tag}\``,

--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -49,8 +49,12 @@ jobs:
             exit 1
           fi
 
-          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
-          echo "tag=v${VERSION}"    >> "$GITHUB_OUTPUT"
+          # flip-utils tags carry their own prefix. The platform release (release.yml) owns the
+          # bare `v*` namespace; sharing it meant a version number used by one artefact silently
+          # suppressed the other's release — see the tag-existence check below, which skips the
+          # PyPI publish outright when it finds a tag it does not own.
+          echo "version=${VERSION}"            >> "$GITHUB_OUTPUT"
+          echo "tag=flip-utils-v${VERSION}"    >> "$GITHUB_OUTPUT"
           echo "Detected version: ${VERSION}"
 
       - name: Check if tag already exists
@@ -117,10 +121,17 @@ jobs:
           set -euo pipefail
           VERSION="${{ steps.version.outputs.version }}"
           TAG="${{ steps.version.outputs.tag }}"
-          PREV_TAG=$(git tag --list 'v*.*.*' | sort -V | grep -v "^${TAG}$" | tail -n1)
+          # Match only this artefact's tags, so the changelog spans flip-utils history rather than
+          # whatever the platform released most recently. The `|| true` is load-bearing under
+          # `set -o pipefail`: the tag for THIS release already exists by now (created above), so on
+          # the first prefixed release grep filters the only match away and exits 1 — which would
+          # kill the step immediately after an irreversible PyPI publish. Empty is a valid answer
+          # here and is handled by the ${PREV_TAG:-initial release} default below.
+          PREV_TAG=$(git tag --list 'flip-utils-v*.*.*' | sort -V | grep -v "^${TAG}$" | tail -n1 || true)
 
           # Strip the license comment block and substitute placeholders
           HEADER=$(sed '/^<!--/,/-->/d' "$GITHUB_WORKSPACE/.github/RELEASE_NOTES_TEMPLATE.md" \
+            | sed "s/{{PROJECT}}/flip-utils/g" \
             | sed "s/{{VERSION}}/${VERSION}/g" \
             | sed "s/{{TAG}}/${TAG}/g" \
             | sed "s/{{PREV_TAG}}/${PREV_TAG:-initial release}/g")
@@ -146,6 +157,6 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh release create "${{ steps.version.outputs.tag }}" \
-            --title "flip ${{ steps.version.outputs.tag }}" \
+            --title "flip-utils v${{ steps.version.outputs.version }}" \
             --notes-file "${{ steps.notes.outputs.notes_file }}" \
             dist/*

--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -129,8 +129,12 @@ jobs:
           # here and is handled by the ${PREV_TAG:-initial release} default below.
           PREV_TAG=$(git tag --list 'flip-utils-v*.*.*' | sort -V | grep -v "^${TAG}$" | tail -n1 || true)
 
-          # Strip the license comment block and substitute placeholders
-          HEADER=$(sed '/^<!--/,/-->/d' "$GITHUB_WORKSPACE/.github/RELEASE_NOTES_TEMPLATE.md" \
+          # Strip the license comment block and substitute placeholders.
+          # The range delimiters are anchored to whole lines (`^<!--$` / `^-->$`) because only the
+          # license block spans lines that way. The template's other comments are single-line
+          # `<!-- ... -->`, and an unanchored `/^<!--/,/-->/` opens a range on one of those that
+          # does not close until the NEXT comment — silently eating every section in between.
+          HEADER=$(sed '/^<!--$/,/^-->$/d' "$GITHUB_WORKSPACE/.github/RELEASE_NOTES_TEMPLATE.md" \
             | sed "s/{{PROJECT}}/flip-utils/g" \
             | sed "s/{{VERSION}}/${VERSION}/g" \
             | sed "s/{{TAG}}/${TAG}/g" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,10 +60,42 @@ jobs:
                   git tag "${{ steps.version.outputs.tag }}"
                   git push origin "${{ steps.version.outputs.tag }}"
 
+            # generate_release_notes lets GitHub choose the previous release itself, which is
+            # whatever was published most recently — including a flip-utils release cut seconds
+            # after ours on the same push. Pin the range to the previous *platform* tag instead,
+            # the way release-pypi.yml already does for its own artefact.
+            - name: Prepare release notes
+              if: steps.tag_check.outputs.exists == 'false'
+              id: notes
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              run: |
+                  set -euo pipefail
+                  TAG="${{ steps.version.outputs.tag }}"
+                  # `|| true` is load-bearing under `set -o pipefail` — the tag for THIS release
+                  # was created by the step above, so when it is the only match grep exits 1.
+                  # Empty is a valid answer and is handled below.
+                  PREV_TAG=$(git tag --list 'v*.*.*' | sort -V | grep -v "^${TAG}$" | tail -n1 || true)
+
+                  API_ARGS=(-X POST
+                    -f "tag_name=${TAG}"
+                    -f "target_commitish=${{ github.sha }}")
+                  if [[ -n "$PREV_TAG" ]]; then
+                    API_ARGS+=(-f "previous_tag_name=${PREV_TAG}")
+                    echo "Generating notes for ${PREV_TAG}...${TAG}"
+                  else
+                    echo "No previous platform tag found — generating notes from the start."
+                  fi
+
+                  gh api "repos/${{ github.repository }}/releases/generate-notes" \
+                    "${API_ARGS[@]}" --jq '.body' > /tmp/release_notes.md
+
+                  echo "notes_file=/tmp/release_notes.md" >> "$GITHUB_OUTPUT"
+
             - name: Create GitHub Release
               if: steps.tag_check.outputs.exists == 'false'
               uses: softprops/action-gh-release@v2
               with:
                   tag_name: ${{ steps.version.outputs.tag }}
                   name: "Release ${{ steps.version.outputs.tag }}"
-                  generate_release_notes: true
+                  body_path: ${{ steps.notes.outputs.notes_file }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -528,7 +528,7 @@ A push to `main` cuts **two independent releases**, from two independently-versi
 
 The `flip-utils-` prefix is what keeps them apart: every `git tag --list 'v*.*.*'` lookup in the release and preview workflows matches platform tags only, so each train's changelog spans its own history. **Do not drop the prefix or widen those globs** — the two version sequences advance independently and will overlap.
 
-> **Note:** `v0.4.1` is a flip-utils tag that predates this split and still sits in the platform namespace. The platform must not use version 0.4.1.
+> **Historical note:** flip-utils 0.4.1 was released just before this split and originally tagged `v0.4.1`, in the platform namespace. It was retro-tagged as `flip-utils-v0.4.1` (same commit, `c55f79e8`) and the old tag deleted, so the two namespaces are clean from `v0.4.0` / `flip-utils-v0.4.1` onwards. The published PyPI artefact was never affected.
 
 ### Versioning
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -517,6 +517,19 @@ The new branch should be based on the latest `develop` branch.
 
 Releases are cut from `main`. The version is set in the root `pyproject.toml`, and merging to `main` triggers [`.github/workflows/release.yml`](.github/workflows/release.yml), which reads that version, creates a `v<MAJOR.MINOR.PATCH>` git tag, and publishes a GitHub Release with auto-generated notes. On the same merge, the per-service `.github/workflows/docker_build_*.yml` workflows rebuild every service and push the `:prod` image tag (alongside `:<sha>`) to GHCR. There is no separate release-publishing step beyond merging to `main`.
 
+### Two release trains, two tag namespaces
+
+A push to `main` cuts **two independent releases**, from two independently-versioned artefacts. They must never share a tag namespace: each workflow skips its own release when it finds its tag already present, so a version number claimed by one artefact would silently suppress the other's release — or, for flip-utils, its PyPI publish.
+
+| Artefact | Version source | Workflow | Tag | Release title |
+| --- | --- | --- | --- | --- |
+| FLIP platform | root [`pyproject.toml`](pyproject.toml) | [`release.yml`](.github/workflows/release.yml) | `v<X.Y.Z>` | `Release v<X.Y.Z>` |
+| flip-utils (PyPI `flip-utils`) | [`flip-utils/flip/__init__.py`](flip-utils/flip/__init__.py) | [`release-pypi.yml`](.github/workflows/release-pypi.yml) | `flip-utils-v<X.Y.Z>` | `flip-utils v<X.Y.Z>` |
+
+The `flip-utils-` prefix is what keeps them apart: every `git tag --list 'v*.*.*'` lookup in the release and preview workflows matches platform tags only, so each train's changelog spans its own history. **Do not drop the prefix or widen those globs** — the two version sequences advance independently and will overlap.
+
+> **Note:** `v0.4.1` is a flip-utils tag that predates this split and still sits in the platform namespace. The platform must not use version 0.4.1.
+
 ### Versioning
 
 FLIP follows [Semantic Versioning](https://semver.org/). The version in the **root** [`pyproject.toml`](pyproject.toml) is the FLIP release version — it is what `release.yml` reads to create the git tag.


### PR DESCRIPTION
<!--
Copyright (c) 2026 Guy's and St Thomas' NHS Foundation Trust & King's College London
Licensed under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at
    http://www.apache.org/licenses/LICENSE-2.0
Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
-->

# Description

Promotes the release-pipeline fixes to `main`. **Five files, all CI workflows plus CONTRIBUTING — no
application code changes**, so this carries no service or image impact.

All of it fixes faults in how FLIP cuts releases, found and remediated on the v0.4.0 cut earlier today —
three merged PRs: #926, #929 and #933.

## What's in it

**#926 — the release-notes preview described the wrong artefact.**
`pr-release-notes-preview.yml` read the flip-utils package version rather than the root `pyproject.toml` that
`release.yml` actually tags from, so every release PR announced the wrong number (#924 said `v0.4.1` for a
`v0.4.0` cut; #808 said `v0.4.0` for `v0.3.0`). Its changelog had also **never once rendered** — the workflow
granted itself `contents: read` while `releases/generate-notes` needs `contents: write`, and the failure was
swallowed into "could not generate at this time", which read as an empty release rather than a broken
workflow. Both fixed; the error is now reported loudly.

**#929 — the platform and flip-utils releases shared one `v*` tag namespace.**
A push to `main` cuts two releases from two independently-versioned artefacts, and each workflow's
tag-existence check asks only *"does `v<my version>` exist?"*, never whose tag it is — so a version number
claimed by one silently suppressed the other's release, or its PyPI publish. This stopped being hypothetical
on the v0.4.0 cut: the platform tagged `v0.4.0` and flip-utils tagged `v0.4.1` seventy-eight seconds later.
flip-utils tags now carry a `flip-utils-v` prefix, so every `git tag --list 'v*.*.*'` lookup matches platform
tags only.

Also in #929: `release.yml` used `generate_release_notes: true`, letting GitHub pick the previous release
itself — which had become the flip-utils release cut 78 seconds after v0.4.0. The next platform release would
have generated a **near-empty changelog** on any version number. Notes are now generated against the previous
*platform* tag explicitly.

**#933 — the release-notes template lost four of its six sections.**
`release-pypi.yml` stripped the license block with an unanchored `sed` range, `/^<!--/,/-->/d`. A range looks
for its end pattern on *subsequent* lines, so a single-line `<!-- … -->` opened a range that did not close
until the next comment — deleting Breaking Changes, New Features, Bug Fixes and PRs merged in this release,
then a third range ran to EOF. Two of six sections survived, silently; visible on the published
`flip-utils v0.4.1` notes. Both delimiters are now anchored to whole lines, and the shell strip produces
byte-identical output to the JavaScript one in the preview workflow, so the two cannot drift.

## Already done by hand, outside these PRs

The stray `v0.4.1` flip-utils tag was re-tagged as `flip-utils-v0.4.1` on the same commit (`c55f79e8`), its
GitHub Release retargeted and retitled `flip-utils v0.4.1`, and the old tag deleted. The published PyPI
artefacts were never touched. Both namespaces verified clean against the live repo:

```
platform next release compares against:    v0.4.0
flip-utils next release compares against:  flip-utils-v0.4.1
v* glob picks up flip-utils tags?          no
```

## ⚠️ No version bump — this merge cuts no release

The root `pyproject.toml` stays at **0.4.0**, which `main` already carries and `v0.4.0` already tags. So on
merge, `release.yml`'s tag-existence check finds the tag present and **skips both the tag step and the GitHub
Release** — by design, not by fault. Likewise `release-pypi.yml` finds `flip-utils-v0.4.1` present and skips
its publish.

That is the intent: these are CI-only changes with nothing user-facing to release. The point of merging is to
get the corrected workflows onto `main` so the **next** real release uses them — and because a `push` event
runs the workflow file from the pushed commit, they take effect on the very merge that delivers them.

If a tagged release *is* wanted for these fixes, the root version must be bumped first, per CONTRIBUTING
["Cutting a release"](../blob/develop/CONTRIBUTING.md#cutting-a-release).

## Linked Issues

Closes #925, closes #927 — both already closed by the `develop`-targeted PRs.

## Checklist

- [x] Follows the project's coding conventions and style guide
- [x] Updates documentation — CONTRIBUTING gains a "Two release trains, two tag namespaces" section
- [ ] I have added tests that prove my fix is effective or that my feature works — n/a, workflow changes
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Type of Change

- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make -C docs/ docs`.

## Testing

All three constituent PRs were 25/25 green on `develop`. These workflows only run on push to `main`, so they
could not execute on their own PRs; they were verified by simulating the tag globs against a scratch repo
seeded with the real tag set, then against the live repo, and by diffing the two template-strip
implementations. See #926, #929 and #933 for the full matrices.

**#926's fix is already confirmed working — by this PR.** The preview comment below is the first successful
run of `pr-release-notes-preview.yml` in the workflow's history: it names the version from the root
`pyproject.toml` (`FLIP v0.4.0`, previously it would have said `v0.4.1`) and, for the first time, actually
generated its changelog rather than falling back to "could not generate at this time".

That comment also reads `Comparing: v0.4.0...v0.4.0`, which is the visible signature of the no-bump decision —
the previous platform tag and the release version are the same, so the range is empty and no release will be
cut. Working as intended, not a fault.

**Still unexercised until the next real release:**

1. flip-utils tags `flip-utils-v<version>`, not `v<version>` (#929).
2. The platform Release notes span the previous *platform* tag rather than being near-empty (#929).
3. The template renders all six sections into a flip-utils release body (#933).

All three run only on a push to `main` that actually cuts a release, which this one deliberately does not.

## Additional Notes

`develop` shows as 4 commits *behind* `main` — those are `main`-only merge commits from PRs #531, #654, #808
and #924. That is the normal shape of this repo's release flow (`main` is never merged back into `develop`)
and does not conflict.


## Acceptance Criteria

### From issue #925

- [x] The preview comment on a `develop` → `main` PR announces the version from the **root `pyproject.toml`** —
  the same value `release.yml` uses to create the tag.
- [x] The preview's changelog section contains the generated changelog (categorised per
  [`.github/release.yml`](../blob/develop/.github/release.yml)), not
  `_Could not generate changelog preview at this time._`.
- [x] `contents: write` is scoped to the job, not the workflow, matching the pattern in `release.yml`.
- [x] The preview heading names the platform (`FLIP`), not the PyPI package (`flip`), consistent with
  `RELEASE_NOTES_TEMPLATE.md`.

### From issue #927

- [x] flip-utils releases tag under a distinct prefix (`flip-utils-v*`); platform releases keep `v*`.
- [x] Each workflow's tag-existence check can only be satisfied by a tag of its own artefact — a version
      number used by one artefact never suppresses the other's release or publish.
- [x] Each workflow's `PREV_TAG` resolves to the previous tag **of the same artefact**. Covers `release.yml`,
      `release-pypi.yml`, and `pr-release-notes-preview.yml`.
- [x] The existing `v0.1.1` … `v0.4.0` platform tags and their GitHub Releases are unchanged.
- [x] CONTRIBUTING ["Cutting a release"](../blob/develop/CONTRIBUTING.md#cutting-a-release) documents the two
      tag namespaces and which workflow owns each.
- [x] The stray `v0.4.1` tag is resolved (done by hand — see above).

