### PR TITLE
[Bug]: release-notes template sed range silently deletes four sections

### DIFF
--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -129,8 +129,12 @@ jobs:
           # here and is handled by the ${PREV_TAG:-initial release} default below.
           PREV_TAG=$(git tag --list 'flip-utils-v*.*.*' | sort -V | grep -v "^${TAG}$" | tail -n1 || true)
 
-          # Strip the license comment block and substitute placeholders
-          HEADER=$(sed '/^<!--/,/-->/d' "$GITHUB_WORKSPACE/.github/RELEASE_NOTES_TEMPLATE.md" \
+          # Strip the license comment block and substitute placeholders.
+          # The range delimiters are anchored to whole lines (`^<!--$` / `^-->$`) because only the
+          # license block spans lines that way. The template's other comments are single-line
+          # `<!-- ... -->`, and an unanchored `/^<!--/,/-->/` opens a range on one of those that
+          # does not close until the NEXT comment — silently eating every section in between.
+          HEADER=$(sed '/^<!--$/,/^-->$/d' "$GITHUB_WORKSPACE/.github/RELEASE_NOTES_TEMPLATE.md" \
             | sed "s/{{PROJECT}}/flip-utils/g" \
             | sed "s/{{VERSION}}/${VERSION}/g" \
             | sed "s/{{TAG}}/${TAG}/g" \


### PR DESCRIPTION
<!--
Copyright (c) 2026 Guy's and St Thomas' NHS Foundation Trust & King's College London
Licensed under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at
    http://www.apache.org/licenses/LICENSE-2.0
Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
-->

# Description

The strip that removes the license block from `RELEASE_NOTES_TEMPLATE.md` used an **unanchored `sed` range**:

```bash
sed '/^<!--/,/-->/d'
```

A `sed` range looks for its end pattern on *subsequent* lines, so a single-line `<!-- … -->` opens a range that
does not close until the **next** comment. The template has three such comments after the license block:

```
1:<!--                                                              ← license block opens
12:-->                                                              ← intended end
18:<!-- Optional: summarise the key highlights of this release... -->
28:<!-- auto-populated by the release workflow -->
34:<!-- auto-populated by the release workflow -->
```

- Range 1 deletes 1–12 — the license block. Intended.
- Range 2 opens at 18, closes at **28**, deleting **Breaking Changes, New Features, Bug Fixes and PRs merged
  in this release**.
- Range 3 opens at 34, finds no further `-->`, and deletes to EOF — the trailing rule.

Two of six sections survived, silently. Visible on the published `flip-utils v0.4.1` notes, which carry only
Highlights and Acknowledgements.

## The fix

Anchor both delimiters to whole lines — `sed '/^<!--$/,/^-->$/d'`. Only the license block spans lines that way;
the template's other comments are single-line and match neither `^<!--$` nor `^-->$`, so the range can no
longer cover anything else.

The surviving comments are author guidance (`<!-- auto-populated by the release workflow -->`) and render
invisibly in Markdown, so leaving them in the published body costs nothing.

## The preview already had this right

`pr-release-notes-preview.yml` performs the same strip in JavaScript, non-greedy and without a global flag, so
it removes exactly the first comment block:

```js
header = header.replace(/<!--[\s\S]*?-->\n?/, '');
```

Two implementations of one operation, only one correct. The fixed shell strip now produces **byte-identical**
output to the JS on the same template, so the preview and the published notes cannot drift apart.

## Linked Issues

Fixes #932

## Checklist

- [x] Follows the project's coding conventions and style guide
- [ ] Updates documentation — n/a, no documented behaviour changes
- [ ] I have added tests that prove my fix is effective or that my feature works — n/a, see Testing below
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Type of Change

- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make -C docs/ docs`.

## Testing

This workflow only runs on push to `main`, so it cannot execute on this PR. Verified by running both strips
against the real template.

**All six sections plus the header now survive; the license block is gone:**

```console
$ sed '/^<!--$/,/^-->$/d' .github/RELEASE_NOTES_TEMPLATE.md
     2  # :package: {{PROJECT}} {{VERSION}} Release Notes
     4  ## :sparkles: Highlights
     8  ## :warning: Breaking Changes
    10  ## :seedling: New Features
    12  ## :bug: Bug Fixes
    14  ## :file_folder: PRs merged in this release
    18  ## :star: Acknowledgements
    24  ---

Release Notes                  present      Bug Fixes                   present
Highlights                     present      PRs merged in this release  present
Breaking Changes               present      Acknowledgements            present
New Features                   present      'Apache License'            0 occurrences
```

**Shell and JS produce identical output** — `diff` between the two implementations on the same template is
empty.

**Robustness** — the acceptance criterion that adding a comment must not change which sections survive.
Injecting two extra inline comments into the template:

| | unmodified template | + 2 extra comments |
|---|---|---|
| old `/^<!--/,/-->/` | **2** of 6 sections | **3** of 6 |
| new `/^<!--$/,/^-->$/` | **6** of 6 | **6** of 6 |

The old strip's output depended on how many comments the template happened to contain, and where. The new one
does not.

Workflow still parses as valid YAML.

## Additional Notes

Only `release-pypi.yml` uses this template — `release.yml` builds the platform release body entirely from
`releases/generate-notes` and never touches it. So this affects flip-utils release notes only.

An already-published body is static text, so `flip-utils v0.4.1`'s notes cannot be repaired by this change;
it applies from the next flip-utils release onward.


## Acceptance Criteria

*Imported from issue #932*

- [ ] A flip-utils release body contains the full template: the `# :package: … Release Notes` header and all
      six sections (Highlights, Breaking Changes, New Features, Bug Fixes, PRs merged in this release,
      Acknowledgements).
- [ ] Only the leading license block is stripped; no template content is removed.
- [ ] The shell and JavaScript strips behave identically on the same template.
- [ ] Adding or removing an HTML comment in the template does not change which sections survive.