### PR TITLE
docs: weekly drift audit — templates, cohort validation, telemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ for FL server/client/API), and [`fl-apps/`](fl-apps/) (job-type implementations 
 | [`docs/`](docs/) | Sphinx documentation source (ReadTheDocs) |
 | [`flip-utils/`](flip-utils/) | `flip` Python package — platform logic, NVFLARE components, Flower helpers |
 | [`fl-services/`](fl-services/) | Docker images for FL networks, nested per backend ([`fl-services/nvflare/`](fl-services/nvflare/): `fl-server`, `fl-client`, `fl-api-base`, `fl-base`; [`fl-services/flower/`](fl-services/flower/): `superlink`, `supernode`, `fl-api-flower`, `fl-base`) |
-| [`fl-apps/`](fl-apps/) | FL job-type implementations / app templates, nested per backend ([`fl-apps/nvflare/`](fl-apps/nvflare/): `standard`, `standard_client_api`, `evaluation`, `evaluation_client_api`, `diffusion_model`, `fed_opt`; [`fl-apps/flower/`](fl-apps/flower/): `standard`, `evaluation`) |
+| [`fl-apps/`](fl-apps/) | FL job-type implementations / app templates, nested per backend ([`fl-apps/nvflare/`](fl-apps/nvflare/): `standard`, `standard_client_api`, `evaluation`, `evaluation_client_api`, `diffusion_model`, `diffusion_model_client_api`, `fed_opt`; [`fl-apps/flower/`](fl-apps/flower/): `standard`, `evaluation`) |
 | [`fl-tutorials/`](fl-tutorials/) | End-to-end tutorial examples, nested per backend ([`fl-tutorials/nvflare/`](fl-tutorials/nvflare/): xray classification, spleen seg/eval, diffusion; [`fl-tutorials/flower/`](fl-tutorials/flower/): xray classification, spleen seg/eval, numpy) |
 
 Both backends are now provisioned in-tree (gitignored): the NVFLARE workspace at
@@ -463,7 +463,7 @@ The repository is organised as follows:
 - `flip-ui`: Frontend UI (Vue 3 / TypeScript / TailwindCSS)
 - `flip-utils`: The `flip` Python package (pip-installable `flip-utils`) — platform logic, NVFLARE components, Flower helpers
 - `fl-services`: Docker images for FL networks, per backend: `fl-services/nvflare/{fl-server,fl-client,fl-api-base,fl-base}` and `fl-services/flower/{superlink,supernode,fl-api-flower,fl-base}`. Each backend's `Makefile` also owns its network provisioning under `provision/`.
-- `fl-apps`: FL app templates per backend: `fl-apps/nvflare/{standard,standard_client_api,evaluation,evaluation_client_api,diffusion_model,fed_opt}`, `fl-apps/flower/{standard,evaluation}` (plus `check_required_files.sh`)
+- `fl-apps`: FL app templates per backend: `fl-apps/nvflare/{standard,standard_client_api,evaluation,evaluation_client_api,diffusion_model,diffusion_model_client_api,fed_opt}`, `fl-apps/flower/{standard,evaluation}` (plus `check_required_files.sh`)
 - `fl-tutorials`: End-to-end tutorial examples per backend: `fl-tutorials/nvflare/` (xray classification, spleen seg/eval, diffusion) and `fl-tutorials/flower/` (xray classification, spleen seg/eval, numpy)
 - `trust`: Services deployed inside each trust environment
   - `data-access-api`: Data-access API (OMOP queries)

--- a/docs/source/user-guides/user-common.rst
+++ b/docs/source/user-guides/user-common.rst
@@ -190,17 +190,13 @@ Create Cohort Query
 -------------------
 
 .. note::
-    A number of keywords are restricted and the cohort query will not be run in the instance that any of these keywords are entered, such as:
-
-        - ``alter user``
-        - ``alter table``
-        - ``alter database``
-        - ``drop table``
-        - ``drop user``
-        - ``drop role``
-        - ``drop database``
-        - ``create table``
-        - ``substring``
+    Cohort queries must be a single ``SELECT`` statement against the ``omop`` schema. The query is
+    parsed and validated on the trust side (not by keyword matching), so only read-only ``SELECT``
+    shapes are accepted — ``INSERT``, ``UPDATE``, ``DELETE``, ``MERGE`` and DDL (``CREATE``,
+    ``ALTER``, ``DROP``) are rejected wherever they appear in the query tree, and only literal
+    integer ``LIMIT``/``OFFSET`` values are allowed. There is no keyword denylist, so ordinary
+    read-only functions such as ``SUBSTRING()`` are permitted. Trust-side execution runs as a
+    read-only database role, so anything that slips past the parser cannot mutate the database.
 
 1. Click the 'Create Cohort Query' button in the bottom left corner of the project page
 2. Enter a query in SQL format, for example:

--- a/flip-utils/README.md
+++ b/flip-utils/README.md
@@ -22,7 +22,7 @@ pip-installable `flip` Python package (published as `flip-utils` on PyPI) that s
 image and is imported as `from flip import ...` by user-uploaded training code. Sibling FL trees in the same mono-repo:
 
 - **[`flip-utils/flip/`](./flip/)** — pip-installable Python package with platform logic, NVFLARE components, Flower helpers and utilities (this directory)
-- **[`../fl-apps/`](../fl-apps/)** — FL job-type implementations / app templates per backend (`nvflare/{standard,standard_client_api,evaluation,evaluation_client_api,diffusion_model,fed_opt}`, `flower/{standard,evaluation}`)
+- **[`../fl-apps/`](../fl-apps/)** — FL job-type implementations / app templates per backend (`nvflare/{standard,standard_client_api,evaluation,evaluation_client_api,diffusion_model,diffusion_model_client_api,fed_opt}`, `flower/{standard,evaluation}`)
 - **[`../fl-tutorials/`](../fl-tutorials/)** — runnable end-to-end tutorial examples per backend (`nvflare/`, `flower/`)
 - **[`../fl-services/`](../fl-services/)** — Docker images and network provisioning for FL networks per backend (`nvflare/`, `flower/`); each backend's `Makefile` owns build / provision / up / down / submit
 
@@ -159,9 +159,9 @@ Pass the job type to the `FLIP()` factory (`FLIP(job_type=...)`). The `JobType` 
 | `fed_opt` | Custom federated optimization |
 
 The NVFLARE backend additionally ships template directories under `fl-apps/nvflare/` for
-the Client-API variants (`standard_client_api`, `evaluation_client_api`); these are
-selected as app templates and are not `JobType` enum members. The corresponding configs
-live in `fl-apps/nvflare/<template>/app/config/`.
+the Client-API variants (`standard_client_api`, `evaluation_client_api`,
+`diffusion_model_client_api`); these are selected as app templates and are not `JobType`
+enum members. The corresponding configs live in `fl-apps/nvflare/<template>/app/config/`.
 
 ### Development Mode
 
@@ -215,6 +215,7 @@ Paths below are relative to `../fl-tutorials/nvflare/` (the NVFLARE tutorials tr
 | `evaluation` | `image_evaluation/3d_spleen_segmentation_evaluation` |
 | `standard_client_api` | `image_classification/xray_classification_client_api` |
 | `evaluation_client_api` | `image_evaluation/3d_spleen_segmentation_evaluation_client_api` |
+| `diffusion_model_client_api` | `image_synthesis/latent_diffusion_model_client_api` |
 
 ---
 

--- a/flip-utils/flip/flower/strategy.py
+++ b/flip-utils/flip/flower/strategy.py
@@ -34,7 +34,7 @@ from collections.abc import Iterable
 from flwr.app import ArrayRecord, Message, MetricRecord
 from flwr.common import ConfigRecord
 from flwr.serverapp import Grid
-from flwr.serverapp.strategy import FedAvg
+from flwr.serverapp.strategy import FedAvg, Result
 
 from flip import FLIP
 from flip.constants.flip_constants import ModelStatus
@@ -72,7 +72,7 @@ class FlipFedAvg(FedAvg):
         # wires the FedAvg hooks to it.
         self._telemetry = RoundTelemetry()
 
-    def start(self, grid: Grid, initial_arrays: ArrayRecord, num_rounds: int = 3, **kwargs):
+    def start(self, grid: Grid, initial_arrays: ArrayRecord, num_rounds: int = 3, **kwargs) -> Result:
         """Capture the round total and mark the run as executing on the hub."""
         self.num_rounds = num_rounds
         self.flip.update_status(self.model_id, ModelStatus.RUNNING)

--- a/trust/AGENTS.md
+++ b/trust/AGENTS.md
@@ -95,7 +95,7 @@ GHCR login from `~/.docker/config.json`.
 | File | Purpose |
 |------|---------|
 | `Makefile` | Trust stack orchestration (parameterized `up-trust KIT=<name>`) |
-| `deploy/compose_trust.development.yml` | Dev Docker Compose (builds from source) |
+| `deploy/compose_trust.development.yml` | Dev Docker Compose (pulls repo-built services from GHCR by default via `pull_policy: always`; `BUILD=true` rebuilds from the `build:` block instead) |
 | `deploy/compose_trust.production.yml` | Prod Docker Compose (GHCR images; declares the `trust-local-{loki,grafana}-data` named volumes as defaults) |
 | `deploy/compose_trust.{env}.{flower\|nvflare}.yml` | FL backend variants |
 | `deploy/compose_trust.{env}.gpu.yml` | GPU passthrough overlay — added by `up-trust` / `up-fl-clients-kit` via `GPU_OVERRIDE` only when the kit's `NUM_AVAILABLE_GPUS > 0`; reserves host NVIDIA GPU(s) for the fl-client. `up-trust-ec2` never applies it (the EC2 t3.xlarge is GPU-less, so the fl-client is CPU-only there regardless of the kit) |

--- a/trust/CLAUDE.md
+++ b/trust/CLAUDE.md
@@ -95,7 +95,7 @@ GHCR login from `~/.docker/config.json`.
 | File | Purpose |
 |------|---------|
 | `Makefile` | Trust stack orchestration (parameterized `up-trust KIT=<name>`) |
-| `deploy/compose_trust.development.yml` | Dev Docker Compose (builds from source) |
+| `deploy/compose_trust.development.yml` | Dev Docker Compose (pulls repo-built services from GHCR by default via `pull_policy: always`; `BUILD=true` rebuilds from the `build:` block instead) |
 | `deploy/compose_trust.production.yml` | Prod Docker Compose (GHCR images; declares the `trust-local-{loki,grafana}-data` named volumes as defaults) |
 | `deploy/compose_trust.{env}.{flower\|nvflare}.yml` | FL backend variants |
 | `deploy/compose_trust.{env}.gpu.yml` | GPU passthrough overlay — added by `up-trust` / `up-fl-clients-kit` via `GPU_OVERRIDE` only when the kit's `NUM_AVAILABLE_GPUS > 0`; reserves host NVIDIA GPU(s) for the fl-client. `up-trust-ec2` never applies it (the EC2 t3.xlarge is GPU-less, so the fl-client is CPU-only there regardless of the kit) |

--- a/trust/imaging-api/imaging_api/services/users.py
+++ b/trust/imaging-api/imaging_api/services/users.py
@@ -217,7 +217,7 @@ def add_user_to_project(user: User, project_id: str, headers: dict[str, str]) ->
         imaging_api.routers.schemas.User: The user profile.
 
     Raises:
-        HTTPException: If there is an error during the addition of the user to the project.
+        Exception: If XNAT returns a non-200 status for the project-membership PUT.
         imaging_api.utils.exceptions.NotFoundError: If the user or project is not found.
     """
     if not user_exists(user.username, headers):


### PR DESCRIPTION
> _This is an automated scheduled weekly task by Alex's Claude Code._ The run reviews READMEs, Sphinx docs, CLAUDE.md/AGENTS.md pairs, and Python docstring type annotations across the repo against the current `develop` state, and lands only the drift the audit was highly confident about.

# Description

Weekly documentation-drift audit against the current `develop`. Only high-confidence drift was applied; false-positive findings (Terraform variable name, systemic `flip: FLIP` factory-vs-class annotation) were verified against the code and skipped.

## Fl-apps enumerations
- `README.md`, `flip-utils/README.md`: list `diffusion_model_client_api` in the fl-apps trees, the Client-API variants list, and the App/Tutorial compatibility table. The template already ships under `fl-apps/nvflare/diffusion_model_client_api/`, is registered in `fl-apps/nvflare/required_files.json`, and has a matching tutorial at `fl-tutorials/nvflare/image_synthesis/latent_diffusion_model_client_api/` — the user-facing README enumerations were the only place still missing it.

## Cohort-query validation docs
- `docs/source/user-guides/user-common.rst`: the "restricted keywords" note (which listed `alter user`, `drop table`, `substring`, etc.) has been stale since the keyword denylist was deliberately removed at all three layers — see `flip-api/src/flip_api/cohort_services/submit_cohort_query.py`, `flip-ui/src/utils/cohort/query.ts`, `trust/data-access-api/README.md`, and root `CLAUDE.md`. Replaced with an accurate description of the real controls: single `SELECT` against the `omop` schema, sqlglot AST validation, read-only DB role.

## trust/CLAUDE.md + AGENTS.md twin
- The Key Files table said `compose_trust.development.yml` "builds from source". Since the pull-by-default switch (root `CLAUDE.md` "Dev image sourcing" section; `trust/deploy/compose_trust.development.yml` sets `image:` + `pull_policy: always` for orthanc/imaging-api/data-access-api/trust-api), it pulls repo-built services from GHCR by default; `BUILD=true` opts into rebuilding from the `build:` block. Updated to match. `trust/AGENTS.md` regenerated from `trust/CLAUDE.md` via the documented `sed` transform to keep the pair in sync.

## Docstring type annotations
- `flip-utils/flip/flower/strategy.py`: added missing `-> Result` return type on `FlipFedAvg.start` (Flower's `FedAvg.start` returns `Result`; `Result` is publicly re-exported from `flwr.serverapp.strategy`).
- `trust/imaging-api/imaging_api/services/users.py`: `add_user_to_project`'s docstring claimed `Raises: HTTPException`, but the code raises a plain `Exception`. Updated the `Raises:` block to match the actual behaviour.

## Linked Issues

None — routine documentation-drift maintenance.

## Checklist

- [x] Follows the project's coding conventions and style guide
- [x] Updates documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Type of Change

- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [x] In-line docstrings updated.
- [x] Documentation updated, tested `make -C docs/ docs`.

## Testing

Verification performed for this PR:

- [x] `ruff check` passes on `flip-utils/flip/flower/strategy.py` and `trust/imaging-api/imaging_api/services/users.py`.
- [x] All 8 `CLAUDE.md` / `AGENTS.md` pairs verified in sync via `diff <(sed 's/CLAUDE\.md/AGENTS.md/g' <claude>) <agents>`.
- [x] `diffusion_model_client_api` verified present in `fl-apps/nvflare/`, `fl-apps/nvflare/required_files.json`, and `fl-tutorials/nvflare/image_synthesis/latent_diffusion_model_client_api/`.
- [x] Cohort validation claims cross-checked against `flip-api/src/flip_api/cohort_services/submit_cohort_query.py`, `trust/data-access-api/README.md`, and root `CLAUDE.md`.
- [x] Flower `FedAvg.start` return type verified against the installed `flwr.serverapp.strategy.strategy` source in the fl-api-flower venv.
- [x] `compose_trust.development.yml` pull-by-default behaviour verified by re-reading the compose file's `image:` + `pull_policy: always` lines and the `trust/Makefile` comment.

## Additional Notes

Findings from the audit that were **verified and skipped** (kept out of this PR):

- Sphinx audit flagged `TF_VAR_local_trust_public_ip` in `docs/source/deploy-flip/deploy-flip-node-on-prem.rst:274` — false positive; that file already uses the correct plural `LOCAL_TRUST_PUBLIC_IPS` and the `allow-local-trust-nlb` target.
- Docstring audit flagged a systemic `flip: FLIP` (factory-as-type) annotation across ~15 declarations in `flip-utils/`. This is a real annotation, but `FLIP` is used as `flip: FLIP` in user-uploaded tutorial code too, so changing internal helpers to `FLIPBase` in isolation would create inconsistency. Left for a broader coordinated change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JL1PygyRkfqVrGjX1CgPyk)_