### PR TITLE
ci: bump remaining GitHub Actions off Node 20 and fix silent Python version drift

### DIFF
--- a/.github/actions/setup-trust-test-env/action.yml
+++ b/.github/actions/setup-trust-test-env/action.yml
@@ -19,7 +19,10 @@ description: |
 
 inputs:
   python-version:
-    description: Python toolchain version
+    description: |
+      Python toolchain version. This default is the single source of truth for
+      every trust test job — none of the callers override it — and must stay in
+      step with trust/*/.python-version and requires-python (all 3.12).
     required: false
     default: "3.12"
   trust-api-key:

--- a/.github/actions/setup-trust-test-env/action.yml
+++ b/.github/actions/setup-trust-test-env/action.yml
@@ -39,7 +39,7 @@ runs:
   using: composite
   steps:
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ inputs.python-version }}
 

--- a/.github/workflows/check-package-metadata.yml
+++ b/.github/workflows/check-package-metadata.yml
@@ -34,7 +34,7 @@ jobs:
               uses: actions/checkout@v5
 
             - name: Set up Python
-              uses: actions/setup-python@v5
+              uses: actions/setup-python@v6
               with:
                   python-version: "3.12"
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version-file: ./docs/.python-version
 

--- a/.github/workflows/fl-api-test-flower.yml
+++ b/.github/workflows/fl-api-test-flower.yml
@@ -39,7 +39,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           # get python version from ./fl-services/flower/fl-api-flower/.python-version file
           # if not found, use 3.12

--- a/.github/workflows/fl-api-test-flower.yml
+++ b/.github/workflows/fl-api-test-flower.yml
@@ -41,9 +41,9 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          # get python version from ./fl-services/flower/fl-api-flower/.python-version file
-          # if not found, use 3.12
-          python-version: "3.12"
+          # Read the version from the file rather than restating it here, so it
+          # cannot drift from requires-python.
+          python-version-file: ./fl-services/flower/fl-api-flower/.python-version
 
       - name: Install uv (if used for dependency management)
         run: pip install uv

--- a/.github/workflows/fl-api-test-nvflare.yml
+++ b/.github/workflows/fl-api-test-nvflare.yml
@@ -39,7 +39,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           # get python version from ./fl-services/nvflare/fl-api-base/fl_api/.python-version file
           # if not found, use 3.11

--- a/.github/workflows/fl-api-test-nvflare.yml
+++ b/.github/workflows/fl-api-test-nvflare.yml
@@ -41,9 +41,9 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          # get python version from ./fl-services/nvflare/fl-api-base/fl_api/.python-version file
-          # if not found, use 3.11
-          python-version: "3.12"
+          # Read the version from the file rather than restating it here, so it
+          # cannot drift from requires-python.
+          python-version-file: ./fl-services/nvflare/fl-api-base/.python-version
 
       - name: Install uv (if used for dependency management)
         run: pip install uv

--- a/.github/workflows/lighthouse_flip_ui.yml
+++ b/.github/workflows/lighthouse_flip_ui.yml
@@ -116,7 +116,7 @@ jobs:
 
       - name: Upload Lighthouse reports
         if: always()
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: lighthouse-report
           path: flip-ui/.lighthouseci

--- a/.github/workflows/pr-release-notes-preview.yml
+++ b/.github/workflows/pr-release-notes-preview.yml
@@ -58,7 +58,7 @@ jobs:
           echo "head_sha=${{ github.event.pull_request.head.sha }}" >> "$GITHUB_OUTPUT"
 
       - name: Post or update release notes preview comment
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           VERSION: ${{ steps.meta.outputs.version }}
           TAG: ${{ steps.meta.outputs.tag }}

--- a/.github/workflows/pr_acceptance_criteria.yml
+++ b/.github/workflows/pr_acceptance_criteria.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - name: Set PR title from linked issue
         if: github.event.action == 'opened'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -65,7 +65,7 @@ jobs:
             }
 
       - name: Check for linked issues and import acceptance criteria
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -71,7 +71,7 @@ jobs:
 
       - name: Set up Python
         if: steps.check_tag.outputs.skip == 'false'
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,7 +94,7 @@ jobs:
 
             - name: Create GitHub Release
               if: steps.tag_check.outputs.exists == 'false'
-              uses: softprops/action-gh-release@v2
+              uses: softprops/action-gh-release@v3
               with:
                   tag_name: ${{ steps.version.outputs.tag }}
                   name: "Release ${{ steps.version.outputs.tag }}"

--- a/.github/workflows/secret-scanning.yml
+++ b/.github/workflows/secret-scanning.yml
@@ -49,7 +49,7 @@ jobs:
               uses: actions/checkout@v5
 
             - name: Set up Python
-              uses: actions/setup-python@v5
+              uses: actions/setup-python@v6
               with:
                   python-version: "3.11"
 
@@ -69,7 +69,7 @@ jobs:
               uses: actions/checkout@v5
 
             - name: Set up Python
-              uses: actions/setup-python@v5
+              uses: actions/setup-python@v6
               with:
                   python-version: "3.11"
 
@@ -111,7 +111,7 @@ jobs:
               uses: actions/checkout@v5
 
             - name: Set up Python
-              uses: actions/setup-python@v5
+              uses: actions/setup-python@v6
               with:
                   python-version: "3.12"
 

--- a/.github/workflows/test_flip_api.yml
+++ b/.github/workflows/test_flip_api.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           # get python version from ./flip-api/.python-version file
           # if not found, use 3.11
@@ -72,7 +72,7 @@ jobs:
         run: make integration_test
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         with:
           files: flip-api/coverage-unit.xml,flip-api/coverage-integration.xml
           flags: flip-api

--- a/.github/workflows/test_flip_api.yml
+++ b/.github/workflows/test_flip_api.yml
@@ -42,9 +42,13 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          # get python version from ./flip-api/.python-version file
-          # if not found, use 3.11
-          python-version: ${{ github.event.inputs.python-version || '3.11' }}
+          # Stated literally because flip-api, unlike the trust services, has no
+          # .python-version file to point `python-version-file` at; keep this in
+          # step with requires-python and the Dockerfile base (both 3.12). Do not
+          # restore the previous `github.event.inputs.python-version || '3.11'`
+          # form — this workflow has no workflow_dispatch trigger, so that input
+          # was always empty and the job silently ran 3.11.
+          python-version: "3.12"
 
       - name: Install uv (if used for dependency management)
         run: pip install uv

--- a/.github/workflows/test_flip_ui.yml
+++ b/.github/workflows/test_flip_ui.yml
@@ -62,7 +62,7 @@ jobs:
         run: npm run test:unit
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         with:
           files: flip-ui/coverage/cobertura-coverage.xml
           flags: flip-ui
@@ -148,7 +148,7 @@ jobs:
           EOF
 
       - name: Cypress run
-        uses: cypress-io/github-action@v6
+        uses: cypress-io/github-action@v7
         # install-command defaults to `npm ci` when package-lock.json exists,
         # which is what we want here — reproducible installs in CI.
         with:
@@ -164,7 +164,7 @@ jobs:
 
       - name: Upload Cypress screenshots
         if: failure()
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: cypress-screenshots-${{ matrix.group }}
           path: flip-ui/test/cypress/screenshots

--- a/.github/workflows/test_helm_chart.yml
+++ b/.github/workflows/test_helm_chart.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -54,7 +54,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Set up Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@v5
         with:
           version: "v4.2.3"
 
@@ -69,7 +69,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Set up Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@v5
         with:
           version: "v4.2.3"
 
@@ -232,7 +232,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Set up Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@v5
         with:
           version: "v4.2.3"
 

--- a/.github/workflows/test_local_trust_playbook.yml
+++ b/.github/workflows/test_local_trust_playbook.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 

--- a/.github/workflows/test_trust_data_access_api.yml
+++ b/.github/workflows/test_trust_data_access_api.yml
@@ -52,7 +52,7 @@ jobs:
         run: make local_test
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         with:
           files: trust/data-access-api/coverage-unit.xml
           flags: data-access-api
@@ -128,7 +128,7 @@ jobs:
           echo "::endgroup::"
 
       - name: Upload integration coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         with:
           files: trust/data-access-api/coverage-integration.xml
           flags: data-access-api-integration

--- a/.github/workflows/test_trust_data_access_api.yml
+++ b/.github/workflows/test_trust_data_access_api.yml
@@ -43,7 +43,11 @@ jobs:
       - name: Setup trust test env
         uses: ./.github/actions/setup-trust-test-env
         with:
-          python-version: ${{ github.event.inputs.python-version || '3.11' }}
+          # python-version deliberately omitted — the composite action defaults to
+          # the 3.12 that .python-version and requires-python pin. Do not restate
+          # it per job: the previous `github.event.inputs.python-version` form had
+          # no workflow_dispatch trigger to feed it, so this job silently ran 3.11
+          # while the integration job below ran 3.12.
           trust-api-key: ${{ secrets.TRUST_API_KEY }}
           aes-key-base64: ${{ secrets.AES_KEY_BASE64 }}
           postgres-password: ${{ secrets.POSTGRES_PASSWORD }}
@@ -80,7 +84,7 @@ jobs:
       - name: Setup trust test env
         uses: ./.github/actions/setup-trust-test-env
         with:
-          python-version: ${{ github.event.inputs.python-version || '3.12' }}
+          # python-version deliberately omitted — see the unit job above.
           trust-api-key: ${{ secrets.TRUST_API_KEY || 'test-trust-api-key-for-ci' }}
           aes-key-base64: ${{ secrets.AES_KEY_BASE64 || 'QgZ+TBA0lUxcuCiRPLneFe/JjMaUEUJWHACHHGz2gGA=' }}  # pragma: allowlist secret
           postgres-password: ${{ secrets.POSTGRES_PASSWORD || 'test_password' }}

--- a/.github/workflows/test_trust_imaging_api.yml
+++ b/.github/workflows/test_trust_imaging_api.yml
@@ -37,11 +37,14 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
-          # get python version from ./trust/imaging-api/.python-version file
-          # if not found, use 3.11
-          python-version: ${{ github.event.inputs.python-version || '3.11' }}
+          # Read the version from the file rather than restating it here, so it
+          # cannot drift from requires-python. Do not go back to the previous
+          # `github.event.inputs.python-version || '3.11'` form: this workflow has
+          # no `workflow_dispatch` trigger, so that input was always empty and the
+          # job silently ran 3.11 while the file (and pyproject) pin 3.12.
+          python-version-file: ./trust/imaging-api/.python-version
 
       - name: Install uv (if used for dependency management)
         run: pip install uv
@@ -61,7 +64,7 @@ jobs:
         run: make local_test
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         with:
           files: trust/imaging-api/coverage.xml
           flags: imaging-api

--- a/.github/workflows/test_trust_omop_db.yml
+++ b/.github/workflows/test_trust_omop_db.yml
@@ -43,7 +43,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -75,7 +75,7 @@ jobs:
           '
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         with:
           files: trust/omop-db/coverage-unit.xml
           flags: omop-db

--- a/.github/workflows/test_trust_trust_api.yml
+++ b/.github/workflows/test_trust_trust_api.yml
@@ -43,7 +43,11 @@ jobs:
       - name: Setup trust test env
         uses: ./.github/actions/setup-trust-test-env
         with:
-          python-version: ${{ github.event.inputs.python-version || '3.11' }}
+          # python-version deliberately omitted — the composite action defaults to
+          # the 3.12 that .python-version and requires-python pin. Do not restate
+          # it per job: the previous `github.event.inputs.python-version` form had
+          # no workflow_dispatch trigger to feed it, so this job silently ran 3.11
+          # while the integration job below ran 3.12.
           trust-api-key: ${{ secrets.TRUST_API_KEY || 'test-trust-api-key-for-ci' }}
           aes-key-base64: ${{ secrets.AES_KEY_BASE64 || 'dGVzdC1hZXMta2V5LWZvci1jaS10ZXN0aW5nLTMyYnl0ZXM=' }}  # pragma: allowlist secret
           postgres-password: ${{ secrets.POSTGRES_PASSWORD }}
@@ -83,7 +87,7 @@ jobs:
       - name: Setup trust test env
         uses: ./.github/actions/setup-trust-test-env
         with:
-          python-version: ${{ github.event.inputs.python-version || '3.12' }}
+          # python-version deliberately omitted — see the unit job above.
           trust-api-key: ${{ secrets.TRUST_API_KEY || 'test-trust-api-key-for-ci' }}
           aes-key-base64: ${{ secrets.AES_KEY_BASE64 || 'QgZ+TBA0lUxcuCiRPLneFe/JjMaUEUJWHACHHGz2gGA=' }}  # pragma: allowlist secret
           postgres-password: ${{ secrets.POSTGRES_PASSWORD || 'test_password' }}

--- a/.github/workflows/test_trust_trust_api.yml
+++ b/.github/workflows/test_trust_trust_api.yml
@@ -53,7 +53,7 @@ jobs:
         run: make local_test
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         with:
           files: trust/trust-api/coverage-unit.xml
           flags: trust-api
@@ -136,7 +136,7 @@ jobs:
           echo "::endgroup::"
 
       - name: Upload integration coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         with:
           files: trust/trust-api/coverage-integration.xml
           flags: trust-api-integration

--- a/.github/workflows/test_trust_xnat.yml
+++ b/.github/workflows/test_trust_xnat.yml
@@ -55,7 +55,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 

--- a/.github/workflows/unit-tests-heavy.yml
+++ b/.github/workflows/unit-tests-heavy.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -52,7 +52,7 @@ jobs:
 
       - name: Upload coverage (optional)
         if: success()
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -36,7 +36,7 @@ jobs:
               uses: actions/checkout@v5
 
             - name: Set up Python 3.12
-              uses: actions/setup-python@v5
+              uses: actions/setup-python@v6
               with:
                   python-version: "3.12"
 
@@ -55,7 +55,7 @@ jobs:
                 uv run pytest --cov=flip --cov-report=xml -k "not nvflare"
 
             - name: Upload coverage to Codecov
-              uses: codecov/codecov-action@v5
+              uses: codecov/codecov-action@v7
               with:
                   files: ./coverage.xml
                   flags: flip
@@ -79,7 +79,7 @@ jobs:
               uses: actions/checkout@v5
 
             - name: Set up Python 3.12
-              uses: actions/setup-python@v5
+              uses: actions/setup-python@v6
               with:
                   python-version: "3.12"
 
@@ -99,7 +99,7 @@ jobs:
               run: uv run pytest --cov=fl_api --cov-report=xml
 
             - name: Upload coverage to Codecov
-              uses: codecov/codecov-action@v5
+              uses: codecov/codecov-action@v7
               with:
                   files: ./coverage.xml
                   flags: api

--- a/.github/workflows/validate_terraform.yml
+++ b/.github/workflows/validate_terraform.yml
@@ -47,7 +47,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: "~> 1.13"
 


### PR DESCRIPTION
Two related CI cleanups: get every action off the deprecated Node 20 runtime, and stop
the test workflows restating the Python version in a way that had silently drifted.

## 1. Node 20 → Node 24

Every job that combined `setup-python` with `codecov-action` was emitting:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: `actions/github-script@60a0d830…`, `actions/setup-python@v5`

`github-script` is **not declared** in those workflows. It is a nested step inside
`codecov/codecov-action@v5`, which is a *composite* action pinning `github-script`
v7.0.1 (node20) at its `action.yml:233`. The v5 line never bumped that pin — `v5.5.5`
still carries it — so clearing the warning means leaving v5 entirely. That is why
grepping the imaging-api workflow for `github-script` finds nothing.

Finishes the Node 24 migration started in #675, which covered `checkout`,
`setup-node` and `configure-aws-credentials`.

Each action moves to the **lowest release that runs on node24**:

| Action | From | To | Uses |
| --- | --- | --- | --- |
| `actions/setup-python` | v5 | **v6** | 18 (incl. `.github/actions/setup-trust-test-env`) |
| `codecov/codecov-action` | v5 | **v7** | 11 |
| `actions/github-script` | v7 | **v8** | 3 direct |
| `actions/upload-artifact` | v5 | **v6** | 2 |
| `azure/setup-helm` | v4 | **v5** | 3 |
| `hashicorp/setup-terraform` | v3 | **v4** | 1 |
| `softprops/action-gh-release` | v2 | **v3** | 1 |
| `cypress-io/github-action` | v6 | **v7** | 1 (already v7 in `regenerate_docs_gifs`) |

Version choices, since several are major bumps:

- **setup-helm v5, setup-terraform v4, action-gh-release v3, cypress-io v7** — each
  release note documents the node24 runtime move *and nothing else*.
- **setup-python v6, not v7** — v7 additionally migrates to ESM and drops the
  `pip-install` input. v6 is node24, has been out since 2025-09, and clears the
  deprecation with less new surface. No workflow pins an EOL Python, so v7's "remove
  EOL Python versions" change is not a reason to jump.
- **upload-artifact v6, not v7** — same reasoning; v7 adds ESM plus opt-in direct
  uploads we do not use.
- **codecov v7, not v6** — v6 is already node24 (its only change *is* the nested
  `github-script` → v8 bump), but v7 is the release published *after* codecov deleted
  the `codecovsecurity` keybase account in favour of `codecovsecops`. The delta v6→v7
  is a release chore, so taking v7 avoids a possible CLI signature-verification
  surprise on the older line.

All **14** external actions referenced under `.github/` now resolve to a node24
runtime. `trufflesecurity/trufflehog@main` is composite-with-bash only and needs no
bump.

## 2. Python version selection

Five jobs used `python-version: ${{ github.event.inputs.python-version || '3.1x' }}`.
**None of those workflows has a `workflow_dispatch` trigger**, so the input was always
empty and every one of them silently used its hardcoded fallback — while the comment
above it claimed to be reading `.python-version`.

In the trust workflows this was worse than a stale comment: each service's **unit** job
fell through to 3.11 while its own **integration** job fell through to 3.12, so the two
suites of one service ran on different interpreters.

| Workflow | Before | After |
| --- | --- | --- |
| `test_trust_imaging_api.yml` | 3.11 (file says 3.12) | **3.12** via `python-version-file` |
| `test_trust_trust_api.yml` | unit 3.11 / integration 3.12 | **both 3.12** |
| `test_trust_data_access_api.yml` | unit 3.11 / integration 3.12 | **both 3.12** |
| `test_flip_api.yml` | 3.11 | **3.12** |

How each is fixed:

- **imaging-api** → `python-version-file: ./trust/imaging-api/.python-version`, matching
  the existing green idiom in `docs.yml`. setup-python's plain-file parser skips `#`
  lines, so the Apache header in that file is not a problem.
- **trust-api / data-access-api** → both feed the shared `setup-trust-test-env` composite
  action, whose `python-version` input **already defaults to 3.12** (matching
  `trust/*/.python-version` and `requires-python`). Dropped the input from all four call
  sites so that default is the single source of truth, and said so in the input's
  description since nothing overrides it now.
- **flip-api** → states `"3.12"` literally. It is the only Python service with no
  `.python-version` file, so there is nothing for `python-version-file` to read. I
  deliberately did not add one: `requires-python` is `>=3.12` (open), and a pin would
  change which interpreter `uv` picks for local flip-api development — a dev-env side
  effect that does not belong in a CI PR. The literal matches `requires-python` and the
  `python:3.12-slim-bookworm` base.

Also corrected `fl-api-test-nvflare.yml` and `fl-api-test-flower.yml`, which claimed to
read a `.python-version` file while hardcoding the value. Both files exist and say 3.12,
so pointing `python-version-file` at them changes no behaviour — it just makes the comment
true. The nvflare one additionally contradicted itself (`# if not found, use 3.11` directly
above `python-version: "3.12"`) and named a path that does not exist
(`fl-api-base/fl_api/` rather than `fl-api-base/`).

No `python-version` line under `.github/` interpolates a workflow input any more; the only
remaining expression is the composite action forwarding its own input.

## Testing

**CI on the head commit: 18/18 workflows succeeded, 38 checks pass, 1 skip**
(`Validate PR Source Branch`, which only runs for PRs to `main`), 0 fail. The check roster
is smaller than the first push's 42 because the path-filtered workflows do not all re-run —
not a regression.

Swept the annotations of **all 36 jobs across the 18 runs** on the head commit:
**0 Node 20 deprecation annotations.** Before/after on the two jobs that had them:

| Job | develop (before) | this branch (after) |
| --- | --- | --- |
| `imaging-api` | Node 20 warning | *no annotations at all* |
| `flip-ui` | Node 20 warning + 3 line-length warnings | 3 line-length warnings only |

The 3 remaining `flip-ui` line-length warnings are pre-existing on `develop` and unrelated
to this PR, which touches no `.ts`/`.vue` files.

Every Python-version change is confirmed in the job logs:

```
flip-api                     | Successfully set up CPython (3.12.13)
trust-api                    | Successfully set up CPython (3.12.13)
trust-api-integration        | Successfully set up CPython (3.12.13)
data-access-api              | Successfully set up CPython (3.12.13)
data-access-api-integration  | Successfully set up CPython (3.12.13)
imaging-api                  | Resolved ./trust/imaging-api/.python-version as 3.12
flip-fl-api (nvflare)        | Resolved ./fl-services/nvflare/fl-api-base/.python-version as 3.12
flip-fl-api (flower)         | Resolved ./fl-services/flower/fl-api-flower/.python-version as 3.12
```

Also: every changed file parses as valid YAML, and the runtime of each pinned version was
read directly from that action's `action.yml` (`using:`), including the nested step inside
the two composite actions.

## Notes

- Workflow-only change; no Docker image rebuild and no application code touched.
- **The two release workflows cannot run on a PR**, so instead of leaving those bumps
  unverified I checked them against the last release that actually cut one
  (2026-08-07 10:47). Both were emitting the warning, naming exactly the actions bumped here:

  | Workflow | Run | Warning |
  | --- | --- | --- |
  | `release.yml` | [31171515604](https://github.com/londonaicentre/FLIP/actions/runs/31171515604) | `…forced to run on Node.js 24: softprops/action-gh-release@v2` |
  | `release-pypi.yml` | [31171515575](https://github.com/londonaicentre/FLIP/actions/runs/31171515575) | `…forced to run on Node.js 24: actions/setup-python@v5` |

  `action-gh-release@v3` is node24 and still declares all three inputs we pass
  (`tag_name`, `name`, `body_path`), so the bump is input-compatible.
  `release-pypi.yml` creates its release with `gh release create` in a `run:` step, not an
  action, which is why `setup-python` was its only node20 dependency.

  **Worth knowing for whoever watches the next release:** both workflows gate their real
  work behind a tag-existence check, so a release run whose version was not bumped skips
  the very steps that load these actions — the most recent run
  ([31173862933](https://github.com/londonaicentre/FLIP/actions/runs/31173862933)) skipped
  `Create GitHub Release` entirely and therefore showed no warning at all. Confirmation
  that these two bumps work will come on the next run that actually cuts a release, not
  merely the next push to `main`.
- Branch is not `[ticket_id]-[task_name]` because there is no tracking issue for this
  tranche (#675, the previous one, is closed). Happy to file one and rename if preferred.
