### PR TITLE
Any authenticated user can read any user's full profile

### DIFF
--- a/docs/source/sys-admin/admin-user-roles.rst
+++ b/docs/source/sys-admin/admin-user-roles.rst
@@ -114,12 +114,21 @@ own profile regardless of role.
 
 Researchers additionally need to resolve an email address when adding someone to a project, so they
 may check whether an address is registered. That check returns only the user's ID, email address and
-enabled flag — never their name or organisation — and it confirms only addresses the Researcher
-already knows, since there is no way to list or enumerate users without *Manage users*.
+enabled flag — never their name or organisation — and users cannot be *listed* without *Manage
+users*: no endpoint will hand a Researcher the roster.
+
+.. warning::
+
+   The address check is not yet bounded per caller, so users can still be *enumerated* even though
+   they cannot be listed. A Researcher who guesses addresses — an NHS address space is fairly
+   predictable — learns which of them hold accounts, one address per request, and nothing caps how
+   many they may try. What the check discloses stays narrow (ID, email address, enabled flag); how
+   often it may be asked does not. Rate-limiting it per authenticated caller is tracked in
+   `FLIP#961 <https://github.com/londonaicentre/FLIP/issues/961>`_.
 
 .. note::
 
    Unlike project-level writes, this capability follows the *Create projects* permission rather than
    project ownership. A project owner who has been demoted to Viewer keeps their existing project
-   write access (see the warning above) but loses the ability to look up new members, because the
-   add-member form is not shown to Viewers.
+   write access (see the ownership warning further up the page) but loses the ability to look up new
+   members, because the add-member form is not shown to Viewers.

--- a/docs/source/sys-admin/admin-user-roles.rst
+++ b/docs/source/sys-admin/admin-user-roles.rst
@@ -82,3 +82,44 @@ The following table summarises the permissions assigned to each role:
 .. warning::
 
    Project ownership is not revoked by a role change. A user who created a project keeps project-level write access to it (editing, staging, deleting, and submitting cohort queries) even after being demoted to Viewer — ownership, not the current role, is the authority for owned projects. Demotion still removes the user's ability to create new projects or write to projects they do not own. To fully revoke a former owner's access to a project they own, transfer ownership to another user or delete the project.
+
+Who can see whose profile
+-------------------------
+
+User profile visibility follows *Manage users*, not project ownership:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 20 20 20
+
+   * - Can read
+     - Admin
+     - Researcher
+     - Viewer
+   * - Any user's full profile (name, organisation, account status)
+     - Yes
+     - No
+     - No
+   * - Their own full profile
+     - Yes
+     - Yes
+     - Yes
+   * - Whether a given email address is registered, and its user ID
+     - Yes
+     - Yes
+     - No
+
+Only *Manage users* grants the full profile of another user. Every authenticated user can read their
+own profile regardless of role.
+
+Researchers additionally need to resolve an email address when adding someone to a project, so they
+may check whether an address is registered. That check returns only the user's ID, email address and
+enabled flag — never their name or organisation — and it confirms only addresses the Researcher
+already knows, since there is no way to list or enumerate users without *Manage users*.
+
+.. note::
+
+   Unlike project-level writes, this capability follows the *Create projects* permission rather than
+   project ownership. A project owner who has been demoted to Viewer keeps their existing project
+   write access (see the warning above) but loses the ability to look up new members, because the
+   add-member form is not shown to Viewers.

--- a/flip-api/src/flip_api/auth/auth_utils.py
+++ b/flip-api/src/flip_api/auth/auth_utils.py
@@ -52,6 +52,12 @@ def has_permissions(user_id: UUID, required_permissions: list[PermissionRef], db
     both A and B. For an OR check, use :func:`has_any_permission`; passing two permissions here
     when either would do silently denies everyone who holds just one of them.
 
+    An empty list grants nothing (returns False), matching :func:`has_any_permission`, so a caller
+    cannot accidentally allow everyone by passing no permissions. That guard is explicit here
+    because the natural implementation fails *open*: ``all()`` over an empty sequence is True, and
+    the ``except`` below would not catch it — with nothing to check, the query succeeds and the
+    generator never runs.
+
     Args:
         user_id (UUID): The ID of the user to check permissions for.
         required_permissions (list[PermissionRef]): A list of permissions to check against the user's roles.
@@ -60,6 +66,12 @@ def has_permissions(user_id: UUID, required_permissions: list[PermissionRef], db
     Returns:
         bool: True if the user has all required permissions, False otherwise
     """
+    # Deny before touching the DB. A dynamically built list that filtered down to nothing is a
+    # caller bug, so it is worth a log line rather than a silent deny.
+    if not required_permissions:
+        logger.error(f"Refusing to authorize user {user_id} against an empty required-permission list")
+        return False
+
     try:
         user_permission_ids = _user_permission_ids(user_id, db)
 

--- a/flip-api/src/flip_api/auth/auth_utils.py
+++ b/flip-api/src/flip_api/auth/auth_utils.py
@@ -18,9 +18,39 @@ from flip_api.db.models.user_models import PermissionRef, Role, RolePermission, 
 from flip_api.utils.logger import logger
 
 
+def _user_permission_ids(user_id: UUID, db: Session) -> set[UUID]:
+    """
+    Collect the IDs of every permission granted to a user through their roles.
+
+    Raises rather than swallowing DB errors: each caller converts a failure into a deny, so the
+    fail-closed behaviour stays visible at the point where the access decision is made.
+
+    Args:
+        user_id (UUID): The ID of the user to collect permissions for.
+        db (Session): The database session to query user roles and permissions.
+
+    Returns:
+        set[UUID]: The permission IDs granted by the user's roles.
+    """
+    # Get user roles
+    user_roles = db.exec(select(Role).join(UserRole).where(UserRole.user_id == user_id)).all()
+
+    # Get all permissions for these roles
+    user_permission_ids: set[UUID] = set()
+    for role in user_roles:
+        role_permissions = db.exec(select(RolePermission.permission_id).where(RolePermission.role_id == role.id)).all()
+        user_permission_ids.update(role_permissions)
+
+    return user_permission_ids
+
+
 def has_permissions(user_id: UUID, required_permissions: list[PermissionRef], db: Session) -> bool:
     """
-    Check if a user has the required permissions.
+    Check if a user has ALL of the required permissions.
+
+    This is an AND check — ``has_permissions(uid, [A, B], db)`` is True only when the user holds
+    both A and B. For an OR check, use :func:`has_any_permission`; passing two permissions here
+    when either would do silently denies everyone who holds just one of them.
 
     Args:
         user_id (UUID): The ID of the user to check permissions for.
@@ -31,20 +61,37 @@ def has_permissions(user_id: UUID, required_permissions: list[PermissionRef], db
         bool: True if the user has all required permissions, False otherwise
     """
     try:
-        # Get user roles
-        user_roles = db.exec(select(Role).join(UserRole).where(UserRole.user_id == user_id)).all()
-
-        # Get all permissions for these roles
-        user_permission_ids: list[UUID] = []
-        for role in user_roles:
-            role_permissions = db.exec(
-                select(RolePermission.permission_id).where(RolePermission.role_id == role.id)
-            ).all()
-            user_permission_ids.extend(role_permissions)
+        user_permission_ids = _user_permission_ids(user_id, db)
 
         # Check if user has all required permissions
         return all(permission.value in user_permission_ids for permission in required_permissions)
 
     except Exception as e:
-        logger.error(f"Error checking permissions: {str(e)}")
+        logger.error(f"Error checking all-of permissions for user {user_id}: {str(e)}")
+        return False
+
+
+def has_any_permission(user_id: UUID, permissions: list[PermissionRef], db: Session) -> bool:
+    """
+    Check if a user has AT LEAST ONE of the given permissions.
+
+    The OR counterpart to :func:`has_permissions`, which is an AND check. An empty list grants
+    nothing (returns False), so a caller cannot accidentally allow everyone by passing no
+    permissions.
+
+    Args:
+        user_id (UUID): The ID of the user to check permissions for.
+        permissions (list[PermissionRef]): The permissions to check against the user's roles.
+        db (Session): The database session to query user roles and permissions.
+
+    Returns:
+        bool: True if the user holds any one of the given permissions, False otherwise.
+    """
+    try:
+        user_permission_ids = _user_permission_ids(user_id, db)
+
+        return any(permission.value in user_permission_ids for permission in permissions)
+
+    except Exception as e:
+        logger.error(f"Error checking any-of permissions for user {user_id}: {str(e)}")
         return False

--- a/flip-api/src/flip_api/domain/interfaces/project.py
+++ b/flip-api/src/flip_api/domain/interfaces/project.py
@@ -147,6 +147,15 @@ class IProject(BaseModel):  # Base for IProject to avoid repetition
 
 class IReturnedProject(IProject):  # Extends IProject
     owner_email: EmailStr = Field(..., alias="ownerEmail")
+    # Narrow by construction, not by declaration. `CognitoUser` permits `name` and `organisation`,
+    # but they stay empty here because `get_project` fills this list from `get_user_by_email_or_id`
+    # (which populates id/email/is_disabled alone) and never calls `apply_user_profile` — the DB
+    # join that is the only source of those two fields. Do not enrich project members with display
+    # names: that would widen full-profile disclosure to every project co-member, which is the leak
+    # FLIP#907 closed on `/users/{user_id}`. The shape to hold to is `ProjectMemberLookup`; typing
+    # this field as one so the response model enforces it rather than a field default is FLIP#996,
+    # which is not a one-line change — `get_project` passes `CognitoUser` instances, and that field
+    # type rejects them at construction.
     users: list[CognitoUser]
     # Surfaced read-only so the edit form can display the project's
     # DICOM->NIfTI setting. Fixed at creation and immutable afterwards (the

--- a/flip-api/src/flip_api/domain/schemas/users.py
+++ b/flip-api/src/flip_api/domain/schemas/users.py
@@ -12,37 +12,13 @@
 
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict, EmailStr, Field, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, EmailStr, Field, model_validator
 
 
 class UserPermissionsResponse(BaseModel):
     """Response model for user permissions."""
 
     permissions: list[str] = Field(..., description="List of permissions assigned to the user.")
-
-
-class GetUser(BaseModel):
-    """Model for retrieving a user by ID or email."""
-
-    userId: str = Field(..., description="User identifier (email or UUID)")
-
-
-class GetUserByEmail(GetUser):
-    """Model specifically for retrieving a user by email."""
-
-    userId: EmailStr
-
-
-class GetUserById(GetUser):
-    """Model specifically for retrieving a user by UUID."""
-
-    @field_validator("userId")
-    def validate_uuid(cls, v: str) -> str:
-        try:
-            UUID(v)
-        except ValueError:
-            raise ValueError("'userId' must be a valid GUID")
-        return v
 
 
 class Disabled(BaseModel):
@@ -80,6 +56,27 @@ class CognitoUser(BaseModel):
     email: EmailStr = Field(..., description="User's email address")
     name: str = Field(default="", description="User's display name")
     organisation: str = Field(default="", description="User's organisation")
+    is_disabled: bool = Field(default=False, description="Indicates if the user is disabled", alias="isDisabled")
+
+    model_config = ConfigDict(
+        populate_by_name=True,
+    )
+
+
+class ProjectMemberLookup(BaseModel):
+    """Minimal identity a project editor needs in order to add someone as a project member.
+
+    Omits ``name`` and ``organisation``: the add-member flow in ``ProjectUsers.vue`` only ever
+    reads id / email / isDisabled, and its endpoint is reachable by every Researcher (FLIP#907).
+
+    Stated as its own model rather than a subclass of :class:`CognitoUser` because a pydantic
+    subclass can only add fields, never drop them — so the narrowing has to be expressed here.
+    (Inverting the hierarchy, so ``CognitoUser`` extends this, would remove the repetition and
+    keep the same guarantee; that is a larger change to a widely-used schema.)
+    """
+
+    id: UUID = Field(..., description="User ID from Cognito")
+    email: EmailStr = Field(..., description="User's email address")
     is_disabled: bool = Field(default=False, description="Indicates if the user is disabled", alias="isDisabled")
 
     model_config = ConfigDict(

--- a/flip-api/src/flip_api/user_services/get_user.py
+++ b/flip-api/src/flip_api/user_services/get_user.py
@@ -100,6 +100,20 @@ def lookup_project_member(
     project. That disclosure is one bit about an address the caller already holds, and it is
     bounded to Researchers and Admins — there is no self-signup on this platform.
 
+    What is bounded is *what* one call discloses, not *how often* it may be asked: nothing
+    rate-limits this route per caller, so a predictable address space stays walkable one guess at a
+    time. Tracked in FLIP#961 rather than fixed here — the only stable per-caller key is the
+    verified ``sub``, which means giving ``verify_token`` a ``Request`` to stash it on, i.e.
+    changing the dependency every authenticated route uses.
+
+    The address rides in the query string, which means it is retained in the CloudFront standard
+    access logs (``cs-uri-query``) and the WAF logs (``httpRequest.args``, unredacted) — so the set
+    of addresses a caller probed persists for those buckets' retention window. Kept as a ``GET``
+    anyway: it is a read, ``/api/*`` is served by the caching-disabled policy so there is no CDN
+    exposure, and the route this replaced carried the address in the path, which is logged just the
+    same. A ``POST`` with the address in the body would keep it out of those logs, at the cost of a
+    non-idempotent verb for a lookup — recorded here so the trade is not re-derived from scratch.
+
     Args:
         request (Request): FastAPI request object for headers.
         email (EmailStr): Email address of the prospective project member.

--- a/flip-api/src/flip_api/user_services/get_user.py
+++ b/flip-api/src/flip_api/user_services/get_user.py
@@ -12,32 +12,165 @@
 
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException, Request, status
-from pydantic import ValidationError
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
+from pydantic import EmailStr
 from sqlmodel import Session
 
+from flip_api.auth.auth_utils import has_any_permission, has_permissions
 from flip_api.auth.dependencies import verify_token
 from flip_api.db.database import get_session
-from flip_api.domain.schemas.users import CognitoUser, GetUserByEmail, GetUserById
+from flip_api.db.models.user_models import PermissionRef
+from flip_api.domain.schemas.users import CognitoUser, ProjectMemberLookup
 from flip_api.utils.cognito_helpers import apply_user_profile, get_user_by_email_or_id, get_user_pool_id
 from flip_api.utils.logger import logger
 
 router = APIRouter(prefix="/users", tags=["user_services"])
 
 
-# [#114] ✅
-@router.get("/{user_id}", response_model=CognitoUser, response_model_by_alias=True)
-def get_user(
-    user_id: str,
+# ROUTE ORDER BELOW IS LOAD-BEARING: FastAPI matches in declaration order and `/{user_id}` matches
+# any single segment, so `/me` and `/lookup` must stay above it. Pinned by the route-ordering test
+# in tests/unit/user_services/test_get_user.py, which also covers the pre-existing `/users/access`.
+
+
+@router.get(
+    "/me",
+    response_model=CognitoUser,
+    response_model_by_alias=True,
+    summary="Get the caller's own profile",
+    description="Get the authenticated caller's own user details. Requires no permission — the token is the caller.",
+)
+def get_current_user(
     request: Request,
     db: Session = Depends(get_session),
     token_id: UUID = Depends(verify_token),
 ) -> CognitoUser:
     """
-    Get user details by ID or email.
+    Get the authenticated caller's own user details.
+
+    Deliberately carries no permission check: the bearer token *is* the authorization, so every
+    authenticated user can read their own profile and no one else's. This is the only self-service
+    read path — ``get_user`` below is administrative and has no self escape hatch (FLIP#907).
+
+    Resolution is by the token's ``sub`` UUID rather than by email, so the caller cannot influence
+    which record is returned.
 
     Args:
-        user_id (str): User ID or email.
+        request (Request): FastAPI request object for headers.
+        db (Session): Database session.
+        token_id (UUID): User ID from authentication token.
+
+    Returns:
+        CognitoUser: The caller's own user details.
+
+    Raises:
+        HTTPException: 404 if the token's subject has no matching Cognito record.
+    """
+    user_pool_id = get_user_pool_id(request)
+    user = get_user_by_email_or_id(user_pool_id, user_id=token_id)
+
+    return apply_user_profile(user, db)
+
+
+@router.get(
+    "/lookup",
+    response_model=ProjectMemberLookup,
+    response_model_by_alias=True,
+    summary="Look up a prospective project member by email",
+    description=(
+        "Resolve an email address to the minimal identity needed to add a project member. "
+        "Requires CAN_CREATE_PROJECTS or CAN_MANAGE_USERS permission."
+    ),
+)
+def lookup_project_member(
+    request: Request,
+    email: EmailStr = Query(..., description="Email address of the prospective project member"),
+    db: Session = Depends(get_session),
+    token_id: UUID = Depends(verify_token),
+) -> ProjectMemberLookup:
+    """
+    Resolve an email address to the minimal identity needed to add a project member.
+
+    Requires CAN_CREATE_PROJECTS or CAN_MANAGE_USERS permission.
+
+    Narrow by construction — see :class:`ProjectMemberLookup`. This route exists so Researchers,
+    who need an email-to-id resolution to add a member, stay off the full-profile route.
+
+    It does confirm to a Researcher whether a given address is registered, which is unavoidable:
+    the UI has to be able to report "cannot be found" rather than silently drop a colleague from a
+    project. That disclosure is one bit about an address the caller already holds, and it is
+    bounded to Researchers and Admins — there is no self-signup on this platform.
+
+    Args:
+        request (Request): FastAPI request object for headers.
+        email (EmailStr): Email address of the prospective project member.
+        db (Session): Database session.
+        token_id (UUID): User ID from authentication token.
+
+    Returns:
+        ProjectMemberLookup: The user's ID, email and disabled status.
+
+    Raises:
+        HTTPException: 403 if the caller lacks permission, 404 if no user matches the address.
+    """
+    # Authorize BEFORE touching Cognito: an unauthorised caller must get the same 403 whether or
+    # not the address exists, otherwise this becomes an account-existence oracle for Viewers.
+    if not has_any_permission(token_id, [PermissionRef.CAN_CREATE_PROJECTS, PermissionRef.CAN_MANAGE_USERS], db):
+        logger.error(f"User with ID: {token_id} attempted to look up a project member without permission")
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="User is not permitted to look up project members.",
+        )
+
+    user_pool_id = get_user_pool_id(request)
+
+    try:
+        user = get_user_by_email_or_id(user_pool_id, email=email)
+    except HTTPException as e:
+        if e.status_code == status.HTTP_404_NOT_FOUND:
+            # The helper's message renders as "... or ID: None is not registered." for an
+            # email lookup; give the UI something it can show verbatim instead.
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found.")
+        raise
+
+    # Deliberately NOT apply_user_profile: that DB join is the only source of `name` and
+    # `organisation`. Do not "tidy" this to match get_user below.
+    return ProjectMemberLookup(
+        id=user.id,
+        email=user.email,
+        is_disabled=user.is_disabled,
+    )  # type: ignore[call-arg]
+
+
+# [#114] ✅
+@router.get(
+    "/{user_id}",
+    response_model=CognitoUser,
+    response_model_by_alias=True,
+    summary="Get any user's details",
+    description="Get a user's full details by ID. Requires CAN_MANAGE_USERS permission.",
+)
+def get_user(
+    user_id: UUID,
+    request: Request,
+    db: Session = Depends(get_session),
+    token_id: UUID = Depends(verify_token),
+) -> CognitoUser:
+    """
+    Get user details by ID.
+
+    Requires CAN_MANAGE_USERS permission. There is intentionally no self escape hatch — callers
+    reading their own profile use ``GET /users/me``, which keeps this route's rule to a single
+    sentence and matches every sibling route under ``/users`` (FLIP#907).
+
+    ``user_id`` is typed as a UUID rather than sniffed as "email or UUID" as it once was, matching
+    every sibling route under ``/users``. A malformed id is therefore a 422 from parameter
+    validation, which names the problem, rather than a bare 404 from the router.
+
+    Looking a user up by email address was dropped with the same change: the member lookup moved to
+    ``GET /users/lookup`` (FLIP#907), leaving this route no email callers.
+
+    Args:
+        user_id (UUID): User ID.
         request (Request): FastAPI request object for headers.
         db (Session): Database session.
         token_id (UUID): User ID from authentication token.
@@ -46,36 +179,20 @@ def get_user(
         CognitoUser: User details if found
 
     Raises:
-        HTTPException: If the user ID format is invalid, if the user is not found, or if there is an error getting the
+        HTTPException: If the caller lacks permission, if the user is not found, or if there is an error getting the
                        user details.
     """
-    del token_id  # Unused variable
     try:
-        # Try to validate as email first
-        try:
-            GetUserByEmail(userId=user_id)
-            is_email = True
-        except ValidationError:
-            # If not email, try as UUID
-            try:
-                GetUserById(userId=user_id)
-                is_email = False
-            except ValidationError:
-                # If neither, return error
-                raise HTTPException(
-                    status_code=status.HTTP_400_BAD_REQUEST,
-                    detail="Invalid user ID format. Must be a valid email or UUID.",
-                )
+        # Checked before any Cognito call, so an unauthorised caller gets an identical 403 whether
+        # or not the account exists.
+        if not has_permissions(token_id, [PermissionRef.CAN_MANAGE_USERS], db):
+            logger.error(f"User with ID: {token_id} was unable to manage users")
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN, detail=f"User with ID: {token_id} was unable to manage users"
+            )
 
         user_pool_id = get_user_pool_id(request)
-
-        if is_email:
-            user = get_user_by_email_or_id(user_pool_id, email=user_id)
-        else:
-            user = get_user_by_email_or_id(user_pool_id, user_id=UUID(user_id))
-
-        if not user:
-            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"User '{user_id}' cannot be found.")
+        user = get_user_by_email_or_id(user_pool_id, user_id=user_id)
 
         return apply_user_profile(user, db)
 

--- a/flip-api/tests/unit/auth/test_auth_utils.py
+++ b/flip-api/tests/unit/auth/test_auth_utils.py
@@ -66,6 +66,20 @@ def test_has_permissions_returns_false_when_db_raises():
     assert has_permissions(uuid4(), [PermissionRef.CAN_CREATE_PROJECTS], db) is False
 
 
+def test_has_permissions_denies_on_an_empty_permission_list():
+    """An empty list must grant nothing, mirroring has_any_permission.
+
+    This is the fail-open direction, so it needs an explicit guard rather than falling out of the
+    implementation: ``all()`` over an empty sequence is True, and the except-and-deny path would
+    not catch it either, since with nothing to check the query succeeds. Asserting the DB is never
+    touched pins that the deny happens up front and cannot depend on the query.
+    """
+    db = _db_granting(PermissionRef.CAN_CREATE_PROJECTS)
+
+    assert has_permissions(uuid4(), [], db) is False
+    db.exec.assert_not_called()
+
+
 def test_has_any_permission_returns_true_when_one_of_several_is_held():
     """Holding either permission is enough — this is the OR counterpart."""
     db = _db_granting(PermissionRef.CAN_CREATE_PROJECTS)

--- a/flip-api/tests/unit/auth/test_auth_utils.py
+++ b/flip-api/tests/unit/auth/test_auth_utils.py
@@ -14,8 +14,11 @@ from unittest.mock import MagicMock
 from uuid import uuid4
 
 from flip_api.auth import auth_utils
-from flip_api.auth.auth_utils import has_permissions
+from flip_api.auth.auth_utils import has_any_permission, has_permissions
 from flip_api.db.models.user_models import PermissionRef
+
+# The either-or pair guarding GET /users/lookup (FLIP#907).
+LOOKUP_PERMISSIONS = [PermissionRef.CAN_CREATE_PROJECTS, PermissionRef.CAN_MANAGE_USERS]
 
 
 def test_module_does_not_expose_local_jwt_primitives():
@@ -31,40 +34,28 @@ def test_module_does_not_expose_local_jwt_primitives():
     assert not leaked, f"auth_utils re-introduced JWT primitives: {sorted(leaked)}"
 
 
-def test_has_permissions_returns_true_when_user_has_every_required_permission():
-    """Happy path: every required permission resolves to a role-permission row."""
-    user_id = uuid4()
-    role = MagicMock(id=uuid4())
-    required = [PermissionRef.CAN_CREATE_PROJECTS, PermissionRef.CAN_APPROVE_PROJECTS]
-
+def _db_granting(*permissions: PermissionRef) -> MagicMock:
+    """Build a session mock whose single role grants exactly ``permissions``."""
     db = MagicMock()
     db.exec.return_value.all.side_effect = [
-        [role],
-        [p.value for p in required],
+        [MagicMock(id=uuid4())],
+        [p.value for p in permissions],
     ]
+    return db
 
-    assert has_permissions(user_id, required, db) is True
+
+def test_has_permissions_returns_true_when_user_has_every_required_permission():
+    """Happy path: every required permission resolves to a role-permission row."""
+    required = [PermissionRef.CAN_CREATE_PROJECTS, PermissionRef.CAN_APPROVE_PROJECTS]
+
+    assert has_permissions(uuid4(), required, _db_granting(*required)) is True
 
 
 def test_has_permissions_returns_false_when_a_required_permission_is_missing():
     """A required permission with no matching role-permission row fails the check."""
-    user_id = uuid4()
-    role = MagicMock(id=uuid4())
+    required = [PermissionRef.CAN_CREATE_PROJECTS, PermissionRef.CAN_APPROVE_PROJECTS]
 
-    db = MagicMock()
-    db.exec.return_value.all.side_effect = [
-        [role],
-        [PermissionRef.CAN_CREATE_PROJECTS.value],
-    ]
-
-    assert (
-        has_permissions(
-            user_id,
-            [PermissionRef.CAN_CREATE_PROJECTS, PermissionRef.CAN_APPROVE_PROJECTS],
-            db,
-        )
-        is False
-    )
+    assert has_permissions(uuid4(), required, _db_granting(PermissionRef.CAN_CREATE_PROJECTS)) is False
 
 
 def test_has_permissions_returns_false_when_db_raises():
@@ -73,3 +64,45 @@ def test_has_permissions_returns_false_when_db_raises():
     db.exec.side_effect = RuntimeError("db down")
 
     assert has_permissions(uuid4(), [PermissionRef.CAN_CREATE_PROJECTS], db) is False
+
+
+def test_has_any_permission_returns_true_when_one_of_several_is_held():
+    """Holding either permission is enough — this is the OR counterpart."""
+    db = _db_granting(PermissionRef.CAN_CREATE_PROJECTS)
+
+    assert has_any_permission(uuid4(), LOOKUP_PERMISSIONS, db) is True
+
+
+def test_has_any_permission_returns_false_when_none_are_held():
+    """A user holding an unrelated permission is denied."""
+    db = _db_granting(PermissionRef.CAN_MANAGE_SITE_BANNER)
+
+    assert has_any_permission(uuid4(), LOOKUP_PERMISSIONS, db) is False
+
+
+def test_has_any_permission_denies_on_an_empty_permission_list():
+    """An empty list must grant nothing, so a caller cannot accidentally allow everyone."""
+    db = _db_granting(PermissionRef.CAN_CREATE_PROJECTS)
+
+    assert has_any_permission(uuid4(), [], db) is False
+
+
+def test_has_any_permission_returns_false_when_db_raises():
+    """Fails closed on a DB error, matching has_permissions."""
+    db = MagicMock()
+    db.exec.side_effect = RuntimeError("db down")
+
+    assert has_any_permission(uuid4(), [PermissionRef.CAN_CREATE_PROJECTS], db) is False
+
+
+def test_and_or_helpers_disagree_on_a_partially_privileged_user():
+    """Guard the AND/OR trap: the two helpers must not be interchangeable.
+
+    ``has_permissions`` requires ALL of the listed permissions, so passing two when either would
+    do silently denies every user holding just one. ``has_any_permission`` is the OR check that
+    such a call site actually wants.
+    """
+    researcher = PermissionRef.CAN_CREATE_PROJECTS
+
+    assert has_permissions(uuid4(), LOOKUP_PERMISSIONS, _db_granting(researcher)) is False
+    assert has_any_permission(uuid4(), LOOKUP_PERMISSIONS, _db_granting(researcher)) is True

--- a/flip-api/tests/unit/project_services/test_get_project.py
+++ b/flip-api/tests/unit/project_services/test_get_project.py
@@ -129,7 +129,7 @@ def test_get_project_details_invalid_id(client, mock_db):
 
 
 def test_get_project_details_returns_users_as_objects(client, mock_db, mock_project):
-    """Test that users are returned as objects with id, email, and isDisabled fields."""
+    """Test that users are returned as objects with id, email, and isDisabled — and nothing more."""
     owner_user = CognitoUser(id=TEST_OWNER_ID, email="owner@example.com", is_disabled=False)
     access_user = CognitoUser(id=TEST_USER_ID, email="user@example.com", is_disabled=False)
 
@@ -164,6 +164,14 @@ def test_get_project_details_returns_users_as_objects(client, mock_db, mock_proj
         assert "email" in user
         assert "isDisabled" in user
         assert user["isDisabled"] is False
+        # A project co-member must not learn anyone's name or organisation — that is the
+        # disclosure FLIP#907 closed on `/users/{user_id}`, and this path is currently narrow only
+        # because it never calls `apply_user_profile` (see the comment on IReturnedProject.users).
+        # The keys are still on the wire because CognitoUser defaults them to "", so assert they
+        # are empty rather than absent; enriching this path would populate them and fail here.
+        # FLIP#996 tracks making the response model enforce it instead.
+        assert user.get("name", "") == ""
+        assert user.get("organisation", "") == ""
 
 
 def test_get_project_details_filters_disabled_users(client, mock_db, mock_project):

--- a/flip-api/tests/unit/user_services/test_get_user.py
+++ b/flip-api/tests/unit/user_services/test_get_user.py
@@ -21,9 +21,11 @@ from flip_api.auth.dependencies import verify_token
 from flip_api.db.database import get_session
 from flip_api.domain.schemas.users import CognitoUser
 from flip_api.main import app
-from flip_api.user_services.get_user import get_user
 
 client = TestClient(app)
+
+MODULE = "flip_api.user_services.get_user"
+USER_POOL_ID = "test-user-pool"
 
 
 # ---------------------
@@ -31,36 +33,36 @@ client = TestClient(app)
 # ---------------------
 
 
+@pytest.fixture
+def caller_id():
+    """The authenticated caller's Cognito ``sub``."""
+    return uuid4()
+
+
 @pytest.fixture(autouse=True)
-def override_deps():
-    """Override auth dependency for all tests using TestClient."""
-    app.dependency_overrides[verify_token] = lambda: uuid4()
+def override_deps(caller_id):
+    """Override auth and DB dependencies for all tests using TestClient."""
+    app.dependency_overrides[verify_token] = lambda: caller_id
     app.dependency_overrides[get_session] = lambda: None
     yield
     app.dependency_overrides.clear()
 
 
+@pytest.fixture
+def profiled_user():
+    """A Cognito user carrying the DB-backed profile fields that must not leak from /lookup."""
+    return CognitoUser(
+        id=uuid4(),
+        email="test.user@example.com",
+        name="Dr Test User",
+        organisation="King's College London",
+        is_disabled=False,
+    )
+
+
 # ---------------------
-# TestClient tests (exercises full response serialization)
+# GET /users/{user_id} — serialization
 # ---------------------
-
-
-def test_get_user_by_email_response_serialization():
-    """Test that the endpoint correctly serializes a CognitoUser response with aliased fields."""
-    cognito_user = CognitoUser(id=uuid4(), email="test@example.com", is_disabled=False)
-
-    with (
-        patch("flip_api.user_services.get_user.get_user_pool_id", return_value="test-pool"),
-        patch("flip_api.user_services.get_user.get_user_by_email_or_id", return_value=cognito_user),
-    ):
-        response = client.get(f"/api/users/{cognito_user.email}")
-
-    assert response.status_code == status.HTTP_200_OK
-    data = response.json()
-    assert data["id"] == str(cognito_user.id)
-    assert data["email"] == cognito_user.email
-    assert data["isDisabled"] is False
-    assert "is_disabled" not in data
 
 
 def test_get_user_by_uuid_response_serialization():
@@ -69,8 +71,9 @@ def test_get_user_by_uuid_response_serialization():
     cognito_user = CognitoUser(id=user_uuid, email="test@example.com", is_disabled=True)
 
     with (
-        patch("flip_api.user_services.get_user.get_user_pool_id", return_value="test-pool"),
-        patch("flip_api.user_services.get_user.get_user_by_email_or_id", return_value=cognito_user),
+        patch(f"{MODULE}.has_permissions", return_value=True),
+        patch(f"{MODULE}.get_user_pool_id", return_value=USER_POOL_ID),
+        patch(f"{MODULE}.get_user_by_email_or_id", return_value=cognito_user),
     ):
         response = client.get(f"/api/users/{user_uuid}")
 
@@ -81,98 +84,353 @@ def test_get_user_by_uuid_response_serialization():
 
 
 # ---------------------
-# Direct function call tests
+# GET /users/{user_id} — lookup behaviour for an authorised caller
 # ---------------------
 
 
-def test_get_user_by_email(mock_request, user_email, user_data):
-    """Test successfully retrieving a user by email."""
-    with (
-        patch("flip_api.user_services.get_user.get_user_pool_id") as mock_get_user_pool_id,
-        patch("flip_api.user_services.get_user.get_user_by_email_or_id") as mock_get_user,
-        patch("flip_api.user_services.get_user.GetUserByEmail", side_effect=lambda **kwargs: None),
-    ):
-        # Set up mocks
-        user_pool_id = "test-user-pool"
-        mock_get_user_pool_id.return_value = user_pool_id
-        mock_get_user.return_value = user_data
-
-        # Execute
-        result = get_user(user_email, mock_request)
-
-        # Assert
-        assert result == user_data
-        mock_get_user_pool_id.assert_called_once_with(mock_request)
-        mock_get_user.assert_called_once_with(user_pool_id, email=user_email)
-
-
-def test_get_user_by_uuid(mock_request, user_id, user_data):
+def test_get_user_by_uuid(user_id, user_data):
     """Test successfully retrieving a user by UUID."""
     with (
-        patch("flip_api.user_services.get_user.get_user_pool_id") as mock_get_user_pool_id,
-        patch("flip_api.user_services.get_user.get_user_by_email_or_id") as mock_get_user,
-        patch("flip_api.user_services.get_user.GetUserById", side_effect=lambda **kwargs: None),
+        patch(f"{MODULE}.has_permissions", return_value=True),
+        patch(f"{MODULE}.get_user_pool_id", return_value=USER_POOL_ID) as mock_get_user_pool_id,
+        patch(f"{MODULE}.get_user_by_email_or_id", return_value=user_data) as mock_get_user,
     ):
-        # Set up mocks
-        user_pool_id = "test-user-pool"
-        mock_get_user_pool_id.return_value = user_pool_id
-        mock_get_user.return_value = user_data
+        response = client.get(f"/api/users/{user_id}")
 
-        # Execute
-        result = get_user(user_id, mock_request)
-
-        # Assert
-        assert result == user_data
-        mock_get_user_pool_id.assert_called_once_with(mock_request)
-        mock_get_user.assert_called_once_with(user_pool_id, user_id=UUID(user_id))
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json()["id"] == str(user_data.id)
+    mock_get_user_pool_id.assert_called_once()
+    mock_get_user.assert_called_once_with(USER_POOL_ID, user_id=UUID(user_id))
 
 
-def test_invalid_user_id_format(mock_request):
-    """Test with an invalid ID format (neither email nor UUID)."""
-    invalid_id = "not-an-email-or-uuid"
+@pytest.mark.parametrize("bad_id", ["not-an-email-or-uuid", "someone@example.com"])
+def test_non_uuid_user_id_is_rejected_by_parameter_validation(bad_id):
+    """A non-UUID segment fails parameter validation with a message naming the problem.
 
-    # Execute and assert
-    with pytest.raises(HTTPException) as exc_info:
-        get_user(invalid_id, mock_request)
+    `user_id` is typed as a UUID, so FastAPI rejects anything else before the handler runs — the
+    same 422 every sibling route under /users produces. The email form this endpoint used to
+    accept falls into that bucket now that the member lookup lives at /users/lookup (FLIP#907).
 
-    assert exc_info.value.status_code == status.HTTP_400_BAD_REQUEST
-    assert "Invalid user ID format" in exc_info.value.detail
+    422 rather than a router-level 404 is deliberate: it tells the caller *why* the id was
+    rejected, and it discloses nothing, since the shape of an id is independent of whether any
+    account exists.
+    """
+    with patch(f"{MODULE}.has_permissions", return_value=True) as mock_has_permissions:
+        response = client.get(f"/api/users/{bad_id}")
+
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    assert "valid UUID" in response.text
+    mock_has_permissions.assert_not_called()
 
 
-def test_user_not_found(mock_request, user_id):
-    """Test when user is not found in Cognito."""
+def test_user_not_found(user_id):
+    """Test when user is not found in Cognito.
+
+    ``get_user_by_email_or_id`` raises the 404 itself and is annotated non-Optional, so this
+    asserts the propagated error rather than a falsy-return branch the helper cannot produce.
+    """
+    not_found = HTTPException(
+        status_code=status.HTTP_404_NOT_FOUND,
+        detail=f"User with email: None or ID: {user_id} is not registered.",
+    )
+
     with (
-        patch("flip_api.user_services.get_user.get_user_pool_id") as mock_get_user_pool_id,
-        patch("flip_api.user_services.get_user.get_user_by_email_or_id") as mock_get_user,
-        patch("flip_api.user_services.get_user.GetUserById", side_effect=lambda **kwargs: None),
+        patch(f"{MODULE}.has_permissions", return_value=True),
+        patch(f"{MODULE}.get_user_pool_id", return_value=USER_POOL_ID),
+        patch(f"{MODULE}.get_user_by_email_or_id", side_effect=not_found),
     ):
-        # Set up mocks
-        user_pool_id = "test-user-pool"
-        mock_get_user_pool_id.return_value = user_pool_id
-        mock_get_user.return_value = None  # User not found
+        response = client.get(f"/api/users/{user_id}")
 
-        # Execute and assert
-        with pytest.raises(HTTPException) as exc_info:
-            get_user(user_id, mock_request)
-
-        assert exc_info.value.status_code == status.HTTP_404_NOT_FOUND
-        assert f"User '{user_id}' cannot be found" in exc_info.value.detail
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+    assert "is not registered" in response.json()["detail"]
 
 
-def test_internal_server_error(mock_request, user_id):
+def test_internal_server_error(user_id):
     """Test handling of internal server errors."""
     with (
-        patch("flip_api.user_services.get_user.get_user_pool_id") as mock_get_user_pool_id,
-        patch("flip_api.user_services.get_user.GetUserById", side_effect=lambda **kwargs: None),
-        patch("flip_api.user_services.get_user.logger") as mock_logger,
+        patch(f"{MODULE}.has_permissions", return_value=True),
+        patch(f"{MODULE}.get_user_pool_id", side_effect=Exception("Test exception")),
+        patch(f"{MODULE}.logger") as mock_logger,
     ):
-        # Set up mocks
-        mock_get_user_pool_id.side_effect = Exception("Test exception")
+        response = client.get(f"/api/users/{user_id}")
 
-        # Execute and assert
-        with pytest.raises(HTTPException) as exc_info:
-            get_user(user_id, mock_request)
+    assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+    assert "Internal server error" in response.json()["detail"]
+    mock_logger.error.assert_called_once()
 
-        assert exc_info.value.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
-        assert "Internal server error" in exc_info.value.detail
-        mock_logger.error.assert_called_once()
+
+# ---------------------
+# Route ordering
+# ---------------------
+
+
+@pytest.mark.parametrize("static_path", ["/api/users/me", "/api/users/lookup", "/api/users/access"])
+def test_static_user_routes_are_matched_before_the_catch_all(static_path):
+    """Every static segment under /api/users must be registered before GET /api/users/{user_id}.
+
+    `/{user_id}` matches any single segment — "me", "lookup" and "access" included. Starlette takes
+    the first match, so a static route registered after it is silently unreachable and answers as
+    the catch-all instead.
+
+    `/me` and `/lookup` are pinned by their declaration order within get_user.py, but
+    `/api/users/access` lives in access_request.py and depends on the ordering of the ROUTERS tuple
+    in main.py, which nothing else enforces. This covers both.
+    """
+
+    def first_get_index(path):
+        return next(
+            i
+            for i, route in enumerate(app.routes)
+            if getattr(route, "path", None) == path and "GET" in (getattr(route, "methods", None) or set())
+        )
+
+    assert first_get_index(static_path) < first_get_index("/api/users/{user_id}")
+
+
+def test_static_user_routes_resolve_to_their_own_handlers():
+    """Belt and braces: each static route actually answers, rather than falling into the catch-all.
+
+    The index assertion above would still pass if a static route were somehow shadowed by a route
+    registered even earlier, so confirm the responses are not the catch-all's.
+    """
+    with (
+        patch(f"{MODULE}.has_permissions", return_value=False),
+        patch(f"{MODULE}.has_any_permission", return_value=False),
+    ):
+        # The catch-all denies with 403; /lookup denies with its own 403 detail, and /me needs no
+        # permission at all — so neither can be answering as get_user.
+        assert client.get("/api/users/lookup", params={"email": "a@b.com"}).json()["detail"] == (
+            "User is not permitted to look up project members."
+        )
+        assert client.get(f"/api/users/{uuid4()}").status_code == status.HTTP_403_FORBIDDEN
+
+
+# ---------------------
+# GET /users/{user_id} — authorization (FLIP#907)
+# ---------------------
+
+
+class TestGetUserAuthorization:
+    """The route is administrative: CAN_MANAGE_USERS only, with no self escape hatch."""
+
+    def test_caller_without_permission_is_forbidden(self, user_id):
+        """A caller lacking CAN_MANAGE_USERS cannot read another user's profile."""
+        with (
+            patch(f"{MODULE}.has_permissions", return_value=False),
+            patch(f"{MODULE}.get_user_by_email_or_id") as mock_get_user,
+        ):
+            response = client.get(f"/api/users/{user_id}")
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        # The permission check must precede the lookup, or the 403-vs-404 split leaks whether the
+        # account exists.
+        mock_get_user.assert_not_called()
+
+    def test_denial_is_identical_for_a_user_that_does_not_exist(self, user_id):
+        """An unauthorised caller cannot tell a real account from an absent one."""
+        not_found = HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="is not registered.")
+
+        with (
+            patch(f"{MODULE}.has_permissions", return_value=False),
+            patch(f"{MODULE}.get_user_by_email_or_id", side_effect=not_found),
+        ):
+            response = client.get(f"/api/users/{user_id}")
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    def test_self_lookup_is_not_a_backdoor(self, caller_id):
+        """Reading your own record through this route is denied too — /users/me is the self path."""
+        with patch(f"{MODULE}.has_permissions", return_value=False):
+            response = client.get(f"/api/users/{caller_id}")
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+# ---------------------
+# GET /users/me (FLIP#907)
+# ---------------------
+
+
+class TestGetCurrentUser:
+    """Every authenticated user can read their own profile, and only their own."""
+
+    def test_returns_own_profile_without_any_permission(self, caller_id, profiled_user):
+        """The token is the authorization — no permission is required or consulted."""
+        with (
+            patch(f"{MODULE}.has_permissions", return_value=False) as mock_has_permissions,
+            patch(f"{MODULE}.has_any_permission", return_value=False) as mock_has_any,
+            patch(f"{MODULE}.get_user_pool_id", return_value=USER_POOL_ID),
+            patch(f"{MODULE}.get_user_by_email_or_id", return_value=profiled_user) as mock_get,
+        ):
+            response = client.get("/api/users/me")
+
+        assert response.status_code == status.HTTP_200_OK
+        mock_has_permissions.assert_not_called()
+        mock_has_any.assert_not_called()
+        # Resolved from the token's sub, never from a caller-supplied email.
+        mock_get.assert_called_once_with(USER_POOL_ID, user_id=caller_id)
+
+    def test_returns_full_profile_fields(self, profiled_user):
+        """The self route keeps the DB-backed profile fields the header display name needs."""
+        with (
+            patch(f"{MODULE}.get_user_pool_id", return_value=USER_POOL_ID),
+            patch(f"{MODULE}.get_user_by_email_or_id", return_value=profiled_user),
+            patch(f"{MODULE}.apply_user_profile", return_value=profiled_user) as mock_apply,
+        ):
+            response = client.get("/api/users/me")
+
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data["name"] == "Dr Test User"
+        assert data["organisation"] == "King's College London"
+        assert data["isDisabled"] is False
+        mock_apply.assert_called_once()
+
+    def test_404_when_token_subject_has_no_cognito_record(self):
+        """A valid token whose sub no longer resolves is a genuine 404."""
+        not_found = HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="is not registered.")
+
+        with (
+            patch(f"{MODULE}.get_user_pool_id", return_value=USER_POOL_ID),
+            patch(f"{MODULE}.get_user_by_email_or_id", side_effect=not_found),
+        ):
+            response = client.get("/api/users/me")
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_route_is_not_shadowed_by_the_catch_all(self, profiled_user):
+        """Regression: /users/me must not be matched as /users/{user_id}.
+
+        `/{user_id}` is a bare `str` param that would happily swallow "me" and reject it as an
+        invalid id format. This fails if the decorators in get_user.py are ever reordered.
+        """
+        with (
+            patch(f"{MODULE}.get_user_pool_id", return_value=USER_POOL_ID),
+            patch(f"{MODULE}.get_user_by_email_or_id", return_value=profiled_user),
+        ):
+            response = client.get("/api/users/me")
+
+        assert response.status_code == status.HTTP_200_OK
+        assert "Invalid user ID format" not in response.text
+
+
+# ---------------------
+# GET /users/lookup (FLIP#907)
+# ---------------------
+
+
+class TestLookupProjectMember:
+    """The narrow member lookup: enough to add a project member, and nothing more."""
+
+    def test_caller_without_permission_is_forbidden(self):
+        """A Viewer cannot use the lookup, and learns nothing about the address."""
+        with (
+            patch(f"{MODULE}.has_any_permission", return_value=False),
+            patch(f"{MODULE}.get_user_by_email_or_id") as mock_get_user,
+        ):
+            response = client.get("/api/users/lookup", params={"email": "someone@example.com"})
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        mock_get_user.assert_not_called()
+
+    def test_returns_only_the_narrow_record(self, profiled_user):
+        """The whole point of FLIP#907: name and organisation must never appear here."""
+        with (
+            patch(f"{MODULE}.has_any_permission", return_value=True),
+            patch(f"{MODULE}.get_user_pool_id", return_value=USER_POOL_ID),
+            patch(f"{MODULE}.get_user_by_email_or_id", return_value=profiled_user),
+        ):
+            response = client.get("/api/users/lookup", params={"email": profiled_user.email})
+
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert set(data) == {"id", "email", "isDisabled"}
+        assert data["id"] == str(profiled_user.id)
+        assert data["email"] == profiled_user.email
+
+    def test_does_not_apply_the_db_profile(self, profiled_user):
+        """apply_user_profile is the only source of name/organisation, so it must not be called."""
+        with (
+            patch(f"{MODULE}.has_any_permission", return_value=True),
+            patch(f"{MODULE}.get_user_pool_id", return_value=USER_POOL_ID),
+            patch(f"{MODULE}.get_user_by_email_or_id", return_value=profiled_user),
+            patch(f"{MODULE}.apply_user_profile") as mock_apply,
+        ):
+            response = client.get("/api/users/lookup", params={"email": profiled_user.email})
+
+        assert response.status_code == status.HTTP_200_OK
+        mock_apply.assert_not_called()
+
+    def test_reports_disabled_accounts(self, profiled_user):
+        """The UI rejects disabled accounts before submitting, so the flag has to come through."""
+        disabled = profiled_user.model_copy(update={"is_disabled": True})
+
+        with (
+            patch(f"{MODULE}.has_any_permission", return_value=True),
+            patch(f"{MODULE}.get_user_pool_id", return_value=USER_POOL_ID),
+            patch(f"{MODULE}.get_user_by_email_or_id", return_value=disabled),
+        ):
+            response = client.get("/api/users/lookup", params={"email": disabled.email})
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["isDisabled"] is True
+
+    def test_unknown_email_returns_a_generic_not_found(self):
+        """The 404 detail must not echo the queried address back to the caller."""
+        email = "nobody@example.com"
+        not_found = HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"User with email: {email} or ID: None is not registered.",
+        )
+
+        with (
+            patch(f"{MODULE}.has_any_permission", return_value=True),
+            patch(f"{MODULE}.get_user_pool_id", return_value=USER_POOL_ID),
+            patch(f"{MODULE}.get_user_by_email_or_id", side_effect=not_found),
+        ):
+            response = client.get("/api/users/lookup", params={"email": email})
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+        assert response.json()["detail"] == "User not found."
+        assert email not in response.text
+
+    def test_a_cognito_failure_is_not_reported_as_a_missing_user(self):
+        """Only the 404 gets rewritten — anything else propagates unchanged.
+
+        `get_user_by_email_or_id` raises a sanitised 500 when the Cognito `ListUsers` call fails.
+        Folding that into the "User not found." branch would report an outage as a missing account,
+        hiding the failure from the caller and from anyone reading the logs.
+        """
+        upstream = HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Internal server error while listing users",
+        )
+
+        with (
+            patch(f"{MODULE}.has_any_permission", return_value=True),
+            patch(f"{MODULE}.get_user_pool_id", return_value=USER_POOL_ID),
+            patch(f"{MODULE}.get_user_by_email_or_id", side_effect=upstream),
+        ):
+            response = client.get("/api/users/lookup", params={"email": "someone@example.com"})
+
+        assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+        assert response.json()["detail"] == "Internal server error while listing users"
+
+    def test_rejects_a_malformed_email(self):
+        """A non-email query value is a validation error, not a Cognito call."""
+        with patch(f"{MODULE}.has_any_permission", return_value=True):
+            response = client.get("/api/users/lookup", params={"email": "not-an-email"})
+
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+    def test_requires_the_email_parameter(self):
+        """Regression: /users/lookup must not be matched as /users/{user_id}.
+
+        A missing `email` is a 422 from query validation. If the catch-all won the match instead,
+        "lookup" would be rejected as an invalid id format (400) or denied outright (403).
+        """
+        with patch(f"{MODULE}.has_any_permission", return_value=True):
+            response = client.get("/api/users/lookup")
+
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+        assert "Invalid user ID format" not in response.text

--- a/flip-ui/mocks/server.ts
+++ b/flip-ui/mocks/server.ts
@@ -252,14 +252,25 @@ export const makeServer = ({ environment = "development" } = {}): Server<AppRegi
                 return new Response(200, undefined, allRoles);
             });
 
-            this.get(baseUrl + "/users/:email", (schema: AppSchema, request) => {
-                const user = schema.db.users.findBy({ email: request.params.email });
+            // Static segments must be registered before any /users/:param route so they are not
+            // swallowed by it — the same ordering constraint the hub enforces (FLIP#907).
+            this.get(baseUrl + "/users/me", (schema: AppSchema) => {
+                const user = schema.db.users.findBy({ email: "mr.admin@example.com" });
+
+                return new Response(200, undefined, user);
+            });
+
+            this.get(baseUrl + "/users/lookup", (schema: AppSchema, request) => {
+                const user = schema.db.users.findBy({ email: request.queryParams.email as string });
 
                 if (!user) {
                     return new Response(404);
                 }
 
-                return new Response(200, undefined, user);
+                // Mirror the hub: name and organisation are withheld from this route.
+                const { id, email, isDisabled } = user;
+
+                return new Response(200, undefined, { id, email, isDisabled });
             });
 
             // #endregion

--- a/flip-ui/src/layouts/MainLayout.vue
+++ b/flip-ui/src/layouts/MainLayout.vue
@@ -91,8 +91,16 @@ const headerTitle = ref(route.name?.toString() ?? "");
 const pageRoute = ref(route.fullPath?.toString() ?? "");
 const emailAddress = authStore.user?.attributes?.email ?? "";
 
+// The cache key is scoped to the caller's Cognito `sub`, not left as a constant "/users/me".
+// swrv's cache is module-level and never expires (ttl defaults to 0); sign-out is an SPA
+// route change that leaves it intact. A constant key would therefore hand the next account
+// signing in to the same tab the previous user's profile, and `dedupingInterval` would
+// suppress the refetch that should correct it. The key never reaches the network — swrv passes
+// it to the fetcher, but `getCurrentUser` declares no parameter and resolves the caller from the
+// token — so this keeps the "no address in the URL" property the endpoint split exists for
+// (FLIP#907).
 const { data: currentUserProfile } = useSWRV(
-    () => emailAddress && "/users/me",
+    () => authStore.user?.userId && `/users/me#${authStore.user.userId}`,
     getCurrentUser,
     {
         dedupingInterval: 60_000,

--- a/flip-ui/src/layouts/MainLayout.vue
+++ b/flip-ui/src/layouts/MainLayout.vue
@@ -69,7 +69,7 @@ import { usePermissions } from "@/composables/usePermissions";
 import DeploymentMode from "@/pages/DeploymentMode.vue";
 import CreateModelModal from "@/partials/models/CreateModelModal.vue";
 import { getProject, IProject } from "@/services/project-service";
-import { validateUser } from "@/services/user-service";
+import { getCurrentUser } from "@/services/user-service";
 import { useAuthStore } from "@/store/auth";
 import { useErrorStore } from "@/store/error";
 import { useModalsStore } from "@/store/modals";
@@ -92,8 +92,8 @@ const pageRoute = ref(route.fullPath?.toString() ?? "");
 const emailAddress = authStore.user?.attributes?.email ?? "";
 
 const { data: currentUserProfile } = useSWRV(
-    () => emailAddress && `/users/${emailAddress}`,
-    () => validateUser(emailAddress),
+    () => emailAddress && "/users/me",
+    getCurrentUser,
     {
         dedupingInterval: 60_000,
         revalidateOnFocus: false,

--- a/flip-ui/src/layouts/__tests__/MainLayout.spec.ts
+++ b/flip-ui/src/layouts/__tests__/MainLayout.spec.ts
@@ -86,6 +86,7 @@ vi.mock("@/utils/snackbar", () => ({
 function mountMainLayout(options: {
     permissions?: string[];
     email?: string;
+    userId?: string;
     bannerEnabled?: boolean;
     bannerMessage?: string;
     deploymentMode?: boolean;
@@ -97,6 +98,7 @@ function mountMainLayout(options: {
     const {
         permissions = [],
         email = "test@example.com",
+        userId = "1",
         bannerEnabled,
         bannerMessage = "Test banner",
         deploymentMode = false,
@@ -129,9 +131,9 @@ function mountMainLayout(options: {
                         auth: {
                             user: {
                                 username: "testuser",
-                                userId: "1",
+                                userId,
                                 attributes: {
-                                    sub: "1",
+                                    sub: userId,
                                     email
                                 },
                                 permissions
@@ -193,10 +195,33 @@ describe("MainLayout", () => {
 
             mountMainLayout();
 
-            expect(swrvKeys).toContain("/users/me");
+            expect(swrvKeys.some(key => typeof key === "string" && key.startsWith("/users/me"))).toBe(true);
             // The header used to resolve the caller by putting their email in the path. That
             // route is now admin-only, and addresses do not belong in URLs anyway (FLIP#907).
             expect(swrvKeys.some(key => typeof key === "string" && /^\/users\/.+@/.test(key))).toBe(false);
+        });
+
+        it("scopes the cache key to the signed-in user", () => {
+            // swrv's cache is module-level and survives sign-out (an SPA route change), so a
+            // constant key would serve the previous account's profile to the next user in the
+            // same tab — and `dedupingInterval` would suppress the correcting refetch.
+            swrvKeys.length = 0;
+
+            mountMainLayout({ userId: "user-a" });
+            mountMainLayout({ userId: "user-b" });
+
+            const selfKeys = swrvKeys.filter(key => typeof key === "string" && key.startsWith("/users/me"));
+
+            expect(selfKeys).toHaveLength(2);
+            expect(new Set(selfKeys).size).toBe(2);
+        });
+
+        it("does not subscribe before the signed-in user is known", () => {
+            swrvKeys.length = 0;
+
+            mountMainLayout({ userId: "" });
+
+            expect(swrvKeys.some(key => typeof key === "string" && key.startsWith("/users/me"))).toBe(false);
         });
     });
 

--- a/flip-ui/src/layouts/__tests__/MainLayout.spec.ts
+++ b/flip-ui/src/layouts/__tests__/MainLayout.spec.ts
@@ -51,11 +51,14 @@ vi.mock("@/router", () => ({
     default: { push: vi.fn() }
 }));
 
+// Records every key swrv is given, so tests can assert which endpoints the layout subscribes to.
+const { swrvKeys } = vi.hoisted(() => ({ swrvKeys: [] as unknown[] }));
+
 vi.mock("swrv", () => ({
     // Invoke the key function like real swrv does, so the page's key builders
-    // (e.g. the `/users/${email}` lookup) are exercised rather than skipped.
+    // (e.g. the `/users/me` self lookup) are exercised rather than skipped.
     default: (keyFn?: unknown) => {
-        if (typeof keyFn === "function") keyFn();
+        if (typeof keyFn === "function") swrvKeys.push(keyFn());
 
         return {
             data: ref(null),
@@ -181,6 +184,19 @@ describe("MainLayout", () => {
             const wrapper = mountMainLayout();
 
             expect(wrapper.exists()).toBe(true);
+        });
+    });
+
+    describe("current user profile", () => {
+        it("subscribes to /users/me rather than a by-email lookup", () => {
+            swrvKeys.length = 0;
+
+            mountMainLayout();
+
+            expect(swrvKeys).toContain("/users/me");
+            // The header used to resolve the caller by putting their email in the path. That
+            // route is now admin-only, and addresses do not belong in URLs anyway (FLIP#907).
+            expect(swrvKeys.some(key => typeof key === "string" && /^\/users\/.+@/.test(key))).toBe(false);
         });
     });
 

--- a/flip-ui/src/partials/projects/CreateProjectModal.vue
+++ b/flip-ui/src/partials/projects/CreateProjectModal.vue
@@ -151,7 +151,7 @@ import AiSwitch from "@/components/AiSwitch/AiSwitch.vue";
 import AiTextArea from "@/components/AiTextArea/AiTextArea.vue";
 import { routeChange } from "@/router";
 import { createProject, IProjectCreate } from "@/services/project-service";
-import { IProjectUser } from "@/services/user-service";
+import { IProjectUserLookup } from "@/services/user-service";
 import { useModalsStore } from "@/store/modals";
 import { projectSchema } from "@/utils/forms/validation";
 import { Snackbar } from "@/utils/snackbar";
@@ -168,9 +168,9 @@ const modalStore = useModalsStore();
 const schema = projectSchema;
 
 const formSubmitting = ref(false);
-let users: IProjectUser[] = [];
+let users: IProjectUserLookup[] = [];
 
-const handleUsers = (updatedUsers: IProjectUser[]) => {
+const handleUsers = (updatedUsers: IProjectUserLookup[]) => {
     users = updatedUsers;
 };
 

--- a/flip-ui/src/partials/projects/EditProjectDrawer.vue
+++ b/flip-ui/src/partials/projects/EditProjectDrawer.vue
@@ -212,6 +212,7 @@ import AiConfirmModal from "@/components/AiModal/AiConfirmModal.vue";
 import AiSwitch from "@/components/AiSwitch/AiSwitch.vue";
 import router from "@/router";
 import { deleteProject, IProjectUser } from "@/services/project-service";
+import { IProjectUserLookup } from "@/services/user-service";
 import { useAuthStore } from "@/store/auth";
 import { useErrorStore } from "@/store/error";
 import { projectSchema } from "@/utils/forms/validation";
@@ -272,7 +273,7 @@ const updateProject = (values: unknown) => {
     });
 };
 
-const handleUpdatedUsers = (latestUsers: IProjectUser[]) => {
+const handleUpdatedUsers = (latestUsers: IProjectUserLookup[]) => {
     userList = latestUsers.map(u => u.id);
 };
 

--- a/flip-ui/src/partials/projects/ProjectUsers.vue
+++ b/flip-ui/src/partials/projects/ProjectUsers.vue
@@ -115,12 +115,15 @@ import { object } from "yup";
 import AiAlert from "@/components/AiAlert/AiAlert.vue";
 import AiButton from "@/components/AiButton/AiButton.vue";
 import AiInput from "@/components/AiInput/AiInput.vue";
-import { IProjectUser, validateUser } from "@/services/user-service";
+import { IProjectUserLookup, lookupProjectUser } from "@/services/user-service";
 import { useAuthStore } from "@/store/auth";
 import { emailValidation } from "@/utils/forms/validation";
 
 export interface IProjectUsersProps {
-    users?: IProjectUser[];
+    // Only the narrow shape is needed here — this component reads id / email / isDisabled and
+    // nothing else. Existing members (IProjectUser) are assignable to it, and newly looked-up
+    // ones only ever carry these three fields (FLIP#907).
+    users?: IProjectUserLookup[];
     readonly?: boolean;
 }
 
@@ -141,7 +144,10 @@ const currentUserId = authStore.user?.userId;
 
 const formSubmit = ref<boolean>(false);
 let enteredEmail: string;
-const userList = ref<IProjectUser[]>(props.users);
+// Copy rather than alias `props.users`: the list is mutated in place on add/remove, and newly
+// looked-up members are the narrower IProjectUserLookup shape, so writing them straight back into
+// the parent's IProjectUser[] would be unsound as well as a prop mutation.
+const userList = ref<IProjectUserLookup[]>([...props.users]);
 const displayUsers = computed(() => userList.value.filter(u => u.id !== currentUserId));
 const invalidUser = ref<string[]>([]);
 const userIsDirty = ref(false);
@@ -162,7 +168,7 @@ const submit = async(v: unknown, { resetForm }: {resetForm: () => void} ): Promi
             return handleError(`${email} has already been added to the list`);
         }
 
-        const user = await validateUser(email);
+        const user = await lookupProjectUser(email);
 
         if (user) {
             if (user.isDisabled) {

--- a/flip-ui/src/partials/projects/__tests__/ProjectUsers.spec.ts
+++ b/flip-ui/src/partials/projects/__tests__/ProjectUsers.spec.ts
@@ -12,12 +12,14 @@
  */
 
 import { createTestingPinia } from "@pinia/testing";
-import { mount } from "@vue/test-utils";
-import { describe, expect, test, vi } from "vitest";
+import { flushPromises, mount } from "@vue/test-utils";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+import { lookupProjectUser } from "@/services/user-service";
 
 import ProjectUsers from "../ProjectUsers.vue";
 
-vi.mock("@/services/user-service", () => ({ validateUser: vi.fn() }));
+vi.mock("@/services/user-service", () => ({ lookupProjectUser: vi.fn() }));
 
 function mountProjectUsers(props: Record<string, unknown> = {}) {
     // Cast: the component declares `users` as required, but the whole
@@ -46,10 +48,20 @@ function mountProjectUsers(props: Record<string, unknown> = {}) {
             ],
             directives: { tippy: () => {} },
             stubs: {
-                AiAlert: { template: "<div><slot /></div>" },
+                // Renders `text` so the add-user error messages are assertable.
+                AiAlert: {
+                    props: ["text"],
+                    template: "<div>{{ text }}<slot /></div>"
+                },
                 AiButton: { template: "<button><slot /></button>" },
                 AiInput: { template: "<input />" },
-                Form: { template: "<form><slot /></form>" }
+                // Declares the submit event so tests can drive the real handler without
+                // standing up vee-validate.
+                Form: {
+                    name: "Form",
+                    emits: ["submit"],
+                    template: "<form><slot /></form>"
+                }
             }
         }
     });
@@ -104,5 +116,82 @@ describe("ProjectUsers — defensive prop default", () => {
         });
         expect(wrapper.text()).not.toContain("self@e.com");
         expect(wrapper.text()).toContain("bob@e.com");
+    });
+});
+
+describe("ProjectUsers — add-user submit path", () => {
+    beforeEach(() => {
+        vi.mocked(lookupProjectUser).mockReset();
+    });
+
+    // Drives the component's real submit handler. vee-validate's Form is stubbed, so the submit
+    // event is emitted directly with the (values, actions) pair the real Form would supply.
+    async function submitEmail(wrapper: ReturnType<typeof mountProjectUsers>, email: string) {
+        const resetForm = vi.fn();
+
+        wrapper.findComponent({ name: "Form" }).vm.$emit("submit", { email }, { resetForm });
+        await flushPromises();
+
+        return resetForm;
+    }
+
+    const errorText = (wrapper: ReturnType<typeof mountProjectUsers>) =>
+        wrapper.find("[data-test=\"invalid-user-project-list\"]").text();
+
+    test("adds the resolved user and emits the updated list", async () => {
+        const resolved = {
+            id: "u9",
+            email: "new@e.com",
+            isDisabled: false
+        };
+        vi.mocked(lookupProjectUser).mockResolvedValue(resolved);
+        const wrapper = mountProjectUsers({ users: [] });
+
+        const resetForm = await submitEmail(wrapper, "new@e.com");
+
+        expect(lookupProjectUser).toHaveBeenCalledWith("new@e.com");
+        expect(wrapper.text()).toContain("new@e.com");
+        expect(wrapper.emitted("updatedUsers")?.at(-1)?.[0]).toEqual([resolved]);
+        expect(resetForm).toHaveBeenCalled();
+    });
+
+    test("rejects a disabled account without adding it", async () => {
+        vi.mocked(lookupProjectUser).mockResolvedValue({
+            id: "u9",
+            email: "off@e.com",
+            isDisabled: true
+        });
+        const wrapper = mountProjectUsers({ users: [] });
+
+        await submitEmail(wrapper, "off@e.com");
+
+        expect(errorText(wrapper)).toContain("off@e.com is disabled");
+        expect(wrapper.emitted("updatedUsers")).toBeUndefined();
+    });
+
+    test("reports an unknown address as not found", async () => {
+        // The hub answers an unregistered address with 404 (FLIP#907).
+        vi.mocked(lookupProjectUser).mockRejectedValue({ response: { status: 404 } });
+        const wrapper = mountProjectUsers({ users: [] });
+
+        await submitEmail(wrapper, "ghost@e.com");
+
+        expect(errorText(wrapper)).toContain("ghost@e.com cannot be found");
+        expect(wrapper.emitted("updatedUsers")).toBeUndefined();
+    });
+
+    test("does not call the hub for an address already in the list", async () => {
+        const wrapper = mountProjectUsers({
+            users: [{
+                id: "u1",
+                email: "alice@e.com",
+                isDisabled: false
+            }]
+        });
+
+        await submitEmail(wrapper, "alice@e.com");
+
+        expect(lookupProjectUser).not.toHaveBeenCalled();
+        expect(errorText(wrapper)).toContain("alice@e.com has already been added");
     });
 });

--- a/flip-ui/src/services/__tests__/user-service.spec.ts
+++ b/flip-ui/src/services/__tests__/user-service.spec.ts
@@ -13,9 +13,11 @@
 
 import { _http } from "@/services/api";
 import { getAccessRequests,
+    getCurrentUser,
     getMfaStatus,
     getUserPermissions,
     getUsers,
+    lookupProjectUser,
     registerUser,
     resetUserMfa,
     revokeToken,
@@ -23,8 +25,7 @@ import { getAccessRequests,
     updateAccessRequestStatus,
     updateUserDisabledState,
     updateUserProfile,
-    updateUserRoles,
-    validateUser } from "@/services/user-service";
+    updateUserRoles } from "@/services/user-service";
 import { Snackbar } from "@/utils/snackbar";
 
 // Stub the low-level axios wrapper so each test can assert the URL + payload
@@ -244,8 +245,8 @@ describe("user-service", () => {
         });
     });
 
-    describe("validateUser", () => {
-        it("GETs /users/{email} and returns the resolved user", async () => {
+    describe("getCurrentUser", () => {
+        it("GETs /users/me and returns the caller's own profile", async () => {
             const user = {
                 id: "u-1",
                 email: "x@example.test",
@@ -255,10 +256,36 @@ describe("user-service", () => {
             };
             vi.mocked(_http.get).mockResolvedValue({ data: user } as never);
 
-            const result = await validateUser("x@example.test");
+            const result = await getCurrentUser();
 
-            expect(_http.get).toHaveBeenCalledWith("/users/x@example.test");
+            expect(_http.get).toHaveBeenCalledWith("/users/me");
             expect(result).toEqual(user);
+        });
+    });
+
+    describe("lookupProjectUser", () => {
+        it("GETs /users/lookup with the email as a query parameter", async () => {
+            const user = {
+                id: "u-1",
+                email: "x@example.test",
+                isDisabled: false
+            };
+            vi.mocked(_http.get).mockResolvedValue({ data: user } as never);
+
+            const result = await lookupProjectUser("x@example.test");
+
+            expect(_http.get).toHaveBeenCalledWith("/users/lookup?email=x%40example.test");
+            expect(result).toEqual(user);
+        });
+
+        it("percent-encodes addresses containing a plus", async () => {
+            // A bare `+` in a query string decodes server-side as a space, which would turn
+            // "a+tag@example.test" into an address that no longer resolves.
+            vi.mocked(_http.get).mockResolvedValue({ data: {} } as never);
+
+            await lookupProjectUser("a+tag@example.test");
+
+            expect(_http.get).toHaveBeenCalledWith("/users/lookup?email=a%2Btag%40example.test");
         });
     });
 

--- a/flip-ui/src/services/user-service.ts
+++ b/flip-ui/src/services/user-service.ts
@@ -56,6 +56,18 @@ export interface IProjectUser {
     isDisabled: boolean;
 }
 
+/**
+ * What `GET /users/lookup` returns when resolving an email to a prospective project member.
+ *
+ * Deliberately narrower than IProjectUser: the hub withholds `name` and `organisation` from
+ * everyone who lacks CAN_MANAGE_USERS, so the add-member flow never sees them (FLIP#907).
+ */
+export interface IProjectUserLookup {
+    id: string;
+    email: string;
+    isDisabled: boolean;
+}
+
 export interface IAccessRequest {
     email: string;
     fullName: string;
@@ -133,8 +145,14 @@ export async function updateUserProfile(userId: string, profile: IUserProfileDto
     return response.data;
 }
 
-export async function validateUser(email: string): Promise<IProjectUser> {
-    const response = await _http.get<IProjectUser>(`/users/${email}`);
+export async function getCurrentUser(): Promise<IProjectUser> {
+    const response = await _http.get<IProjectUser>("/users/me");
+
+    return response.data;
+}
+
+export async function lookupProjectUser(email: string): Promise<IProjectUserLookup> {
+    const response = await _http.get<IProjectUserLookup>(`/users/lookup?email=${encodeURIComponent(email)}`);
 
     return response.data;
 }

--- a/flip-ui/test/cypress/fixtures/user/getCurrentUser.json
+++ b/flip-ui/test/cypress/fixtures/user/getCurrentUser.json
@@ -1,0 +1,7 @@
+{
+    "id": "5c052df5-4886-450a-9c0c-649c5f8c4fc6",
+    "email": "mr.admin@example.com",
+    "name": "",
+    "organisation": "",
+    "isDisabled": false
+}

--- a/flip-ui/test/cypress/integration/group-1/project/view_project.spec.ts
+++ b/flip-ui/test/cypress/integration/group-1/project/view_project.spec.ts
@@ -40,7 +40,13 @@ describe("Project Page: Researcher & Owner [UNAPPROVED]", () => {
         }
         ).as("getProject");
 
-        cy.intercept("GET", "/users/validUser@gmail.com", { statusCode: 200 }).as("validUser");
+        cy.intercept(
+
+            { method: "GET", pathname: "/users/lookup", query: { email: "validUser@gmail.com" } },
+
+            { statusCode: 200 }
+
+        ).as("validUser");
 
         cy.intercept("PUT", `projects/${validProject.id}`, { statusCode: 200 }).as("updateProject");
         cy.intercept("DELETE", `projects/${validProject.id}`, {
@@ -197,7 +203,13 @@ describe("Editing Project", () => {
         }
         ).as("getProject");
 
-        cy.intercept("GET", "users/validUser@gmail.com", { statusCode: 200 }).as("validUser");
+        cy.intercept(
+
+            { method: "GET", pathname: "/users/lookup", query: { email: "validUser@gmail.com" } },
+
+            { statusCode: 200 }
+
+        ).as("validUser");
         cy.intercept("PUT", `projects/${validProject.id}`, { statusCode: 200 }).as("updateProject");
 
         cy.visit("/project/" + validProject.id);
@@ -213,7 +225,16 @@ describe("Editing Project", () => {
         cy.getBySel("add-user-project-btn").click();
 
 
-        cy.intercept("GET", "/users/invalidUser@gmail.com", { statusCode: 404 }).as("invalidUser");
+        cy.intercept(
+
+
+            { method: "GET", pathname: "/users/lookup", query: { email: "invalidUser@gmail.com" } },
+
+
+            { statusCode: 404 }
+
+
+        ).as("invalidUser");
         cy.getBySel("add-user-project-input").clear().type("invalidUser@gmail.com");
         cy.getBySel("add-user-project-btn").click();
         cy.wait("@invalidUser");

--- a/flip-ui/test/cypress/integration/group-3/project/create_project.spec.ts
+++ b/flip-ui/test/cypress/integration/group-3/project/create_project.spec.ts
@@ -89,7 +89,7 @@ describe("create project", () => {
     });
 
     it("successfully validates the email when adding a user", () => {
-        cy.intercept("GET", `/users/${validUsers[0].email}`, {
+        cy.intercept({ method: "GET", pathname: "/users/lookup", query: { email: validUsers[0].email } }, {
             statusCode: 200,
             body: {
                 "id": "12345",
@@ -107,7 +107,7 @@ describe("create project", () => {
     });
 
     it("does not add a disabled user to the project", () => {
-        cy.intercept("GET", `/users/${validUsers[0].email}`, {
+        cy.intercept({ method: "GET", pathname: "/users/lookup", query: { email: validUsers[0].email } }, {
             statusCode: 200,
             body: {
                 "id": "12345",
@@ -150,7 +150,13 @@ describe("create project", () => {
             body: { "id": validProject.id }
         }).as("createProject");
 
-        cy.intercept("GET", `/users/${validUsers[0].email}`, { statusCode: 404 }).as("validateUser");
+        cy.intercept(
+
+            { method: "GET", pathname: "/users/lookup", query: { email: validUsers[0].email } },
+
+            { statusCode: 404 }
+
+        ).as("validateUser");
 
         cy.getBySel("project-name").type("Test Project Name");
         cy.getBySel("project-description").type("Test Project Description");
@@ -181,7 +187,7 @@ describe("create project", () => {
             body: { "id": validProject.id }
         }).as("createProject");
 
-        cy.intercept("GET", `/users/${validUsers[0].email}`, {
+        cy.intercept({ method: "GET", pathname: "/users/lookup", query: { email: validUsers[0].email } }, {
             statusCode: 200,
             body: {
                 "id": "ad1fbfc0-e6dc-40e1-9a6c-0019cf490fa3",
@@ -227,7 +233,7 @@ describe("create project", () => {
         cy.getBySel("project-name").type("Test Project Name");
         cy.getBySel("project-description").type("Test Project Description");
 
-        cy.intercept("GET", `/users/${validUsers[0].email}`, {
+        cy.intercept({ method: "GET", pathname: "/users/lookup", query: { email: validUsers[0].email } }, {
             statusCode: 200,
             body: {
                 "id": "ad1fbfc0-e6dc-40e1-9a6c-0019cf490fa3",
@@ -242,7 +248,7 @@ describe("create project", () => {
 
         cy.getBySel("added-user-0").contains(validUsers[0].email).should("be.visible");
 
-        cy.intercept("GET", `/users/${validUsers[1].email}`, {
+        cy.intercept({ method: "GET", pathname: "/users/lookup", query: { email: validUsers[1].email } }, {
             statusCode: 200,
             body: {
                 "id": "2635f591-1430-4d20-86e2-c0ee88c0a0c5",
@@ -257,7 +263,7 @@ describe("create project", () => {
 
         cy.getBySel("added-user-1").contains(validUsers[1].email).should("be.visible");
 
-        cy.intercept("GET", `/users/${validUsers[2].email}`, {
+        cy.intercept({ method: "GET", pathname: "/users/lookup", query: { email: validUsers[2].email } }, {
             statusCode: 200,
             body: {
                 "id": "9057b483-d483-47a1-af3b-72ca23893caa",
@@ -300,7 +306,7 @@ describe("create project", () => {
         cy.getBySel("project-name").type("Test Project Name");
         cy.getBySel("project-description").type("Test Project Description");
 
-        cy.intercept("GET", `/users/${validUsers[0].email}`, {
+        cy.intercept({ method: "GET", pathname: "/users/lookup", query: { email: validUsers[0].email } }, {
             statusCode: 200,
             body: {
                 "id": "ad1fbfc0-e6dc-40e1-9a6c-0019cf490fa3",
@@ -316,7 +322,7 @@ describe("create project", () => {
 
         cy.getBySel("added-user-0").contains(validUsers[0].email).should("be.visible");
 
-        cy.intercept("GET", `/users/${validUsers[1].email}`, {
+        cy.intercept({ method: "GET", pathname: "/users/lookup", query: { email: validUsers[1].email } }, {
             statusCode: 200,
             body: {
                 "id": "2635f591-1430-4d20-86e2-c0ee88c0a0c5",
@@ -331,7 +337,7 @@ describe("create project", () => {
 
         cy.getBySel("added-user-1").contains(validUsers[1].email).should("be.visible");
 
-        cy.intercept("GET", `/users/${validUsers[2].email}`, {
+        cy.intercept({ method: "GET", pathname: "/users/lookup", query: { email: validUsers[2].email } }, {
             statusCode: 200,
             body: {
                 "id": "9057b483-d483-47a1-af3b-72ca23893caa",

--- a/flip-ui/test/cypress/support/globalIntercepts.ts
+++ b/flip-ui/test/cypress/support/globalIntercepts.ts
@@ -47,6 +47,18 @@ beforeEach(() => {
     }
     ).as("getPermissionsGlobal");
 
+    // The main layout resolves the signed-in user's profile on every page load. The fixture
+    // carries an empty `name` on purpose: specs sign in as different users, and the header falls
+    // back to the signed-in email address when there is no profile name, which is what they
+    // assert on. Override this intercept in a spec that needs the display-name path.
+    cy.intercept(
+        "GET",
+        "/users/me", {
+        statusCode: 200,
+        fixture: "user/getCurrentUser"
+    }
+    ).as("getCurrentUserGlobal");
+
     cy.intercept(
         "GET",
         "/projects?pageNumber=1&pageSize=20", {


### PR DESCRIPTION
Closes #907.

## The problem

`GET /api/users/{user_id}` depended on `verify_token` and then threw the caller away:

```python
del token_id  # Unused variable
```

No permission check, no self check, no router-level dependency. The path segment was accepted as
either an email or a UUID, so **any authenticated user — including a Viewer, the lowest-privilege
role — could resolve an arbitrary email address to a full profile**: name, organisation and account
status. Useful for targeting NHS staff by name and trust.

It was the outlier: every sibling route under `/users` already gates on `CAN_MANAGE_USERS`
(`get_users`, `update_user`, `delete_user`, `set_user_roles`, `register_user`, `reset_user_mfa`,
`access_request`).

## Why a self-check wasn't enough

Two working call sites used the endpoint, and the fix sketch on the issue would have broken one of
them. It proposed `str(token_id) != user_id`, but `MainLayout.vue` looks the caller up **by email**
while `token_id` is the Cognito `sub` UUID — so every Viewer would have silently lost their header
display name (it falls back to the raw email address, no error). The read path is split three ways
instead.

## What changed

| Route | Auth | Response |
|---|---|---|
| `GET /users/me` *(new)* | `verify_token` only | full profile — `{id, email, name, organisation, isDisabled}` |
| `GET /users/lookup?email=` *(new)* | `CAN_CREATE_PROJECTS` **or** `CAN_MANAGE_USERS` | `{id, email, isDisabled}` |
| `GET /users/{user_id}` | `CAN_MANAGE_USERS` | full profile (shape unchanged) |

- **`/users/me`** carries no permission check — the token *is* the authorization. It resolves by the
  token's `sub`, so the by-email form that made a naive self-check wrong cannot recur.
- **`/users/lookup`** returns only what the add-member flow ever read. `ProjectUsers.vue` uses `id`,
  `email` and `isDisabled` and never touches `name`/`organisation`, so **Researchers no longer see
  anyone's name or organisation**. This is the same shape project co-membership already exposes via
  `UserAccessInfo`.
- **`/users/{user_id}`** is now administrative only, with **no self escape hatch** — `/users/me` is
  the one self path, which keeps each route's rule to a single sentence.

### The oracle is closed, not moved

On `/users/{user_id}` the permission check is the **first** statement — before format validation and
before any Cognito call. An unauthorised caller therefore gets an identical 403 for a real user, an
unknown user and a malformed id alike. `TestGetUserAuthorization` asserts `get_user_by_email_or_id`
is never called on the denied path.

`/users/lookup` does still confirm to a Researcher whether an address is registered. That is
unavoidable and deliberate: the UI has to be able to say "cannot be found" rather than silently drop
a colleague from a project. It discloses one bit about an address the caller already typed, is
bounded to Researchers and Admins, and there is no self-signup — accounts arrive via admin
`register_user` or an approved `access_request`. Documented in the route docstring and the
sys-admin docs.

### `has_permissions` is an AND check

`has_permissions(uid, [A, B], db)` requires **both**, so gating the lookup with a single
two-permission call would have denied every Researcher. Added `has_any_permission` alongside it,
sharing one `_user_permission_ids` query.
`test_and_or_helpers_disagree_on_a_partially_privileged_user` pins the distinction.

### Route ordering, and why `{user_id}` is now a typed UUID

`/{user_id}` matches **any** single segment, so it will swallow `/users/me` and `/users/lookup`
unless they are declared first. Both live in `get_user.py` above it, which pins them regardless of
how `ROUTERS` in `main.py` is later sorted.

A parametrised test asserts that ordering, and covers the **pre-existing** `GET /api/users/access`
— which survived only because `access_request.router` happens to precede `get_user.router` in that
tuple, enforced by nothing until now.

`user_id` is also now typed `UUID` instead of being sniffed as "email or UUID". That was legacy: the
dual form arrived with the original repo migration, and only the *email* half was ever called — by
the two UI paths this PR moved to `/users/me` and `/users/lookup`. No caller ever passed a UUID.
With those migrated, the sniffing block, the `400 "Invalid user ID format"` branch and the now-dead
`GetUser` / `GetUserByEmail` / `GetUserById` schemas are all deleted.

A malformed id is therefore a `422 "Input should be a valid UUID"` from parameter validation —
identical to what `PUT`, `DELETE`, `/roles`, `/mfa/reset` and `/permissions` already return, so the
whole `/users` namespace now answers the same way. `GET /users/<email>` lands in that bucket too,
which is the intended removal of the email form.

> An earlier revision of this branch used a `"/{user_id:uuid}"` path convertor, which made the
> ordering collision structurally impossible. It was reverted: it answered a malformed id with a
> bare router-level 404 — and in practice a misleading `405`, since the sibling `PUT`/`DELETE`
> still match the path — losing the message that names the problem, and leaving one route in the
> namespace behaving unlike the other five. Converting the siblings too would have downgraded
> their informative 422s. Consistency with the existing house pattern won.

## UI

`validateUser` is replaced by `getCurrentUser` and `lookupProjectUser`. `MainLayout` subscribes to
`/users/me#<sub>` (no address in the URL); `ProjectUsers` uses the narrow lookup, with the type
cascading through `EditProjectDrawer` and `CreateProjectModal`.

The `#<sub>` suffix is a cache scope, not part of the request. An earlier revision of this branch
used the bare constant `/users/me`, which shared the cached profile across accounts in a single tab:
swrv's cache is module-level and never expires (`ttl` defaults to 0), sign-out is an SPA
`router.push` that leaves it intact, and `revalidate()` assigns the cached value before deciding
whether to refetch — which `dedupingInterval: 60_000` then suppresses. A second user signing in
within a minute of the first signing out saw the first user's name in the header with no request
pending to correct it. Keying on the token's `sub` fixes it, and also removes what had become a
vestigial gate: the key was conditioned on the `email` attribute, which `/users/me` does not need.
`getCurrentUser` declares no parameter, so the key swrv hands the fetcher is ignored and nothing
about the caller reaches the URL.

## Tests

- **flip-api:** 1468 unit tests green; `ruff` and `mypy` clean. New coverage for authorization,
  `/users/me`, `/users/lookup`, and route precedence.
- **flip-ui:** 1129 vitest green; `eslint` clean. The add-user **submit path had no vitest coverage
  at all** — success, disabled-account, 404 and duplicate branches are now tested. `MainLayout.spec`
  pins the per-user cache scoping: two `userId`s must produce two keys, and no key is emitted before
  the signed-in user is known. Both fail against the constant key.
- **Cypress** stubs moved to the object matcher; this fixes one in `view_project.spec.ts` that was
  missing its leading slash and had been silently non-matching.

## Type of Change

- [x] **Breaking change.** `GET /users/{email}` and the `400 "Invalid user ID format"` branch are
  both gone; `GET /users/{user_id}` now requires `CAN_MANAGE_USERS` and a UUID. The break is
  internal — nothing outside `flip-ui` calls the hub's `GET /users/{id|email}` (the only other
  `/users` reference in the tree is `deploy/README.md`'s `POST /users/{user_id}/mfa/reset`), and
  every flip-ui caller is migrated in this PR.
- [x] New tests added to cover the changes.
- [x] In-line docstrings updated.
- [x] Documentation updated (`docs/source/sys-admin/admin-user-roles.rst`).

## Notes for the reviewer

- `docs/source/sys-admin/admin-user-roles.rst` gains a "Who can see whose profile" section, flagging
  that member lookup follows *Create projects* rather than project ownership — otherwise it reads as
  contradicting the existing ownership-is-not-revoked warning.
- **#562** (split `update_user` permissions) was **closed as not planned** while this PR was open:
  self-service profile editing isn't wanted, and with that dropped the proposed split would leave
  `name`/`organisation` editable by nobody. Admin renames stay possible and stay audited
  (`UsersAudit.modified_by_user_id`). This PR changes only the *read* path — `update_user.py` is
  untouched.
- Follow-ups deliberately not taken here: `/users/me` still makes a Cognito `ListUsers` call for
  identity the token already carries; `_user_permission_ids` is 1+N queries (pre-existing, ~28 call
  sites); and authorization-as-a-declared-dependency would let a test enumerate every route and
  assert it authorizes — the guard that would have caught this bug class. Happy to file these.
- **#961** files the remaining review point: `/users/lookup` bounds *what* a Researcher learns but
  not *how often*, so the address space is still walkable. It is a key-function problem rather than
  new plumbing, but not a one-line one — the shipped `slowapi` `key_func` is trust-scoped and would
  collapse every Researcher into one bucket behind CloudFront, hashing the `Authorization` header
  gives a bucket that resets on every token refresh, and the stable key (the verified `sub`) means
  giving `verify_token` a `Request` to stash it on — a change to the dependency every authenticated
  route uses. That belongs in its own PR.

### Second review round (e7256a37)

- **Docs overclaim, corrected.** `admin-user-roles.rst` said there was "no way to list or enumerate
  users without *Manage users*". Listing is gated; enumeration is not — `/users/lookup` resolves one
  address per call, and the only rate rule in the tree (the CloudFront WAF `RateLimitPerIp`) is in
  **count/shadow mode**, so nothing is enforced at the edge either. The claim is now narrowed to
  listing, with a warning naming the residual and pointing at **#961**.
- **`has_permissions([])` denied.** `all()` over an empty sequence is `True`, reached after a
  *successful* query — so the `except → return False` path never engaged and it failed open on the
  happy path. Now guarded before the DB call, matching `has_any_permission`, which already documented
  and tested the property. Nothing passes an empty list today (all 24 call sites are inline literals),
  but there is no permission `Depends()` factory yet and the obvious refactor of those 24 blocks is
  exactly what would introduce a defaultable list.
- **Query-string retention documented.** The lookup address lands in the CloudFront standard logs
  (`cs-uri-query`) and the WAF logs (`httpRequest.args`, unredacted), both 30-day; ALB access logging
  is off. Kept as a `GET` — it is a read, `/api/*` is caching-disabled, and the route it replaced
  carried the address in the path — with the trade recorded in the route docstring.
- **#995** — swrv's cache survives sign-out, so any constant-keyed subscription can cross accounts in
  one tab. The `MainLayout` key is fixed in this PR; #995 carries the general fix (clear or namespace
  the cache on sign-out, which needs an explicit `SWRVCache` since the default is not exported).
- **#996** — nested project members are narrow only by accident: `IReturnedProject.users` is
  `list[CognitoUser]`, kept empty by construction because the project path never calls
  `apply_user_profile`. Guarded here with a do-not-enrich comment and a test asserting
  `name`/`organisation` stay empty. Typing it `list[ProjectMemberLookup]` is **not** the no-op it
  looks like — the fields default to `""` so they are on the wire today (retyping drops two keys), and
  `get_project` passes `CognitoUser` instances, which that field type rejects at construction, so a
  bare retype 500s every project-detail request. #996 carries the full change.


## Acceptance Criteria

*Imported from issue #907*

- [x] A Viewer can no longer read an arbitrary user's full profile
- [x] Adding a project member by email still works
- [x] The self-lookup in the main layout still works
- [x] Decision recorded on whether the member lookup gets its own narrow endpoint





