### PR TITLE
[Bug]: Docker network driver_opts in the dev compose have never applied and misstate the topology

### DIFF
--- a/deploy/compose.development.yml
+++ b/deploy/compose.development.yml
@@ -237,53 +237,43 @@ services:
 volumes:
   pgadmin_data:
 
+# Every network here is created outside compose by `make create-networks` —
+# trust-network-* as swarm overlays (`--driver overlay --attachable`) because the
+# XNAT stack attaches to them via `docker stack deploy`, the rest as plain bridges.
+# They are therefore `external: true` and compose only looks them up by name.
+#
+# These blocks used to also carry `driver: bridge` and `driver_opts` pinning a
+# per-network bridge name plus a distinct host_binding_ipv4 (127.0.0.1, .10.0.1,
+# .20.0.1, .30.0.1, .40.0.1, .50.0.1). None of it has ever applied: compose ignores
+# driver options for external networks, and `create-networks` passes no `-o`, so
+# every network reports `opts=map[]` and published ports bind to 0.0.0.0. The
+# `driver: bridge` was additionally wrong for trust-network-*, which are overlay.
+# Removed rather than left standing as a description of behaviour that does not
+# happen. If loopback-only binding is wanted, it belongs on the `docker network
+# create` calls in `create-networks` as `-o`, not here (FLIP#959).
 networks:
   default:
     external: true
     name: ${FLIP_INSTANCE:+$FLIP_INSTANCE-}central-hub-network
-    driver: bridge
-    driver_opts:
-      com.docker.network.bridge.name: "central-hub-network"
-      com.docker.network.bridge.host_binding_ipv4: "127.0.0.1"
 
   # Shared network for trust-to-hub communication (outbound from trust only).
   # Trusts poll the hub for tasks and push results back — no inbound connections to trusts.
   central-hub-trust-apis-network:
     external: true
     name: ${FLIP_INSTANCE:+$FLIP_INSTANCE-}central-hub-trust-apis-network
-    driver: bridge
-    driver_opts:
-      com.docker.network.bridge.name: "central-hub-trust-apis-network"
-      com.docker.network.bridge.host_binding_ipv4: "127.10.0.1"
 
   trust-network-1:
     external: true
     name: deploy_trust-network-1
-    driver: bridge
-    driver_opts:
-      com.docker.network.bridge.name: "deploy_trust-network-1"
-      com.docker.network.bridge.host_binding_ipv4: "127.20.0.1"
 
   trust-network-2:
     external: true
     name: deploy_trust-network-2
-    driver: bridge
-    driver_opts:
-      com.docker.network.bridge.name: "deploy_trust-network-2"
-      com.docker.network.bridge.host_binding_ipv4: "127.30.0.1"
 
   shared-net-1:
     external: true
     name: ${FLIP_INSTANCE:+$FLIP_INSTANCE-}deploy_shared-net-1
-    driver: bridge
-    driver_opts:
-      com.docker.network.bridge.name: "deploy_shared-net-1"
-      com.docker.network.bridge.host_binding_ipv4: "127.40.0.1"
 
   shared-net-2:
     external: true
     name: ${FLIP_INSTANCE:+$FLIP_INSTANCE-}deploy_shared-net-2
-    driver: bridge
-    driver_opts:
-      com.docker.network.bridge.name: "deploy_shared-net-2"
-      com.docker.network.bridge.host_binding_ipv4: "127.50.0.1"

--- a/deploy/providers/AWS/check_status.py
+++ b/deploy/providers/AWS/check_status.py
@@ -1539,9 +1539,11 @@ def main(
                     "docker network ls --format '{{.Name}}' 2>/dev/null",
                 )
 
+                # Only the trust overlay is load-bearing here. A production trust
+                # attaches to `default` alone (trust/deploy/compose_trust.production.yml),
+                # so deploy_shared-net-{1,2} — which exist only in the single-host dev
+                # topology — were never used on a trust EC2 and warned every run (FLIP#959).
                 expected_networks = [
-                    "deploy_shared-net-1",
-                    "deploy_shared-net-2",
                     "deploy_trust-network-1",
                 ]
                 if success:


### PR DESCRIPTION
# Description

> **Stacked on #958** (`957-parameterise-dev-hub-instance`). Retarget to `develop` once that merges.

The six network declarations in the dev compose carried `driver: bridge` plus `driver_opts` pinning a per-network bridge name and a distinct `host_binding_ipv4` (`127.0.0.1`, `.10.0.1`, `.20.0.1`, `.30.0.1`, `.40.0.1`, `.50.0.1`). The values are internally consistent, so they read like deliberate design.

**None of it has ever taken effect.** All six networks are `external: true`, and compose ignores driver options for external networks — it only looks them up by name. They are created by `make create-networks` with a bare `docker network create` and no `-o`. On a live host:

```
central-hub-network             bridge/local   opts=map[]
central-hub-trust-apis-network  bridge/local   opts=map[]
deploy_shared-net-1             bridge/local   opts=map[]
deploy_shared-net-2             bridge/local   opts=map[]
deploy_trust-network-1          overlay/swarm  opts=map[...vxlanid_list:4128]
```

So published ports bind to `0.0.0.0`, not loopback, despite what the file says.

The `driver: bridge` was also **wrong** for `trust-network-{1,2}`: those are created `--driver overlay --attachable` because the XNAT stack attaches to them via `docker stack deploy` (`trust/xnat/Makefile:232,356-360`), and a swarm service cannot join a local bridge. Inert today, but a trap — anyone later making these networks compose-managed would get local bridges and silently break XNAT. (That is exactly the change I nearly proposed before checking.)

Removed rather than left standing as a description of behaviour that does not happen. A comment records what was declared and where it would have to go if the intent is revived.

Also drops `deploy_shared-net-{1,2}` from the trust-EC2 network check in `check_status.py`. A production trust attaches to `default` alone (`trust/deploy/compose_trust.production.yml`), so those two were never present on that host and warned on every run.

## Linked Issues

Fixes #959

## Checklist

- [x] Follows the project's coding conventions and style guide
- [x] Updates documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Type of Change

- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [x] In-line docstrings updated.
- [ ] Documentation updated, tested `make -C docs/ docs`.

## Verification

- `docker compose config` rendered for both FL backends before and after: the diff is **exactly** the 24 removed lines per backend and nothing else — services, ports and volumes byte-identical.
- `docker network inspect` on the live networks reports `opts=map[]` before **and** after, i.e. nothing was applying and nothing starts applying.
- `make -n create-networks` unchanged (still 6 network commands).
- `ruff check check_status.py` clean with the AWS provider's own config, matching the base branch.

## ⚠️ Question for the reviewer before merging

**Was the loopback-only binding an intentional security control?**

Nothing in the repo answers this. `external: true` and these blocks are present in the initial open-source import (`346680a0` "Migrate to FLIP repository"); the pre-import history is squashed, and no commit message, comment, doc or issue explains them.

If it *was* intentional, this PR is the wrong fix — the right one is to pass `-o` on the `docker network create` calls in `create-networks` and actually bind dev ports to loopback. It would also mean dev hub/trust ports have been exposed on all interfaces since the import rather than on localhost, which is worth knowing independently of this change.

I have removed the declarations but preserved the values and intent in a comment, so nothing is lost either way and the decision stays reversible.

## Out of scope

`deploy/providers/AWS/Makefile:797-801` runs `create-networks` on the trust EC2, which creates `central-hub-network` on a host that has no hub. Harmless but confusing; left alone.


## Acceptance Criteria

*Imported from issue #959*

- `docker network inspect` shows `opts=map[]` before and after the change — i.e. nothing was applying and nothing starts applying.
- `docker compose config` for both FL backends differs only within the six network blocks.
- Published hub ports bind exactly as they did before.
- The overlay-vs-bridge discrepancy on `trust-network-{1,2}` is no longer stated incorrectly.