### PR TITLE
Soft-deleting a project marks Trust imaging DELETED but never deletes it (405), and shouldn't delete it at all

### DIFF
--- a/docs/source/sys-admin/admin-platform-support.rst
+++ b/docs/source/sys-admin/admin-platform-support.rst
@@ -65,6 +65,13 @@ As a system, the FLIP solution handles the following types of data:
 2. Transient XNAT cached image data, potentially enriched locally with segmentation, labelling, etc., sourced from Trust PACS.
 3. Log files including event logs and other information generated as part of the operation of the system.
 
+.. note::
+
+   The XNAT cached image data at item 2 **survives deletion of the project it belongs to**. Deleting a project
+   in FLIP is a soft delete of the platform record and does not remove anything from a Trust's XNAT, because
+   the local enrichment (segmentation, labelling, contours, annotations) cannot be re-derived from PACS the way
+   the images themselves can. Removing that data is an explicit administrator action taken at the Trust.
+
 Backup
 ======
 

--- a/docs/source/user-guides/user-common.rst
+++ b/docs/source/user-guides/user-common.rst
@@ -152,8 +152,14 @@ Delete Project
    Projects can be deleted at any time, but:
 
    - Any running training sessions will be deleted and no longer accessible
-   - Images associated with the project will be deleted from XNAT
-   - The project will no longer be visible within XNAT
+   - Imaging already pulled to each Trust is **deliberately retained** in that Trust's XNAT. Deleting a project
+     is a soft delete: the platform record is kept and the deletion audited, but the imaging is not touched.
+     Images could be re-pulled from PACS, whereas the segmentations, contours and annotations added during
+     data enrichment could not — so a project deletion never destroys them
+   - The project therefore remains visible within XNAT to users with access to it there, and is no longer
+     reachable through FLIP
+   - Removing a Trust's imaging is a **separate administrator action**, carried out at the Trust, and is not
+     part of deleting a project
 
 1. Select 'Edit Project'
 2. Under 'Advanced Options', click the 'Delete Project' button

--- a/flip-api/src/flip_api/project_services/delete_project.py
+++ b/flip-api/src/flip_api/project_services/delete_project.py
@@ -68,6 +68,14 @@ def delete_project_endpoint(
     # annotations added during data enrichment could not. Imaging removal, when it is wanted,
     # belongs in an explicit purge with its own confirmation — not as a silent cascade off a
     # soft delete. See FLIP#963.
+    #
+    # Two consequences, so neither is rediscovered later:
+    #   * Retention is open-ended. That purge does not exist yet (tracked in FLIP#997), and there is
+    #     no TTL, retention sweep or admin endpoint either — so imaging for every deleted project
+    #     persists until someone acts directly in XNAT.
+    #   * Retained imaging is not re-adopted. Nothing sets `Projects.deleted` back to False, and a
+    #     re-created project gets a new id, so imaging-api would create a fresh XNAT project while
+    #     the old one stays keyed to the deleted project's id and unreachable from the UI.
 
     # Get the project models and abort training if necessary
     project_models, _ = get_project_models_service(project_id, db, all_results=True)

--- a/flip-api/src/flip_api/project_services/delete_project.py
+++ b/flip-api/src/flip_api/project_services/delete_project.py
@@ -19,7 +19,6 @@ from flip_api.auth.access_manager import can_modify_project
 from flip_api.auth.dependencies import verify_token
 from flip_api.db.database import get_session
 from flip_api.fl_services.services.fl_service import abort_model_training
-from flip_api.project_services.services.image_service import delete_imaging_project, get_imaging_projects
 from flip_api.project_services.services.project_services import delete_project, get_project_models_service
 from flip_api.utils.logger import logger
 
@@ -63,11 +62,12 @@ def delete_project_endpoint(
             detail=f"User with ID: {user_id} is not allowed to modify this project",
         )
 
-    # Get imaging projects from trusts and delete them
-    trusts_imaging_projects = get_imaging_projects(project_id, db)
-
-    for imaging_project in trusts_imaging_projects:
-        delete_imaging_project(imaging_project, db)
+    # Trust imaging is deliberately left in place. Deleting a project is a *soft* delete on the hub
+    # (the row is retained and audited), but removing the Trust's XNAT project would be
+    # irreversible: images could be re-pulled from PACS, while the segmentations, contours and
+    # annotations added during data enrichment could not. Imaging removal, when it is wanted,
+    # belongs in an explicit purge with its own confirmation — not as a silent cascade off a
+    # soft delete. See FLIP#963.
 
     # Get the project models and abort training if necessary
     project_models, _ = get_project_models_service(project_id, db, all_results=True)

--- a/flip-api/src/flip_api/project_services/services/image_service.py
+++ b/flip-api/src/flip_api/project_services/services/image_service.py
@@ -153,12 +153,16 @@ def delete_imaging_project(imaging_project: ImagingProject, db: Session) -> bool
 
     Not called when a project is soft-deleted — that deliberately leaves Trust imaging intact,
     because enrichment (segmentations, annotations) cannot be re-derived from PACS. This exists
-    for an explicit purge path. See FLIP#963.
+    for an explicit purge path (FLIP#997), which has not been built. See FLIP#963.
 
     The status is **not** marked ``DELETED`` here: queuing a task is a request, not a result, and
-    the Trust may fail to carry it out. Recording the outcome is the responsibility of whatever
-    processes the Trust's response, so the hub never claims imaging is gone while it is still
-    present in XNAT.
+    the Trust may fail to carry it out. **Nothing records the outcome yet** — this is not a job that
+    already lives elsewhere. `trust_tasks.py` post-processes ``CREATE_IMAGING`` results only
+    (`needs_post_processing` is gated on that task type), and `project_images_helpers.update_status`
+    has no caller, so no component can write ``XNATImageStatus.DELETED`` at all. The purge must
+    therefore add **both** halves: a caller for this function, and a ``DELETE_IMAGING`` result
+    handler that sets the status once a Trust confirms the deletion — so the hub never claims
+    imaging is gone while it is still present in XNAT.
 
     Args:
         imaging_project (ImagingProject): The imaging project to delete.

--- a/flip-api/src/flip_api/project_services/services/image_service.py
+++ b/flip-api/src/flip_api/project_services/services/image_service.py
@@ -16,7 +16,7 @@ from datetime import datetime, timedelta, timezone
 from uuid import UUID
 
 from sqlalchemy.exc import SQLAlchemyError
-from sqlmodel import Session, col, select, update
+from sqlmodel import Session, col, select
 
 from flip_api.db.models.main_models import ProjectTrustIntersect, TrustTask, XNATProjectStatus
 from flip_api.db.models.main_models import Trust as DBTrust
@@ -149,14 +149,23 @@ def get_imaging_projects(project_id: UUID, db: Session) -> list[ImagingProject]:
 
 def delete_imaging_project(imaging_project: ImagingProject, db: Session) -> bool:
     """
-    Queue a task to delete an imaging project and update its status in the database.
+    Queue a task asking a Trust to delete an imaging project.
+
+    Not called when a project is soft-deleted — that deliberately leaves Trust imaging intact,
+    because enrichment (segmentations, annotations) cannot be re-derived from PACS. This exists
+    for an explicit purge path. See FLIP#963.
+
+    The status is **not** marked ``DELETED`` here: queuing a task is a request, not a result, and
+    the Trust may fail to carry it out. Recording the outcome is the responsibility of whatever
+    processes the Trust's response, so the hub never claims imaging is gone while it is still
+    present in XNAT.
 
     Args:
         imaging_project (ImagingProject): The imaging project to delete.
         db (Session): The database session for executing queries.
 
     Returns:
-        bool: True if the task was queued and status updated successfully, False otherwise.
+        bool: True if the task was queued successfully, False otherwise.
     """
     try:
         # Queue deletion task for the trust
@@ -166,17 +175,10 @@ def delete_imaging_project(imaging_project: ImagingProject, db: Session) -> bool
             payload=json.dumps({"imaging_project_id": str(imaging_project.xnat_project_id)}),
         )
         db.add(task)
-
-        statement = (
-            update(XNATProjectStatus)
-            .where(col(XNATProjectStatus.id) == imaging_project.id)
-            .values(retrieve_image_status=XNATImageStatus.DELETED)
-        )
-        db.execute(statement)
         db.commit()
         logger.info(
-            f"Queued deletion task and marked imaging project {imaging_project.xnat_project_id} "
-            f"(ID: {imaging_project.id}) as DELETED."
+            f"Queued deletion task for imaging project {imaging_project.xnat_project_id} "
+            f"(ID: {imaging_project.id}); status unchanged until the Trust confirms."
         )
         return True
     except Exception as e:

--- a/flip-api/src/flip_api/project_services/services/project_services.py
+++ b/flip-api/src/flip_api/project_services/services/project_services.py
@@ -813,16 +813,25 @@ def get_reimport_queries_service(max_reimport_count: int, session: Session) -> l
     Assumes relationships:
     - XNATProjectStatus.trust -> Trust
     - (optional) Queries -> XNATProjectStatus via project_id
+
+    A deleted project is excluded via ``Projects.deleted``, not via the imaging status: soft delete leaves
+    Trust imaging intact (FLIP#963) and no longer writes ``DELETED``, so the project row is the only gate
+    that still moves. Without it the sweep would keep queueing ``REIMPORT_STUDIES`` for deleted projects,
+    pulling *new* patient imaging into a Trust's XNAT after deletion — acquisition, not retention. The
+    ``!= DELETED`` predicate is kept as a belt-and-braces check for rows written before FLIP#963 and for the
+    explicit purge path (FLIP#997), which will set that status once a Trust confirms the deletion.
     """
     try:
         stmt = (
             select(Queries, XNATProjectStatus, Trust)
             .join(XNATProjectStatus, col(Queries.project_id) == col(XNATProjectStatus.project_id))
             .join(Trust, col(XNATProjectStatus.trust_id) == Trust.id)
+            .join(Projects, col(XNATProjectStatus.project_id) == Projects.id)
             .where(
                 XNATProjectStatus.reimport_count < max_reimport_count,
                 XNATProjectStatus.retrieve_image_status != XNATImageStatus.DELETED,
                 XNATProjectStatus.query_at_creation == Queries.id,
+                col(Projects.deleted).is_(False),
             )
         )
 

--- a/flip-api/tests/integration/test_project_db_flow.py
+++ b/flip-api/tests/integration/test_project_db_flow.py
@@ -28,16 +28,19 @@ from flip_api.db.models.main_models import (
     ProjectsAudit,
     ProjectTrustIntersect,
     ProjectUserAccess,
+    Queries,
+    XNATProjectStatus,
 )
 from flip_api.domain.interfaces.project import IProjectApproval
 from flip_api.domain.schemas.actions import ProjectAuditAction
 from flip_api.domain.schemas.projects import ProjectDetails
-from flip_api.domain.schemas.status import ProjectStatus
+from flip_api.domain.schemas.status import ProjectStatus, XNATImageStatus
 from flip_api.project_services.services.project_services import (
     approve_project,
     create_project,
     delete_project,
     get_project,
+    get_reimport_queries_service,
 )
 
 
@@ -216,3 +219,68 @@ def test_approve_project_raises_for_soft_deleted_project(session, project_payloa
     payload = IProjectApproval(project_id=project_id, trust_ids=[])
     with pytest.raises(ValueError, match="does not exist or is deleted"):
         approve_project(session, payload, creator_id)
+
+
+@pytest.fixture
+def project_eligible_for_reimport(session, user_factory, trust_factory, project_payload):
+    """A live project wired up exactly as the reimport sweep expects to find it.
+
+    ``get_reimport_queries_service`` joins ``Queries`` → ``XNATProjectStatus`` → ``Trust`` and
+    additionally requires ``XNATProjectStatus.query_at_creation == Queries.id``, so all four rows
+    have to line up before the sweep will return anything at all.
+    """
+    creator_id = user_factory().id
+    project_id = create_project(payload=project_payload, current_user_id=creator_id, session=session)
+
+    trust = trust_factory.build()
+    session.add(trust)
+
+    query = Queries(name="Cohort", query="SELECT 1", project_id=project_id, created_by=creator_id)
+    session.add(query)
+    session.flush()
+
+    session.add(
+        XNATProjectStatus(
+            xnat_project_id=uuid4(),
+            project_id=project_id,
+            trust_id=trust.id,
+            retrieve_image_status=XNATImageStatus.CREATED,
+            query_at_creation=query.id,
+            reimport_count=0,
+        )
+    )
+    session.commit()
+
+    return {"project_id": project_id, "creator_id": creator_id, "trust": trust, "query": query}
+
+
+def test_reimport_sweep_returns_queries_for_a_live_project(session, project_eligible_for_reimport):
+    """Baseline: the sweep must still pick up a live project, or the deleted-project test proves nothing."""
+    ctx = project_eligible_for_reimport
+
+    reimport_queries = get_reimport_queries_service(max_reimport_count=5, session=session)
+
+    assert len(reimport_queries) == 1
+    assert reimport_queries[0].query_id == ctx["query"].id
+    assert reimport_queries[0].trust_id == ctx["trust"].id
+
+
+def test_reimport_sweep_skips_a_soft_deleted_project(session, project_eligible_for_reimport):
+    """A soft-deleted project must drop out of the reimport sweep (FLIP#963).
+
+    Soft delete deliberately leaves Trust imaging intact and no longer writes
+    ``retrieve_image_status = DELETED``, so the status flag can no longer be the gate. Without the
+    ``Projects.deleted`` predicate the scheduled sweep would keep queueing ``REIMPORT_STUDIES`` for
+    a deleted project, pulling *new* patient imaging into a Trust's XNAT after deletion.
+    """
+    ctx = project_eligible_for_reimport
+    delete_project(ctx["project_id"], ctx["creator_id"], session)
+
+    assert get_reimport_queries_service(max_reimport_count=5, session=session) == []
+
+    status_row = session.exec(
+        select(XNATProjectStatus).where(XNATProjectStatus.project_id == ctx["project_id"])
+    ).one()
+    assert status_row.retrieve_image_status == XNATImageStatus.CREATED, (
+        "Imaging status must be untouched by the delete — the project row is what gates the sweep"
+    )

--- a/flip-api/tests/unit/project_services/services/test_image_services.py
+++ b/flip-api/tests/unit/project_services/services/test_image_services.py
@@ -127,29 +127,41 @@ class TestDeleteImagingProject:
         result = delete_imaging_project(sample_imaging_project_data, mock_db_session)
 
         assert result is True
-        # Should add a TrustTask and update status
+        # Queues a TrustTask for the trust to act on.
         mock_db_session.add.assert_called_once()
-        mock_db_session.execute.assert_called_once()
         mock_db_session.commit.assert_called_once()
 
     @patch(MOCK_LOGGER_PATH)
-    def test_db_update_fails(
+    def test_status_is_not_marked_deleted_on_queue(
         self,
         mock_logger: MagicMock,
         mock_db_session: MagicMock,
         sample_imaging_project_data: ImagingProject,
     ):
-        db_update_error = Exception("DB Update Failed")
-        mock_db_session.execute.side_effect = db_update_error
+        """Queuing a task is a request, not a result — the trust may never carry it out.
+
+        Marking the status DELETED here made the hub assert imaging was gone while it was still
+        fully present in XNAT (FLIP#963).
+        """
+        delete_imaging_project(sample_imaging_project_data, mock_db_session)
+
+        mock_db_session.execute.assert_not_called()
+
+    @patch(MOCK_LOGGER_PATH)
+    def test_db_failure_rolls_back(
+        self,
+        mock_logger: MagicMock,
+        mock_db_session: MagicMock,
+        sample_imaging_project_data: ImagingProject,
+    ):
+        db_error = Exception("DB Commit Failed")
+        mock_db_session.commit.side_effect = db_error
 
         result = delete_imaging_project(sample_imaging_project_data, mock_db_session)
 
         assert result is False
-        mock_logger.error.assert_called_with(
-            f"Error queuing imaging project deletion: {db_update_error}", exc_info=True
-        )
+        mock_logger.error.assert_called_with(f"Error queuing imaging project deletion: {db_error}", exc_info=True)
         mock_db_session.rollback.assert_called_once()
-        mock_db_session.commit.assert_not_called()
 
 
 # --- get_xnat_project_status_info ---

--- a/flip-api/tests/unit/project_services/test_delete_project.py
+++ b/flip-api/tests/unit/project_services/test_delete_project.py
@@ -50,16 +50,12 @@ def override_dependencies():
 def mock_services(monkeypatch):
     mocks = {
         "can_modify_project": MagicMock(return_value=True),
-        "get_imaging_projects": MagicMock(return_value=[]),
-        "delete_imaging_project": MagicMock(),
         "get_project_models_service": MagicMock(return_value=(MagicMock(data=[]), None)),
         "abort_model_training": MagicMock(),
         "delete_project": MagicMock(),
     }
 
     monkeypatch.setattr(delete_project_module, "can_modify_project", mocks["can_modify_project"])
-    monkeypatch.setattr(delete_project_module, "get_imaging_projects", mocks["get_imaging_projects"])
-    monkeypatch.setattr(delete_project_module, "delete_imaging_project", mocks["delete_imaging_project"])
     monkeypatch.setattr(delete_project_module, "get_project_models_service", mocks["get_project_models_service"])
     monkeypatch.setattr(delete_project_module, "abort_model_training", mocks["abort_model_training"])
     monkeypatch.setattr(delete_project_module, "delete_project", mocks["delete_project"])
@@ -71,6 +67,22 @@ def test_delete_project_success(override_dependencies, mock_services):
     project_id = uuid4()
 
     response = client.delete(f"/api/projects/{project_id}")
+
+    assert response.status_code == status.HTTP_204_NO_CONTENT
+    mock_services["delete_project"].assert_called_once()
+
+
+def test_delete_project_leaves_trust_imaging_intact(override_dependencies, mock_services):
+    """A soft delete must not touch Trust imaging (FLIP#963).
+
+    Removing the Trust's XNAT project is irreversible — images can be re-pulled from PACS, but the
+    segmentations and annotations added during data enrichment cannot. The endpoint must therefore
+    not reach for the imaging-delete machinery at all.
+    """
+    assert not hasattr(delete_project_module, "delete_imaging_project")
+    assert not hasattr(delete_project_module, "get_imaging_projects")
+
+    response = client.delete(f"/api/projects/{uuid4()}")
 
     assert response.status_code == status.HTTP_204_NO_CONTENT
     mock_services["delete_project"].assert_called_once()

--- a/flip-api/tests/unit/project_services/test_delete_project.py
+++ b/flip-api/tests/unit/project_services/test_delete_project.py
@@ -53,12 +53,16 @@ def mock_services(monkeypatch):
         "get_project_models_service": MagicMock(return_value=(MagicMock(data=[]), None)),
         "abort_model_training": MagicMock(),
         "delete_project": MagicMock(),
+        "get_imaging_projects": MagicMock(),
+        "delete_imaging_project": MagicMock(),
     }
 
     monkeypatch.setattr(delete_project_module, "can_modify_project", mocks["can_modify_project"])
     monkeypatch.setattr(delete_project_module, "get_project_models_service", mocks["get_project_models_service"])
     monkeypatch.setattr(delete_project_module, "abort_model_training", mocks["abort_model_training"])
     monkeypatch.setattr(delete_project_module, "delete_project", mocks["delete_project"])
+    monkeypatch.setattr(delete_project_module, "get_imaging_projects", mocks["get_imaging_projects"], raising=False)
+    monkeypatch.setattr(delete_project_module, "delete_imaging_project", mocks["delete_imaging_project"], raising=False)
 
     return mocks
 
@@ -79,12 +83,11 @@ def test_delete_project_leaves_trust_imaging_intact(override_dependencies, mock_
     segmentations and annotations added during data enrichment cannot. The endpoint must therefore
     not reach for the imaging-delete machinery at all.
     """
-    assert not hasattr(delete_project_module, "delete_imaging_project")
-    assert not hasattr(delete_project_module, "get_imaging_projects")
-
     response = client.delete(f"/api/projects/{uuid4()}")
 
     assert response.status_code == status.HTTP_204_NO_CONTENT
+    mock_services["get_imaging_projects"].assert_not_called()
+    mock_services["delete_imaging_project"].assert_not_called()
     mock_services["delete_project"].assert_called_once()
 
 

--- a/trust/trust-api/tests/services/test_task_handlers.py
+++ b/trust/trust-api/tests/services/test_task_handlers.py
@@ -188,8 +188,11 @@ async def test_handle_delete_imaging_success(mock_make_request):
     result = await handle_delete_imaging({"imaging_project_id": "img-123"})
 
     assert result["success"] is True
+    mock_make_request.assert_awaited_once()
     call_args = mock_make_request.call_args
     assert call_args.kwargs["method"] == "DELETE"
+    assert call_args.kwargs["url"].endswith("/projects/img-123")
+    assert "params" not in call_args.kwargs
     _assert_trust_internal_auth_header(call_args)
 
 

--- a/trust/trust-api/tests/services/test_task_handlers.py
+++ b/trust/trust-api/tests/services/test_task_handlers.py
@@ -185,15 +185,26 @@ async def test_handle_delete_imaging_success(mock_make_request):
     """Should call imaging-api to delete project."""
     mock_make_request.return_value = {"status": "deleted"}
 
-    result = await handle_delete_imaging({"imaging_project_id": "img-123"})
+    imaging_project_id = str(uuid4())
+    result = await handle_delete_imaging({"imaging_project_id": imaging_project_id})
 
     assert result["success"] is True
     mock_make_request.assert_awaited_once()
     call_args = mock_make_request.call_args
     assert call_args.kwargs["method"] == "DELETE"
-    assert call_args.kwargs["url"].endswith("/projects/img-123")
+    assert call_args.kwargs["url"].endswith(f"/projects/{imaging_project_id}")
     assert "params" not in call_args.kwargs
     _assert_trust_internal_auth_header(call_args)
+
+
+@pytest.mark.asyncio
+async def test_handle_delete_imaging_rejects_non_uuid_id(mock_make_request):
+    """Should refuse an id that is not a UUID instead of interpolating it into the URL path."""
+    result = await handle_delete_imaging({"imaging_project_id": "../other-resource"})
+
+    assert result["success"] is False
+    assert "imaging_project_id" in result["error"]
+    mock_make_request.assert_not_called()
 
 
 # ---- Get imaging status handler ----
@@ -273,7 +284,7 @@ async def test_handle_delete_imaging_error(mock_make_request):
     """Should return failure on error."""
     mock_make_request.side_effect = Exception("Service unavailable")
 
-    result = await handle_delete_imaging({"imaging_project_id": "img-123"})
+    result = await handle_delete_imaging({"imaging_project_id": str(uuid4())})
 
     assert result["success"] is False
     assert "Service unavailable" in result["error"]

--- a/trust/trust-api/trust_api/routers/schemas.py
+++ b/trust/trust-api/trust_api/routers/schemas.py
@@ -54,9 +54,13 @@ class CentralHubProject(BaseModel):
 
 
 class DeleteImagingInput(BaseModel):
-    """Input for deleting an imaging project."""
+    """Input for deleting an imaging project.
 
-    imaging_project_id: str = Field(..., description="The XNAT project ID to delete")
+    The id is interpolated into the imaging-api URL path, so it is validated as a UUID here rather
+    than trusted as a raw string — the hub always emits one (``str(xnat_project_id)``, a UUID column).
+    """
+
+    imaging_project_id: UUID = Field(..., description="The XNAT project ID to delete")
 
 
 class GetImagingStatusInput(BaseModel):

--- a/trust/trust-api/trust_api/services/task_handlers.py
+++ b/trust/trust-api/trust_api/services/task_handlers.py
@@ -193,10 +193,12 @@ async def handle_delete_imaging(payload: dict[str, Any]) -> dict[str, Any]:
     try:
         validated = DeleteImagingInput(**payload)
         imaging_project_id = validated.imaging_project_id
+        # imaging-api exposes DELETE /projects/{project_id} as a PATH parameter. Passing it as a
+        # query parameter against /projects/ matched no route and returned 405, so the deletion
+        # silently never happened while the hub recorded it as done. See FLIP#963.
         await make_request(
             method="DELETE",
-            url=f"{IMAGING_API_URL}/projects/",
-            params={"project_id": imaging_project_id},
+            url=f"{IMAGING_API_URL}/projects/{imaging_project_id}",
             headers=trust_internal_headers(),
         )
 


### PR DESCRIPTION
# Description

Soft-deleting a project cascaded an **irreversible** imaging deletion to every Trust — except the cascade was broken, so it silently did nothing while the hub recorded that it had succeeded. Both halves were wrong, and each hid the other.

Found while cleaning up a throwaway project during #776 (PR #955).

## What changes

**Trust imaging is no longer touched by a soft delete.** Removing a Trust's XNAT project cannot be undone: images can be re-pulled from PACS, but the segmentations, contours and annotations added during *data enrichment* cannot — `docs/source/sys-admin/admin-platform-support.rst:65` describes XNAT as *"transient cached image data, **potentially enriched locally with segmentation, labelling**, etc."*. The hub keeps its own row and audits the deletion, so pairing that with irreversible Trust-side destruction was a poor match — especially as nothing in flip-api ever sets `deleted = False`, so there is no restore path to make the retained record meaningful.

Imaging removal, when it is wanted, belongs in an explicit purge with its own confirmation. The two defects that made the current behaviour invisible are fixed too, so that machinery is correct when someone builds it:

| Defect | Fix |
|---|---|
| trust-api called `DELETE /projects/` with `project_id` as a **query** param; imaging-api exposes `DELETE /projects/{project_id}` as a **path** param → no route matched → **405**, deletion never happened | Call the path-parameter form (`task_handlers.py`) |
| `delete_imaging_project()` set `retrieve_image_status = DELETED` in the same transaction that queued the task, before any Trust had been asked | Status is left alone; queuing a task is a request, not a result (`image_service.py`) |

## Evidence (dev stack, before the fix)

```
trust-api: DELETE http://imaging-api:8000/projects/?project_id=9bb8e261-… "HTTP/1.1 405 Method Not Allowed"

centralhub=# SELECT task_type, status FROM trust_task WHERE task_type='DELETE_IMAGING';
 DELETE_IMAGING | FAILED
 DELETE_IMAGING | FAILED

centralhub=# SELECT xnat_project_id, retrieve_image_status FROM xnat_project_status WHERE project_id='cf497b94-…';
 9bb8e261-… | DELETED     <- XNAT project and all its data still fully present
 14c766ec-… | DELETED
```

Both XNAT projects had to be removed by hand, using the call imaging-api would have made (`DELETE /data/projects/<id>?removeFiles=true`).

## The `DELETED` write was also the reimport gate (added after review)

Removing that write had a second effect that was not obvious. `get_reimport_queries_service` selects on
`reimport_count < MAX_REIMPORT_COUNT` and `retrieve_image_status != DELETED`, with **no filter on
`Projects.deleted`** — and `delete_project` does not remove the `Queries` or `ProjectTrustIntersect` rows. So
the `DELETED` write was the only thing taking a soft-deleted project out of the scheduled reimport sweep
(`PROJECT_REIMPORT_RATE` 60 min, `MAX_REIMPORT_COUNT` 5).

Left as it was, the sweep would keep queueing `REIMPORT_STUDIES` for a deleted project whenever the last known
import status still showed failed or queue-failed studies — i.e. **new patient imaging could be pulled into a
Trust's XNAT after the project was deleted**. That is acquisition, not retention, and wider than this PR
argues for.

The sweep is now gated on the project row, which is the only gate that still moves; the `!= DELETED` predicate
stays as a belt-and-braces check for rows written before this change and for the purge path.

## Linked Issues

Closes #963

## Checklist

- [x] Follows the project's coding conventions and style guide
- [x] Updates documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Type of Change

- [ ] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [x] In-line docstrings updated.
- [x] Documentation updated, tested `make -C docs/ docs`.

**Behaviour change, deliberately:** project deletion no longer requests Trust imaging deletion. In practice nothing is *losing* a capability that worked — the cascade has been returning 405 — but the intent changes from "delete imaging" to "retain it", so it is flagged as breaking rather than a silent fix.

## Verification

- `flip-api` unit suite: **1503 passed**; integration suite: **116 passed**; ruff clean, mypy clean on `project_services`.
- `make -C docs/ docs`: build succeeded (one pre-existing unrelated warning in `component-fl-nodes.rst`).
- Regression tests: soft delete does not reach for the imaging-delete machinery; queuing a delete task does not write a status; the trust-api call is the path-parameter form with no `params`.
- The reimport gate is covered in `tests/integration/test_project_db_flow.py` against the throwaway Postgres — a live project still yields a reimport query, a soft-deleted one yields none. It is an **integration** test deliberately: the existing unit tests for `get_reimport_queries_service` mock `session.exec(...).all()` and never see a `WHERE` clause, so a unit test there could only assert on compiled SQL, which tests SQLAlchemy rather than behaviour. Confirmed the new test fails without the `Projects.deleted` predicate and passes with it.

⚠️ **Testing note for reviewers:** running these tests with the *main checkout's* `flip-api/.venv` silently exercises the main checkout's source — `__editable__.flip_api-0.4.0.pth` points at `<main>/flip-api/src`, so a worktree's changes are invisible and the suite passes regardless. Set `PYTHONPATH=<worktree>/flip-api/src` (or build a venv in the worktree) or you will be testing the wrong code.

## Follow-ups (not in this PR)

- **#997** — an explicit administrator purge that *does* remove Trust imaging, with confirmation. Until it exists, retention is open-ended: there is no TTL, retention sweep or admin endpoint, so imaging for every deleted project persists until someone acts directly in XNAT. Retained imaging is also **not re-adopted** by a re-created project (nothing sets `Projects.deleted` back to `False`, and a re-created project gets a new id → a fresh XNAT project), so it can only be removed by an administrator in XNAT. Both points are now recorded in the `delete_project` comment.
- The purge must add **both** halves. `trust_tasks.py` post-processes `CREATE_IMAGING` results only (`needs_post_processing` is gated on that task type) and `project_images_helpers.update_status` has no caller, so after this PR nothing can write `XNATImageStatus.DELETED` at all — a caller for `delete_imaging_project()` without a `DELETE_IMAGING` result handler would reintroduce exactly the "hub claims it is gone while it is still there" bug this PR fixes. Captured in #997 and in the function's docstring.
- `delete_imaging_project()` returns a bool its caller ignores, so a queue-time failure is invisible. Relevant to that purge path; captured in #997.
- trust-api logs the `X-Trust-Internal-Service-Key` value in plaintext at DEBUG level. Dev-only exposure today, but it should be redacted.


## Acceptance Criteria

*Imported from issue #963*

- [x] Soft-deleting a project no longer queues `DELETE_IMAGING`, and no longer marks `retrieve_image_status = DELETED`. Trust imaging is left intact.
- [x] The trust-api → imaging-api call is corrected to the path-parameter form (`DELETE /projects/{project_id}`), so the mechanism is right for a future explicit purge.
- [x] `retrieve_image_status` is never set to `DELETED` on the strength of a queued task alone.
- [x] Existing unit tests updated; a regression test covers "soft delete leaves imaging untouched".
- [x] *(added in review)* The scheduled reimport sweep is gated on `Projects.deleted`, so a soft-deleted project can no longer acquire new imaging at a Trust. Covered by an integration test.
- [x] *(added in review)* `docs/source/user-guides/user-common.rst` and `docs/source/sys-admin/admin-platform-support.rst` state the retention behaviour this PR actually implements.

