### PR TITLE
fix(xnat): run the plugin-readiness wait after site initialisation, not before

### DIFF
--- a/trust/xnat/tests/test_plugin_wait_ordering.py
+++ b/trust/xnat/tests/test_plugin_wait_ordering.py
@@ -1,0 +1,185 @@
+# Copyright (c) 2026 Guy's and St Thomas' NHS Foundation Trust & King's College London
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""
+The plugin-readiness wait must run *after* site initialization (FLIP#966).
+
+``wait-for-xnat-plugins.sh`` probes an authenticated plugin route. An uninitialized
+XNAT redirects **every** authenticated route to ``/setup`` — ``/data/projects`` does
+it too, so this is not a plugin-specific behaviour — which means the probe cannot
+answer until ``configure-xnat.sh`` has POSTed ``{"initialized": true}``.
+
+Running the wait before that POST deadlocks: the loop blocks on a condition that
+only a later step in the same script can satisfy. Every fresh trust bring-up failed
+this way, after burning the full timeout and then blaming the DQR plugin — which was
+loaded and fine.
+
+Two things are pinned here:
+
+1. the ordering in ``configure-xnat.sh``, so the wait cannot drift back above the
+   init POST or below the first plugin-dependent call; and
+2. the probe's own behaviour on a redirect — it must fail fast and say why, rather
+   than treat it as a transient and poll until timeout.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+CONFIGURE_XNAT = REPO_ROOT / "trust/xnat/xnat/config/configure-xnat.sh"
+PLUGIN_WAIT = REPO_ROOT / "trust/xnat/xnat/config/wait-for-xnat-plugins.sh"
+
+# A wedged wait is a hung bring-up; a test that inherits that hang is useless.
+TIMEOUT_SECONDS = 30
+
+
+def _line_of(pattern: str, path: Path = CONFIGURE_XNAT) -> int:
+    """Find the 1-indexed line number matching a regex, asserting it is unique enough.
+
+    Args:
+        pattern: Regex to search for.
+        path: Script to search.
+
+    Returns:
+        The 1-indexed line number of the first match.
+    """
+    for number, line in enumerate(path.read_text().splitlines(), start=1):
+        if re.search(pattern, line) and not line.lstrip().startswith("#"):
+            return number
+    pytest.fail(f"no non-comment line matching {pattern!r} in {path.name}")
+
+
+def test_plugin_wait_runs_after_site_initialization() -> None:
+    """The ordering that FLIP#966 was: init must come first, or the wait deadlocks."""
+    init_line = _line_of(r'\\"initialized\\": true')
+    wait_line = _line_of(r"bash wait-for-xnat-plugins\.sh")
+
+    assert init_line < wait_line, (
+        f"wait-for-xnat-plugins.sh runs at line {wait_line}, before site initialization at "
+        f"line {init_line}. An uninitialized XNAT redirects every authenticated route to "
+        "/setup, so the probe can never answer and the bring-up deadlocks (FLIP#966)."
+    )
+
+
+def test_plugin_wait_runs_before_any_plugin_dependent_call() -> None:
+    """It still has to guard what it exists to guard — the DQR and OHIF config."""
+    wait_line = _line_of(r"bash wait-for-xnat-plugins\.sh")
+    dqr_line = _line_of(r"Configuring DQR plugin")
+
+    assert wait_line < dqr_line, (
+        f"wait-for-xnat-plugins.sh runs at line {wait_line}, after the DQR configuration at "
+        f"line {dqr_line}. Plugin settings would then race a Tomcat that has not registered "
+        "its plugin routes, leaving XNAT half-configured."
+    )
+
+
+@pytest.mark.parametrize("redirect_status", ["301", "302", "307"])
+def test_probe_fails_fast_on_a_redirect(tmp_path: Path, redirect_status: str) -> None:
+    """A redirect means "site not initialized" — never "plugin still loading".
+
+    Waiting cannot clear it, so the script must exit non-zero straight away rather
+    than poll to timeout. Driven with a stub ``curl`` on PATH, the same mock-bin
+    idiom as ``test_guard_scripts.py``.
+    """
+    stub_bin = tmp_path / "bin"
+    stub_bin.mkdir()
+    # -w '%{http_code}' asks for the status; -w '%{redirect_url}' asks for the target. The stub
+    # answers whichever this invocation requested, so the script's own error path works too.
+    (stub_bin / "curl").write_text(
+        "#!/bin/sh\n"
+        'for arg in "$@"; do\n'
+        '  case "$arg" in\n'
+        "    '%{redirect_url}') printf 'http://xnat-web:8080/setup'; exit 0 ;;\n"
+        f"    '%{{http_code}}') printf '{redirect_status}'; exit 0 ;;\n"
+        "  esac\n"
+        "done\n"
+        f"printf '{redirect_status}'\n"
+    )
+    (stub_bin / "curl").chmod(0o755)
+
+    env = {
+        "PATH": f"{stub_bin}:/usr/bin:/bin",
+        "XNAT_ADMIN_USER": "admin",
+        "XNAT_ADMIN_INITIAL_PASSWORD": "initial",  # pragma: allowlist secret
+        "XNAT_ADMIN_PASSWORD": "rotated",  # pragma: allowlist secret
+        # Generous budget on purpose: if the script polls instead of failing fast, the assertion
+        # below must fail on the exit path rather than be rescued by a short timeout.
+        "XNAT_PLUGIN_READINESS_TIMEOUT_SECONDS": "900",
+        "XNAT_PLUGIN_READINESS_POLL_SECONDS": "1",
+    }
+
+    result = subprocess.run(
+        ["bash", str(PLUGIN_WAIT)],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=TIMEOUT_SECONDS,
+    )
+
+    assert result.returncode != 0, "a redirect must fail the wait, not satisfy it"
+    combined = result.stdout + result.stderr
+    assert "not initialized" in combined, (
+        "the error must name site initialization as the cause — a bare 'DQR not ready' sends "
+        f"the reader after a plugin that is fine. Got:\n{combined}"
+    )
+    assert "DQR not ready yet" not in combined, (
+        "the script polled on a redirect instead of failing fast; it would burn the whole "
+        f"timeout budget. Got:\n{combined}"
+    )
+
+
+def test_probe_still_succeeds_on_2xx(tmp_path: Path) -> None:
+    """The happy path is untouched — a ready plugin route still ends the wait."""
+    stub_bin = tmp_path / "bin"
+    stub_bin.mkdir()
+    (stub_bin / "curl").write_text("#!/bin/sh\nprintf '200'\n")
+    (stub_bin / "curl").chmod(0o755)
+
+    result = subprocess.run(
+        ["bash", str(PLUGIN_WAIT)],
+        env={
+            "PATH": f"{stub_bin}:/usr/bin:/bin",
+            "XNAT_ADMIN_USER": "admin",
+            "XNAT_ADMIN_INITIAL_PASSWORD": "initial",  # pragma: allowlist secret
+            "XNAT_ADMIN_PASSWORD": "rotated",  # pragma: allowlist secret
+            "XNAT_PLUGIN_READINESS_TIMEOUT_SECONDS": "30",
+            "XNAT_PLUGIN_READINESS_POLL_SECONDS": "1",
+        },
+        capture_output=True,
+        text=True,
+        timeout=TIMEOUT_SECONDS,
+    )
+
+    assert result.returncode == 0, f"a 200 must satisfy the wait. Got:\n{result.stdout}{result.stderr}"
+    assert "is ready" in result.stdout
+
+
+def test_shellcheck_clean_if_available() -> None:
+    """Cheap belt-and-braces on the edited script when shellcheck is installed."""
+    shellcheck = shutil.which("shellcheck")
+    if not shellcheck:
+        pytest.skip("shellcheck not installed")
+
+    result = subprocess.run(
+        [shellcheck, "-S", "error", str(PLUGIN_WAIT), str(CONFIGURE_XNAT)],
+        capture_output=True,
+        text=True,
+        timeout=TIMEOUT_SECONDS,
+        cwd=os.fspath(REPO_ROOT),
+    )
+    assert result.returncode == 0, result.stdout + result.stderr

--- a/trust/xnat/xnat/config/configure-xnat.sh
+++ b/trust/xnat/xnat/config/configure-xnat.sh
@@ -50,14 +50,10 @@ until curl --output /dev/null --silent --head --fail \
 done
 echo "XNAT is up!"
 
-# Tomcat can serve the login page before plugin routes have registered. Wait
-# for the authenticated DQR settings endpoint before issuing any site changes;
-# otherwise a fresh boot races into a stream of 404s and leaves XNAT only
-# partially configured. The helper accepts either the initial or already-
-# rotated admin password, so a configuration-only retry remains idempotent.
-# XNAT_URL is passed explicitly: it is a plain (unexported) variable here, and the helper otherwise
-# falls back to its own default — so the two could silently probe and configure different hosts.
-XNAT_URL="$XNAT_URL" bash wait-for-xnat-plugins.sh
+# NOTE: the plugin-readiness wait deliberately does NOT run here. It cannot: the probe is an
+# authenticated plugin route, and an uninitialized XNAT redirects every authenticated route to
+# /setup, so it can only answer once the site has been initialized below. See FLIP#966 — running
+# it here deadlocked every fresh bring-up against a step downstream of itself.
 
 # Helper: curl wrapper for XNAT's REST API — same contract as xnat_curl in
 # configure-dcm2niix.sh, except credentials are passed by the caller: this
@@ -164,6 +160,21 @@ xnat_curl -X POST "$XNAT_URL/xapi/siteConfig" \
   -u "${XNAT_ADMIN_USER}:${XNAT_ADMIN_INITIAL_PASSWORD}" \
   -H "Content-Type: application/json" \
   -d "{\"initialized\": true, \"siteUrl\": \"${XNAT_SITE_URL:-$XNAT_URL}\"}"
+
+# Now that the site is initialized, authenticated routes stop redirecting to /setup and the
+# plugin-readiness probe can actually answer.
+#
+# Tomcat serves the login page before plugin routes have registered, so everything below that
+# touches a plugin — the DQR settings, the OHIF viewer preferences — would otherwise race into a
+# stream of 404s and leave XNAT half-configured. This is the earliest point the wait can succeed,
+# and still ahead of every plugin-dependent call. Nothing between here and those calls (password
+# rotation, service account, roles, guest) touches a plugin route.
+#
+# The helper accepts either the initial or already-rotated admin password, so a configuration-only
+# retry stays idempotent. XNAT_URL is passed explicitly: it is a plain (unexported) variable here
+# and the helper otherwise falls back to its own default, so the two could silently probe and
+# configure different hosts.
+XNAT_URL="$XNAT_URL" bash wait-for-xnat-plugins.sh
 
 # Change admin password
 echo "Changing admin password..."

--- a/trust/xnat/xnat/config/wait-for-xnat-plugins.sh
+++ b/trust/xnat/xnat/config/wait-for-xnat-plugins.sh
@@ -65,6 +65,14 @@ probe() {
   printf '%s' "$status"
 }
 
+# Only called on the fatal redirect path, to name the destination in the error. Worth one extra
+# request there because "302" alone does not say *why*, and the destination (/setup) does.
+probe_redirect_target() {
+  curl -sS -o /dev/null -w '%{redirect_url}' \
+    --connect-timeout 5 --max-time 10 \
+    -u "${XNAT_ADMIN_USER}:${credential}" "$READINESS_URL" 2>/dev/null || true
+}
+
 echo "Waiting for the XNAT DQR plugin to be ready..."
 wait_start=$SECONDS
 last_status="000"
@@ -148,6 +156,25 @@ while true; do
           exit 1
         fi
       fi
+      ;;
+    3*)
+      # An uninitialized XNAT redirects EVERY authenticated route to /setup — not just plugin
+      # routes; /data/projects does it too. So a redirect here says nothing about plugins and
+      # everything about the site never having been switched on.
+      #
+      # Fail immediately rather than poll. Waiting cannot clear it: the step that would —
+      # POST /xapi/siteConfig {"initialized": true} in configure-xnat.sh — runs *after* this
+      # wait, so a retry loop is waiting on something downstream of itself. Treating it as
+      # transient is what made this cost a full timeout and then report a healthy plugin as
+      # "not ready" (FLIP#966).
+      redirect_target="$(probe_redirect_target)"
+      echo "ERROR: XNAT redirected the readiness probe (HTTP $last_status)." >&2
+      echo "  endpoint: $READINESS_URL" >&2
+      [[ -n "$redirect_target" ]] && echo "  redirected to: $redirect_target" >&2
+      echo "  This means XNAT is not initialized yet — every authenticated route redirects to" >&2
+      echo "  /setup until site initialization runs, so no amount of waiting will help. This" >&2
+      echo "  readiness wait must run AFTER configure-xnat.sh initializes the site." >&2
+      exit 1
       ;;
     *)
       # 404 (plugin route not registered yet), 000 (transport), 5xx (still starting): not a


### PR DESCRIPTION
Closes #966

## Description

**A never-configured XNAT cannot be brought up on `develop` today.** `make up-trust` dies after ~5 minutes:

```
ERROR: XNAT DQR plugin did not become ready within 304s.
  endpoint: http://xnat-web:8080/xapi/dqr/settings
  last HTTP status: 302
```

`configure-xnat.sh` waited on an **authenticated plugin route** before initialising the site. An uninitialised XNAT **302-redirects every authenticated route to `/setup`**, so the probe could never answer — and the step that would have unblocked it, `POST /xapi/siteConfig`, was the next one it never reached. A wait blocking on something downstream of itself.

Not DQR-specific: `/data/projects` 302s pre-init too. It is *"the site is not switched on yet"* wearing a plugin's name. Proven on the stuck instance — `POST /xapi/siteConfig` → 200, and immediately after, `GET /xapi/dqr/settings` → 200.

It only fires on a **fresh** XNAT, which is why it survived review: an already-configured instance answers the probe and looks fine.

Introduced by #918 (`0046dc28`, `5ac174f5`).

## Approach

**Move the wait to immediately after the init POST.** That is the earliest point it can succeed and still ahead of every plugin-dependent call — nothing in between (password rotation, service account, roles, guest disable) touches a plugin route, and the init call itself touches only core `siteConfig`. The original intent — don't POST plugin settings into a Tomcat that hasn't registered its plugins — is preserved for everything that actually needs it.

**Make a redirect fatal rather than transient.** The probe had no `3xx` arm, so 302 fell through to the generic retry and burned the whole timeout printing `DQR not ready yet` about a healthy plugin. After init a redirect can only mean the ordering regressed, so it now fails immediately, names the redirect destination, and says the wait must run after site initialisation.

## Testing

**Verified live against a genuinely fresh XNAT** (wiped data dir, empty xnat-db) — the exact case that previously failed:

```
Activating XNAT instance...
Waiting for the XNAT DQR plugin to be ready...
XNAT DQR plugin is ready (HTTP 200).
Changing admin password...
Configuring DQR plugin...
XNAT configuration complete!
```

`make -C trust/xnat up-xnat KIT=GSTT` → exit 0, dcm2niix configured and validated.

New `test_plugin_wait_ordering.py` pins the ordering from **both** sides (after init, before the first plugin-dependent call) and drives the redirect path through a stubbed `curl` across 301/302/307. **Mutation-checked**: restoring the old ordering fails the suite.

Full xnat suite: 179 passed, ruff + mypy clean.

## Checklist

- [x] Follows the project's coding conventions and style guide
- [x] New and existing unit tests pass locally with my changes
- [x] New tests added to cover the changes

## Type of Change

- [x] Non-breaking change (fix or new feature that would not break existing functionality).

## Acceptance Criteria

*Imported from issue #966*

- [ ] `make -C trust/xnat up-xnat KIT=<CODE>` succeeds against a wiped XNAT data dir + empty xnat-db
- [ ] A 302 from the readiness probe fails immediately with a message naming site initialisation, not after the full timeout
- [ ] Re-running against an already-configured XNAT still short-circuits (idempotent)