### PR TITLE
[Bug]: test_trust_makefile_exports_the_artifacts_bucket fails on any configured dev machine

### DIFF
--- a/trust/xnat/tests/test_startup.py
+++ b/trust/xnat/tests/test_startup.py
@@ -405,10 +405,22 @@ def test_plugin_download_names_the_variable_it_needs(bucket: str) -> None:
 def test_trust_makefile_exports_the_artifacts_bucket_to_the_xnat_sub_make() -> None:
     """`make -C trust up-trust` reaches up-xnat, which in development needs this in its env.
 
-    The bucket name is defined here as a *makefile* variable rather than on the command line,
-    because make exports command-line variables to sub-makes automatically — that route would pass
-    whether or not the export directive exists, and `trust/Makefile` gets its value from an
-    ``-include``d env file, which is not auto-exported.
+    The bucket name is seeded as a *makefile* variable rather than on the command line, because
+    make auto-exports command-line variables — that route would pass whether or not the export
+    directive exists, so it would prove nothing. ``trust/Makefile`` gets its real value from an
+    ``-include``d env file, which is likewise not auto-exported.
+
+    The assertion is on *presence*, not on the seeded value. Asserting the value fails on any
+    checkout with a populated ``.env.development``, because the real bucket name from that file
+    wins over the seed — so the test used to pass in CI (clean checkout, no env file) and fail on
+    a configured developer machine, which is exactly backwards (FLIP#970).
+
+    Presence alone is still a real assertion. Verified against GNU Make: neither an ``-include``d
+    nor an ``--eval``'d variable is exported on its own, so *whichever* value arrives, it can only
+    have got there through the ``export`` directive under test::
+
+        -include'd + export  -> from-env-file      -include'd, no export  -> NOT-EXPORTED
+        --eval'd   + export  -> probe-bucket       --eval'd,   no export  -> NOT-EXPORTED
     """
     result = subprocess.run(
         [
@@ -418,6 +430,8 @@ def test_trust_makefile_exports_the_artifacts_bucket_to_the_xnat_sub_make() -> N
             # deploy/fl_backend.mk hard-fails on an unset backend, and a CI checkout has no
             # .env.development to supply one.
             "FL_BACKEND=nvflare",
+            # Seeds a value for the CI case, where no env file supplies one. On a configured
+            # checkout the env file's real value arrives instead — either proves the export.
             "--eval=FLIP_ARTIFACTS_BUCKET_NAME=probe-bucket",
             "--eval=__probe: ; @printenv FLIP_ARTIFACTS_BUCKET_NAME || echo NOT-EXPORTED",
             "__probe",
@@ -429,7 +443,15 @@ def test_trust_makefile_exports_the_artifacts_bucket_to_the_xnat_sub_make() -> N
         timeout=60,
     )
 
-    assert "probe-bucket" in result.stdout, result.stdout + result.stderr
+    combined = result.stdout + result.stderr
+    assert "NOT-EXPORTED" not in result.stdout, (
+        "FLIP_ARTIFACTS_BUCKET_NAME did not reach the sub-make environment — the "
+        "`export FLIP_ARTIFACTS_BUCKET_NAME` directive in trust/Makefile is missing. Without it "
+        f"the dev XNAT plugin download runs against a bucket-less S3 URI.\n{combined}"
+    )
+    # Guards the guard: a make failure that printed neither the value nor NOT-EXPORTED would
+    # otherwise satisfy the assertion above by saying nothing at all.
+    assert result.stdout.strip(), f"the probe target produced no output at all\n{combined}"
 
 
 def test_root_smoke_target_resolves_relative_paths_from_repo_root() -> None:


### PR DESCRIPTION
Closes #970

## Description

`test_trust_makefile_exports_the_artifacts_bucket_to_the_xnat_sub_make` **passed in CI and failed on any developer machine that was actually configured** — exactly backwards.

It planted a marker value and asserted that exact value came out the other end:

```python
"--eval=FLIP_ARTIFACTS_BUCKET_NAME=probe-bucket",
...
assert "probe-bucket" in result.stdout
```

But `trust/Makefile` also `-include`s `../.env.development`, whose **real** bucket name wins over the marker. CI has no env file, so nothing overrode it and it passed there every time.

Cost a detour while verifying #966 — the red looked like a regression in that PR until I ruled it out.

## Approach

Assert on **presence** (`NOT-EXPORTED` absent) rather than on the seeded value. The question the test actually asks is *"does the `export` directive exist?"*, and presence answers it. Verified against GNU Make:

| case | result |
|---|---|
| `-include`'d **+ export** | value |
| `-include`'d, **no export** | `NOT-EXPORTED` |
| `--eval`'d **+ export** | value |
| `--eval`'d, **no export** | `NOT-EXPORTED` |

Neither route is auto-exported, so whichever value arrives can only have got there through the directive under test. Only a *command-line* variable would pass regardless — which is why the test deliberately avoids that route, and that reasoning is unchanged (now stated explicitly in the docstring rather than implied).

Also added: an assertion that the probe produced output at all. A make failure printing neither the value nor `NOT-EXPORTED` would otherwise satisfy a bare negative assertion by saying nothing.

## Testing

Mutation-checked in **all four** combinations:

| | export present | export removed |
|---|---|---|
| **with** `.env.development` | ✅ passes (previously **failed**) | ✅ fails |
| **without** (CI) | ✅ passes | ✅ fails |

The bottom-right cell is the one that matters: the env file cannot mask the regression.

Full xnat suite on the previously-failing configuration: 174 passed, ruff + mypy clean.

## Checklist

- [x] Follows the project's coding conventions and style guide
- [x] New and existing unit tests pass locally with my changes

## Type of Change

- [x] Non-breaking change (fix or new feature that would not break existing functionality).

## Acceptance Criteria

*Imported from issue #970*

- [ ] The test passes on a checkout **with** a populated `.env.development`
- [ ] It still fails if the `export FLIP_ARTIFACTS_BUCKET_NAME` line is removed from `trust/Makefile`
- [ ] It continues to pass in CI (no `.env.development`)