### PR TITLE
Release v0.5.0

### DIFF
--- a/flip-api/pyproject.toml
+++ b/flip-api/pyproject.toml
@@ -12,7 +12,7 @@
 
 [project]
 name = "flip-api"
-version = "0.4.0"
+version = "0.5.0"
 description = ""
 readme = "README.md"
 authors = [

--- a/flip-api/uv.lock
+++ b/flip-api/uv.lock
@@ -813,7 +813,7 @@ wheels = [
 
 [[package]]
 name = "flip-api"
-version = "0.4.0"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },

--- a/flip-ui/package-lock.json
+++ b/flip-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "flip-ui",
-    "version": "0.4.0",
+    "version": "0.5.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "flip-ui",
-            "version": "0.4.0",
+            "version": "0.5.0",
             "dependencies": {
                 "echarts": "^6.1.0",
                 "highlight.js": "^10.7.3",

--- a/flip-ui/package.json
+++ b/flip-ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "flip-ui",
-    "version": "0.4.0",
+    "version": "0.5.0",
     "engines": {
         "node": "^20.19.0 || >=22.12.0"
     },

--- a/flip-utils/flip/__init__.py
+++ b/flip-utils/flip/__init__.py
@@ -37,4 +37,4 @@ from flip.exceptions import ResultsUploadError
 
 __all__ = ["FLIP", "FLIPBase", "ResultsUploadError"]
 
-__version__ = "0.4.1"
+__version__ = "0.5.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@
 #
 [project]
 name = "flip"
-version = "0.4.0"
+version = "0.5.0"
 description = ""
 readme = "README.md"
 authors = [

--- a/trust/data-access-api/pyproject.toml
+++ b/trust/data-access-api/pyproject.toml
@@ -12,7 +12,7 @@
 
 [project]
 name = "data-access-api"
-version = "0.4.0"
+version = "0.5.0"
 description = "flip Trust Data Access API"
 readme = "README.md"
 authors = [

--- a/trust/data-access-api/uv.lock
+++ b/trust/data-access-api/uv.lock
@@ -393,7 +393,7 @@ wheels = [
 
 [[package]]
 name = "data-access-api"
-version = "0.4.0"
+version = "0.5.0"
 source = { virtual = "." }
 dependencies = [
     { name = "cryptography" },

--- a/trust/imaging-api/pyproject.toml
+++ b/trust/imaging-api/pyproject.toml
@@ -12,7 +12,7 @@
 
 [project]
 name = "imaging-api"
-version = "0.4.0"
+version = "0.5.0"
 description = "flip Trust Imaging API"
 readme = "README.md"
 authors = [

--- a/trust/imaging-api/uv.lock
+++ b/trust/imaging-api/uv.lock
@@ -784,7 +784,7 @@ wheels = [
 
 [[package]]
 name = "imaging-api"
-version = "0.4.0"
+version = "0.5.0"
 source = { virtual = "." }
 dependencies = [
     { name = "asyncpg" },

--- a/trust/trust-api/pyproject.toml
+++ b/trust/trust-api/pyproject.toml
@@ -12,7 +12,7 @@
 
 [project]
 name = "trust-api"
-version = "0.4.0"
+version = "0.5.0"
 description = "flip Trust API"
 readme = "README.md"
 authors = [

--- a/trust/trust-api/uv.lock
+++ b/trust/trust-api/uv.lock
@@ -1368,7 +1368,7 @@ wheels = [
 
 [[package]]
 name = "trust-api"
-version = "0.4.0"
+version = "0.5.0"
 source = { virtual = "." }
 dependencies = [
     { name = "cryptography" },

--- a/uv.lock
+++ b/uv.lock
@@ -8,5 +8,5 @@ exclude-newer-span = "P3D"
 
 [[package]]
 name = "flip"
-version = "0.4.0"
+version = "0.5.0"
 source = { editable = "." }


### PR DESCRIPTION
# Description

Bumps the platform version from **0.4.0 → 0.5.0** ahead of cutting the next release from `develop`.

This is a **major** bump: the release promotes a breaking change — `refactor(fl)!` retired the legacy NVFLARE Executor syntax in favour of the Client API, affecting the `flip` package public API and the fl-apps / fl-tutorials job types.

## Version bumps

| Component | Version |
|---|---|
| FLIP (root — becomes the release tag) | 0.4.0 → 0.5.0 |
| flip-api | 0.4.0 → 0.5.0 |
| flip-ui | 0.4.0 → 0.5.0 |
| trust-api | 0.4.0 → 0.5.0 |
| imaging-api | 0.4.0 → 0.5.0 |
| data-access-api | 0.4.0 → 0.5.0 |
| flip-utils (`flip` on PyPI) | 0.4.1 → 0.5.0 |

Every service tracks the platform version. All had code changes in this release scope (flip-api 59 files, flip-ui 76, trust-api 17, imaging-api 6, data-access-api 9, flip-utils 47), so no service is left behind. flip-utils moves to 0.5.0 for the same breaking `refactor(fl)!` change, not merely a patch.

Lock files (`uv.lock` × 5, `package-lock.json`) updated to match; `uv lock --check` passes on all five projects.

## Checklist

- [x] Follows the project's coding conventions and style guide
- [ ] Updates documentation — n/a, version strings only
- [ ] I have added tests that prove my fix is effective or that my feature works — n/a, version strings + lock metadata
- [x] New and existing unit tests pass locally with my changes (`uv lock --check` green)
- [x] Any dependent changes have been merged and published

## Type of Change

- [ ] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] Breaking change (this release cut promotes a breaking `refactor(fl)!` change).
- [ ] New tests added to cover the changes.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make -C docs/ docs`.

## Linked Issues

None — this is a release version bump. Issue links live on the individual PRs being promoted.