### PR TITLE
[Bug]: fl-client kit volume ignores flBackend, dropping staged Flower credentials

### DIFF
--- a/.github/workflows/test_helm_chart.yml
+++ b/.github/workflows/test_helm_chart.yml
@@ -256,6 +256,11 @@ jobs:
       # manifest and not merely somewhere in the release. The S3-on case is asserted too: it is
       # the positive control that stops the staged case passing vacuously if the volume stopped
       # rendering altogether.
+      # The volume is asserted by parsing the manifest and selecting the named entry
+      # under spec.template.spec.volumes, not by grepping around the string
+      # "name: fl-client-kit" — that string also names the two volumeMounts entries,
+      # so a context-window grep tests whichever node happens to sit near a match
+      # rather than the volume itself.
       - name: fl-client kit volume follows the active backend (FLIP#999)
         run: |
           for backend in nvflare flower; do
@@ -263,15 +268,27 @@ jobs:
             # kitFromS3 flag is disabled — the other backend's is left at its values.yaml
             # default, which is exactly the shape that regressed.
             helm template trust-release deploy/providers/kubernetes/ \
-              --set trustName=CI --set trustNumber=1 \
               --set flBackend="${backend}" \
               --set "flClient.${backend}.kitFromS3.enabled=false" \
               --set flClient.kitHostPath=/opt/fl-kit \
               --show-only templates/fl-client.yaml > /tmp/kit-staged-"${backend}".yaml
-            if ! grep -A2 -F 'name: fl-client-kit' /tmp/kit-staged-"${backend}".yaml | grep -qF 'hostPath:'; then
-              echo "::error::${backend}: a kit staged at flClient.kitHostPath did not render as a hostPath — the staged kit is silently dropped"
-              exit 1
-            fi
+            python3 - "${backend}" hostPath /tmp/kit-staged-"${backend}".yaml <<'PY'
+          import sys, yaml
+          backend, want, path = sys.argv[1], sys.argv[2], sys.argv[3]
+          # --show-only still emits the file's other documents (ServiceAccount, ConfigMap).
+          docs = [d for d in yaml.safe_load_all(open(path)) if d and d.get("kind") == "Deployment"]
+          if len(docs) != 1:
+              sys.exit(f"::error::{backend}: expected exactly 1 fl-client Deployment, got {len(docs)}")
+          vols = docs[0]["spec"]["template"]["spec"]["volumes"]
+          vol = next((v for v in vols if v["name"] == "fl-client-kit"), None)
+          if vol is None:
+              sys.exit(f"::error::{backend}: no fl-client-kit volume rendered at all")
+          if want not in vol:
+              sys.exit(
+                  f"::error::{backend}: a kit staged at flClient.kitHostPath rendered as "
+                  f"{sorted(k for k in vol if k != 'name')}, not {want} — the staged kit is silently dropped"
+              )
+          PY
             if grep -qF 'name: kit-init' /tmp/kit-staged-"${backend}".yaml; then
               echo "::error::${backend}: kit-init rendered with kitFromS3 disabled — it would overwrite the staged kit"
               exit 1
@@ -279,15 +296,26 @@ jobs:
 
             # Fetched from S3: emptyDir for kit-init to populate, and kit-init present.
             helm template trust-release deploy/providers/kubernetes/ \
-              --set trustName=CI --set trustNumber=1 \
               --set flBackend="${backend}" \
               --set "flClient.${backend}.kitFromS3.enabled=true" \
-              --set "flClient.${backend}.kitFromS3.bucket=ci-bucket" \
               --show-only templates/fl-client.yaml > /tmp/kit-s3-"${backend}".yaml
-            if ! grep -A2 -F 'name: fl-client-kit' /tmp/kit-s3-"${backend}".yaml | grep -qF 'emptyDir:'; then
-              echo "::error::${backend}: kitFromS3 enabled but the volume is not an emptyDir for kit-init to populate"
-              exit 1
-            fi
+            python3 - "${backend}" emptyDir /tmp/kit-s3-"${backend}".yaml <<'PY'
+          import sys, yaml
+          backend, want, path = sys.argv[1], sys.argv[2], sys.argv[3]
+          # --show-only still emits the file's other documents (ServiceAccount, ConfigMap).
+          docs = [d for d in yaml.safe_load_all(open(path)) if d and d.get("kind") == "Deployment"]
+          if len(docs) != 1:
+              sys.exit(f"::error::{backend}: expected exactly 1 fl-client Deployment, got {len(docs)}")
+          vols = docs[0]["spec"]["template"]["spec"]["volumes"]
+          vol = next((v for v in vols if v["name"] == "fl-client-kit"), None)
+          if vol is None:
+              sys.exit(f"::error::{backend}: no fl-client-kit volume rendered at all")
+          if want not in vol:
+              sys.exit(
+                  f"::error::{backend}: kitFromS3 is enabled but the volume rendered as "
+                  f"{sorted(k for k in vol if k != 'name')}, not {want} for kit-init to populate"
+              )
+          PY
             if ! grep -qF 'name: kit-init' /tmp/kit-s3-"${backend}".yaml; then
               echo "::error::${backend}: kitFromS3 enabled but kit-init did not render — nothing would populate the volume"
               exit 1

--- a/.github/workflows/test_helm_chart.yml
+++ b/.github/workflows/test_helm_chart.yml
@@ -243,6 +243,57 @@ jobs:
             exit 1
           fi
 
+      # FLIP#999. The fl-client-kit volume and the kit-init initContainer encode the same
+      # decision — "is this backend's kit fetched from S3?" — and must agree: kit-init present
+      # means the volume is an emptyDir for it to populate, kit-init absent means the volume is
+      # the hostPath at flClient.kitHostPath. They were gated separately, and the volume's gate
+      # read only the NVFLARE flag, which values.yaml defaults to true. A Flower trust staging
+      # its kit on the node therefore rendered an emptyDir and started with empty /certs and
+      # /keys — no error at deploy time, just a SuperNode that never registers and logs a
+      # repeating "Connection attempt failed", indistinguishable from a TLS or network fault.
+      #
+      # Asserted per backend with --show-only, so the strings have to appear in the fl-client
+      # manifest and not merely somewhere in the release. The S3-on case is asserted too: it is
+      # the positive control that stops the staged case passing vacuously if the volume stopped
+      # rendering altogether.
+      - name: fl-client kit volume follows the active backend (FLIP#999)
+        run: |
+          for backend in nvflare flower; do
+            # Staged on the node: hostPath, and NO kit-init. Only this backend's own
+            # kitFromS3 flag is disabled — the other backend's is left at its values.yaml
+            # default, which is exactly the shape that regressed.
+            helm template trust-release deploy/providers/kubernetes/ \
+              --set trustName=CI --set trustNumber=1 \
+              --set flBackend="${backend}" \
+              --set "flClient.${backend}.kitFromS3.enabled=false" \
+              --set flClient.kitHostPath=/opt/fl-kit \
+              --show-only templates/fl-client.yaml > /tmp/kit-staged-"${backend}".yaml
+            if ! grep -A2 -F 'name: fl-client-kit' /tmp/kit-staged-"${backend}".yaml | grep -qF 'hostPath:'; then
+              echo "::error::${backend}: a kit staged at flClient.kitHostPath did not render as a hostPath — the staged kit is silently dropped"
+              exit 1
+            fi
+            if grep -qF 'name: kit-init' /tmp/kit-staged-"${backend}".yaml; then
+              echo "::error::${backend}: kit-init rendered with kitFromS3 disabled — it would overwrite the staged kit"
+              exit 1
+            fi
+
+            # Fetched from S3: emptyDir for kit-init to populate, and kit-init present.
+            helm template trust-release deploy/providers/kubernetes/ \
+              --set trustName=CI --set trustNumber=1 \
+              --set flBackend="${backend}" \
+              --set "flClient.${backend}.kitFromS3.enabled=true" \
+              --set "flClient.${backend}.kitFromS3.bucket=ci-bucket" \
+              --show-only templates/fl-client.yaml > /tmp/kit-s3-"${backend}".yaml
+            if ! grep -A2 -F 'name: fl-client-kit' /tmp/kit-s3-"${backend}".yaml | grep -qF 'emptyDir:'; then
+              echo "::error::${backend}: kitFromS3 enabled but the volume is not an emptyDir for kit-init to populate"
+              exit 1
+            fi
+            if ! grep -qF 'name: kit-init' /tmp/kit-s3-"${backend}".yaml; then
+              echo "::error::${backend}: kitFromS3 enabled but kit-init did not render — nothing would populate the volume"
+              exit 1
+            fi
+          done
+
   kind-e2e:
     name: kind E2E
     runs-on: ubuntu-latest

--- a/.github/workflows/test_helm_chart.yml
+++ b/.github/workflows/test_helm_chart.yml
@@ -271,7 +271,7 @@ jobs:
           # that string also names every volumeMount that reads the kit, so a context-window
           # grep tests whichever node happens to sit near a match rather than the volume itself.
           assert_kit_volume() { # <backend> <expected volume type> <manifest> <what a mismatch means>
-            uv run --no-project --with pyyaml python - "$@" <<'PY'
+            uv run --no-project --with "pyyaml==6.0.3" python - "$@" <<'PY'
           import sys, yaml
 
           backend, want, path, consequence = sys.argv[1:5]

--- a/.github/workflows/test_helm_chart.yml
+++ b/.github/workflows/test_helm_chart.yml
@@ -73,6 +73,11 @@ jobs:
         with:
           version: "v4.2.3"
 
+      # For the PyYAML the kit-volume assertion runs under — the runner image's
+      # system python is not guaranteed to carry it.
+      - name: Install uv
+        run: pip install uv
+
       - name: Render template (default/nvflare)
         run: helm template trust-release deploy/providers/kubernetes/ > /dev/null
 
@@ -244,25 +249,51 @@ jobs:
           fi
 
       # FLIP#999. The fl-client-kit volume and the kit-init initContainer encode the same
-      # decision — "is this backend's kit fetched from S3?" — and must agree: kit-init present
-      # means the volume is an emptyDir for it to populate, kit-init absent means the volume is
-      # the hostPath at flClient.kitHostPath. They were gated separately, and the volume's gate
-      # read only the NVFLARE flag, which values.yaml defaults to true. A Flower trust staging
-      # its kit on the node therefore rendered an emptyDir and started with empty /certs and
-      # /keys — no error at deploy time, just a SuperNode that never registers and logs a
-      # repeating "Connection attempt failed", indistinguishable from a TLS or network fault.
+      # decision — "is this backend's kit fetched from S3?" — and must agree (why, and what
+      # goes wrong when they do not, is on flip-trust.flClientKitFromS3 in _helpers.tpl). The
+      # regression this guards: gated separately, the volume's gate read only the NVFLARE flag,
+      # which values.yaml defaults to true, so a Flower trust staging its kit on the node
+      # rendered an emptyDir and started with empty /certs and /keys — no error at deploy time,
+      # just a SuperNode that never registers and logs a repeating "Connection attempt failed",
+      # indistinguishable from a TLS or network fault. That silence is why the shapes are
+      # asserted in CI rather than left to review.
       #
-      # Asserted per backend with --show-only, so the strings have to appear in the fl-client
-      # manifest and not merely somewhere in the release. The S3-on case is asserted too: it is
-      # the positive control that stops the staged case passing vacuously if the volume stopped
-      # rendering altogether.
-      # The volume is asserted by parsing the manifest and selecting the named entry
-      # under spec.template.spec.volumes, not by grepping around the string
-      # "name: fl-client-kit" — that string also names the two volumeMounts entries,
-      # so a context-window grep tests whichever node happens to sit near a match
-      # rather than the volume itself.
+      # Scoped with --show-only, so the shapes have to hold in the fl-client manifest and not
+      # merely somewhere in the release. kitHostPath is set in BOTH cases below, so each pair
+      # of renders differs on kitFromS3 alone and the assertions pin the precedence between
+      # the two flags: kitFromS3 must win over a leftover kitHostPath, or kit-init would
+      # aws-s3-sync --delete and chown the staged node directory as root. Without that, a
+      # volume gate reading kitHostPath alone would pass every assertion here.
       - name: fl-client kit volume follows the active backend (FLIP#999)
         run: |
+          # The volume is asserted by parsing the manifest and selecting the named entry under
+          # spec.template.spec.volumes, not by grepping around the string "name: fl-client-kit":
+          # that string also names every volumeMount that reads the kit, so a context-window
+          # grep tests whichever node happens to sit near a match rather than the volume itself.
+          assert_kit_volume() { # <backend> <expected volume type> <manifest> <what a mismatch means>
+            uv run --no-project --with pyyaml python - "$@" <<'PY'
+          import sys, yaml
+
+          backend, want, path, consequence = sys.argv[1:5]
+
+          def die(msg):
+              print(f"::error::{msg}")  # workflow commands are read from stdout, not stderr
+              sys.exit(1)
+
+          # --show-only still emits the file's other documents (ServiceAccount, ConfigMap).
+          docs = [d for d in yaml.safe_load_all(open(path)) if d and d.get("kind") == "Deployment"]
+          if len(docs) != 1:
+              die(f"{backend}: expected exactly 1 fl-client Deployment, got {len(docs)}")
+          vols = docs[0]["spec"]["template"]["spec"]["volumes"]
+          vol = next((v for v in vols if v["name"] == "fl-client-kit"), None)
+          if vol is None:
+              die(f"{backend}: no fl-client-kit volume rendered at all")
+          if want not in vol:
+              got = sorted(k for k in vol if k != "name")
+              die(f"{backend}: fl-client-kit rendered as {got}, not {want} — {consequence}")
+          PY
+          }
+
           for backend in nvflare flower; do
             # Staged on the node: hostPath, and NO kit-init. Only this backend's own
             # kitFromS3 flag is disabled — the other backend's is left at its values.yaml
@@ -272,50 +303,23 @@ jobs:
               --set "flClient.${backend}.kitFromS3.enabled=false" \
               --set flClient.kitHostPath=/opt/fl-kit \
               --show-only templates/fl-client.yaml > /tmp/kit-staged-"${backend}".yaml
-            python3 - "${backend}" hostPath /tmp/kit-staged-"${backend}".yaml <<'PY'
-          import sys, yaml
-          backend, want, path = sys.argv[1], sys.argv[2], sys.argv[3]
-          # --show-only still emits the file's other documents (ServiceAccount, ConfigMap).
-          docs = [d for d in yaml.safe_load_all(open(path)) if d and d.get("kind") == "Deployment"]
-          if len(docs) != 1:
-              sys.exit(f"::error::{backend}: expected exactly 1 fl-client Deployment, got {len(docs)}")
-          vols = docs[0]["spec"]["template"]["spec"]["volumes"]
-          vol = next((v for v in vols if v["name"] == "fl-client-kit"), None)
-          if vol is None:
-              sys.exit(f"::error::{backend}: no fl-client-kit volume rendered at all")
-          if want not in vol:
-              sys.exit(
-                  f"::error::{backend}: a kit staged at flClient.kitHostPath rendered as "
-                  f"{sorted(k for k in vol if k != 'name')}, not {want} — the staged kit is silently dropped"
-              )
-          PY
+            assert_kit_volume "${backend}" hostPath /tmp/kit-staged-"${backend}".yaml \
+              "the kit staged at flClient.kitHostPath is silently dropped"
             if grep -qF 'name: kit-init' /tmp/kit-staged-"${backend}".yaml; then
               echo "::error::${backend}: kit-init rendered with kitFromS3 disabled — it would overwrite the staged kit"
               exit 1
             fi
 
-            # Fetched from S3: emptyDir for kit-init to populate, and kit-init present.
+            # Fetched from S3 (kitHostPath still set — see the step comment): emptyDir for
+            # kit-init to populate, and kit-init present. Also the positive control that stops
+            # the staged case above passing vacuously if the volume stopped rendering at all.
             helm template trust-release deploy/providers/kubernetes/ \
               --set flBackend="${backend}" \
               --set "flClient.${backend}.kitFromS3.enabled=true" \
+              --set flClient.kitHostPath=/opt/fl-kit \
               --show-only templates/fl-client.yaml > /tmp/kit-s3-"${backend}".yaml
-            python3 - "${backend}" emptyDir /tmp/kit-s3-"${backend}".yaml <<'PY'
-          import sys, yaml
-          backend, want, path = sys.argv[1], sys.argv[2], sys.argv[3]
-          # --show-only still emits the file's other documents (ServiceAccount, ConfigMap).
-          docs = [d for d in yaml.safe_load_all(open(path)) if d and d.get("kind") == "Deployment"]
-          if len(docs) != 1:
-              sys.exit(f"::error::{backend}: expected exactly 1 fl-client Deployment, got {len(docs)}")
-          vols = docs[0]["spec"]["template"]["spec"]["volumes"]
-          vol = next((v for v in vols if v["name"] == "fl-client-kit"), None)
-          if vol is None:
-              sys.exit(f"::error::{backend}: no fl-client-kit volume rendered at all")
-          if want not in vol:
-              sys.exit(
-                  f"::error::{backend}: kitFromS3 is enabled but the volume rendered as "
-                  f"{sorted(k for k in vol if k != 'name')}, not {want} for kit-init to populate"
-              )
-          PY
+            assert_kit_volume "${backend}" emptyDir /tmp/kit-s3-"${backend}".yaml \
+              "kit-init would have nothing to populate"
             if ! grep -qF 'name: kit-init' /tmp/kit-s3-"${backend}".yaml; then
               echo "::error::${backend}: kitFromS3 enabled but kit-init did not render — nothing would populate the volume"
               exit 1

--- a/deploy/providers/kubernetes/README.md
+++ b/deploy/providers/kubernetes/README.md
@@ -286,6 +286,27 @@ helm install trust-release ./ --set flBackend=nvflare
 helm install trust-release ./ --set flBackend=flower
 ```
 
+#### Staged participant kit (no S3)
+
+By default the `kit-init` initContainer fetches the active backend's participant kit
+from S3 into an `emptyDir`. Air-gapped trusts and local `kind` clusters can stage the
+kit on the node instead:
+
+```yaml
+flClient:
+  <backend>:            # nvflare or flower — the active backend's flag
+    kitFromS3:
+      enabled: false
+  kitHostPath: /opt/fl-kit/<slot>   # node directory holding the kit
+```
+
+The `fl-client-kit` volume then mounts `kitHostPath` directly and no `kit-init` runs.
+The directory must be readable by the FL image's runtime user (uid 1000 for the
+NVFLARE client, uid 49999 for the Flower SuperNode). With `kitFromS3` disabled and
+`kitHostPath` unset, the kit volume renders as an empty `emptyDir` — nothing fails at
+deploy time and the client starts without credentials, so configure one or the other.
+When `kitFromS3` is enabled it wins over a set `kitHostPath`.
+
 ### GPU Configuration
 
 ```yaml
@@ -507,6 +528,7 @@ The chart is validated in CI via:
 3. **Network policy blocking**: Check egress CIDRs allow reaching the Central Hub and FL server. Temporarily disable policies with `--set networkPolicies.enabled=false` to isolate.
 4. **GPU not visible**: Verify `nvidia.com/gpu` annotation on the fl-client pod. Check CUDA env vars (`CUDA_VISIBLE_DEVICES`, `NVIDIA_VISIBLE_DEVICES`) are set via `flClient.gpu.enabled: true`.
 5. **Flower superlink**: For Flower backend, verify `flClient.flower.superlink` is a reachable gRPC endpoint and root certificates are in the kit.
+6. **Staged kit not mounted**: With the active backend's `kitFromS3.enabled=false`, verify `flClient.kitHostPath` is set and the node directory is readable by the client's runtime uid (NVFLARE 1000, Flower 49999) — unset, the kit volume renders empty with no deploy-time error and the client starts without credentials.
 
 ### Network policy blocking intra-service traffic
 

--- a/deploy/providers/kubernetes/templates/_helpers.tpl
+++ b/deploy/providers/kubernetes/templates/_helpers.tpl
@@ -141,9 +141,5 @@ single backend's flag lets the two disagree, which renders an empty volume and
 drops a staged kit silently (#999) — so both call this helper.
 */}}
 {{- define "flip-trust.flClientKitFromS3" -}}
-{{- if eq .Values.flBackend "nvflare" }}
-{{- if .Values.flClient.nvflare.kitFromS3.enabled }}true{{ end }}
-{{- else if eq .Values.flBackend "flower" }}
-{{- if .Values.flClient.flower.kitFromS3.enabled }}true{{ end }}
-{{- end }}
+{{- if (index .Values.flClient .Values.flBackend).kitFromS3.enabled }}true{{ end }}
 {{- end }}

--- a/deploy/providers/kubernetes/templates/_helpers.tpl
+++ b/deploy/providers/kubernetes/templates/_helpers.tpl
@@ -128,3 +128,22 @@ FL client image name based on backend selection
 {{- printf "%s/flower-supernode:%s" $registry $tag }}
 {{- end }}
 {{- end }}
+
+{{/*
+Whether the FL client's participant kit is fetched from S3 by the kit-init
+initContainer, for the ACTIVE backend. Returns a non-empty string when true and
+an empty string (falsy) otherwise.
+
+Both the kit-init initContainer and the fl-client-kit volume must agree on this:
+when the kit comes from S3 the volume is an emptyDir that kit-init populates,
+otherwise it is the hostPath at flClient.kitHostPath. Gating one of them on a
+single backend's flag lets the two disagree, which renders an empty volume and
+drops a staged kit silently (#999) — so both call this helper.
+*/}}
+{{- define "flip-trust.flClientKitFromS3" -}}
+{{- if eq .Values.flBackend "nvflare" }}
+{{- if .Values.flClient.nvflare.kitFromS3.enabled }}true{{ end }}
+{{- else if eq .Values.flBackend "flower" }}
+{{- if .Values.flClient.flower.kitFromS3.enabled }}true{{ end }}
+{{- end }}
+{{- end }}

--- a/deploy/providers/kubernetes/templates/fl-client.yaml
+++ b/deploy/providers/kubernetes/templates/fl-client.yaml
@@ -92,7 +92,7 @@ spec:
           operator: Exists
           effect: NoSchedule
       {{- end }}
-      {{- if or (and (eq .Values.flBackend "nvflare") .Values.flClient.nvflare.kitFromS3.enabled) (and (eq .Values.flBackend "flower") .Values.flClient.flower.kitFromS3.enabled) }}
+      {{- if include "flip-trust.flClientKitFromS3" . }}
       initContainers:
         - name: kit-init
           image: amazon/aws-cli:2.22.0
@@ -310,7 +310,7 @@ spec:
             medium: Memory
             sizeLimit: {{ .Values.flClient.shmSize }}
         - name: fl-client-kit
-{{- if .Values.flClient.nvflare.kitFromS3.enabled }}
+{{- if include "flip-trust.flClientKitFromS3" . }}
           emptyDir: {}
 {{- else if .Values.flClient.kitHostPath }}
           hostPath:

--- a/deploy/providers/kubernetes/templates/fl-client.yaml
+++ b/deploy/providers/kubernetes/templates/fl-client.yaml
@@ -310,9 +310,7 @@ spec:
             medium: Memory
             sizeLimit: {{ .Values.flClient.shmSize }}
         - name: fl-client-kit
-{{- if include "flip-trust.flClientKitFromS3" . }}
-          emptyDir: {}
-{{- else if .Values.flClient.kitHostPath }}
+{{- if and (not (include "flip-trust.flClientKitFromS3" .)) .Values.flClient.kitHostPath }}
           hostPath:
             path: {{ .Values.flClient.kitHostPath | quote }}
             type: Directory

--- a/deploy/providers/kubernetes/templates/fl-client.yaml
+++ b/deploy/providers/kubernetes/templates/fl-client.yaml
@@ -101,15 +101,10 @@ spec:
             - -c
             - |
               set -euo pipefail
-              {{- if eq .Values.flBackend "nvflare" }}
-              S3_PATH="{{ tpl .Values.flClient.nvflare.kitFromS3.pathTemplate . }}"
-              S3_BUCKET="{{ .Values.flClient.nvflare.kitFromS3.bucket }}"
+              {{- $kitFromS3 := (index .Values.flClient .Values.flBackend).kitFromS3 }}
+              S3_PATH="{{ tpl $kitFromS3.pathTemplate . }}"
+              S3_BUCKET="{{ $kitFromS3.bucket }}"
               DEST_DIR="/opt/fl-client/kit"
-              {{- else }}
-              S3_PATH="{{ tpl .Values.flClient.flower.kitFromS3.pathTemplate . }}"
-              S3_BUCKET="{{ .Values.flClient.flower.kitFromS3.bucket }}"
-              DEST_DIR="/opt/fl-client/kit"
-              {{- end }}
               echo "Syncing s3://${S3_BUCKET}/${S3_PATH} to ${DEST_DIR}..."
               {{- if .Values.flClient.s3EndpointOverride }}
               aws s3 sync "s3://${S3_BUCKET}/${S3_PATH}" "${DEST_DIR}" --delete --endpoint-url {{ .Values.flClient.s3EndpointOverride | quote }}

--- a/deploy/providers/kubernetes/values.yaml
+++ b/deploy/providers/kubernetes/values.yaml
@@ -293,6 +293,14 @@ flClient:
     repository: ghcr.io/londonaicentre
     tag: stag
     pullPolicy: Always
+  # Node path holding a pre-staged participant kit, used INSTEAD of fetching from
+  # S3. Only consulted when the active backend's kitFromS3.enabled is false: the
+  # fl-client-kit volume is then a hostPath here, rather than an emptyDir that the
+  # kit-init initContainer populates. Leave empty to require the S3 path.
+  # For air-gapped trusts and local kind clusters, where the kit is copied onto the
+  # node out of band. The directory must be readable by the FL image's runtime user
+  # — 49999 (app) for the Flower SuperNode, which differs from the NVFLARE client.
+  kitHostPath: ""
   nvflare:
     kitFromS3:
       enabled: true

--- a/deploy/providers/kubernetes/values.yaml
+++ b/deploy/providers/kubernetes/values.yaml
@@ -296,10 +296,13 @@ flClient:
   # Node path holding a pre-staged participant kit, used INSTEAD of fetching from
   # S3. Only consulted when the active backend's kitFromS3.enabled is false: the
   # fl-client-kit volume is then a hostPath here, rather than an emptyDir that the
-  # kit-init initContainer populates. Leave empty to require the S3 path.
-  # For air-gapped trusts and local kind clusters, where the kit is copied onto the
-  # node out of band. The directory must be readable by the FL image's runtime user
-  # — 49999 (app) for the Flower SuperNode, which differs from the NVFLARE client.
+  # kit-init initContainer populates. Nothing enforces that one of the two sources
+  # is configured — kitFromS3 disabled with this left empty renders an empty
+  # emptyDir, and the client starts without credentials, failing only at connect
+  # time. For air-gapped trusts and local kind clusters, where the kit is copied
+  # onto the node out of band. The directory must be readable by the FL image's
+  # runtime user — 49999 (app) for the Flower SuperNode, 1000 (flip) for the
+  # NVFLARE client.
   kitHostPath: ""
   nvflare:
     kitFromS3:


### PR DESCRIPTION
## Description

The chart's `fl-client-kit` volume was gated on the **NVFLARE** kit flag regardless of the selected FL backend, so a Flower trust staging its kit on the node got an empty volume instead of its credentials.

`templates/fl-client.yaml` had exactly two references to `kitFromS3.enabled`, and they encoded the same decision:

- the `kit-init` initContainer gated on the **active backend**;
- the `fl-client-kit` volume gated on `.Values.flClient.nvflare.kitFromS3.enabled` **alone**.

`values.yaml` defaults that NVFLARE flag to `true`, so a Flower deployment that disabled only `flClient.flower.kitFromS3.enabled` and set `flClient.kitHostPath` still took the first branch and rendered `emptyDir: {}`. The staged kit was silently dropped and the SuperNode started with empty `/certs` and `/keys`.

The failure is invisible at deploy time: the pod starts, never registers with the SuperLink, and logs a repeating `Connection attempt failed, retrying in …` — indistinguishable from a TLS/hostname or networking fault. (When the SuperNode command references a specific cert path, as the chart's does, it instead crash-loops on `Path argument --root-certificates does not point to a file` — both signatures were reproduced live, see Testing.)

**Affected:** Flower deployments with `kitFromS3` disabled — local `kind` dev trusts and air-gapped/on-prem trusts that stage kits out of band. **Not affected:** S3-based deployments of either backend, where `emptyDir` is correct because `kit-init` populates it.

## Changes

- **`templates/_helpers.tpl`** — new `flip-trust.flClientKitFromS3` helper holding the "is this backend's kit fetched from S3" decision once. It selects the active backend's sub-map (`index .Values.flClient .Values.flBackend`) rather than branching per backend name, so it has no third "neither backend" outcome. (`values.schema.json` already pins `flBackend` to the `nvflare`/`flower` enum, so the `index` lookup cannot nil-deref on a typo — helm rejects the value before rendering.)
- **`templates/fl-client.yaml`** — both the initContainer gate and the volume gate now call that helper, so they cannot drift apart again. The volume's three-way branch (whose first and last arms both rendered `emptyDir`) collapses to hostPath-or-emptyDir. `kit-init`'s per-backend S3 env branch collapses onto the same index-by-backend idiom (both arms set the same `DEST_DIR`), so the file carries one spelling of "pick the active backend's kit config".
- **`values.yaml`** — document `flClient.kitHostPath`. It is honoured by the template but had no values entry and no README mention; the alternative to the S3 path being invisible is part of why the mis-gating went unnoticed. Defaults to `""`, so no rendered output changes. The comment names both runtime uids (Flower 49999, NVFLARE 1000) and is explicit that with `kitFromS3` disabled and `kitHostPath` unset the volume renders as an empty `emptyDir` with no deploy-time error — that pre-existing shape is out of scope here (a `fail` guard would be a render-contract change; candidate follow-up).
- **`README.md`** — the staged-kit route is documented ("Staged participant kit (no S3)" under FL Backend Configuration) plus a "FL client won't connect" troubleshooting entry; previously the only kit path the README knew was S3.
- **`.github/workflows/test_helm_chart.yml`** — per-backend regression assertions in the existing `helm-template` job. The volume is identified by parsing the manifest and selecting `spec.template.spec.volumes[name=fl-client-kit]` (a context grep around that string also matches the volumeMounts entries, so it would test whichever node sat near a match). The parser exists once as a shell function; annotations go to stdout; PyYAML is pinned via `uv run --with pyyaml` rather than trusting the runner image. **`kitHostPath` is set in the S3-on renders too**, so each pair of renders differs on `kitFromS3` alone and the assertions pin the precedence between the two flags — without that, a volume gate reading `kitHostPath` alone passes every assertion (found by mutation testing during review; such a gate would also let `kit-init` `aws s3 sync --delete` + `chown` a staged node directory as root).

## Rendered behaviour

`fl-client-kit` volume / `kit-init` presence, before and after:

| Backend | `kitFromS3` | `kitHostPath` | Before | After |
| --- | --- | --- | --- | --- |
| flower | on | — | `emptyDir` + kit-init | unchanged |
| flower | off | set | **`emptyDir`, no kit-init** ❌ | `hostPath`, no kit-init ✅ |
| flower | off | unset | `emptyDir` | unchanged |
| nvflare | on | — | `emptyDir` + kit-init | unchanged |
| nvflare | off | set | `hostPath`, no kit-init | unchanged |
| nvflare | off | unset | `emptyDir` | unchanged |

Only the marked row changes. The volume and `kit-init` now always agree.

## Testing

- `helm lint` clean; chart `tests/` suite 20 passed.
- All eight `{backend} x {kitFromS3} x {kitHostPath}` shapes rendered and diffed against `develop`: only the marked row changes; the cleanup commits are byte-identical across all eight. Default render unchanged, so no existing deployment's manifests move.
- **The CI step was mutation-tested**: it fails on the pre-fix template (flower + `kitHostPath` → `emptyDir`), on a volume gate reading `kitHostPath` alone (the precedence mutation), and on an inverted helper — and passes on the fixed chart.
- **Verified on a live dev Kubernetes deployment** (kind, throwaway namespace, client-only release, flower + `flower.kitFromS3.enabled=false` + `kitHostPath=/opt/fl-kit-flower/net-1`, `nvflare.kitFromS3` left at its default `true` — the exact regressed shape):
  - **develop's chart**: volume rendered `emptyDir: {}`, SuperNode crash-looped with `Path argument --root-certificates does not point to a file` — the bug, live.
  - **`helm upgrade` to this branch's chart, same values**: volume rendered `hostPath: /opt/fl-kit-flower/net-1`, the staged `ca.crt`/`server.pem`/SuperNode keys appeared under `/certs` and `/keys` readable by uid 49999, and the SuperNode started, bound ClientAppIo on 9094 and sat in the expected connection-retry loop (no Flower SuperLink was running — the shared stack is on NVFLARE).

The local hybrid dev topology that surfaced the bug carries the `nvflare.kitFromS3.enabled=false` workaround in its override file; this makes that workaround unnecessary.

## Acceptance criteria

- [x] With `flBackend=flower`, `flClient.flower.kitFromS3.enabled=false` and `flClient.kitHostPath` set, `fl-client-kit` renders as a `hostPath` — no `nvflare.kitFromS3.enabled=false` workaround needed.
- [x] The volume gate and the `kit-init` gate derive from a single shared expression.
- [x] All four combinations render correctly, for both backends.
- [x] A regression check in `test_helm_chart.yml` asserts the flower + `kitHostPath` shape renders `hostPath` and not `emptyDir`.

Closes #999


## Acceptance Criteria

*Imported from issue #999*

- With `flBackend=flower`, `flClient.flower.kitFromS3.enabled=false` and `flClient.kitHostPath` set, the rendered `fl-client-kit` volume is a `hostPath` pointing at `kitHostPath` — without needing `flClient.nvflare.kitFromS3.enabled=false` as a workaround.
- The volume gate and the `kit-init` initContainer gate cannot drift apart again: both derive the "is the kit fetched from S3 for the active backend" decision from a single shared expression.
- All four combinations in the table above render as marked "correct", for both backends.
- A regression check in `.github/workflows/test_helm_chart.yml` asserts the flower + `kitHostPath` shape renders `hostPath` and not `emptyDir`, so the silent failure cannot return unnoticed.
