### PR TITLE
fix(trust-api): add the missing .dockerignore so a dev checkout's .venv can't clobber the image

### DIFF
--- a/trust/trust-api/.dockerignore
+++ b/trust/trust-api/.dockerignore
@@ -1,0 +1,52 @@
+# Copyright (c) 2026 Guy's and St Thomas' NHS Foundation Trust & King's College London
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Dockerfile
+# Hidden files
+.dockerignore
+.git
+.DS_Store
+.vscode
+
+# Build artifacts
+*.pyc
+*.so
+*.egg
+*.whl
+
+# Local settings
+.env
+.env.local
+.env.development
+.env.test
+.env.production
+local.properties
+
+# IDE files
+.idea
+*.iml
+.classpath
+.project
+
+# Log files
+*.log
+*.err
+
+# Test directories
+test
+tests
+coverage
+.pytest_cache
+
+# Virtual environment
+.venv
+venv


### PR DESCRIPTION
## What

`trust/trust-api/` is the only one of the three trust services with **no `.dockerignore`**. `imaging-api` and `data-access-api` ship an identical one; this adds a byte-for-byte copy so the three stay consistent.

## Why

`trust-api/Dockerfile`'s `production` stage does `COPY . .`. Without a `.dockerignore`, building the image from a working checkout copies the **host's `.venv`** over the `/app/.venv` that `uv sync` just built in the `development` stage. The interpreter symlink then dangles:

```
# built from a dev checkout, no .dockerignore
$ docker run --rm --entrypoint sh trust-api -c '/app/.venv/bin/python -c "print(1)"'
sh: 1: /app/.venv/bin/python: not found

# same build, with this .dockerignore
$ docker run --rm --entrypoint sh trust-api -c '/app/.venv/bin/python -c "import sys;print(sys.version.split()[0], sys.prefix)"'
3.12.14 /app/.venv
```

At runtime uv logs `Ignoring existing virtual environment linked to non-existent Python interpreter: .venv/bin/python3 -> python` and rebuilds the environment on every container start, so the readiness probe never passes and the pod sits `0/1` and restart-loops.

It also copies `.env`, `.vscode`, `tests/` and `.pytest_cache` into the image, none of which the sibling services ship. (The tracked `trust-api/.env` only sets `PYTHONPATH`, so there is no secret exposure here — it is just avoidable image content.)

## Why nothing caught this

Two layers independently hide it:

- **CI builds from a clean checkout**, which has no `.venv`, so the published `ghcr.io/londonaicentre/trust-api` images are unaffected.
- **Compose bind-mounts the source** (`trust_api/`), so dev never depends on what the copy produced.

It only bites images built from a developer's tree — `make build`, and the **Kubernetes / prod image path**, where there are no bind mounts at all.

## How it was found

Hit while standing up a Kubernetes trust (`deploy/providers/kubernetes`) for a live dual-backend e2e smoke: the `trust-api` pod came up `0/1` and restart-looped on exactly this, while `imaging-api` and `data-access-api` built from the same commit came up clean.

## Testing

Built `trust/trust-api` from a checkout containing a host `.venv`, with and without the file — output above. No source change, so no unit/integration impact.