### PR TITLE
[Bug]: Metrics plots colour the same trust differently in each plot, and plots are unsorted

### DIFF
--- a/flip-ui/src/components/AiChart/AiModelMetricsChart.vue
+++ b/flip-ui/src/components/AiChart/AiModelMetricsChart.vue
@@ -40,6 +40,10 @@ import { useSiteSettings } from "@/store/siteSettingsStore";
 
 interface IAiCohortChartProps {
     data: IModelMetricData
+    /** Palette slot per series label, assigned by the parent over every plot it renders, so the
+     * same trust keeps one colour across plots even when its per-plot arrival order differs or a
+     * plot is missing it entirely. Absent (single standalone chart), slots follow sorted order. */
+    styleIndexBySeries?: Record<string, number>
 }
 
 const props = defineProps<IAiCohortChartProps>();
@@ -91,6 +95,10 @@ onMounted(() => {
             const chartOptions: ComputedRef<ECOption> = computed(() => {
                 const darkMode = siteSettings.getSettings.darkMode;
                 const chrome = chartChrome(darkMode);
+                // Series sort with the legend: the backend's per-plot arrival order must not
+                // decide palette slots, or the same trust changes colour from plot to plot.
+                const sortedMetrics = [...props.data.metrics]
+                    .sort((a, b) => a.seriesLabel.localeCompare(b.seriesLabel));
 
                 return {
                     color: [...CHART_SERIES_COLORS[darkMode ? "dark" : "light"]],
@@ -152,10 +160,7 @@ onMounted(() => {
                         }
                     },
                     legend: {
-                        data: props.data.metrics
-                            .map(d => d.seriesLabel)
-                            .slice()
-                            .sort((a, b) => a.localeCompare(b)),
+                        data: sortedMetrics.map(d => d.seriesLabel),
                         orient: "vertical",
                         // Floats inside the plot, vertically centred on the right edge; the
                         // translucent card backing keeps it legible where lines pass beneath.
@@ -218,13 +223,14 @@ onMounted(() => {
                         splitLine: { lineStyle: { color: chrome.gridLine } },
                         minorSplitLine: { show: false }
                     },
-                    series: props.data.metrics.map((element, seriesIdx) => {
+                    series: sortedMetrics.map((element, seriesIdx) => {
                         const sortedData = [...element.data].sort((a, b) => a.xValue - b.xValue);
                         const totalPoints = sortedData.length;
                         const totalDuration = 3000; // total animation time (ms)
                         // Guard the empty-series case — 3000/0 = Infinity is an invalid echarts duration.
                         const perPointDelay = totalPoints ? totalDuration / totalPoints : 0;
-                        const { color: seriesColor, lineType } = seriesStyle(seriesIdx, darkMode);
+                        const { color: seriesColor, lineType } =
+                            seriesStyle(props.styleIndexBySeries?.[element.seriesLabel] ?? seriesIdx, darkMode);
 
                         return {
                             name: element.seriesLabel,

--- a/flip-ui/src/components/AiChart/__tests__/AiModelMetricsChart.spec.ts
+++ b/flip-ui/src/components/AiChart/__tests__/AiModelMetricsChart.spec.ts
@@ -177,7 +177,7 @@ describe("AiModelMetricsChart", () => {
         expect(opts.toolbox.feature.dataZoom.filterMode).toBe("none");
     });
 
-    it("emits a line series per metric and sorts the legend alphabetically", async () => {
+    it("emits a line series per metric, sorted to match the alphabetical legend", async () => {
         mountChart();
         await nextTick();
         await flushPromises();
@@ -185,9 +185,70 @@ describe("AiModelMetricsChart", () => {
         const opts = setOption.mock.calls[0][0];
         expect(opts.series).toHaveLength(2);
         expect(opts.series.every((s: { type: string }) => s.type === "line")).toBe(true);
-        // Series preserve input order, legend gets a sorted snapshot.
-        expect(opts.series.map((s: { name: string }) => s.name)).toEqual(["Trust B", "Trust A"]);
+        // Series sort with the legend: palette slots follow the label, not the
+        // backend's per-plot arrival order, so tooltip and legend order agree.
+        expect(opts.series.map((s: { name: string }) => s.name)).toEqual(["Trust A", "Trust B"]);
         expect(opts.legend.data).toEqual(["Trust A", "Trust B"]);
+    });
+
+    it("keys series colours by styleIndexBySeries, so a trust keeps its colour across plots", async () => {
+        mount(AiModelMetricsChart, {
+            props: {
+                data: DATA,
+                // The parent derives the slots from every plot's series, so a plot
+                // missing a trust must not shift the colours of the trusts it has.
+                styleIndexBySeries: {
+                    "Trust A": 2,
+                    "Trust B": 0
+                }
+            },
+            global: {
+                plugins: [createTestingPinia({
+                    createSpy: vi.fn,
+                    stubActions: false
+                })]
+            }
+        });
+        await nextTick();
+        await flushPromises();
+
+        const opts = setOption.mock.calls[0][0];
+        expect(opts.series[0].name).toBe("Trust A");
+        expect(opts.series[0].itemStyle.color).toBe(CHART_SERIES_COLORS.light[2]);
+        expect(opts.series[1].name).toBe("Trust B");
+        expect(opts.series[1].itemStyle.color).toBe(CHART_SERIES_COLORS.light[0]);
+    });
+
+    it("dashes a series whose assigned slot sits beyond the palette", async () => {
+        mount(AiModelMetricsChart, {
+            props: {
+                data: {
+                    yLabel: "y",
+                    xLabel: "x",
+                    metrics: [{
+                        seriesLabel: "A",
+                        data: [{
+                            xValue: 1,
+                            yValue: 0.5
+                        }]
+                    }]
+                },
+                styleIndexBySeries: { A: 8 }
+            },
+            global: {
+                plugins: [createTestingPinia({
+                    createSpy: vi.fn,
+                    stubActions: false
+                })]
+            }
+        });
+        await nextTick();
+        await flushPromises();
+
+        // The ninth slot wraps the palette; the dashed line carries the distinction.
+        const opts = setOption.mock.calls[0][0];
+        expect(opts.series[0].itemStyle.color).toBe(CHART_SERIES_COLORS.light[0]);
+        expect(opts.series[0].lineStyle.type).toBe("dashed");
     });
 
     it("sorts each series' data by xValue", async () => {

--- a/flip-ui/src/partials/models/TrainingActionsMenu.vue
+++ b/flip-ui/src/partials/models/TrainingActionsMenu.vue
@@ -29,7 +29,7 @@
         </button>
 
         <AiButton
-            light
+            primary
             data-test="download-results-btn"
             aria-label="Download Results"
             tooltip="Download Results"

--- a/flip-ui/src/partials/models/TrainingMetrics.vue
+++ b/flip-ui/src/partials/models/TrainingMetrics.vue
@@ -109,7 +109,7 @@
              a 16:9 box. min-h-0 lets it shrink below its content on a short window;
              the card carries the readability floor. -->
         <div v-if="view === 'single'" class="w-full flex-1 min-h-0 pt-4" role="tabpanel">
-            <AiMetricsChart v-if="activeChart" :data="activeChart" />
+            <AiMetricsChart v-if="activeChart" :data="activeChart" :style-index-by-series="styleIndexBySeries" />
         </div>
 
         <!-- Every plot at once. The cells keep a readable height and the view scrolls,
@@ -152,7 +152,7 @@
                         :data-test="`metrics-grid-plot-${chart.yLabel}-${chart.xLabel}`"
                         class="w-full aspect-[3/2] md:aspect-video min-h-[13rem] max-h-[24rem]"
                     >
-                        <AiMetricsChart :data="chart" />
+                        <AiMetricsChart :data="chart" :style-index-by-series="styleIndexBySeries" />
                     </div>
                 </figure>
             </div>
@@ -198,23 +198,6 @@ const chartId = (chart: IModelMetricData) => JSON.stringify([chart.yLabel, chart
 
 const activeChartId = ref<string | null>(null);
 
-// Default to the first chart whenever the data first loads or the active tab
-// disappears from the response (e.g. backend dropped a metric).
-watch(
-    data,
-    next => {
-        if (!next?.length) {
-            activeChartId.value = null;
-
-            return;
-        }
-        if (!activeChartId.value || !next.some(c => chartId(c) === activeChartId.value)) {
-            activeChartId.value = chartId(next[0]);
-        }
-    },
-    { immediate: true }
-);
-
 // Distinct x-axis labels per metric name. A metric plotted against a single x-axis shows just its
 // name; only when the same metric appears under more than one x-label do we disambiguate the tabs.
 const xLabelsByMetric = computed(() => {
@@ -247,17 +230,47 @@ const nameToCode = computed(() => {
 });
 
 // Every chart, with trust names shortened to their codes. Both views draw from
-// this, so a legend reads the same whichever layout you are in.
+// this, so a legend reads the same whichever layout you are in. Sorted by metric
+// title (then x-label) rather than backend arrival order, so related plots
+// (TRAIN-*/VAL-* pairs) sit together in the tabs and the grid (FLIP#1011).
 const charts = computed(() => {
     const codes = nameToCode.value;
 
-    return (data.value ?? []).map(chart => ({
-        ...chart,
-        metrics: chart.metrics.map(s => ({
-            ...s,
-            seriesLabel: codes.get(s.seriesLabel) ?? s.seriesLabel
+    return (data.value ?? [])
+        .map(chart => ({
+            ...chart,
+            metrics: chart.metrics.map(s => ({
+                ...s,
+                seriesLabel: codes.get(s.seriesLabel) ?? s.seriesLabel
+            }))
         }))
-    }));
+        .sort((a, b) => a.yLabel.localeCompare(b.yLabel) || a.xLabel.localeCompare(b.xLabel));
+});
+
+// Default to the first (sorted) chart whenever the data first loads or the active
+// tab disappears from the response (e.g. backend dropped a metric).
+watch(
+    charts,
+    next => {
+        if (!next.length) {
+            activeChartId.value = null;
+
+            return;
+        }
+        if (!activeChartId.value || !next.some(c => chartId(c) === activeChartId.value)) {
+            activeChartId.value = chartId(next[0]);
+        }
+    },
+    { immediate: true }
+);
+
+// One palette slot per series label, shared by every plot: slots are assigned over
+// the union of labels across all charts, so neither per-plot arrival order nor a
+// plot missing a trust can change what colour that trust wears elsewhere (FLIP#1011).
+const styleIndexBySeries = computed(() => {
+    const labels = new Set(charts.value.flatMap(c => c.metrics.map(s => s.seriesLabel)));
+
+    return Object.fromEntries([...labels].sort((a, b) => a.localeCompare(b)).map((label, idx) => [label, idx]));
 });
 
 const activeChart = computed(() => charts.value.find(c => chartId(c) === activeChartId.value) ?? null);

--- a/flip-ui/src/partials/models/TrainingMetrics.vue
+++ b/flip-ui/src/partials/models/TrainingMetrics.vue
@@ -198,11 +198,19 @@ const chartId = (chart: IModelMetricData) => JSON.stringify([chart.yLabel, chart
 
 const activeChartId = ref<string | null>(null);
 
+// The single guarded read of the response — every derived view below goes through it.
+// Array.isArray, not ?? []: a stubbed or misbehaving backend can 200 with an empty
+// body ("" from the fetch layer), and unlike the template's lazy reads the
+// activeChartId watcher evaluates `charts` eagerly on every response. The service
+// normalises this too, but the component also renders from SWRV cache and stubbed
+// responses, so the guard stays here as well.
+const metrics = computed(() => (Array.isArray(data.value) ? data.value : []));
+
 // Distinct x-axis labels per metric name. A metric plotted against a single x-axis shows just its
 // name; only when the same metric appears under more than one x-label do we disambiguate the tabs.
 const xLabelsByMetric = computed(() => {
     const map = new Map<string, Set<string>>();
-    for (const chart of data.value ?? []) {
+    for (const chart of metrics.value) {
         const labels = map.get(chart.yLabel) ?? new Set<string>();
         labels.add(chart.xLabel);
         map.set(chart.yLabel, labels);
@@ -236,10 +244,7 @@ const nameToCode = computed(() => {
 const charts = computed(() => {
     const codes = nameToCode.value;
 
-    // Array.isArray, not ?? []: a stubbed or misbehaving backend can 200 with an empty
-    // body ("" from the fetch layer), and unlike the template's lazy reads the
-    // activeChartId watcher evaluates this computed eagerly on every response.
-    return (Array.isArray(data.value) ? data.value : [])
+    return metrics.value
         .map(chart => ({
             ...chart,
             metrics: chart.metrics.map(s => ({

--- a/flip-ui/src/partials/models/TrainingMetrics.vue
+++ b/flip-ui/src/partials/models/TrainingMetrics.vue
@@ -236,7 +236,10 @@ const nameToCode = computed(() => {
 const charts = computed(() => {
     const codes = nameToCode.value;
 
-    return (data.value ?? [])
+    // Array.isArray, not ?? []: a stubbed or misbehaving backend can 200 with an empty
+    // body ("" from the fetch layer), and unlike the template's lazy reads the
+    // activeChartId watcher evaluates this computed eagerly on every response.
+    return (Array.isArray(data.value) ? data.value : [])
         .map(chart => ({
             ...chart,
             metrics: chart.metrics.map(s => ({

--- a/flip-ui/src/partials/models/__tests__/TrainingMetrics.spec.ts
+++ b/flip-ui/src/partials/models/__tests__/TrainingMetrics.spec.ts
@@ -255,6 +255,16 @@ describe("TrainingMetrics", () => {
         expect(wrapper.find("[data-test=chart-stub]").attributes("data-y-label")).toBe("TRAIN_LOSS");
     });
 
+    test("shows the empty state for a non-array metrics response instead of crashing", async () => {
+        // A stubbed or misbehaving backend can answer 200 with an empty body, which the
+        // fetch layer hands over as "" — the eager charts watcher must not .map over it.
+        setData("");
+        const wrapper = mountTrainingMetrics();
+        await flushPromises();
+
+        expect(wrapper.text()).toContain("Any metrics sent during the run will show here.");
+    });
+
     test("clears the active chart when the response empties", async () => {
         setData([TRAIN_LOSS]);
         const wrapper = mountTrainingMetrics();

--- a/flip-ui/src/partials/models/__tests__/TrainingMetrics.spec.ts
+++ b/flip-ui/src/partials/models/__tests__/TrainingMetrics.spec.ts
@@ -49,8 +49,8 @@ vi.mock("@/services/model-service", () => ({ getModelMetrics: vi.fn(async () => 
 vi.mock("@/components/AiChart/AiModelMetricsChart.vue", () => ({
     default: {
         name: "AiMetricsChart",
-        props: ["data"],
-        template: "<div data-test=\"chart-stub\" :data-y-label=\"data.yLabel\" :data-x-label=\"data.xLabel\" :data-series-labels=\"data.metrics.map(m => m.seriesLabel).join(',')\" />"
+        props: ["data", "styleIndexBySeries"],
+        template: "<div data-test=\"chart-stub\" :data-y-label=\"data.yLabel\" :data-x-label=\"data.xLabel\" :data-series-labels=\"data.metrics.map(m => m.seriesLabel).join(',')\" :data-style-index=\"JSON.stringify(styleIndexBySeries)\" />"
     }
 }));
 
@@ -454,6 +454,46 @@ describe("TrainingMetrics plot layout", () => {
 
         expect(second.find("[data-test=metrics-grid]").exists()).toBe(true);
         expect(second.find("[data-test=metrics-view-grid]").attributes("aria-pressed")).toBe("true");
+    });
+
+    test("sorts the plots by metric title, whatever order the backend sends", async () => {
+        setData([VAL_F1, TRAIN_LOSS]);
+        const wrapper = mountTrainingMetrics();
+        await flushPromises();
+
+        const tabs = wrapper.findAll("[role=tab]");
+        expect(tabs.map(t => t.text())).toEqual(["TRAIN_LOSS", "VAL-F1-SCORE"]);
+        // The default plot is the first sorted one, not the first to arrive.
+        expect(wrapper.get("[data-test=chart-stub]").attributes("data-y-label")).toBe("TRAIN_LOSS");
+    });
+
+    test("gives every trust one palette slot, shared by every plot in the grid", async () => {
+        // VAL_F1 carries KCH only; TRAIN_LOSS carries KCH + UCLH. Were slots assigned
+        // per plot, KCH would take slot 0 in one plot and share it with UCLH's absence
+        // shifting colours in the other.
+        setData([VAL_F1, TRAIN_LOSS]);
+        const wrapper = mountTrainingMetrics({
+            approvedTrusts: [{
+                name: "Kings College Hospital",
+                code: "KCH"
+            }]
+        });
+        await flushPromises();
+
+        await wrapper.find("[data-test=metrics-view-grid]").trigger("click");
+
+        const maps = wrapper.findAll("[data-test=chart-stub]").map(s => s.attributes("data-style-index"));
+        // The union of series labels over every plot, sorted, after code-shortening.
+        expect(maps).toEqual([
+            JSON.stringify({
+                KCH: 0,
+                UCLH: 1
+            }),
+            JSON.stringify({
+                KCH: 0,
+                UCLH: 1
+            })
+        ]);
     });
 
     test("there is no layout switch when there is nothing to lay out", async () => {

--- a/flip-ui/src/partials/models/__tests__/TrainingMetrics.spec.ts
+++ b/flip-ui/src/partials/models/__tests__/TrainingMetrics.spec.ts
@@ -263,6 +263,10 @@ describe("TrainingMetrics", () => {
         await flushPromises();
 
         expect(wrapper.text()).toContain("Any metrics sent during the run will show here.");
+        // Every derived view reads the same guarded value, so a non-array response yields no
+        // tabs (an empty xLabelsByMetric) as well as no charts.
+        expect(wrapper.find("[role=tablist]").exists()).toBe(false);
+        expect(wrapper.find("[data-test=chart-stub]").exists()).toBe(false);
     });
 
     test("clears the active chart when the response empties", async () => {

--- a/flip-ui/src/services/__tests__/model-service.spec.ts
+++ b/flip-ui/src/services/__tests__/model-service.spec.ts
@@ -392,8 +392,26 @@ describe("model-service", () => {
             expect(result).toEqual([]);
         });
 
+        it("getDownloadUrlForResults returns [] when the backend body is empty", async () => {
+            // A 200 with no body reaches the fetch layer as the string "" — `?? []` lets it
+            // through and every caller then treats a string as an array (FLIP#1011).
+            vi.mocked(_http.get).mockResolvedValue({ data: "" } as never);
+
+            const result = await getDownloadUrlForResults("m-1");
+
+            expect(result).toEqual([]);
+        });
+
         it("getLogsForModel returns [] when body is null", async () => {
             vi.mocked(_http.get).mockResolvedValue({ data: null } as never);
+
+            const result = await getLogsForModel("/logs/m-1");
+
+            expect(result).toEqual([]);
+        });
+
+        it("getLogsForModel returns [] when the backend body is empty", async () => {
+            vi.mocked(_http.get).mockResolvedValue({ data: "" } as never);
 
             const result = await getLogsForModel("/logs/m-1");
 
@@ -420,6 +438,14 @@ describe("model-service", () => {
 
         it("getModelMetrics returns [] when body is null", async () => {
             vi.mocked(_http.get).mockResolvedValue({ data: null } as never);
+
+            const result = await getModelMetrics("/metrics/m-1");
+
+            expect(result).toEqual([]);
+        });
+
+        it("getModelMetrics returns [] when the backend body is empty", async () => {
+            vi.mocked(_http.get).mockResolvedValue({ data: "" } as never);
 
             const result = await getModelMetrics("/metrics/m-1");
 

--- a/flip-ui/src/services/model-service.ts
+++ b/flip-ui/src/services/model-service.ts
@@ -493,16 +493,18 @@ export async function initialiseTraining(
     await _http.post(`/fl/initiate/${modelId}`, initTrainingRequestData);
 }
 
+// Array.isArray, not ?? []: a 200 with an empty body reaches the fetch layer as the string "",
+// which `??` passes straight through and every caller then treats as an array (FLIP#1011).
 export async function getDownloadUrlForResults(modelId: string): Promise<string[]> {
     const response = await _http.get<string[]>(`/files/model/${modelId}/fl/results`);
 
-    return response.data ?? [];
+    return Array.isArray(response.data) ? response.data : [];
 }
 
 export async function getLogsForModel(url: string): Promise<ILog[]> {
     const response = await _http.get<ILog[]>(url);
 
-    return response.data ?? [];
+    return Array.isArray(response.data) ? response.data : [];
 }
 
 export async function stopTraining(modelId: string): Promise<undefined> {
@@ -515,6 +517,6 @@ export async function getModelMetrics(url: string): Promise<IModelMetricData[]> 
 
     const response = await _http.get<IModelMetricData[]>(url);
 
-    return response.data ?? [];
+    return Array.isArray(response.data) ? response.data : [];
 }
 


### PR DESCRIPTION
Closes #1011

## What

- **One colour per trust, in every plot.** Palette slots were keyed by each plot's series arrival order (`seriesStyle(seriesIdx, …)`), so the same trust wore a different colour in each grid cell (stag example on the issue: AWSEC2 green in TRAIN-PRECISION-Edema, orange in VAL-PRECISION-Edema next to it). `TrainingMetrics` now assigns one palette slot per series label over the **union of labels across all plots** and passes the map to every `AiModelMetricsChart` via a new optional `styleIndexBySeries` prop — so neither per-plot arrival order nor a trust missing from one plot can shift colours. A standalone chart (no map) falls back to sorted-order slots.
- **Series sort with the legend.** The legend was already alphabetical but the series (palette + tooltip order) were not; both now agree.
- **Plots sorted by metric title.** Tabs, the narrow-window dropdown and the grid cells sort by y-label then x-label instead of backend arrival order, so TRAIN-*/VAL-* pairs sit together. The default active plot is the first sorted one.
- **Non-array response guard.** The default-plot watcher now evaluates the `charts` computed eagerly, which surfaced a latent fragility: a backend answering 200 with an empty body ("" from the fetch layer — exactly what the Cypress catch-all intercept does) reached `.map` and crashed the page. `charts` now guards with `Array.isArray` and renders the empty state instead.

- **`Download Results` promoted to the primary purple.** The button used `AiButton`'s `light` variant (`bg-primary-200/70`), which read as a de-emphasised secondary sitting next to the red `Stop Training`. It now uses `primary` — the same `bg-primary-500` fill as `Create Project` and the platform's other call-to-action buttons — so the terminal action on a finished run is the one that draws the eye.

## Testing

- TDD: 6 new/updated Vitest cases (colour keyed by the map, slot-beyond-palette dashes, series/legend agreement, plot sorting, identical map to every grid cell, non-array response) each watched fail, then pass.
- `npm run lint` (0 errors; 3 pre-existing warnings in an untouched file) and full `npm run test:unit` (112 files, 1263 passed / 1 skipped) green, re-run after the `Download Results` restyle.
- Deployed to stag and verified the live bundle carries the change.

## Acceptance Criteria

*Imported from issue #1011*

- A trust keeps the same colour in every plot of a model's metrics view (single and grid), regardless of the per-plot series arrival order and even when a trust is missing from some plots.
- Legend order, series order and tooltip order agree (alphabetical by series label).
- Plots (tabs, the narrow-window dropdown, and grid cells) are sorted by metric title (y-label, then x-label).
