### PR TITLE
[Bug]: First login after MFA enrolment fails with 403s for up to 60 seconds

### DIFF
--- a/flip-api/src/flip_api/utils/cognito_helpers.py
+++ b/flip-api/src/flip_api/utils/cognito_helpers.py
@@ -458,11 +458,15 @@ def reset_user_mfa(username: str, user_pool_id: str) -> None:
 
 # TTL cache for is_mfa_enabled. verify_token calls this on every
 # authenticated request, so a short-lived in-process cache sidesteps the
-# Cognito AdminGetUser round-trip and its throttling ceiling. The cache is
-# invalidated from reset_user_mfa so admin resets take effect immediately;
-# the TTL is the upper bound on staleness when a user's MFA preference
-# changes through a path that doesn't go through reset_user_mfa (e.g. the
-# user enrolling via updateMFAPreference on the client).
+# Cognito AdminGetUser round-trip and its throttling ceiling. Only positive
+# (enrolled) results are cached: enrolment happens client-side (Amplify
+# updateMFAPreference straight to Cognito), so the hub gets no signal to
+# invalidate — a cached False would 403 every MFA-gated call for up to the
+# TTL right after a first-time user enrols. Unenrolled users are parked on
+# the setup page and generate almost no gated traffic, so re-checking them
+# per request costs nothing. The True→False transition only happens through
+# reset_user_mfa, which invalidates the entry so admin resets take effect
+# immediately.
 _MFA_STATE_TTL_SECONDS = 60.0
 _mfa_state_cache: dict[tuple[str, str], tuple[bool, float]] = {}
 _mfa_state_cache_lock = threading.Lock()
@@ -483,8 +487,10 @@ def is_mfa_enabled(username: str, user_pool_id: str) -> bool:
     user has both verified a software token and had their preference set
     with Enabled=True.
 
-    Results are cached for a short TTL because ``verify_token`` calls this
-    on every authenticated request; see ``_MFA_STATE_TTL_SECONDS``.
+    Positive results are cached for a short TTL because ``verify_token``
+    calls this on every authenticated request; negative results are never
+    cached so client-side enrolment is visible immediately — see the
+    comment on ``_MFA_STATE_TTL_SECONDS``.
 
     Args:
         username (str): Username (email)
@@ -517,8 +523,9 @@ def is_mfa_enabled(username: str, user_pool_id: str) -> bool:
         ) from e
 
     enabled = "SOFTWARE_TOKEN_MFA" in response.get("UserMFASettingList", [])
-    with _mfa_state_cache_lock:
-        _mfa_state_cache[cache_key] = (enabled, time.monotonic() + _MFA_STATE_TTL_SECONDS)
+    if enabled:
+        with _mfa_state_cache_lock:
+            _mfa_state_cache[cache_key] = (enabled, time.monotonic() + _MFA_STATE_TTL_SECONDS)
     return enabled
 
 

--- a/flip-api/tests/unit/utils/test_cognito_helpers.py
+++ b/flip-api/tests/unit/utils/test_cognito_helpers.py
@@ -1528,6 +1528,30 @@ class TestIsMfaEnabled:
 
         assert mock_client_instance.admin_get_user.call_count == 1
 
+    def test_negative_result_is_not_cached(self, mock_boto3_client, mock_settings):
+        """A not-enrolled result must never be cached: first-time enrolment
+        happens client-side (Amplify updateMFAPreference straight to Cognito),
+        so the hub gets no invalidation signal — a cached False would 403
+        every MFA-gated call for up to the TTL right after the user enrols."""
+        mock_client_instance = mock_boto3_client.return_value
+        mock_client_instance.admin_get_user.return_value = {
+            "Username": "user@example.com",
+            "UserMFASettingList": [],
+        }
+
+        # Pre-enrolment status check (what /users/me/mfa/status does).
+        assert is_mfa_enabled("user@example.com", "pool-id") is False
+
+        # User enrols via the client; Cognito now reports an active token.
+        mock_client_instance.admin_get_user.return_value = {
+            "Username": "user@example.com",
+            "UserMFASettingList": ["SOFTWARE_TOKEN_MFA"],
+        }
+
+        # The very next gated call must see the fresh state, not a stale False.
+        assert is_mfa_enabled("user@example.com", "pool-id") is True
+        assert mock_client_instance.admin_get_user.call_count == 2
+
     def test_cache_is_invalidated_by_reset_user_mfa(self, mock_boto3_client, mock_settings):
         """admin_set_user_mfa_preference must invalidate the cached entry so the
         next verify_token call sees the fresh Cognito state."""


### PR DESCRIPTION
Closes #1015

## What

First-time MFA enrolment (and re-enrolment after an admin MFA reset) left the user in a broken app for up to 60 seconds: every API call 403'd with "MFA enrolment required", which the UI surfaced as "Couldn't load your permissions", a "(Viewer)" role fallback, a generic red error banner and a stuck spinner. Waiting a minute or re-logging in "fixed" it — so every new user's first impression was a broken login.

## Root cause

`is_mfa_enabled` (`flip-api/src/flip_api/utils/cognito_helpers.py`) keeps a 60s TTL cache consulted by `verify_token` on every authenticated request — and it cached **negative** results too. The pre-enrolment `GET /users/me/mfa/status` call (the one that routes the user to the setup page) primes the cache with `False`. Enrolment then happens entirely client-side — Amplify's `verifyTOTPSetup` + `updateMFAPreference` go straight to Cognito — so the hub never gets a signal to invalidate. When the user finishes enrolment (typically well inside 60s) and the UI fetches permissions/projects, `verify_token` reads the stale `False` and 403s until the TTL lapses.

The pool is deliberately OPTIONAL (MFA enforced at the app layer — see the rationale comment in `deploy/providers/AWS/modules/cognito/main.tf`), so **all** first-time users take this post-auth enrolment path. Dev never reproduces it (`ENFORCE_MFA=false` in the dev compose); it bites stag/prod only.

## Fix

Cache only `enabled=True`. The asymmetry mirrors the state machine:

- `False` is transitional — the user is mid-enrolment, parked on the setup page, generating almost no gated traffic — and its only exit (client-side enrolment) is invisible to the hub, so it can never be safely cached.
- `True` is the hot path the cache exists for (per-request `AdminGetUser` throttle ceiling), and its only exit — admin MFA reset via `reset_user_mfa` — already invalidates the entry explicitly (behaviour unchanged, still covered by `test_cache_is_invalidated_by_reset_user_mfa`).

## Testing

- New `TestIsMfaEnabled::test_negative_result_is_not_cached` — written first and confirmed to fail with the stale-`False` behaviour before the fix (returned `False` after the mock flipped to enrolled, `admin_get_user` called once instead of twice).
- Full flip-api unit suite green on this branch; ruff + mypy clean on the touched files.
- Field check after deploy: reset MFA on a test user, re-enrol briskly (<60s), and the first minute should be clean — no `User <id> hit MFA-gated route without active TOTP` warnings in flip-api logs right after enrolment.

Hub-only change: no migration, no env vars, no UI changes — a flip-api redeploy picks it up.


## Acceptance Criteria

*Imported from issue #1015*

- Immediately after completing first-time TOTP enrolment (QR scan + code within 60s of signing in), the user lands on /projects with their permissions and role loaded — no 403s, no "Couldn't load your permissions", no Viewer fallback.
- The same holds after an admin MFA reset followed by prompt re-enrolment.
- Enrolled users' MFA state remains cached (the AdminGetUser throttle-protection the cache exists for), and admin MFA resets still take effect immediately.