### PR TITLE
[Task]: clear the open Dependabot alerts — 12 stale-manifest ghosts, 3 fixable floors, 3 blocked upstream

### DIFF
--- a/fl-services/nvflare/fl-api-base/pyproject.toml
+++ b/fl-services/nvflare/fl-api-base/pyproject.toml
@@ -40,7 +40,10 @@ exclude-newer = "3 days"
 constraint-dependencies = [
     "aiohttp>=3.14.3",           # CVE-2026-47265, CVE-2026-34993, CVE-2026-34525/16/15/14/13/12, CVE-2026-22815, CVE-2026-21860
     "cryptography>=50.0.0",      # CVE-2026-26007, CVE-2026-39892, CVE-2026-34073
-    # flask>=3.1.3 omitted: nvflare==2.8.0 hard-pins flask==3.0.2; unresolvable until nvflare relaxes that pin
+    # flask>=3.1.3 omitted: nvflare==2.8.0 (and 2.8.1) hard-pin flask==3.0.2, so no constraint can
+    # lift it. nvflare 2.9.0rc1 pins flask==3.1.3, so the fix lands with that upgrade (#1037);
+    # until then Dependabot #258/#400 stay open. FLIP imports no flask and never launches
+    # nvflare's dashboard/edge modules, its only flask consumers.
     "idna>=3.15",                # CVE-2026-45409
     "protobuf>=6.33.5",          # CVE-2026-0994, CVE-2025-4565
     "pygments>=2.20.0",          # CVE-2026-4539

--- a/flip-ui/package-lock.json
+++ b/flip-ui/package-lock.json
@@ -4639,17 +4639,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/@istanbuljs/load-nyc-config/node_modules/argparse": {
-            "version": "1.0.10",
-            "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-            "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-            "dev": true,
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "sprintf-js": "~1.0.2"
-            }
-        },
         "node_modules/@istanbuljs/load-nyc-config/node_modules/find-up": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -4663,21 +4652,6 @@
             },
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-            "version": "3.15.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-            "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
-            "dev": true,
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "argparse": "^1.0.7",
-                "esprima": "^4.0.0"
-            },
-            "bin": {
-                "js-yaml": "bin/js-yaml.js"
             }
         },
         "node_modules/@istanbuljs/load-nyc-config/node_modules/locate-path": {
@@ -9761,6 +9735,17 @@
             "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/argparse": {
+            "version": "1.0.10",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+            "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "sprintf-js": "~1.0.2"
+            }
         },
         "node_modules/array-buffer-byte-length": {
             "version": "1.0.2",
@@ -16767,6 +16752,21 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/js-yaml": {
+            "version": "3.15.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+            "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "argparse": "^1.0.7",
+                "esprima": "^4.0.0"
+            },
+            "bin": {
+                "js-yaml": "bin/js-yaml.js"
+            }
+        },
         "node_modules/jsbn": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
@@ -17902,9 +17902,9 @@
             "license": "MIT"
         },
         "node_modules/nanoid": {
-            "version": "3.3.16",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-            "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+            "version": "3.3.18",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+            "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
             "funding": [
                 {
                     "type": "github",

--- a/flip-ui/package.json
+++ b/flip-ui/package.json
@@ -134,7 +134,8 @@
         "@babel/plugin-transform-modules-systemjs": ">=7.29.4",
         "tmp": ">=0.2.6 <0.3.0",
         "form-data": ">=4.0.6",
-        "js-yaml": ">=3.15.0 <4.0.0",
+        "js-yaml": ">=3.15.1 <4.0.0",
+        "nanoid": ">=3.3.18 <4.0.0",
         "@babel/core": ">=7.29.6 <8.0.0"
     },
     "babel": {

--- a/flip-utils/pyproject.toml
+++ b/flip-utils/pyproject.toml
@@ -108,7 +108,10 @@ constraint-dependencies = [
     "click>=8.3.3",              # CVE-2026-7246
     "cryptography>=50.0.0",      # CVE-2026-26007, CVE-2026-39892, CVE-2026-34073
     "filelock>=3.20.3",          # CVE-2025-68146, CVE-2026-22701
-    # flask>=3.1.3 omitted: nvflare==2.8.0 hard-pins flask==3.0.2; unresolvable until nvflare relaxes that pin
+    # flask>=3.1.3 omitted: nvflare==2.8.0 (and 2.8.1) hard-pin flask==3.0.2, so no constraint can
+    # lift it. nvflare 2.9.0rc1 pins flask==3.1.3, so the fix lands with that upgrade (#1037);
+    # until then Dependabot #258/#400 stay open. FLIP imports no flask and never launches
+    # nvflare's dashboard/edge modules, its only flask consumers.
     "fonttools>=4.62.0",         # arbitrary code execution (dev-only, via matplotlib)
     "idna>=3.15",                # CVE-2026-45409
     "pillow>=12.3.0",            # CVE-2026-42311/42310/42309/42308/40192/25990
@@ -117,6 +120,12 @@ constraint-dependencies = [
     "pyjwt>=2.12.0",             # CVE-2026-32597
     "python-dotenv>=1.2.2",      # CVE-2026-28684
     "requests>=2.33.0",          # CVE-2026-25645
+    # setuptools>=83.0.0 (CVE-2026-59890) omitted: torch 2.11.0 declares setuptools<82, and the
+    # torch pin is itself fixed by the cu128 index above, so the floor is unreachable until the
+    # cu130 migration in #826 (torch 2.13.0 drops the ceiling). Dependabot #475 stays open with
+    # #439 for the same reason. Not overridden: the advisory is a MANIFEST.in sdist-exclusion
+    # bypass on macOS APFS/HFS+ and this repo has no MANIFEST.in, no setuptools build backend
+    # outside flip-api (which ships as an image, never an sdist), and no macOS runner.
     "urllib3>=2.7.0",            # CVE-2026-44431, CVE-2025-66471/66418
     "werkzeug>=3.1.6",           # CVE-2026-27199, CVE-2026-21860, CVE-2025-66221, CVE-2024-49767/49766
 ]


### PR DESCRIPTION
# Description

Closes the two Dependabot alerts that are actually fixable, and records at the point of omission why each remaining one is not — so the next reader finds the reason in the file rather than re-deriving it.

## What changed

**`flip-ui/package.json` overrides** — two floors, both verified resolved:

| Package | Was | Now | Alert |
|---|---|---|---|
| `js-yaml` | `>=3.15.0 <4.0.0` | `>=3.15.1 <4.0.0` | #512, GHSA-5p4m-2wfm-xmqj (High) |
| `nanoid` | *(none)* | `>=3.3.18 <4.0.0` | #515, CVE-2026-67213 (High) |

- The `js-yaml` `<4.0.0` bound stays deliberately: `@istanbuljs/load-nyc-config` peer-requires the v3 line, and 4.x is *also* affected with the fix not backported. 3.15.1 is the `v3-legacy` dist-tag.
- `nanoid` carries production scope because it reaches the graph through `vue → @vue/compiler-sfc → postcss → nanoid`, not only the dev chain. `postcss` asks for `^3.3.16`, so the 3.x `legacy` line satisfies it and the `<4.0.0` bound keeps it there (`latest` is 6.0.1). An override rather than a bare `npm update` matches the 14 existing entries in that block and survives re-resolution.

The `package-lock.json` diff is exactly those two packages. `js-yaml` also hoists from `@istanbuljs/load-nyc-config/node_modules/` to top level (with its `argparse`), which is just npm de-duplicating now that only one copy exists.

**Two comment blocks** in `flip-utils/pyproject.toml` and `fl-services/nvflare/fl-api-base/pyproject.toml`, documenting the omissions. No Python lockfile is regenerated — these edits are comments only, and `uv lock --check` passes unchanged for both projects.

## Why setuptools (#475) is a comment and not a floor

This started as a planned one-line `setuptools>=83.0.0` constraint. `uv lock` rejects it:

```
Because torch==2.11.0+cu128 depends on setuptools<82 and setuptools>=83.0.0,
we can conclude that torch==2.11.0+cu128 cannot be used.
```

Verified against PyPI: torch 2.11.0 declares `setuptools<82`, torch 2.13.0 drops the ceiling, and 81.0.0 is the only 81.x release. The torch pin is itself fixed by the cu128 index, because no torch >=2.13.0 build runs on the dev fleet (cu126 has no `sm_120`, cu128 stops at 2.11.0, cu130 needs driver >=580).

So **#475 is gated on the same decision as #439** and closes with it under #826 — it is not an independent fix.

Not force-overridden. torch caps setuptools because 82 removed `pkg_resources`, so an override risks `torch.utils.cpp_extension` at runtime in the FL images; and the advisory is a `MANIFEST.in` sdist-exclusion bypass on macOS APFS/HFS+, while this repo has no `MANIFEST.in` anywhere, no setuptools build backend outside `flip-api` (which ships as an image, never an sdist), and no macOS runner. Bad trade.

## Alert board after this PR

The other 12 open alerts are **ghosts** — they name manifests deleted from `develop` in June (`fl_services/fl-api-base/uv.lock`, renamed in `fd36c0a9`+`7676a4e3`; `fl-apps/tutorials/.../3d_spleen_segmentation/uv.lock`, deleted in `fecc1f4a`). The live successors are already patched (`cryptography 50.0.0`, `aiohttp 3.14.3`, `monai 1.6.0`). They need a dependency-graph refresh or dismissal, not a code change — handled outside this PR under #1036.

What legitimately stays open, each now documented in-tree: #439 + #475 (torch pin, #826), #258 + #400 (flask, blocked until nvflare 2.9.0 — #1037), #514 (extract-zip, no patched release exists; needs the Cypress 14 → 15 upgrade, tracked separately).

## Linked Issues

Fixes #1036

The ghost-alert dismissals and the follow-up issues that #1036 also called for are already done outside this PR: alerts #440, #473, #480, #503-#508 and #516-#518 are dismissed as `not_used`, and #1037 (nvflare 2.9.0), #1039 (Cypress 15), #1040 (map-apps monai ceiling) and #1041 (flip-ui dev-scope drift) are filed. Merging this closes the last of it.

## Checklist

- [x] Follows the project's coding conventions and style guide
- [x] Updates documentation — the rationale lives in the pyproject comments, which is where the existing omission notes live
- [ ] I have added tests that prove my fix is effective or that my feature works — n/a, dependency floors; `npm ls` / `npm audit` are the check
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Type of Change

- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make -C docs/ docs`.

## Testing

```
$ npm ls nanoid js-yaml
flip-ui@0.5.0
├─┬ postcss@8.5.25
│ └── nanoid@3.3.18
└─┬ ts-jest@29.4.6
  └─┬ @jest/transform@30.3.0
    └─┬ babel-plugin-istanbul@7.0.1
      └─┬ @istanbuljs/load-nyc-config@1.1.0
        └── js-yaml@3.15.1

$ npm audit
extract-zip  *   High   (only remaining finding; no patched release, needs Cypress 15)

$ npm run lint          # clean
$ npm run test:unit     # Test Files 112 passed (112) | Tests 1266 passed, 1 skipped (1267)

$ uv lock --check --project flip-utils                        # Resolved 148 packages
$ uv lock --check --project fl-services/nvflare/fl-api-base   # Resolved 93 packages
$ git status --porcelain -- '*uv.lock'                        # empty — no Python lock touched
```

- [ ] Quick tests passed locally by running `make unit-test` — ran the flip-ui suite directly; no Python source changed, so the Python suites are unaffected.
- [ ] Integration tests pass (if applicable) by running `make integration-test` — n/a.

## Additional Notes

`uv` 0.11.16 was used throughout, matching the pins in `.pre-commit-config.yaml` and the `dependency-cooldown` CI gate, so no lockfile picked up a rewritten `exclude-newer`.



## Acceptance Criteria

*Imported from issue #1036*

- [x] `flip-ui/package.json` overrides floor `js-yaml` at `>=3.15.1 <4.0.0` and `nanoid` at `>=3.3.18 <4.0.0`; `npm ls nanoid js-yaml` shows only patched versions and `npm audit` reports nothing but `extract-zip`.
- [x] Each alert that stays open is documented at the point of omission, so the next reader finds the reason without re-deriving it: the `# flask>=3.1.3 omitted:` blocks in `flip-utils/pyproject.toml` and `fl-services/nvflare/fl-api-base/pyproject.toml` name #1037, and a matching `# setuptools>=83.0.0 omitted:` block names #826.
- [x] No `uv.lock` is modified — the Python-side changes are comments only, and `uv lock --check` passes for both projects.
- [x] The 12 ghost alerts are closed — either by a dependency-graph re-scan dropping the dead manifests, or dismissed as `not_used` with the rename/deletion commit cited.
- [ ] `gh api /repos/londonaicentre/FLIP/dependabot/alerts?state=open` returns five rows: #258, #400 (flask), #439, #475 (torch pin), #514 (Cypress, tracked separately).

  *(5 is the only one that cannot be ticked pre-merge: the board currently shows seven rows — those five plus #512 and #515, which close when this merges. Verified today that the other twelve are gone.)*
