### PR TITLE
[Feature]: fl_service: fail loudly on missing config.json instead of logging a doomed job_type=standard guess

### DIFF
--- a/flip-api/src/flip_api/fl_services/services/fl_service.py
+++ b/flip-api/src/flip_api/fl_services/services/fl_service.py
@@ -515,7 +515,11 @@ def bundle_nvflare_application(model_id: UUID, job_type: str = DEFAULT_JOB_TYPE)
     Raises:
         EnvironmentError: If the S3 bucket environment variables are not set.
         FileNotFoundError: If the base or model files are missing.
+        FileNotFoundError: If no config.json is among the scanned model files — it is required for
+            every job type, and declares the job_type that selects the base application.
         FileNotFoundError: If required files for the job type are missing.
+        RuntimeError: If the required-files manifest lookup returns no files for the job type,
+            i.e. the manifest under FL_APP_BASE_DIR is missing or malformed.
 
     Returns:
         str: The destination bucket S3 path where the bundled application is located.
@@ -537,27 +541,32 @@ def bundle_nvflare_application(model_id: UUID, job_type: str = DEFAULT_JOB_TYPE)
     if not model_files:
         raise FileNotFoundError("Model files missing on the S3 bucket")
 
-    # Determine job_type from config.json if present
+    # Determine job_type from config.json. The file itself is non-negotiable — every nvflare job
+    # type requires it — so refuse here rather than logging a doomed job_type=standard guess that
+    # the required-files check below would reject anyway (FLIP#1053).
     input_config: dict = {}
     config_file = next((k for k in model_files if k.endswith("/config.json")), None)
     if not config_file:
-        logger.info("No config.json file was found in the scanned files. Using job_type=standard.")
-    else:
-        # We download the file
-        try:
-            s3_config_object = s3.get_object(config_file)
-            config_object = s3_config_object["Body"].read()
-            input_config = json.loads(config_object) if config_object else {}
-        except Exception as e:
-            logger.error(f"Error reading config.json from S3: {str(e)}. Using job_type=standard.")
-            raise ValueError("Error reading config.json from S3") from e
+        raise FileNotFoundError(
+            "No config.json found in the scanned model files. config.json is a required file for every "
+            "nvflare job type — it declares the job_type that selects the base application. Upload it "
+            "and let the scan complete, then start training again."
+        )
+    # We download the file
+    try:
+        s3_config_object = s3.get_object(config_file)
+        config_object = s3_config_object["Body"].read()
+        input_config = json.loads(config_object) if config_object else {}
+    except Exception as e:
+        logger.error(f"Error reading config.json from S3: {str(e)}.")
+        raise ValueError("Error reading config.json from S3") from e
 
-        jt = input_config.get("job_type")
-        if not jt:
-            logger.info("No 'job_type' found in config.json. Using job_type=standard.")
-        else:
-            job_type = _normalise_job_type(jt, FLBackend.NVFLARE)
-            logger.info(f"job_type in config.json: {job_type}. Using it to select base application.")
+    jt = input_config.get("job_type")
+    if not jt:
+        logger.info("No 'job_type' found in config.json. Using job_type=standard.")
+    else:
+        job_type = _normalise_job_type(jt, FLBackend.NVFLARE)
+        logger.info(f"job_type in config.json: {job_type}. Using it to select base application.")
 
     # Locate the base application for this job_type on the local FL_APP_BASE_DIR tree. This
     # bundler is the nvflare-specific path, so the backend segment is fixed:
@@ -589,6 +598,14 @@ def bundle_nvflare_application(model_id: UUID, job_type: str = DEFAULT_JOB_TYPE)
     # Validate required model files exist for the job type before uploading anything, so a bad
     # submission fails fast without leaving a partial bundle in the destination bucket.
     required_files = JobRequiredFiles.get_required_files(job_type, FLBackend.NVFLARE)
+    if not required_files:
+        # No real job type has an empty file list, so [] means the manifest lookup itself failed —
+        # without this guard the bundle would sail through with zero required-file validation.
+        raise RuntimeError(
+            f"Required-files manifest for nvflare defines no files for job type '{job_type}' — the "
+            "manifest under FL_APP_BASE_DIR is missing or malformed. This is a deployment "
+            "misconfiguration, not a problem with the uploaded model files."
+        )
     model_rel = {
         k.replace(f"{model_bucket_s3_path}/", "", 1) for k in model_files
     }  # relative paths of model files (i.e. without the bucket prefix)
@@ -721,7 +738,11 @@ def bundle_flower_application(model_id: UUID, job_type: str = DEFAULT_JOB_TYPE) 
     Raises:
         EnvironmentError: If the S3 bucket environment variables are not set.
         FileNotFoundError: If the base or model files are missing.
+        FileNotFoundError: If no config.json is among the scanned model files — it is required for
+            every job type, and declares the job_type that selects the base application.
         FileNotFoundError: If required files for the job type are missing.
+        RuntimeError: If the required-files manifest lookup returns no files for the job type,
+            i.e. the manifest under FL_APP_BASE_DIR is missing or malformed.
 
     Returns:
         str: The destination bucket S3 path where the bundled application is located.
@@ -743,26 +764,31 @@ def bundle_flower_application(model_id: UUID, job_type: str = DEFAULT_JOB_TYPE) 
     if not model_files:
         raise FileNotFoundError("Model files missing on the S3 bucket")
 
-    # Determine job_type from config.json if present
+    # Determine job_type from config.json. The file itself is non-negotiable — every flower job
+    # type requires it — so refuse here rather than logging a doomed job_type=standard guess that
+    # the required-files check below would reject anyway (FLIP#1053).
     config_file = next((k for k in model_files if k.endswith("/config.json")), None)
     if not config_file:
-        logger.info("No config.json file was found in the scanned files. Using job_type=standard.")
-    else:
-        # We download the file
-        try:
-            s3_config_object = s3.get_object(config_file)
-            config_object = s3_config_object["Body"].read()
-            input_config = json.loads(config_object) if config_object else {}
-        except Exception as e:
-            logger.error(f"Error reading config.json from S3: {str(e)}. Using job_type=standard.")
-            raise ValueError("Error reading config.json from S3") from e
+        raise FileNotFoundError(
+            "No config.json found in the scanned model files. config.json is a required file for every "
+            "flower job type — it declares the job_type that selects the base application. Upload it "
+            "and let the scan complete, then start training again."
+        )
+    # We download the file
+    try:
+        s3_config_object = s3.get_object(config_file)
+        config_object = s3_config_object["Body"].read()
+        input_config = json.loads(config_object) if config_object else {}
+    except Exception as e:
+        logger.error(f"Error reading config.json from S3: {str(e)}.")
+        raise ValueError("Error reading config.json from S3") from e
 
-        jt = input_config.get("job_type")
-        if not jt:
-            logger.info("No 'job_type' found in config.json. Using job_type=standard.")
-        else:
-            job_type = _normalise_job_type(jt, FLBackend.FLOWER)
-            logger.info(f"job_type in config.json: {job_type}. Using it to select base application.")
+    jt = input_config.get("job_type")
+    if not jt:
+        logger.info("No 'job_type' found in config.json. Using job_type=standard.")
+    else:
+        job_type = _normalise_job_type(jt, FLBackend.FLOWER)
+        logger.info(f"job_type in config.json: {job_type}. Using it to select base application.")
 
     # Locate the base application for this job_type on the local FL_APP_BASE_DIR tree. This
     # bundler is the flower-specific path, so the backend segment is fixed:
@@ -782,6 +808,14 @@ def bundle_flower_application(model_id: UUID, job_type: str = DEFAULT_JOB_TYPE) 
     # Validate required model files exist for the job type before uploading anything, so a bad
     # submission fails fast without leaving a partial bundle in the destination bucket.
     required_files = JobRequiredFiles.get_required_files(job_type, FLBackend.FLOWER)
+    if not required_files:
+        # No real job type has an empty file list, so [] means the manifest lookup itself failed —
+        # without this guard the bundle would sail through with zero required-file validation.
+        raise RuntimeError(
+            f"Required-files manifest for flower defines no files for job type '{job_type}' — the "
+            "manifest under FL_APP_BASE_DIR is missing or malformed. This is a deployment "
+            "misconfiguration, not a problem with the uploaded model files."
+        )
     model_rel = {
         k.replace(f"{model_bucket_s3_path}/", "", 1) for k in model_files
     }  # relative paths of model files (i.e. without the bucket prefix)

--- a/flip-api/tests/unit/fl_services/services/test_fl_service.py
+++ b/flip-api/tests/unit/fl_services/services/test_fl_service.py
@@ -1302,8 +1302,14 @@ def test_bundle_nvflare_application_no_base_files(mock_s3, mocked_settings, mode
 
     mock_client = mock_s3.return_value
     # No base tree written -> the local FL_APP_BASE_DIR/nvflare/standard directory is absent
+    mock_client.get_object.return_value = {
+        "Body": MagicMock(read=MagicMock(return_value=json.dumps({}).encode("utf-8")))
+    }
     mock_client.list_objects.side_effect = [
-        [f"{model_bucket}/{model_id}/trainer.py"],  # model files (no config.json)
+        [
+            f"{model_bucket}/{model_id}/trainer.py",
+            f"{model_bucket}/{model_id}/config.json",
+        ],
     ]
 
     with pytest.raises(FileNotFoundError, match="Base application files missing in the local base directory"):
@@ -1320,8 +1326,14 @@ def test_bundle_nvflare_application_no_app_folders(mock_s3, mock_required, mocke
     write_base_tree(base_dir, "nvflare", "standard", ["notapp/file1.py"])  # no app* folder
 
     mock_client = mock_s3.return_value
+    mock_client.get_object.return_value = {
+        "Body": MagicMock(read=MagicMock(return_value=json.dumps({}).encode("utf-8")))
+    }
     mock_client.list_objects.side_effect = [
-        [f"{model_bucket}/{model_id}/trainer.py"],  # model files (no config.json)
+        [
+            f"{model_bucket}/{model_id}/trainer.py",
+            f"{model_bucket}/{model_id}/config.json",
+        ],
         [],  # destination bucket empty (clear check)
     ]
     mock_client.copy_object.return_value = None
@@ -1333,10 +1345,14 @@ def test_bundle_nvflare_application_no_app_folders(mock_s3, mock_required, mocke
 @patch("flip_api.fl_services.services.fl_service.verify_bundle_paths")
 @patch("flip_api.fl_services.services.fl_service.JobRequiredFiles.get_required_files")
 @patch("flip_api.fl_services.services.fl_service.S3Client")
-def test_bundle_nvflare_application_no_config_clears_existing_dest(
+def test_bundle_nvflare_application_clears_existing_dest(
     mock_s3, mock_required, mock_verify, mocked_settings, model_id
 ):
-    """No config.json falls back to job_type=standard, and stale destination files are cleared first."""
+    """Stale destination files from an earlier run are cleared before the new bundle is written.
+
+    The config.json here has no ``job_type`` key, which doubles as the pin on the documented live
+    fallback: key absent -> the ``standard`` job type is assumed and the bundle succeeds.
+    """
     base_dir = mocked_settings.FL_APP_BASE_DIR
     model_bucket = mocked_settings.SCANNED_MODEL_FILES_BUCKET
     dest_bucket = mocked_settings.FL_APP_DESTINATION_BUCKET
@@ -1344,11 +1360,15 @@ def test_bundle_nvflare_application_no_config_clears_existing_dest(
     write_base_tree(base_dir, "nvflare", "standard", ["app/file1.py"])
 
     mock_client = mock_s3.return_value
-    mock_required.return_value = ["trainer.py", "validator.py"]
+    mock_client.get_object.return_value = {
+        "Body": MagicMock(read=MagicMock(return_value=json.dumps({}).encode("utf-8")))
+    }
+    mock_required.return_value = ["trainer.py", "validator.py", "config.json"]
     model_files = [
         f"{model_bucket}/{model_id}/trainer.py",
         f"{model_bucket}/{model_id}/validator.py",
-    ]  # no config.json -> job_type stays "standard"
+        f"{model_bucket}/{model_id}/config.json",
+    ]
     stale_dest_files = [f"{dest_bucket}/{model_id}/stale.py"]
     mock_client.list_objects.side_effect = [model_files, stale_dest_files]
     mock_client.object_exists.return_value = False
@@ -1358,6 +1378,65 @@ def test_bundle_nvflare_application_no_config_clears_existing_dest(
 
     assert result == f"{dest_bucket}/{model_id}"
     mock_client.delete_objects.assert_called_once_with(stale_dest_files)
+
+
+@patch("flip_api.fl_services.services.fl_service.JobRequiredFiles.get_required_files")
+@patch("flip_api.fl_services.services.fl_service.S3Client")
+def test_bundle_nvflare_application_missing_config_json_is_rejected(mock_s3, mock_required, mocked_settings, model_id):
+    """config.json is a required NVFLARE file, so a submission without one never reaches a Trust.
+
+    The bundler refuses at the guard — before clearing the destination bucket — instead of logging
+    a doomed ``job_type=standard`` guess that the required-files check would reject moments later.
+    """
+    model_bucket = mocked_settings.SCANNED_MODEL_FILES_BUCKET
+
+    write_base_tree(mocked_settings.FL_APP_BASE_DIR, "nvflare", "standard", ["app/file1.py"])
+
+    mock_client = mock_s3.return_value
+    mock_required.return_value = ["trainer.py", "config.json", "models.py"]
+    mock_client.list_objects.side_effect = [
+        [
+            f"{model_bucket}/{model_id}/trainer.py",
+            f"{model_bucket}/{model_id}/models.py",
+        ],  # no config.json
+        [],  # destination bucket (clear check)
+    ]
+
+    with pytest.raises(FileNotFoundError, match="No config.json"):
+        fl_service.bundle_nvflare_application(model_id)
+
+    mock_client.delete_objects.assert_not_called()
+
+
+@patch("flip_api.fl_services.services.fl_service.verify_bundle_paths")
+@patch("flip_api.fl_services.services.fl_service.JobRequiredFiles.get_required_files")
+@patch("flip_api.fl_services.services.fl_service.S3Client")
+def test_bundle_nvflare_application_empty_manifest_is_rejected(
+    mock_s3, mock_required, mock_verify, mocked_settings, model_id
+):
+    """An empty required-files lookup means the manifest is missing or malformed, never a real job type.
+
+    ``JobRequiredFiles.get_required_files`` returns ``[]`` when the manifest under FL_APP_BASE_DIR
+    is absent, which would otherwise let the bundle through with zero required-file validation.
+    """
+    model_bucket = mocked_settings.SCANNED_MODEL_FILES_BUCKET
+
+    write_base_tree(mocked_settings.FL_APP_BASE_DIR, "nvflare", "standard", ["app/file1.py"])
+
+    mock_client = mock_s3.return_value
+    mock_client.get_object.return_value = {
+        "Body": MagicMock(read=MagicMock(return_value=json.dumps({}).encode("utf-8")))
+    }
+    mock_required.return_value = []
+    mock_client.list_objects.side_effect = [
+        [f"{model_bucket}/{model_id}/config.json"],
+        [],  # destination bucket (clear check)
+    ]
+    mock_client.object_exists.return_value = False
+    mock_verify.return_value = None
+
+    with pytest.raises(RuntimeError, match="missing or malformed"):
+        fl_service.bundle_nvflare_application(model_id)
 
 
 # --- bundle_flower_application error / edge paths -------------------------------------------------
@@ -1377,8 +1456,14 @@ def test_bundle_flower_application_no_base_files(mock_s3, mocked_settings, model
 
     mock_client = mock_s3.return_value
     # No base tree written -> the local FL_APP_BASE_DIR/flower/standard directory is absent
+    mock_client.get_object.return_value = {
+        "Body": MagicMock(read=MagicMock(return_value=json.dumps({}).encode("utf-8")))
+    }
     mock_client.list_objects.side_effect = [
-        [f"{model_bucket}/{model_id}/client_app.py"],  # model files (no config.json)
+        [
+            f"{model_bucket}/{model_id}/client_app.py",
+            f"{model_bucket}/{model_id}/config.json",
+        ],
     ]
 
     with pytest.raises(FileNotFoundError, match="Base application files missing in the local base directory"):
@@ -1426,7 +1511,9 @@ def test_bundle_flower_application_missing_config_json_is_rejected(
     """config.json is a required Flower file, so a submission without one never reaches a Trust.
 
     Without it the bundler cannot know the job type, and silently defaulting to ``standard`` would
-    ship an evaluation app as a training job (FLIP job-type selection reads only this file).
+    ship an evaluation app as a training job (FLIP job-type selection reads only this file). The
+    bundler refuses at the guard — before clearing the destination bucket — instead of logging a
+    doomed ``job_type=standard`` guess that the required-files check would reject moments later.
     """
     base_dir = mocked_settings.FL_APP_BASE_DIR
     model_bucket = mocked_settings.SCANNED_MODEL_FILES_BUCKET
@@ -1443,7 +1530,37 @@ def test_bundle_flower_application_missing_config_json_is_rejected(
         [],  # destination bucket (clear check)
     ]
 
-    with pytest.raises(FileNotFoundError, match="Missing required files for job type standard: config.json"):
+    with pytest.raises(FileNotFoundError, match="No config.json"):
+        fl_service.bundle_flower_application(model_id)
+
+    mock_client.delete_objects.assert_not_called()
+
+
+@patch("flip_api.fl_services.services.fl_service.JobRequiredFiles.get_required_files")
+@patch("flip_api.fl_services.services.fl_service.S3Client")
+def test_bundle_flower_application_empty_manifest_is_rejected(mock_s3, mock_required, mocked_settings, model_id):
+    """An empty required-files lookup means the manifest is missing or malformed, never a real job type.
+
+    ``JobRequiredFiles.get_required_files`` returns ``[]`` when the manifest under FL_APP_BASE_DIR
+    is absent, which would otherwise let the bundle through with zero required-file validation.
+    """
+    base_dir = mocked_settings.FL_APP_BASE_DIR
+    model_bucket = mocked_settings.SCANNED_MODEL_FILES_BUCKET
+
+    write_base_tree(base_dir, "flower", "standard", ["app/server_app.py", "pyproject.toml"])
+
+    mock_client = mock_s3.return_value
+    mock_client.get_object.return_value = {
+        "Body": MagicMock(read=MagicMock(return_value=json.dumps({}).encode("utf-8")))
+    }
+    mock_required.return_value = []
+    mock_client.list_objects.side_effect = [
+        [f"{model_bucket}/{model_id}/config.json"],
+        [],  # destination bucket (clear check)
+    ]
+    mock_client.object_exists.return_value = False
+
+    with pytest.raises(RuntimeError, match="missing or malformed"):
         fl_service.bundle_flower_application(model_id)
 
 


### PR DESCRIPTION
Closes #1053.

## What

Both bundlers in `flip-api/src/flip_api/fl_services/services/fl_service.py` logged `No config.json file was found in the scanned files. Using job_type=standard.` and carried on — onto a path that cannot succeed, since `config.json` is a required file for every job type on both backends (NVFLARE always; Flower since #991). The required-files check then failed anyway, so during incident triage the log claimed a fallback was applied moments before the bundle died. Because the bundlers run inside the scheduler's job pickup, the exception message is what lands in the model log (`add_log`) and the UI — it is researcher-facing.

- **Missing `config.json` now fails at the guard**, with a `FileNotFoundError` explaining that the file is required and declares the `job_type` — raised before the destination-bucket clear and before any S3 `get_object`, so the refusal has no side effects. The tests pin `delete_objects` is never called.
- **The misleading tail is also gone from the S3-read-error path**: `Error reading config.json from S3: … Using job_type=standard.` logged the fallback and then immediately raised `ValueError`; the tail is dropped.
- **The residual degenerate path fails loudly too**: `JobRequiredFiles.get_required_files` returns `[]` when the manifest under `FL_APP_BASE_DIR` is missing or malformed, which previously let a bundle through with zero required-file validation. No real job type has an empty file list, so `[]` now raises `RuntimeError` in the bundlers, worded as a deployment misconfiguration rather than a model-files problem. The `[]` contract of `get_required_files` itself is unchanged — `get_job_types`/the UI missing-files panel still rely on it.
- **The live fallback is untouched and now pinned**: `config.json` present but no `job_type` key still assumes `standard` (documented in `user-common.rst`); the reworked `*_clears_existing_dest` NVFLARE test exercises exactly that arm with an empty `{}` config and asserts the bundle succeeds.

## Tests

TDD (each new assertion watched failing first):

- New: `test_bundle_{nvflare,flower}_application_missing_config_json_is_rejected` (the Flower one, added by #991 against the old late error, now asserts the early guard) and `test_bundle_{nvflare,flower}_application_empty_manifest_is_rejected`.
- Updated: `no_base_files` / `no_app_folders` tests now include a `config.json` in their mocked model files so they still reach their target errors; the NVFLARE `no_config_clears_existing_dest` test is reworked as `clears_existing_dest`, doubling as the live-fallback success pin (mirroring #991's Flower rework).
- `make -C flip-api unit_test` green locally: ruff + mypy + 1577 passed.

No docs change needed: #991 already rewrote `user-common.rst` ("The file itself is not optional…") and `package-model-as-map.rst` ("a submission without it is rejected"); this PR makes the code match those words.


## Acceptance Criteria

*Imported from issue #1053*

- [x] A missing `config.json` produces one clear, early error naming `config.json` — no "Using job_type=standard" log on a path that cannot succeed.
- [x] The *other* fallback arm — `config.json` present but no `job_type` key → assume `standard` (~lines 556/761) — is live, correct, and documented in `docs/source/user-guides/user-common.rst`; it must NOT be removed, and a unit test pins its success path.
- [x] The residual degenerate path also fails loudly: `JobRequiredFiles.get_required_files` returning `[]` (manifest missing/malformed under `FL_APP_BASE_DIR`) must raise in the bundlers instead of letting a bundle sail through with zero required-file validation. The `[]` contract of `get_required_files` itself is unchanged (other callers rely on it).
- [x] Unit tests updated for the new error paths, on both backends.