### PR TITLE
docs: extend the OMOP component section (#158)

### DIFF
--- a/docs/source/assets/omop/omop-flip-schema.svg
+++ b/docs/source/assets/omop/omop-flip-schema.svg
@@ -10,11 +10,12 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 -->
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 700" width="1000" height="700"
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 736" width="1000" height="736"
      role="img" aria-labelledby="erd-title erd-desc" font-family="Helvetica, Arial, sans-serif">
   <title id="erd-title">The FLIP subset of the OMOP CDM 5.4 schema</title>
-  <desc id="erd-desc">Entity-relationship diagram of the eight omop-schema tables FLIP cohort
-    queries use. person, visit_occurrence and procedure_occurrence give the clinical context;
+  <desc id="erd-desc">Entity-relationship diagram of the eight omop-schema tables a FLIP
+    cohort query can draw on. person, visit_occurrence and procedure_occurrence give the
+    clinical context;
     the MI-CDM extension tables image_occurrence and image_feature carry the imaging metadata;
     observation and measurement hold image-derived values; concept resolves every concept id.
     image_occurrence.accession_id is a FLIP-specific column that points at the study in the
@@ -60,7 +61,7 @@
     </marker>
   </defs>
 
-  <rect x="0" y="0" width="1000" height="700" fill="#ffffff"/>
+  <rect x="0" y="0" width="1000" height="736" fill="#ffffff"/>
 
   <!-- outside the database -->
   <g>
@@ -73,8 +74,6 @@
   <!-- omop.person -->
   <g>
     <rect x="20" y="40" width="258" height="83" rx="4" class="box"/>
-    <path d="M 20 65 h 258" class="rule"/>
-    <path d="M 20.5 44 h 257 a 0 0 0 0 0 0 0" fill="none"/>
     <rect x="20.8" y="40.8" width="256.4" height="23.4" class="hdr"/>
     <path d="M 20 65 h 258" class="rule"/>
     <text x="32" y="57" class="tname">omop.person</text>
@@ -86,8 +85,6 @@
   <!-- omop.visit_occurrence -->
   <g>
     <rect x="20" y="168" width="258" height="83" rx="4" class="box"/>
-    <path d="M 20 193 h 258" class="rule"/>
-    <path d="M 20.5 172 h 257 a 0 0 0 0 0 0 0" fill="none"/>
     <rect x="20.8" y="168.8" width="256.4" height="23.4" class="hdr"/>
     <path d="M 20 193 h 258" class="rule"/>
     <text x="32" y="185" class="tname">omop.visit_occurrence</text>
@@ -99,8 +96,6 @@
   <!-- omop.procedure_occurrence -->
   <g>
     <rect x="20" y="296" width="258" height="100" rx="4" class="box"/>
-    <path d="M 20 321 h 258" class="rule"/>
-    <path d="M 20.5 300 h 257 a 0 0 0 0 0 0 0" fill="none"/>
     <rect x="20.8" y="296.8" width="256.4" height="23.4" class="hdr"/>
     <path d="M 20 321 h 258" class="rule"/>
     <text x="32" y="313" class="tname">omop.procedure_occurrence</text>
@@ -113,8 +108,6 @@
   <!-- omop.image_occurrence -->
   <g>
     <rect x="352" y="40" width="296" height="185" rx="4" class="box-mi"/>
-    <path d="M 352 65 h 296" class="rule"/>
-    <path d="M 352.5 44 h 295 a 0 0 0 0 0 0 0" fill="none"/>
     <rect x="352.8" y="40.8" width="294.4" height="23.4" class="hdr-mi"/>
     <path d="M 352 65 h 296" class="rule"/>
     <text x="364" y="57" class="tname-mi">omop.image_occurrence  ★</text>
@@ -133,8 +126,6 @@
   <!-- omop.image_feature -->
   <g>
     <rect x="352" y="320" width="296" height="151" rx="4" class="box-mi"/>
-    <path d="M 352 345 h 296" class="rule"/>
-    <path d="M 352.5 324 h 295 a 0 0 0 0 0 0 0" fill="none"/>
     <rect x="352.8" y="320.8" width="294.4" height="23.4" class="hdr-mi"/>
     <path d="M 352 345 h 296" class="rule"/>
     <text x="364" y="337" class="tname-mi">omop.image_feature  ★</text>
@@ -150,8 +141,6 @@
   <!-- omop.concept -->
   <g>
     <rect x="708" y="150" width="252" height="100" rx="4" class="box"/>
-    <path d="M 708 175 h 252" class="rule"/>
-    <path d="M 708.5 154 h 251 a 0 0 0 0 0 0 0" fill="none"/>
     <rect x="708.8" y="150.8" width="250.4" height="23.4" class="hdr"/>
     <path d="M 708 175 h 252" class="rule"/>
     <text x="720" y="167" class="tname">omop.concept</text>
@@ -164,8 +153,6 @@
   <!-- omop.observation -->
   <g>
     <rect x="708" y="320" width="252" height="100" rx="4" class="box"/>
-    <path d="M 708 345 h 252" class="rule"/>
-    <path d="M 708.5 324 h 251 a 0 0 0 0 0 0 0" fill="none"/>
     <rect x="708.8" y="320.8" width="250.4" height="23.4" class="hdr"/>
     <path d="M 708 345 h 252" class="rule"/>
     <text x="720" y="337" class="tname">omop.observation</text>
@@ -178,8 +165,6 @@
   <!-- omop.measurement -->
   <g>
     <rect x="708" y="462" width="252" height="100" rx="4" class="box"/>
-    <path d="M 708 487 h 252" class="rule"/>
-    <path d="M 708.5 466 h 251 a 0 0 0 0 0 0 0" fill="none"/>
     <rect x="708.8" y="462.8" width="250.4" height="23.4" class="hdr"/>
     <path d="M 708 487 h 252" class="rule"/>
     <text x="720" y="479" class="tname">omop.measurement</text>
@@ -190,13 +175,13 @@
   </g>
 
   <!-- foreign keys (solid) -->
-  <path d="M 149 123 V 168" class="edge" marker-end="url(#ar)"/>
+  <path d="M 149 123 V 168" class="edge" marker-start="url(#ar)"/>
   <text x="155" y="141" class="lbl">person_id</text>
-  <path d="M 149 251 V 296" class="edge" marker-end="url(#ar)"/>
+  <path d="M 149 251 V 296" class="edge" marker-start="url(#ar)"/>
   <text x="155" y="269" class="lbl">visit_occurrence_id</text>
-  <path d="M 278 198 H 315 V 124.5 H 352" class="edge" marker-end="url(#ar)"/>
-  <path d="M 278 330 H 341 V 107.5 H 352" class="edge" marker-end="url(#ar)"/>
-  <path d="M 500 225 V 320" class="edge" marker-end="url(#ar)"/>
+  <path d="M 278 198 H 315 V 124.5 H 352" class="edge" marker-start="url(#ar)"/>
+  <path d="M 278 330 H 341 V 107.5 H 352" class="edge" marker-start="url(#ar)"/>
+  <path d="M 500 225 V 320" class="edge" marker-start="url(#ar)"/>
   <text x="506" y="259" class="lbl">image_occurrence_id</text>
 
   <!-- accession_id: the FLIP-specific hop out of the database -->
@@ -215,17 +200,21 @@
   <text x="708" y="141" class="lbl">every *_concept_id resolves here</text>
 
   <!-- legend -->
-  <rect x="20" y="588" width="940" height="92" rx="4" fill="#fafbfc" stroke="#e6e9ee"/>
-  <path d="M 36 610 h 34" class="edge" marker-end="url(#ar)"/>
-  <text x="80" y="614" class="note">Foreign key, declared in
-    <tspan font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="9.5px">OMOPCDM_postgresql_5.4_constraints.sql</tspan></text>
-  <path d="M 36 634 h 34" class="edge-s" marker-end="url(#ar)"/>
-  <text x="80" y="638" class="note">Soft link &#8212; no foreign key. Which table <tspan font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="9.5px">image_feature_event_id</tspan></text>
-  <text x="80" y="652" class="note">points at is decided by <tspan font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="9.5px">image_feature_event_field_concept_id</tspan>.</text>
-  <path d="M 36 670 h 34" class="edge-a" marker-end="url(#ar-a)"/>
-  <text x="80" y="674" class="note"><tspan font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="9.5px">accession_id</tspan>, added by FLIP, is how a cohort row reaches its DICOM study.</text>
-  <text x="600" y="614" class="note"><tspan fill="#61366E" font-weight="700">&#9733;</tspan>  MI-CDM imaging extension table</text>
-  <text x="600" y="638" class="note">Every table here also carries</text>
-  <text x="600" y="652" class="note"><tspan font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="9.5px">person_id</tspan>, a foreign key to</text>
-  <text x="600" y="666" class="note"><tspan font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="9.5px">omop.person</tspan>; those edges are omitted.</text>
+  <rect x="20" y="578" width="940" height="130" rx="4" fill="#fafbfc" stroke="#e6e9ee"/>
+  <path d="M 36 600 h 34" class="edge" marker-start="url(#ar)"/>
+  <text x="80" y="604" class="note">Foreign key, declared in <tspan font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="9.5px">OMOPCDM_postgresql_5.4_constraints.sql</tspan>.</text>
+  <path d="M 36 624 h 34" class="edge-c" marker-end="url(#ar-c)"/>
+  <text x="80" y="628" class="note">Concept-id resolution. The standard tables declare these as foreign keys; the</text>
+  <text x="80" y="642" class="note">MI-CDM tables do not, so nothing in the schema records the link.</text>
+  <path d="M 36 662 h 34" class="edge-s" marker-end="url(#ar)"/>
+  <text x="80" y="666" class="note">Soft link &#8212; no foreign key. <tspan font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="9.5px">image_feature_event_field_concept_id</tspan></text>
+  <text x="80" y="680" class="note">names the target table; <tspan font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="9.5px">1147304</tspan> is the concept for <tspan font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="9.5px">observation</tspan>.</text>
+  <path d="M 36 698 h 34" class="edge-a" marker-end="url(#ar-a)"/>
+  <text x="80" y="702" class="note"><tspan font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="9.5px">accession_id</tspan>, added by FLIP, is how a cohort row reaches its DICOM study.</text>
+  <text x="600" y="604" class="note"><tspan fill="#61366E" font-weight="700">&#9733;</tspan>  MI-CDM imaging extension table</text>
+  <text x="600" y="628" class="note">Arrows point from the table holding the</text>
+  <text x="600" y="642" class="note">key to the table it references.</text>
+  <text x="600" y="666" class="note">Column lists are abridged; the reference</text>
+  <text x="600" y="680" class="note">tables on the page are complete.</text>
+  <text x="600" y="702" class="note">Most <tspan font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="9.5px">person_id</tspan> keys to <tspan font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="9.5px">omop.person</tspan> are omitted.</text>
 </svg>

--- a/docs/source/assets/omop/omop-flip-schema.svg
+++ b/docs/source/assets/omop/omop-flip-schema.svg
@@ -1,0 +1,231 @@
+<!--
+    Copyright (c) 2026 Guy's and St Thomas' NHS Foundation Trust & King's College London
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+        http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 700" width="1000" height="700"
+     role="img" aria-labelledby="erd-title erd-desc" font-family="Helvetica, Arial, sans-serif">
+  <title id="erd-title">The FLIP subset of the OMOP CDM 5.4 schema</title>
+  <desc id="erd-desc">Entity-relationship diagram of the eight omop-schema tables FLIP cohort
+    queries use. person, visit_occurrence and procedure_occurrence give the clinical context;
+    the MI-CDM extension tables image_occurrence and image_feature carry the imaging metadata;
+    observation and measurement hold image-derived values; concept resolves every concept id.
+    image_occurrence.accession_id is a FLIP-specific column that points at the study in the
+    trust PACS and XNAT. image_feature reaches observation or measurement through a soft link
+    (image_feature_event_id) rather than a foreign key, selected by
+    image_feature_event_field_concept_id.</desc>
+
+  <style>
+    .box     { fill: #ffffff; stroke: #c8ced6; stroke-width: 1; }
+    .box-mi  { fill: #ffffff; stroke: #61366E; stroke-width: 1.6; }
+    .hdr     { fill: #f1f3f6; }
+    .hdr-mi  { fill: #efe7f2; }
+    .tname   { font-size: 12.5px; font-weight: 700; fill: #262c33; }
+    .tname-mi{ font-size: 12.5px; font-weight: 700; fill: #61366E; }
+    .col     { font-size: 10.5px; fill: #3d444c;
+               font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+    .col-pk  { font-weight: 700; fill: #262c33; }
+    .col-dim { fill: #767e88; }
+    .col-hi  { font-weight: 700; fill: #8a4b00; }
+    .rule    { stroke: #e6e9ee; stroke-width: 1; }
+    .edge    { stroke: #7a828c; stroke-width: 1.4; fill: none; }
+    .edge-c  { stroke: #b3bac3; stroke-width: 1.1; fill: none; }
+    .edge-s  { stroke: #7a828c; stroke-width: 1.4; fill: none; stroke-dasharray: 5 4; }
+    .edge-a  { stroke: #b45309; stroke-width: 1.6; fill: none; stroke-dasharray: 5 4; }
+    .lbl     { font-size: 9.5px; fill: #5d656f; }
+    .lbl-a   { font-size: 9.5px; fill: #b45309; }
+    .note    { font-size: 10.5px; fill: #4a525b; }
+    .note-b  { font-size: 10.5px; fill: #4a525b; font-weight: 700; }
+  </style>
+
+  <defs>
+    <marker id="ar" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7"
+            orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#7a828c"/>
+    </marker>
+    <marker id="ar-c" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6"
+            orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#b3bac3"/>
+    </marker>
+    <marker id="ar-a" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7"
+            orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#b45309"/>
+    </marker>
+  </defs>
+
+  <rect x="0" y="0" width="1000" height="700" fill="#ffffff"/>
+
+  <!-- outside the database -->
+  <g>
+    <rect x="708" y="40" width="252" height="58" rx="4" fill="#fdf6ec" stroke="#e0b878"
+          stroke-width="1.2" stroke-dasharray="4 3"/>
+    <text x="834" y="63" class="note-b" text-anchor="middle">Trust PACS / XNAT</text>
+    <text x="834" y="80" class="lbl" text-anchor="middle">DICOM studies &#8212; outside the database</text>
+  </g>
+
+  <!-- omop.person -->
+  <g>
+    <rect x="20" y="40" width="258" height="83" rx="4" class="box"/>
+    <path d="M 20 65 h 258" class="rule"/>
+    <path d="M 20.5 44 h 257 a 0 0 0 0 0 0 0" fill="none"/>
+    <rect x="20.8" y="40.8" width="256.4" height="23.4" class="hdr"/>
+    <path d="M 20 65 h 258" class="rule"/>
+    <text x="32" y="57" class="tname">omop.person</text>
+    <text x="32" y="77" class="col col-pk">person_id  PK</text>
+    <text x="32" y="94" class="col col-dim">gender_concept_id</text>
+    <text x="32" y="111" class="col">year_of_birth</text>
+  </g>
+
+  <!-- omop.visit_occurrence -->
+  <g>
+    <rect x="20" y="168" width="258" height="83" rx="4" class="box"/>
+    <path d="M 20 193 h 258" class="rule"/>
+    <path d="M 20.5 172 h 257 a 0 0 0 0 0 0 0" fill="none"/>
+    <rect x="20.8" y="168.8" width="256.4" height="23.4" class="hdr"/>
+    <path d="M 20 193 h 258" class="rule"/>
+    <text x="32" y="185" class="tname">omop.visit_occurrence</text>
+    <text x="32" y="205" class="col col-pk">visit_occurrence_id  PK</text>
+    <text x="32" y="222" class="col">person_id  FK</text>
+    <text x="32" y="239" class="col col-dim">visit_concept_id</text>
+  </g>
+
+  <!-- omop.procedure_occurrence -->
+  <g>
+    <rect x="20" y="296" width="258" height="100" rx="4" class="box"/>
+    <path d="M 20 321 h 258" class="rule"/>
+    <path d="M 20.5 300 h 257 a 0 0 0 0 0 0 0" fill="none"/>
+    <rect x="20.8" y="296.8" width="256.4" height="23.4" class="hdr"/>
+    <path d="M 20 321 h 258" class="rule"/>
+    <text x="32" y="313" class="tname">omop.procedure_occurrence</text>
+    <text x="32" y="333" class="col col-pk">procedure_occurrence_id  PK</text>
+    <text x="32" y="350" class="col">person_id  FK</text>
+    <text x="32" y="367" class="col">visit_occurrence_id  FK</text>
+    <text x="32" y="384" class="col">procedure_source_value</text>
+  </g>
+
+  <!-- omop.image_occurrence -->
+  <g>
+    <rect x="352" y="40" width="296" height="185" rx="4" class="box-mi"/>
+    <path d="M 352 65 h 296" class="rule"/>
+    <path d="M 352.5 44 h 295 a 0 0 0 0 0 0 0" fill="none"/>
+    <rect x="352.8" y="40.8" width="294.4" height="23.4" class="hdr-mi"/>
+    <path d="M 352 65 h 296" class="rule"/>
+    <text x="364" y="57" class="tname-mi">omop.image_occurrence  ★</text>
+    <text x="364" y="77" class="col col-pk">image_occurrence_id  PK</text>
+    <text x="364" y="94" class="col">person_id  FK</text>
+    <text x="364" y="111" class="col">procedure_occurrence_id  FK</text>
+    <text x="364" y="128" class="col">visit_occurrence_id  FK</text>
+    <text x="364" y="145" class="col col-dim">modality_concept_id</text>
+    <text x="364" y="162" class="col col-dim">anatomic_site_concept_id</text>
+    <text x="364" y="179" class="col">image_study_uid</text>
+    <text x="364" y="196" class="col">image_series_uid</text>
+    <rect x="353" y="202" width="294" height="15" fill="#fdf3e3"/>
+    <text x="364" y="213" class="col col-hi">accession_id  ★ FLIP</text>
+  </g>
+
+  <!-- omop.image_feature -->
+  <g>
+    <rect x="352" y="320" width="296" height="151" rx="4" class="box-mi"/>
+    <path d="M 352 345 h 296" class="rule"/>
+    <path d="M 352.5 324 h 295 a 0 0 0 0 0 0 0" fill="none"/>
+    <rect x="352.8" y="320.8" width="294.4" height="23.4" class="hdr-mi"/>
+    <path d="M 352 345 h 296" class="rule"/>
+    <text x="364" y="337" class="tname-mi">omop.image_feature  ★</text>
+    <text x="364" y="357" class="col col-pk">image_feature_id  PK</text>
+    <text x="364" y="374" class="col">person_id  FK</text>
+    <text x="364" y="391" class="col">image_occurrence_id  FK</text>
+    <text x="364" y="408" class="col col-dim">image_feature_concept_id</text>
+    <text x="364" y="425" class="col col-dim">image_feature_event_field_concept_id</text>
+    <text x="364" y="442" class="col col-dim">image_feature_event_id</text>
+    <text x="364" y="459" class="col col-dim">anatomic_site_concept_id</text>
+  </g>
+
+  <!-- omop.concept -->
+  <g>
+    <rect x="708" y="150" width="252" height="100" rx="4" class="box"/>
+    <path d="M 708 175 h 252" class="rule"/>
+    <path d="M 708.5 154 h 251 a 0 0 0 0 0 0 0" fill="none"/>
+    <rect x="708.8" y="150.8" width="250.4" height="23.4" class="hdr"/>
+    <path d="M 708 175 h 252" class="rule"/>
+    <text x="720" y="167" class="tname">omop.concept</text>
+    <text x="720" y="187" class="col col-pk">concept_id  PK</text>
+    <text x="720" y="204" class="col">concept_name</text>
+    <text x="720" y="221" class="col">vocabulary_id</text>
+    <text x="720" y="238" class="col">domain_id</text>
+  </g>
+
+  <!-- omop.observation -->
+  <g>
+    <rect x="708" y="320" width="252" height="100" rx="4" class="box"/>
+    <path d="M 708 345 h 252" class="rule"/>
+    <path d="M 708.5 324 h 251 a 0 0 0 0 0 0 0" fill="none"/>
+    <rect x="708.8" y="320.8" width="250.4" height="23.4" class="hdr"/>
+    <path d="M 708 345 h 252" class="rule"/>
+    <text x="720" y="337" class="tname">omop.observation</text>
+    <text x="720" y="357" class="col col-pk">observation_id  PK</text>
+    <text x="720" y="374" class="col">person_id  FK</text>
+    <text x="720" y="391" class="col col-dim">observation_concept_id</text>
+    <text x="720" y="408" class="col col-dim">value_as_concept_id</text>
+  </g>
+
+  <!-- omop.measurement -->
+  <g>
+    <rect x="708" y="462" width="252" height="100" rx="4" class="box"/>
+    <path d="M 708 487 h 252" class="rule"/>
+    <path d="M 708.5 466 h 251 a 0 0 0 0 0 0 0" fill="none"/>
+    <rect x="708.8" y="462.8" width="250.4" height="23.4" class="hdr"/>
+    <path d="M 708 487 h 252" class="rule"/>
+    <text x="720" y="479" class="tname">omop.measurement</text>
+    <text x="720" y="499" class="col col-pk">measurement_id  PK</text>
+    <text x="720" y="516" class="col">person_id  FK</text>
+    <text x="720" y="533" class="col">value_as_number</text>
+    <text x="720" y="550" class="col col-dim">value_as_concept_id</text>
+  </g>
+
+  <!-- foreign keys (solid) -->
+  <path d="M 149 123 V 168" class="edge" marker-end="url(#ar)"/>
+  <text x="155" y="141" class="lbl">person_id</text>
+  <path d="M 149 251 V 296" class="edge" marker-end="url(#ar)"/>
+  <text x="155" y="269" class="lbl">visit_occurrence_id</text>
+  <path d="M 278 198 H 315 V 124.5 H 352" class="edge" marker-end="url(#ar)"/>
+  <path d="M 278 330 H 341 V 107.5 H 352" class="edge" marker-end="url(#ar)"/>
+  <path d="M 500 225 V 320" class="edge" marker-end="url(#ar)"/>
+  <text x="506" y="259" class="lbl">image_occurrence_id</text>
+
+  <!-- accession_id: the FLIP-specific hop out of the database -->
+  <path d="M 648 209.5 H 664 V 69 H 708" class="edge-a" marker-end="url(#ar-a)"/>
+  <text x="670" y="122" class="lbl-a">accession_id</text>
+
+  <!-- soft links: image_feature -> the table named by its event-field concept -->
+  <path d="M 648 438.5 H 672 V 353.5 H 708" class="edge-s" marker-end="url(#ar)"/>
+  <path d="M 648 438.5 H 682 V 495.5 H 708" class="edge-s" marker-end="url(#ar)"/>
+  <text x="654" y="431.5" class="lbl">image_feature_event_id</text>
+
+  <!-- every *_concept_id resolves through omop.concept -->
+  <path d="M 648 141.5 H 692 V 182 H 708" class="edge-c" marker-end="url(#ar-c)"/>
+  <path d="M 648 404.5 H 698 V 250" class="edge-c" marker-end="url(#ar-c)"/>
+  <path d="M 834 320 V 250" class="edge-c" marker-end="url(#ar-c)"/>
+  <text x="708" y="141" class="lbl">every *_concept_id resolves here</text>
+
+  <!-- legend -->
+  <rect x="20" y="588" width="940" height="92" rx="4" fill="#fafbfc" stroke="#e6e9ee"/>
+  <path d="M 36 610 h 34" class="edge" marker-end="url(#ar)"/>
+  <text x="80" y="614" class="note">Foreign key, declared in
+    <tspan font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="9.5px">OMOPCDM_postgresql_5.4_constraints.sql</tspan></text>
+  <path d="M 36 634 h 34" class="edge-s" marker-end="url(#ar)"/>
+  <text x="80" y="638" class="note">Soft link &#8212; no foreign key. Which table <tspan font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="9.5px">image_feature_event_id</tspan></text>
+  <text x="80" y="652" class="note">points at is decided by <tspan font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="9.5px">image_feature_event_field_concept_id</tspan>.</text>
+  <path d="M 36 670 h 34" class="edge-a" marker-end="url(#ar-a)"/>
+  <text x="80" y="674" class="note"><tspan font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="9.5px">accession_id</tspan>, added by FLIP, is how a cohort row reaches its DICOM study.</text>
+  <text x="600" y="614" class="note"><tspan fill="#61366E" font-weight="700">&#9733;</tspan>  MI-CDM imaging extension table</text>
+  <text x="600" y="638" class="note">Every table here also carries</text>
+  <text x="600" y="652" class="note"><tspan font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="9.5px">person_id</tspan>, a foreign key to</text>
+  <text x="600" y="666" class="note"><tspan font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="9.5px">omop.person</tspan>; those edges are omitted.</text>
+</svg>

--- a/docs/source/components/component-omop-database.rst
+++ b/docs/source/components/component-omop-database.rst
@@ -10,24 +10,237 @@ The `Observational Health Data Sciences and Informatics (OHDSI) <https://www.ohd
 
 To prepare the standardised data to be ingested into each Trust's OMOP Database, resources are provided during the onboarding stage.
 
+.. contents:: On this page
+   :local:
+   :depth: 2
+
+.. _omop-schema:
+
 Schema
 ======
 
-The database implements OMOP CDM 5.4 in the ``omop`` schema, extended with the
-`MI-CDM medical imaging tables <https://www.ncbi.nlm.nih.gov/pmc/articles/PMC11031512/>`_:
-``image_occurrence`` (one row per imaging study/series, carrying the ``accession_id``
-that links a cohort row to its DICOM data in the Trust PACS) and ``image_feature``
-(findings derived from those images). Cohort queries join these against the standard
-clinical tables (``person``, ``visit_occurrence``, ``procedure_occurrence``, ...) —
-see :ref:`the cohort query guide <create-cohort-query>`.
+The database implements `OMOP CDM 5.4 <https://ohdsi.github.io/CommonDataModel/cdm54.html>`_ in the
+``omop`` schema — all 39 standard tables — extended with the two
+:ref:`MI-CDM imaging tables <omop-micdm>`. The DDL lives in the repository at
+``trust/omop-db/files/OMOPCDM_postgresql_5.4_ddl.sql``, derived from the OHDSI
+`CommonDataModel <https://github.com/OHDSI/CommonDataModel>`_ project's
+``inst/ddl/5.4/postgresql`` and extended in place.
+
+Most of those 41 tables are unused by FLIP. The diagram below shows only the part a cohort query
+actually traverses: the clinical context on the left, the imaging metadata in the middle, the values
+and the vocabulary on the right.
+
+.. figure:: ../assets/omop/omop-flip-schema.svg
+   :alt: Entity-relationship diagram of the eight omop-schema tables FLIP cohort queries use, showing person, visit_occurrence and procedure_occurrence linked to the MI-CDM tables image_occurrence and image_feature, which reach observation and measurement through a soft link and resolve concept ids through the concept table; image_occurrence.accession_id points out of the database at the Trust PACS and XNAT.
+   :width: 800
+   :align: center
+
+   The FLIP-relevant subset of OMOP CDM 5.4. Purple tables are the MI-CDM imaging extension;
+   ``accession_id`` is a FLIP addition to it.
+
+.. _omop-micdm:
+
+The MI-CDM imaging extension
+----------------------------
+
+Standard OMOP has nowhere to record an imaging study. The
+`Medical Imaging Common Data Model (MI-CDM) <https://www.ncbi.nlm.nih.gov/pmc/articles/PMC11031512/>`_
+is the OHDSI extension that adds one — the successor to the earlier R-CDM radiology tables — and
+FLIP implements it with two tables.
+
+``image_occurrence`` holds one row per imaging study or series:
+
+.. list-table::
+   :widths: 34 22 44
+   :header-rows: 1
+
+   * - Column
+     - Type
+     - Meaning
+   * - ``image_occurrence_id``
+     - ``serial``
+     - Primary key.
+   * - ``person_id``
+     - ``integer``
+     - The patient. Foreign key to ``person``.
+   * - ``procedure_occurrence_id``
+     - ``integer``
+     - The procedure that produced the images, e.g. the chest X-ray. Foreign key.
+   * - ``visit_occurrence_id``
+     - ``integer``
+     - The encounter the imaging belongs to. Foreign key.
+   * - ``anatomic_site_concept_id``
+     - ``integer``
+     - Body part imaged, as a concept id.
+   * - ``modality_concept_id``
+     - ``integer``
+     - DICOM modality, as a concept id — e.g. ``4300757`` is *Computed tomography*.
+   * - ``image_study_uid`` / ``image_series_uid``
+     - ``varchar(64)``
+     - DICOM Study and Series Instance UIDs.
+   * - ``wadors_uri`` / ``local_path``
+     - ``varchar(512)``
+     - MI-CDM's own pointers to the pixel data. FLIP reads neither — images are resolved
+       through ``accession_id``.
+   * - ``image_occurrence_date``
+     - ``date``
+     - Study date.
+   * - ``accession_id``
+     - ``varchar(255)``
+     - **FLIP addition.** The PACS accession number for the study.
+
+``image_feature`` holds findings derived from those images — one row per finding, not per study:
+
+.. list-table::
+   :widths: 34 22 44
+   :header-rows: 1
+
+   * - Column
+     - Type
+     - Meaning
+   * - ``image_feature_id``
+     - ``serial``
+     - Primary key.
+   * - ``person_id`` / ``image_occurrence_id``
+     - ``integer``
+     - The patient and the study the finding came from. Foreign keys.
+   * - ``image_feature_concept_id``
+     - ``integer``
+     - *Which* finding this row is about, e.g. ``4215818`` *Effusion*.
+   * - ``image_feature_event_field_concept_id``
+     - ``integer``
+     - Which table holds the finding's **value**. ``1147304`` is the concept for ``observation``.
+   * - ``image_feature_event_id``
+     - ``integer``
+     - The row id in that table. Not a foreign key — see below.
+   * - ``image_feature_type_concept_id``
+     - ``integer``
+     - Provenance of the finding, e.g. read from a report versus produced by an algorithm.
+   * - ``image_finding_concept_id`` / ``image_finding_id``
+     - ``integer``
+     - Optional link to a coded finding record.
+   * - ``anatomic_site_concept_id``
+     - ``integer``
+     - Body part the finding concerns.
+   * - ``alg_system`` / ``alg_datetime``
+     - ``varchar`` / ``timestamp``
+     - The algorithm that produced the finding, and when, where applicable.
+
+There is no ``image_study`` table — the study identifier is the ``image_study_uid`` column.
+
+Three consequences matter when writing a cohort query:
+
+``accession_id`` is how a cohort row reaches its images
+   ``image_occurrence.accession_id`` is not part of upstream MI-CDM; FLIP adds it with a bare
+   ``ALTER TABLE ... ADD COLUMN`` in the DDL. It is the accession number XNAT uses to pull the study
+   out of the Trust PACS, so a query that does not project it produces a cohort with no imaging
+   attached. The Data Access API's accession-id route wraps the saved query as
+   ``SELECT accession_id FROM (<query>) AS cohort_subquery``, so omitting the column is a hard error
+   rather than a silent one.
+
+The link from ``image_feature`` to its value is a soft one
+   ``image_feature`` does not carry the finding's value. Instead
+   ``image_feature_event_field_concept_id`` names the table that does and ``image_feature_event_id``
+   gives the row id in it. There is no foreign key to follow and no way to infer the target from the
+   schema, so a query has to pin the field concept itself — ``= 1147304`` for ``observation`` — before
+   joining. This is the one part of the schema that cannot be worked out from the constraints.
+
+Concept ids are meaningless until they are joined
+   Every ``*_concept_id`` resolves through ``omop.concept``, which is populated by the vocabulary
+   load rather than by the data load. On a Trust stack whose vocabulary has never been seeded,
+   ``omop.concept`` is empty and any query joining it returns nothing at all — see
+   :ref:`omop-dev-instance`.
+
+.. _omop-sample-queries:
+
+Sample cohort queries
+=====================
+
+The tutorials in ``fl-tutorials/`` each ship the cohort query they were written against. Two of them
+bracket the range of what a query has to do. Both are shown below exactly as they are in the
+repository; the Flower copies
+(``fl-tutorials/flower/xray_classification/query.sql`` and
+``fl-tutorials/flower/3d_spleen_segmentation/query.sql``) are byte-identical, so cohort queries are
+independent of the FL backend.
+
+Chest X-ray classification — labels out of OMOP
+-----------------------------------------------
+
+.. literalinclude:: ../../../fl-tutorials/nvflare/image_classification/xray_classification/query.sql
+   :language: sql
+   :start-after: -- limitations under the License.
+   :caption: ``fl-tutorials/nvflare/image_classification/xray_classification/query.sql``
+
+This is the general shape of a supervised imaging query, in three steps:
+
+#. ``feature_observation`` narrows ``image_feature`` to the rows whose value lives in
+   ``observation`` (``image_feature_event_field_concept_id = 1147304``), which is what makes
+   ``image_feature_event_id`` safe to join on.
+#. ``observation_value`` **pivots**. ``image_feature`` has one row per finding, so a study with three
+   findings is three rows; the ``MAX(CASE WHEN image_feature_concept_id = ... THEN ... END)``
+   idiom collapses them into one row per study with one column per finding. The concept ids
+   in this tutorial are ``4215818`` *Effusion*, ``4196943`` *Edema* and ``40481136``
+   *Lungs in normal arrangement*.
+#. The outer ``SELECT`` joins ``omop.concept`` to turn modality and anatomy ids into names, and
+   aliases each pivoted column.
+
+Those aliases are load-bearing. The dataframe the FL client receives from ``flip.get_dataframe`` has
+exactly the query's output column names, and the tutorial matches them by **exact string** — the
+``LESIONS`` map in its ``config.json`` contains ``"Effusion"``, ``"Edema"`` and
+``"Lungs in normal arrangement"``, which is why the SQL quotes those aliases verbatim. Renaming a
+column in the query without renaming it in ``config.json`` silently produces an all-masked label.
+
+3D spleen segmentation — labels not in OMOP
+--------------------------------------------
+
+.. literalinclude:: ../../../fl-tutorials/nvflare/image_segmentation/3d_spleen_segmentation/query.sql
+   :language: sql
+   :start-after: -- limitations under the License.
+   :caption: ``fl-tutorials/nvflare/image_segmentation/3d_spleen_segmentation/query.sql``
+
+Four lines, because there is nothing to pivot. A segmentation mask is a 3D volume, and OMOP has no
+column shaped like one, so the query's whole job is to name the studies —
+``modality_concept_id = 4300757`` is *Computed tomography* — and let ``SELECT *`` carry
+``accession_id`` through. The masks reach the model by a separate route: they are uploaded into XNAT
+alongside the converted images during :doc:`data enrichment </user-guides/user-data-enrichment>`.
+
+This is the practical test for a new app. If the label already exists in OMOP, project it as a column
+and no enrichment is needed. If it does not — anything spatial or image-derived — the query only
+selects the cohort, and the labels are enriched into XNAT.
+
+.. note::
+
+   A cohort query must be a single ``SELECT``-shaped statement, no larger than 10 KiB, with every
+   table in the ``omop`` schema and literal integer ``LIMIT``/``OFFSET`` values. The Trust-side
+   ``validate_query`` in ``trust/data-access-api/data_access_api/services/cohort.py`` is the
+   authority on this — it parses the query, checks the syntax tree and re-emits the SQL that actually
+   runs. See :ref:`create-cohort-query` for the user-facing workflow.
 
 Access control
 ==============
 
-Cohort queries issued by the Data Access API connect as the ``data_analyst_reader``
-role: SELECT-only on the ``omop`` schema, with write/DDL rights explicitly revoked
-and a statement timeout applied. These grants (``trust/omop-db/files/create_readonly_users.sql``)
-are the database half of the Data Access API's SQL validation defence-in-depth.
+Cohort queries issued by the Data Access API connect as the ``data_analyst_reader`` role, a member of
+``omop_readonly_base``. The grants are created at first initialisation by
+``trust/omop-db/files/create_readonly_users.sql``: ``CONNECT`` on the database, ``USAGE`` on the
+``omop`` schema and ``SELECT`` on its tables and sequences, with ``INSERT``, ``UPDATE``, ``DELETE``,
+``TRUNCATE`` and ``CREATE`` explicitly revoked, a five-connection limit and a 300-second
+``statement_timeout``. This is the database half of the Data Access API's SQL validation
+defence-in-depth.
+
+.. note::
+
+   The grant is narrower on Compose deployments than on Kubernetes ones. The Kubernetes Trust chart
+   grants the role ``pg_read_all_data``, so on a Kubernetes Trust the schema pin inside
+   ``validate_query`` — not the database grant — is what keeps a query inside ``omop``. Narrowing
+   that grant to match Compose is tracked separately.
+
+Row-level results are additionally gated on the Trust's ``COHORT_QUERY_THRESHOLD`` (default 10): a
+cohort smaller than the threshold is refused with a fixed message, identical to the one a cohort of
+zero produces, so the refusal itself discloses nothing. The threshold is evaluated against the live
+cohort on every call rather than frozen at approval. :doc:`/security` covers the full set of controls
+around the clinical data boundary.
+
+.. _omop-dev-instance:
 
 Mocked instance for development
 ===============================
@@ -38,10 +251,48 @@ in-repo at ``trust/omop-db/`` (schema init chain, read-only roles, vocabulary
 load). Its synthetic cohort rows are maintained as a single canonical CSV
 dataset on the public Hugging Face dataset
 `aicentreflip/trust-data <https://huggingface.co/datasets/aicentreflip/trust-data>`_,
-deterministically split across however many mock Trusts are stood up; dev
-stacks download ready-populated database volumes from the same dataset. The
-OMOP vocabularies (SNOMED CT, LOINC, ...) are licensed material and are kept
-out of every published artifact — the image and data volumes ship vocab-free,
-and each environment streams the vocabulary bundle it is licensed to use into
-its running database as a one-time seeding step — see
-``trust/omop-db/README.md`` for the build, populate and seeding workflow.
+deterministically split across however many mock Trusts are stood up.
+
+Getting the data
+----------------
+
+Dev stacks do not build the database — they download a ready-populated PostgreSQL data volume per
+Trust from the same public dataset, roughly 11 MB each, at
+``https://huggingface.co/datasets/aicentreflip/trust-data/resolve/main/trust<N>/trust<N>_pgdata_<version>.tar``
+(gzip-compressed despite the ``.tar`` name). The version is pinned by ``trust/omop-db/.data_version``
+and the download is anonymous — no AWS credentials. Bringing a Trust up syncs it automatically; to do
+it by hand:
+
+.. code-block:: bash
+
+   make -C trust update-omop-data            # both dev Trusts
+   make -C trust update-omop-data TRUST=1    # Trust_1 (GSTT) only
+
+The canonical CSVs behind those volumes live under ``omop-csv/<version>/`` in the same dataset. Every
+row carries a ``source_trust`` column, and standing up N Trusts is a deterministic split of that one
+dataset — see ``trust/omop-db/README.md`` for the partition modes and for rebuilding the volumes.
+
+Seeding the vocabulary
+----------------------
+
+The published image and the data volumes are deliberately **vocabulary-free**. SNOMED CT, LOINC,
+Read v2 and dm+d are licensed material, so they are kept out of every published artifact and each
+environment loads the bundle it is licensed to use into its own running database, once:
+
+.. code-block:: bash
+
+   make -C trust/omop-db load-omop-vocab                    # Trust_1 (GSTT, port 5434)
+   make -C trust/omop-db load-omop-vocab OMOP_DB_PORT=5436  # Trust_2 (KCH)
+
+.. warning::
+
+   Until this has run, ``omop.concept`` is empty and **every cohort query that joins it returns
+   nothing** — the chest X-ray query above among them. The stack starts cleanly and the failure
+   looks like an empty cohort, not an error. The spleen query is the exception that proves the
+   rule: it filters on a concept id but never joins ``omop.concept``, so it keeps working.
+
+Two ways to obtain the bundle: FLIP developers with organisation AWS access run
+``make -C trust/omop-db fetch-vocab-core``; anyone else can build an equivalent export from
+`OHDSI Athena <https://athena.ohdsi.org/>`_ under their own licences. The DICOM vocabulary is
+separate — it is freely redistributable, ships inside the data volumes, and needs no seeding step.
+``trust/omop-db/README.md`` carries the full vocabulary roster, versions and licensing.

--- a/docs/source/components/component-omop-database.rst
+++ b/docs/source/components/component-omop-database.rst
@@ -16,8 +16,9 @@ To prepare the standardised data to be ingested into each Trust's OMOP Database,
 
 .. _omop-schema:
 
+******
 Schema
-======
+******
 
 The database implements `OMOP CDM 5.4 <https://ohdsi.github.io/CommonDataModel/cdm54.html>`_ in the
 ``omop`` schema — all 39 standard tables — extended with the two
@@ -26,13 +27,16 @@ The database implements `OMOP CDM 5.4 <https://ohdsi.github.io/CommonDataModel/c
 `CommonDataModel <https://github.com/OHDSI/CommonDataModel>`_ project's
 ``inst/ddl/5.4/postgresql`` and extended in place.
 
-Most of those 41 tables are unused by FLIP. The diagram below shows only the part a cohort query
-actually traverses: the clinical context on the left, the imaging metadata in the middle, the values
-and the vocabulary on the right.
+Most of those 41 tables are unused by FLIP. The diagram below shows the part a cohort query can
+draw on: the clinical context on the left, the imaging metadata in the middle, the values and the
+vocabulary on the right.
 
 .. figure:: ../assets/omop/omop-flip-schema.svg
-   :alt: Entity-relationship diagram of the eight omop-schema tables FLIP cohort queries use, showing person, visit_occurrence and procedure_occurrence linked to the MI-CDM tables image_occurrence and image_feature, which reach observation and measurement through a soft link and resolve concept ids through the concept table; image_occurrence.accession_id points out of the database at the Trust PACS and XNAT.
-   :width: 800
+   :alt: Entity-relationship diagram of the eight omop-schema tables a FLIP cohort query can draw
+      on, showing person, visit_occurrence and procedure_occurrence linked to the MI-CDM tables
+      image_occurrence and image_feature, which reach observation and measurement through a soft
+      link and resolve concept ids through the concept table; image_occurrence.accession_id points
+      out of the database at the Trust PACS and XNAT.
    :align: center
 
    The FLIP-relevant subset of OMOP CDM 5.4. Purple tables are the MI-CDM imaging extension;
@@ -41,14 +45,15 @@ and the vocabulary on the right.
 .. _omop-micdm:
 
 The MI-CDM imaging extension
-----------------------------
+============================
 
 Standard OMOP has nowhere to record an imaging study. The
 `Medical Imaging Common Data Model (MI-CDM) <https://www.ncbi.nlm.nih.gov/pmc/articles/PMC11031512/>`_
 is the OHDSI extension that adds one — the successor to the earlier R-CDM radiology tables — and
 FLIP implements it with two tables.
 
-``image_occurrence`` holds one row per imaging study or series:
+``image_occurrence`` holds one row per imaging study or series — FLIP populates one row per
+accession:
 
 .. list-table::
    :widths: 34 22 44
@@ -80,8 +85,10 @@ FLIP implements it with two tables.
      - DICOM Study and Series Instance UIDs.
    * - ``wadors_uri`` / ``local_path``
      - ``varchar(512)``
-     - MI-CDM's own pointers to the pixel data. FLIP reads neither — images are resolved
-       through ``accession_id``.
+     - MI-CDM's own pointers to the pixel data. FLIP resolves images through ``accession_id``
+       instead and reads neither at query time, but ``local_path`` is not dead weight: the spleen
+       tutorial's enrichment step recovers each study's MSD case name from that column of the
+       canonical CSV export.
    * - ``image_occurrence_date``
      - ``date``
      - Study date.
@@ -116,9 +123,13 @@ FLIP implements it with two tables.
    * - ``image_feature_type_concept_id``
      - ``integer``
      - Provenance of the finding, e.g. read from a report versus produced by an algorithm.
-   * - ``image_finding_concept_id`` / ``image_finding_id``
+   * - ``image_finding_concept_id``
      - ``integer``
-     - Optional link to a coded finding record.
+     - The kind of finding the row belongs to, e.g. *nodule*, as a concept id.
+   * - ``image_finding_id``
+     - ``integer``
+     - Groups the ``image_feature`` rows describing one finding. Locally minted — there is no
+       finding table for it to reference.
    * - ``anatomic_site_concept_id``
      - ``integer``
      - Body part the finding concerns.
@@ -133,38 +144,43 @@ Three consequences matter when writing a cohort query:
 ``accession_id`` is how a cohort row reaches its images
    ``image_occurrence.accession_id`` is not part of upstream MI-CDM; FLIP adds it with a bare
    ``ALTER TABLE ... ADD COLUMN`` in the DDL. It is the accession number XNAT uses to pull the study
-   out of the Trust PACS, so a query that does not project it produces a cohort with no imaging
-   attached. The Data Access API's accession-id route wraps the saved query as
-   ``SELECT accession_id FROM (<query>) AS cohort_subquery``, so omitting the column is a hard error
-   rather than a silent one.
+   out of the Trust PACS, and every cohort query that wants imaging must project it. Omitting it
+   fails loudly rather than silently: the Data Access API's accession-id route wraps the saved query
+   as ``SELECT accession_id FROM (<query>) AS cohort_subquery``, so the column's absence surfaces as
+   an error rather than as a cohort with no imaging attached.
 
 The link from ``image_feature`` to its value is a soft one
    ``image_feature`` does not carry the finding's value. Instead
-   ``image_feature_event_field_concept_id`` names the table that does and ``image_feature_event_id``
+   ``image_feature_event_field_concept_id`` names the table that does — ``observation`` for the
+   tutorial queries, ``measurement`` where the value is numeric — and ``image_feature_event_id``
    gives the row id in it. There is no foreign key to follow and no way to infer the target from the
    schema, so a query has to pin the field concept itself — ``= 1147304`` for ``observation`` — before
-   joining. This is the one part of the schema that cannot be worked out from the constraints.
+   joining. The image tables' ``*_concept_id`` columns sit in the same blind spot: unlike the
+   standard tables, neither declares a foreign key to ``concept``, so the constraints describe only
+   five of the links a query actually follows.
 
 Concept ids are meaningless until they are joined
-   Every ``*_concept_id`` resolves through ``omop.concept``, which is populated by the vocabulary
-   load rather than by the data load. On a Trust stack whose vocabulary has never been seeded,
-   ``omop.concept`` is empty and any query joining it returns nothing at all — see
-   :ref:`omop-dev-instance`.
+   Every ``*_concept_id`` resolves through ``omop.concept``, and the licensed core vocabulary that
+   populates it arrives by a separate seeding step, not with the data. Before that step a Trust
+   database still has a non-empty ``omop.concept`` — the DICOM vocabulary ships inside the data
+   volume — so counting its rows tells you nothing; a join on a SNOMED CT or LOINC id simply matches
+   nothing. See :ref:`omop-dev-instance`.
 
 .. _omop-sample-queries:
 
+*********************
 Sample cohort queries
-=====================
+*********************
 
 The tutorials in ``fl-tutorials/`` each ship the cohort query they were written against. Two of them
-bracket the range of what a query has to do. Both are shown below exactly as they are in the
-repository; the Flower copies
+bracket the range of what a query has to do. Both are shown below in full, less the licence
+header; the Flower copies
 (``fl-tutorials/flower/xray_classification/query.sql`` and
 ``fl-tutorials/flower/3d_spleen_segmentation/query.sql``) are byte-identical, so cohort queries are
 independent of the FL backend.
 
 Chest X-ray classification — labels out of OMOP
------------------------------------------------
+===============================================
 
 .. literalinclude:: ../../../fl-tutorials/nvflare/image_classification/xray_classification/query.sql
    :language: sql
@@ -180,18 +196,23 @@ This is the general shape of a supervised imaging query, in three steps:
    findings is three rows; the ``MAX(CASE WHEN image_feature_concept_id = ... THEN ... END)``
    idiom collapses them into one row per study with one column per finding. The concept ids
    in this tutorial are ``4215818`` *Effusion*, ``4196943`` *Edema* and ``40481136``
-   *Lungs in normal arrangement*.
-#. The outer ``SELECT`` joins ``omop.concept`` to turn modality and anatomy ids into names, and
-   aliases each pivoted column.
+   *Lungs in normal arrangement*. The join to ``omop.concept`` that decodes each Yes/No answer
+   (``value_concept``) lives inside this CTE — it is the one an unseeded vocabulary breaks first.
+#. The outer ``SELECT`` joins ``omop.concept`` again to turn modality and anatomy ids into names,
+   and aliases each pivoted column.
 
 Those aliases are load-bearing. The dataframe the FL client receives from ``flip.get_dataframe`` has
 exactly the query's output column names, and the tutorial matches them by **exact string** — the
 ``LESIONS`` map in its ``config.json`` contains ``"Effusion"``, ``"Edema"`` and
-``"Lungs in normal arrangement"``, which is why the SQL quotes those aliases verbatim. Renaming a
-column in the query without renaming it in ``config.json`` silently produces an all-masked label.
+``"Lungs in normal arrangement"``, which is why the SQL quotes those aliases verbatim.
+
+Rename a *lesion* column in the query without renaming it in ``config.json`` and training dies with
+a ``KeyError`` on that lesion — loud, but a long way from the SQL that caused it. Rename the
+*normality* column and nothing raises at all: the negative override simply stops firing, and every
+study silently keeps its per-lesion values. That one is the trap.
 
 3D spleen segmentation — labels not in OMOP
---------------------------------------------
+===========================================
 
 .. literalinclude:: ../../../fl-tutorials/nvflare/image_segmentation/3d_spleen_segmentation/query.sql
    :language: sql
@@ -216,10 +237,12 @@ selects the cohort, and the labels are enriched into XNAT.
    authority on this — it parses the query, checks the syntax tree and re-emits the SQL that actually
    runs. See :ref:`create-cohort-query` for the user-facing workflow.
 
+**************
 Access control
-==============
+**************
 
-Cohort queries issued by the Data Access API connect as the ``data_analyst_reader`` role, a member of
+On Compose deployments, cohort queries issued by the Data Access API connect as
+``DATA_ACCESS_POSTGRES_USER`` — ``data_analyst_reader`` by default — a member of
 ``omop_readonly_base``. The grants are created at first initialisation by
 ``trust/omop-db/files/create_readonly_users.sql``: ``CONNECT`` on the database, ``USAGE`` on the
 ``omop`` schema and ``SELECT`` on its tables and sequences, with ``INSERT``, ``UPDATE``, ``DELETE``,
@@ -229,10 +252,12 @@ defence-in-depth.
 
 .. note::
 
-   The grant is narrower on Compose deployments than on Kubernetes ones. The Kubernetes Trust chart
-   grants the role ``pg_read_all_data``, so on a Kubernetes Trust the schema pin inside
-   ``validate_query`` — not the database grant — is what keeps a query inside ``omop``. Narrowing
-   that grant to match Compose is tracked separately.
+   None of that applies on Kubernetes. The Trust chart creates the role directly with ``CONNECT``
+   and ``pg_read_all_data`` — no base-role membership, no connection limit, no statement timeout and
+   no revokes — so a Kubernetes Trust has neither the 300-second cap nor a schema-scoped grant, and
+   the schema pin inside ``validate_query`` is what keeps a query inside ``omop``. Narrowing the
+   grant to match Compose is tracked in
+   `FLIP#904 <https://github.com/londonaicentre/FLIP/issues/904>`_.
 
 Row-level results are additionally gated on the Trust's ``COHORT_QUERY_THRESHOLD`` (default 10): a
 cohort smaller than the threshold is refused with a fixed message, identical to the one a cohort of
@@ -242,8 +267,9 @@ around the clinical data boundary.
 
 .. _omop-dev-instance:
 
+*******************************
 Mocked instance for development
-===============================
+*******************************
 
 Development and staging Trust stacks run a mocked OMOP database:
 ``ghcr.io/londonaicentre/omop-db``, a PostgreSQL image whose build source lives
@@ -254,7 +280,7 @@ dataset on the public Hugging Face dataset
 deterministically split across however many mock Trusts are stood up.
 
 Getting the data
-----------------
+================
 
 Dev stacks do not build the database — they download a ready-populated PostgreSQL data volume per
 Trust from the same public dataset, roughly 11 MB each, at
@@ -273,7 +299,7 @@ row carries a ``source_trust`` column, and standing up N Trusts is a determinist
 dataset — see ``trust/omop-db/README.md`` for the partition modes and for rebuilding the volumes.
 
 Seeding the vocabulary
-----------------------
+======================
 
 The published image and the data volumes are deliberately **vocabulary-free**. SNOMED CT, LOINC,
 Read v2 and dm+d are licensed material, so they are kept out of every published artifact and each
@@ -286,13 +312,21 @@ environment loads the bundle it is licensed to use into its own running database
 
 .. warning::
 
-   Until this has run, ``omop.concept`` is empty and **every cohort query that joins it returns
-   nothing** — the chest X-ray query above among them. The stack starts cleanly and the failure
-   looks like an empty cohort, not an error. The spleen query is the exception that proves the
-   rule: it filters on a concept id but never joins ``omop.concept``, so it keeps working.
+   Until this has run, **a cohort query that resolves core-vocabulary concepts returns nothing** —
+   the chest X-ray query above among them, because the SNOMED CT ids it joins on are not there. The
+   stack starts cleanly and the result looks like an empty cohort. Don't diagnose it by counting
+   ``omop.concept``: the DICOM vocabulary ships in the data volume, so that table has rows either
+   way. ``omop.concept_ancestor`` is the empty one, and it is what the Data Access API probes — a
+   genuinely empty cohort makes it log an error naming this exact cause and the command to fix it.
+
+   The spleen query is the exception: it filters on a concept id but never joins ``omop.concept``,
+   so it keeps working on an unseeded stack.
 
 Two ways to obtain the bundle: FLIP developers with organisation AWS access run
 ``make -C trust/omop-db fetch-vocab-core``; anyone else can build an equivalent export from
-`OHDSI Athena <https://athena.ohdsi.org/>`_ under their own licences. The DICOM vocabulary is
+`OHDSI Athena <https://athena.ohdsi.org/>`_ under their own licences and unpack it into
+``trust/omop-db/data/vocab_aicentre_core_20240916/``. Do that first — ``load-omop-vocab`` depends on
+``fetch-vocab-core``, which skips the download when the directory is already there but fails without
+AWS access when it is not. The DICOM vocabulary is
 separate — it is freely redistributable, ships inside the data volumes, and needs no seeding step.
 ``trust/omop-db/README.md`` carries the full vocabulary roster, versions and licensing.

--- a/docs/source/glossary.rst
+++ b/docs/source/glossary.rst
@@ -15,6 +15,12 @@ Glossary
     **Flower Framework**
       Flower is an open-source framework for building federated learning systems. It provides tools and libraries to facilitate the development and deployment of federated learning applications. For more information, please see its `official documentation <https://flower.ai/docs/framework/>`_.
 
+    **MI-CDM**
+      Medical Imaging Common Data Model. The OHDSI extension that adds imaging to the OMOP CDM,
+      contributing the ``image_occurrence`` and ``image_feature`` tables. FLIP implements it and
+      adds an ``accession_id`` column to ``image_occurrence`` so that a cohort row can be matched
+      to its DICOM study in the Trust :term:`PACS`. See :ref:`omop-schema`.
+
     **NVIDIA FLARE**
       NVIDIA Federated Learning Application Runtime Environment is a domain-agnostic, open-source, extensible SDK that allows researchers and data scientists to adapt existing ML/DL workflows to a federated paradigm.
       For more information, please see the documentation `here <https://nvflare.readthedocs.io/en/main/index.html>`_.

--- a/docs/source/user-guides/user-common.rst
+++ b/docs/source/user-guides/user-common.rst
@@ -190,7 +190,7 @@ Cohort Query
 
 Cohort data is stored within a `PostgreSQL <https://www.postgresql.org/>`_ database conforming to the OMOP Common Data Model, extended with the :term:`MI-CDM` imaging tables — see :ref:`the schema reference <omop-schema>` for the tables a query can draw on, and :ref:`omop-sample-queries` for two worked examples.
 
-The ``image_occurrence`` table has been modified to include an ``accession_id`` field which contains the reference to the associated DICOM series. As this is the field that XNAT will read from when retrieving the associated DICOM series from PACS, the 'accession_id' needs to be included in all queries if relevant images are to be made available.
+The ``image_occurrence`` table has been modified to include an ``accession_id`` field which contains the reference to the associated DICOM study. As this is the field that XNAT will read from when retrieving the associated DICOM series from PACS, the 'accession_id' needs to be included in all queries if relevant images are to be made available.
 
 .. _create-cohort-query:
 

--- a/docs/source/user-guides/user-common.rst
+++ b/docs/source/user-guides/user-common.rst
@@ -188,7 +188,9 @@ Users can apply a filters to view only projects based on, for example, the curre
 Cohort Query
 ============
 
-Cohort data is stored within a `PostgreSQL <https://www.postgresql.org/>`_ database conforming to the `standard OMOP data model <http://omop-erd.surge.sh/omop_cdm/index.html>`_, extended with the `MI-CDM medical imaging tables <https://www.ncbi.nlm.nih.gov/pmc/articles/PMC11031512/>`_ (``image_occurrence``, ``image_feature`` — successors of the earlier R-CDM radiology tables). The ``image_occurrence`` table has been modified to include an ``accession_id`` field which contains the reference to the associated DICOM series. As this is the field that XNAT will read from when retrieving the associated DICOM series from PACS, the 'accession_id' needs to be included in all queries if relevant images are to be made available.
+Cohort data is stored within a `PostgreSQL <https://www.postgresql.org/>`_ database conforming to the OMOP Common Data Model, extended with the :term:`MI-CDM` imaging tables — see :ref:`the schema reference <omop-schema>` for the tables a query can draw on, and :ref:`omop-sample-queries` for two worked examples.
+
+The ``image_occurrence`` table has been modified to include an ``accession_id`` field which contains the reference to the associated DICOM series. As this is the field that XNAT will read from when retrieving the associated DICOM series from PACS, the 'accession_id' needs to be included in all queries if relevant images are to be made available.
 
 .. _create-cohort-query:
 


### PR DESCRIPTION
Closes #158.

The OMOP component page described the schema in one paragraph and had no diagram, no worked queries, and only a passing mention of MI-CDM. This adds the three things the issue asked for, and finishes the fourth.

### Schema diagram

`docs/source/assets/omop/omop-flip-schema.svg` — a new ERD covering the eight `omop`-schema tables a cohort query actually traverses.

I did **not** port `docs/omop.svg` from the retired private `flip-omop-db` repo as the issue suggested. That file is a 2 MB Git-LFS blob (2676×4072, 705 KB of it base64-embedded fonts) auto-generated from all 41 tables; it is illegible at docs page width, it cannot be linked from public docs because the repo is private, and the 39 stock CDM 5.4 tables in it are already documented by OHDSI. The focused diagram (13 KB, hand-authored, no new build dependency) draws the two things that genuinely cannot be inferred from the FK constraints:

- `image_feature`'s **soft link** to whichever table `image_feature_event_field_concept_id` names — no FK to follow, which is exactly what the X-ray query pivots on;
- `image_occurrence.accession_id` pointing **out of the database** at the trust PACS/XNAT — a FLIP addition to MI-CDM, not part of it.

### MI-CDM

Column references for `image_occurrence` and `image_feature` taken from the in-repo DDL, plus the three consequences that bite a query author: `accession_id` is mandatory if you want imaging, the event-field indirection has to be pinned by hand, and concept ids are inert until the vocabulary is seeded.

### Sample queries

The X-ray and spleen tutorial `query.sql` files, pulled in with `literalinclude` (the `component-fl-nodes.rst` pattern) so the page cannot drift from the tutorials. They bracket the range deliberately — X-ray projects its labels out of OMOP by pivoting `image_feature`; spleen only names the cohort, because a segmentation mask has nowhere to live in OMOP and arrives via XNAT enrichment instead.

### Dev container and data (issue item 4)

Largely satisfied by FLIP#834/#842 since the issue was filed — the tarballs are already public. The page now names the Hugging Face URLs, the `.data_version` pin and the `make` targets, and documents the vocabulary-seeding step and the failure mode when it is skipped (an unseeded `omop.concept` makes every query joining it return an empty cohort, not an error).

### Corrections picked up along the way

- Access control said "SELECT-only on the `omop` schema" unconditionally; the Kubernetes chart grants `pg_read_all_data`, so on a k8s trust the schema pin in `validate_query` is what holds the boundary. Noted, with the follow-up referenced.
- `user-common.rst` carried a near-duplicate MI-CDM paragraph and a link to an unrelated external ERD; replaced with a cross-reference. The operationally important `accession_id` sentence stays where a user writing a query will see it.
- Added an `MI-CDM` glossary entry.

### Verification

- `cd docs && make clean && make docs` — build succeeded, **1 warning**, pre-existing in `component-fl-nodes.rst` (untouched here).
- Confirmed in the built HTML: the SVG renders at 800 px, both anchors resolve from `user-common.rst`, the `:term:` link resolves, and both `literalinclude`s pull the SQL with the Apache header stripped (`WITH feature_observation AS (` … `LIMIT 300`; `SELECT *` … `LIMIT 50`).
- Every column, type and edge in the diagram cross-checked against `OMOPCDM_postgresql_5.4_ddl.sql` and `..._constraints.sql`.
- Concept names (`4300757` *Computed tomography*, `1147304` *observation*, `4215818`, `4196943`, `40481136`) and the claims about `wadors_uri`/`local_path` being unpopulated verified against a live dev trust OMOP database rather than assumed.
- `pre-commit run --files <the four paths>` — all hooks pass, SVG is 13 KB against the 1000 KB cap.

## Acceptance Criteria

*Imported from issue #158*

-

---

## Review round (commit `8a471e7d`)

Ran the change past two review passes before asking for human review. They found **two claims that were flat wrong**, both of which would have misled someone debugging a real problem. I verified each against the code before acting.

**`omop.concept` is not empty before the vocabulary seeding step.** `load_dicom_vocab` runs *outside* the `CORE_VOCAB` conditional in `populate-trust-%` and inserts into `omop.concept`, and the DICOM vocabulary ships inside the published tarballs — which the page itself said 140 lines further down. The version I wrote taught a diagnostic (`count(*) FROM omop.concept`) that returns rows on an unseeded stack and sends you the wrong way. `omop.concept_ancestor` is the genuinely empty table, and it is what `data_access_api` probes.

**Renaming a lesion column does not silently produce an all-masked label.** The xray tutorials' `get_labels_from_radiology_row` has no `else` branch, so the key is absent from `out_dict` and `get_lesion_label` raises `KeyError`. The `-1` fallback I described belongs to `arkplus_fine_tuning`, which this page never mentions. The genuinely silent failure is renaming the *normality* column — the negative override stops firing with no error — so that is what the page now documents.

Also corrected: `image_finding_concept_id`/`image_finding_id` (no finding table exists, and the two columns do different jobs); "the one part of the schema that cannot be worked out from the constraints" (the image tables declare five FKs and none from any `*_concept_id` to `concept`); the access-control guarantees being Compose-only (the k8s chart grants `CONNECT` + `pg_read_all_data` and has no connection limit or statement timeout, so a k8s reader was told about a 300s cap that does not exist); `local_path` being read by the spleen enrichment uploader; the diagram showing what a query *can* draw on rather than what it "actually traverses"; and an accession number identifying a study rather than a series in `user-common.rst`.

**ERD:** removed generator residue (eight no-op zero-radius arcs and eight duplicated divider paths — 16 of 41 `<path>` elements) that made the committed file awkward to hand-edit; foreign-key arrows now point uniformly from the table holding the key to the one it references, instead of opposing the concept edges; the legend documents all four line styles, marks the column lists as abridged, and no longer claims every table carries `person_id` (`concept` does not) while drawing one such edge anyway.

**Also:** headings now follow `docs/template/rst_doc_template.rst` (`#` / `*` / `=`), matching `component-xnat`, `component-logging-stack` and `architecture-overview`; and the figure drops `:width: 800`, since `_static/style.css` widens the content column to 1040px and the fixed width was rendering the diagram at 0.8 scale.

**One review finding rejected.** A reviewer flagged the description of `1147304` as the concept for the `observation` *table*, arguing OMOP's `*_event_field_concept_id` convention is field-level. It is not, for this id: `concept_class_id` is `Table`. The field-level concepts look like `1147165 | observation.observation_id | Field`. Verified against the dev OMOP database; wording unchanged.
