### PR TITLE
hotfix(flip-ui): repair the test-tree typecheck that went red on develop at the #1042 merge; drop the legacy models redirect

### DIFF
--- a/flip-ui/src/router/__tests__/index.spec.ts
+++ b/flip-ui/src/router/__tests__/index.spec.ts
@@ -29,7 +29,6 @@ import { RouteLocationNormalized } from "vue-router";
 import router, { afterEachGuard,
     beforeEachGuard,
     handleRouteError,
-    legacyProjectModelsRedirect,
     routeChange } from "@/router";
 import { doneRouteProgress, startRouteProgress } from "@/router/progress";
 import { authCheck } from "@/utils/auth";
@@ -56,16 +55,6 @@ describe("routeChange", () => {
     it("viewProject pushes /project/:id", () => {
         routeChange.viewProject("proj-1");
         expect(pushSpy).toHaveBeenCalledWith({ path: "/project/proj-1" });
-    });
-
-    it("the retired per-project models route redirects to the scoped estate list", () => {
-        // Bookmarks and old links must keep working: /project/:id/models now means
-        // /models?project=:id. Tested through the exported function because vue-router's
-        // `resolve()` does not follow redirects.
-        expect(legacyProjectModelsRedirect({ params: { projectId: "proj-2" } } as never)).toEqual({
-            path: "/models",
-            query: { project: "proj-2" }
-        });
     });
 
     it("viewModel pushes /project/:pid/model/:mid", () => {

--- a/flip-ui/src/router/index.ts
+++ b/flip-ui/src/router/index.ts
@@ -22,26 +22,7 @@ import { createRouter,
     NavigationGuardNext,
     RouteLocationNormalized } from "vue-router";
 
-/**
- * The per-project models page was merged into the estate-wide list, which carries its scope in a
- * query param. Kept so bookmarks and any external links keep working.
- *
- * A function rather than a `redirect:` in the page's own route block: YAML cannot interpolate
- * `:projectId` into `?project=`, and a redirect stub page would render inside MainLayout's
- * project branch, waiting on a project fetch it does not need before it could redirect.
- */
-export const legacyProjectModelsRedirect = (to: RouteLocationNormalized) => ({
-    path: "/models",
-    query: { project: String(to.params["projectId"]) }
-});
-
-const routes = [
-    ...setupLayouts(generatedRoutes),
-    {
-        path: "/project/:projectId/models",
-        redirect: legacyProjectModelsRedirect
-    }
-];
+const routes = setupLayouts(generatedRoutes);
 
 // import { routes } from "@/router/routes";
 import { IS_DEMO } from "@/demo/bootstrap";

--- a/flip-ui/test/cypress/integration/group-4/project/redirect_invalid_project.spec.ts
+++ b/flip-ui/test/cypress/integration/group-4/project/redirect_invalid_project.spec.ts
@@ -37,17 +37,6 @@ describe("redirect user to the project list page if the given project does not e
         cy.contains("The requested project could not be found.").should("be.visible");
     });
 
-    it("sends the retired per-project models URL to the scoped estate list", () => {
-        // /project/:id/models was merged into /models?project=:id. Nothing fetches the project
-        // on the way, so an unknown id lands on the models page and its own guard takes over.
-        cy.intercept("GET", "/models/projects", { body: [] }).as("getProjectOptions");
-
-        cy.visit(`/project/${projectId}/models`);
-
-        cy.url().should("include", "/models");
-        cy.url().should("not.include", `/project/${projectId}/models`);
-    });
-
     it("redirects to project list on nav to 'model dashboard' of non-existent project", () => {
         cy.fixture("model/getModel").then((getModel) => {
             cy.intercept("GET", `/projects/${getModel.projectId}`, { statusCode: 404 })
@@ -92,8 +81,7 @@ describe("redirect user to the project list page if the given project does not e
         cy.intercept("GET", `/projects/${projectId}`, { statusCode: 400 })
             .as("getProject400");
 
-        // Retargeted from /project/:id/models, which no longer fetches the project: the 400 path
-        // is what this test is about, and the project page still exercises it.
+        // The 400 path is what this test is about; the project page exercises it.
         cy.visit(`/project/${projectId}`);
 
         cy.wait("@getProject400");

--- a/flip-ui/test/global.d.ts
+++ b/flip-ui/test/global.d.ts
@@ -42,13 +42,17 @@ declare namespace Cypress {
         /**
          * Get DOM element by data-test attribute.
          *
+         * Yields what the underlying cy.get yields. Declared as such rather than as
+         * Chainable<Subject>: called on `cy` the current subject is `undefined`, so a
+         * `.then(($el) => ...)` off the result would type `$el` as `undefined`.
+         *
          * @param {string} selector - The data-test attribute of the target DOM element.
-         * @return {HTMLElement} - Target DOM element
+         * @return {JQuery<HTMLElement>} - Target DOM element(s)
          */
         getBySel(
             value: string,
             options?: Partial<Loggable & Timeoutable & Withinable & Shadow>
-        ): Chainable<Subject>,
+        ): Chainable<JQuery<HTMLElement>>,
         /**
          * Login in to AWS Cognito via Amplify Auth API bypassing UI.
          *


### PR DESCRIPTION
## What broke, and when

`develop` has failed the **FLIP UI CI** check since the #1042 merge (`ef5425a3`, 2026-08-28 11:27Z) — the `Run test-tree typecheck` step (`npm run test:types`), which #1042 itself introduced in `d62ab238`. Every open PR now shows the same red `flip-ui` check regardless of what it touches.

It is a semantic collision, not a textual one: #1042's last CI run was on 2026-08-26 (green), #1014 merged on 2026-08-27 15:31Z, and #1042 was never re-run against that develop — so the first tree holding both was the post-merge develop build.

Four errors, two causes:

| Error | Cause | Fix |
| --- | --- | --- |
| `project_list.spec.ts` ×3 — `$cells`/`$dots` typed `undefined`, `$spine` possibly undefined | `getBySel` was declared as `Chainable<Subject>`; on `cy` the current subject is `undefined`, so `.then()` off it yields `undefined`. #1014's spec is the first to `.then()` a `getBySel` result. | `test/global.d.ts`: `getBySel` yields `Chainable<JQuery<HTMLElement>>`, what the `cy.get` underneath yields. |
| `src/router/index.ts(58)` — `routes` not assignable to `RouteRecordRaw[]` | `legacyProjectModelsRedirect` (from #1014) took `RouteLocationNormalized`, but a function-form `redirect` receives `RouteLocation` (whose `name` can be `null`), so the whole untyped array failed to match. | **Removed.** Legacy routes are not supported: nothing in the app links to `/project/:id/models` (the `/projects/<id>/models` hits are API endpoints), and the redirect's only consumers were its own unit case and one group-4 Cypress case — both go with it. `routes` is back to `setupLayouts(generatedRoutes)`. |

## Verification (worktree off `origin/develop`, `npm ci` with Cypress 15.21.0)

- `npm run test:types` — reproduced CI's exact four errors before the change; clean after.
- `npm run lint` — 0 errors (3 pre-existing `max-len` warnings, untouched files).
- `npm run test:unit` — 112 files, 1314 passed, 1 skipped (one fewer than develop: the removed redirect case).
- `vue-tsc --noEmit` is not a CI gate; it reports 40 pre-existing errors on develop, none in `src/router/`, and this change adds none.
- The group-4 Cypress spec loses one case and is otherwise untouched — CI's group-4 shard is the check for it.

## Acceptance criteria

- [x] `develop` merged with this branch passes `Run test-tree typecheck`
- [x] `getBySel(...).then(($el) => ...)` types `$el` as `JQuery<HTMLElement>` in the Cypress test tree
- [x] `/project/:id/models` is no longer a route; no in-app link targets it
- [x] `npm run lint` and `npm run test:unit` unaffected
