### PR TITLE
docs: fix Swagger URL and add missing return annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ make up
 ```
 
 If Swarm is already active, `docker swarm init` reports that and can be skipped. Open `https://localhost` for the UI
-and `http://localhost:8080/docs` for the Central Hub API documentation.
+and `http://localhost:8080/api/docs` for the Central Hub API documentation.
 
 ### Load the OMOP vocabulary
 

--- a/flip-utils/flip/nvflare/components/pt_model_locator.py
+++ b/flip-utils/flip/nvflare/components/pt_model_locator.py
@@ -167,7 +167,7 @@ class EvaluationModelLocator(ModelLocator):
         super().__init__()
         self.models: dict | None = None
 
-    def _resolve_checkpoint_path(self, fl_ctx: FLContext, app_dir: str, name: str, model_checkpoint: str):
+    def _resolve_checkpoint_path(self, fl_ctx: FLContext, app_dir: str, name: str, model_checkpoint: str) -> str | None:
         """Locate a checkpoint: bundled ``custom/`` first, then the FL API's shared staging volume."""
         bundled_path = os.path.join(app_dir, "custom", model_checkpoint)
         if os.path.isfile(bundled_path):

--- a/flip-utils/flip/nvflare/components/pt_model_persistor.py
+++ b/flip-utils/flip/nvflare/components/pt_model_persistor.py
@@ -52,7 +52,7 @@ class InitialCheckpointPTModelPersistor(PTFileModelPersistor):
         super().__init__(model=model, **kwargs)
         self._model_id_arg = model_id
 
-    def _resolve_backbone(self, fl_ctx: FLContext):
+    def _resolve_backbone(self, fl_ctx: FLContext) -> str | None:
         """Locate the declared backbone checkpoint, or ``None`` if none is declared/found."""
         app_dir = fl_ctx.get_engine().get_workspace().get_app_dir(fl_ctx.get_job_id())
         config_path = os.path.join(app_dir, "custom", "config.json")


### PR DESCRIPTION
> _This is an automated scheduled weekly task by Alex's Claude Code — a docs/CLAUDE.md/AGENTS.md/type-annotation drift sweep of `develop`._

# Description

Weekly drift sweep across READMEs, ReadTheDocs sources, `CLAUDE.md` / `AGENTS.md` pairs, and Python type annotations. The audits came back almost entirely clean; only three concrete drift items are fixed here.

## Linked Issues

Fixes #

## Checklist

- [x] Follows the project's coding conventions and style guide
- [x] Updates documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Type of Change

- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] In-line docstrings updated.
- [x] Documentation updated, tested `make -C docs/ docs`.

## Testing

- [ ] Quick tests passed locally by running `make unit-test`.
- [ ] Integration tests pass (if applicable) by running `make integration-test`.

Changes are two annotation-only edits (adding `-> str | None` on two `_resolve_*` helpers whose bodies were already returning `str | None`, so no behavioural change) plus a one-character README URL correction. flip-utils' CI exercises ruff + pytest on these changes; mypy is not currently wired into the flip-utils job (mypy runs only for `fl-services/nvflare/fl-api-base` today), so the added annotations aren't enforced by CI here — worth a separate follow-up to wire flip-utils' full mypy config into `flip-utils-tests.yml`.

## Additional Notes

### What the sweep found

- **`CLAUDE.md` / `AGENTS.md` pairs (9 pairs)**: all in sync. `diff <(sed 's/CLAUDE\.md/AGENTS.md/g' CLAUDE.md) AGENTS.md` produced empty output for every pair. No orphans.
- **READMEs / ReadTheDocs sources**: spot-check across every root, service, `fl-services/`, `fl-apps/`, `fl-tutorials/`, `deploy/`, `docs/source/*.rst` doc — Make targets, env vars, ports, container names, in-tree paths, and cross-references all match current code. Only one wrong URL found (see below).
- **Python return-type annotations** across `flip-api`, `trust-api`, `imaging-api`, `data-access-api`, `flip-utils`: two missing `-> str | None` annotations in `flip-utils/flip/nvflare/components/`. The rest of the service source is clean (mypy CI is doing its job on the services it covers).

### Changes in this PR

1. **`README.md`** — Central Hub Swagger URL: `http://localhost:8080/docs` → `http://localhost:8080/api/docs`. The app mounts Swagger under `API_PREFIX` in `flip-api/src/flip_api/main.py:142` (`docs_url=f"{API_PREFIX}/docs"`), which `flip-api/README.md` already documents correctly; only the root README was stale.
2. **`flip-utils/flip/nvflare/components/pt_model_persistor.py`** — `_resolve_backbone` gets `-> str | None`. The docstring already says "Locate the declared backbone checkpoint, or `None` if none is declared/found" and every `return` path yields `str` or `None`.
3. **`flip-utils/flip/nvflare/components/pt_model_locator.py`** — same treatment for `_resolve_checkpoint_path`.

### Deliberately out of scope

- Wiring flip-utils' full mypy config into `flip-utils-tests.yml` — real gap worth its own PR (raised by @garciadias in review), separate from this drift sweep.
- `flip-api/src/flip_api/fl_services/services/fl_service.py::upload_app` returns `Any` with an in-file TODO acknowledging the response should be typed. That's a real refactor (defining the pydantic response schema for the FL API's `/upload_app` reply), not a drift fix — leaving for a dedicated PR.
- `uv.lock` drift reported by the session bootstrap is unrelated to the drift audit and was left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RgVUqDYb7uNvwnzKw6CPP8