### PR TITLE
refactor(flip-api): split cognito_helpers.py into AWS, user-roles and CORS modules

### DIFF
--- a/deploy/providers/AWS/dev/variables.tf
+++ b/deploy/providers/AWS/dev/variables.tf
@@ -60,7 +60,7 @@ variable "SES_VERIFIED_EMAIL" {
 
 variable "cognito_callback_urls" {
   type        = list(string)
-  description = "OAuth callback URLs for the dev Cognito app client. Doubles as the source for flip-api's CORS allowlist (see flip_api/utils/cognito_helpers.py:get_cors_allowed_origins), so every UI origin that calls the API in dev must be listed here. Cognito only accepts http:// for the localhost host."
+  description = "OAuth callback URLs for the dev Cognito app client. Doubles as the source for flip-api's CORS allowlist (see flip_api/utils/cors.py:get_cors_allowed_origins), so every UI origin that calls the API in dev must be listed here. Cognito only accepts http:// for the localhost host."
   default     = ["https://localhost:443", "http://localhost:44357"]
 }
 

--- a/flip-api/src/flip_api/main.py
+++ b/flip-api/src/flip_api/main.py
@@ -100,7 +100,7 @@ from flip_api.user_services import (
     set_user_roles,
     update_user,
 )
-from flip_api.utils.cognito_helpers import get_cors_allowed_origins
+from flip_api.utils.cors import get_cors_allowed_origins
 from flip_api.utils.rate_limiter import limiter
 from flip_api.utils.security_headers import SecurityHeadersMiddleware
 

--- a/flip-api/src/flip_api/user_services/get_user.py
+++ b/flip-api/src/flip_api/user_services/get_user.py
@@ -21,8 +21,9 @@ from flip_api.auth.dependencies import verify_token
 from flip_api.db.database import get_session
 from flip_api.db.models.user_models import PermissionRef
 from flip_api.domain.schemas.users import CognitoUser, ProjectMemberLookup
-from flip_api.utils.cognito_helpers import apply_user_profile, get_user_by_email_or_id, get_user_pool_id
+from flip_api.utils.cognito_helpers import get_user_by_email_or_id, get_user_pool_id
 from flip_api.utils.logger import logger
+from flip_api.utils.user_roles import apply_user_profile
 
 router = APIRouter(prefix="/users", tags=["user_services"])
 

--- a/flip-api/src/flip_api/user_services/get_users.py
+++ b/flip-api/src/flip_api/user_services/get_users.py
@@ -20,9 +20,10 @@ from flip_api.auth.dependencies import verify_token
 from flip_api.db.database import get_session
 from flip_api.db.models.user_models import PermissionRef
 from flip_api.domain.schemas.users import IUser
-from flip_api.utils.cognito_helpers import get_cognito_users, get_pool_id, get_user_role_data
+from flip_api.utils.cognito_helpers import get_cognito_users, get_pool_id
 from flip_api.utils.logger import logger
 from flip_api.utils.paging_utils import IPagedData, get_paging_details, get_total_pages
+from flip_api.utils.user_roles import get_user_role_data
 
 router = APIRouter(prefix="/users", tags=["user_services"])
 

--- a/flip-api/src/flip_api/user_services/register_user.py
+++ b/flip-api/src/flip_api/user_services/register_user.py
@@ -23,11 +23,10 @@ from flip_api.domain.interfaces.user import IRegisterUser, IUserResponse
 from flip_api.utils.cognito_helpers import (
     create_cognito_user,
     delete_cognito_user,
-    get_all_roles,
     get_user_pool_id,
-    validate_roles,
 )
 from flip_api.utils.logger import logger
+from flip_api.utils.user_roles import get_all_roles, validate_roles
 
 router = APIRouter(prefix="/users", tags=["user_services"])
 

--- a/flip-api/src/flip_api/user_services/set_user_roles.py
+++ b/flip-api/src/flip_api/user_services/set_user_roles.py
@@ -21,8 +21,9 @@ from flip_api.config import get_settings
 from flip_api.db.database import get_session
 from flip_api.db.models.user_models import PermissionRef, Role, UserRole, UsersAudit
 from flip_api.domain.interfaces.user import IRoles
-from flip_api.utils.cognito_helpers import get_username, validate_roles
+from flip_api.utils.cognito_helpers import get_username
 from flip_api.utils.logger import logger
+from flip_api.utils.user_roles import validate_roles
 
 router = APIRouter(prefix="/users", tags=["user_services"])
 

--- a/flip-api/src/flip_api/utils/cognito_helpers.py
+++ b/flip-api/src/flip_api/utils/cognito_helpers.py
@@ -13,11 +13,9 @@
 import logging
 import threading
 import time
-from collections import defaultdict
 from collections.abc import Sequence
 from functools import lru_cache
 from typing import Any
-from urllib.parse import urlparse
 from uuid import UUID
 
 import boto3
@@ -25,13 +23,10 @@ from botocore.exceptions import ClientError
 from fastapi import HTTPException, Request, status
 from pydantic import TypeAdapter, ValidationError
 from pydantic.networks import EmailStr
-from sqlmodel import Session, col, select
 
 from flip_api.config import get_settings
-from flip_api.db.models.user_models import Role, UserProfile, UserRole
-from flip_api.domain.schemas.users import CognitoUser, Disabled, IRole, IUser
+from flip_api.domain.schemas.users import CognitoUser, Disabled
 from flip_api.utils.logger import logger
-from flip_api.utils.paging_utils import PagingInfo
 
 _EMAIL_VALIDATOR: TypeAdapter[str] = TypeAdapter(EmailStr)
 
@@ -44,55 +39,6 @@ def _cognito_client() -> Any:
     and expensive to construct; sharing one avoids paying endpoint-resolution
     cost on every authenticated request."""
     return boto3.client("cognito-idp", region_name=get_settings().AWS_REGION)
-
-
-_DEFAULT_PORTS = {"http": 80, "https": 443}
-
-
-def _origin_from_url(url: str) -> str | None:
-    """Return ``scheme://host[:port]`` for ``url``, omitting ports that match the scheme default.
-
-    Browsers strip default ports from the ``Origin`` header (RFC 6454), so an allowlist entry
-    like ``https://localhost:443`` would never match an actual request — normalize before use.
-    Returns ``None`` for URLs without a usable scheme/host.
-    """
-    parsed = urlparse(url)
-    if not parsed.scheme or not parsed.hostname:
-        return None
-    host = parsed.hostname
-    port = parsed.port
-    if port is None or port == _DEFAULT_PORTS.get(parsed.scheme):
-        return f"{parsed.scheme}://{host}"
-    return f"{parsed.scheme}://{host}:{port}"
-
-
-def get_cors_allowed_origins() -> list[str]:
-    """Derive the CORS allowlist from the Cognito user pool client's CallbackURLs.
-
-    The same Cognito app client that authenticates UI logins already enumerates the trusted UI
-    origins per environment (see ``deploy/providers/AWS/services.tf``). Reusing it as the CORS
-    allowlist keeps "where users can sign in" and "where the UI may call this API" in lockstep,
-    without a separate env var.
-
-    Returns:
-        list[str]: Unique normalized origins (``scheme://host[:port]``) suitable for
-        ``CORSMiddleware(allow_origins=...)``.
-    """
-    settings = get_settings()
-    response = _cognito_client().describe_user_pool_client(
-        UserPoolId=settings.AWS_COGNITO_USER_POOL_ID,
-        ClientId=settings.AWS_COGNITO_APP_CLIENT_ID,
-    )
-    callback_urls: list[str] = response.get("UserPoolClient", {}).get("CallbackURLs", []) or []
-
-    seen: set[str] = set()
-    origins: list[str] = []
-    for url in callback_urls:
-        origin = _origin_from_url(url)
-        if origin and origin not in seen:
-            seen.add(origin)
-            origins.append(origin)
-    return origins
 
 
 def get_pool_id(request: Request) -> str:
@@ -294,24 +240,6 @@ def get_user_by_email_or_id(
         )
 
     return users[0]
-
-
-def apply_user_profile(user: CognitoUser, session: Session) -> CognitoUser:
-    """Attach DB-backed profile fields to a Cognito user response."""
-    if not hasattr(session, "get"):
-        return user
-
-    profile = session.get(UserProfile, user.id)
-    if not profile:
-        return user
-
-    return CognitoUser(
-        id=user.id,
-        email=user.email,
-        name=profile.name,
-        organisation=profile.organisation,
-        is_disabled=user.is_disabled,
-    )  # type: ignore[call-arg]
 
 
 def get_username(user_id: str, user_pool_id: str) -> str:
@@ -554,117 +482,6 @@ def revoke_token(refresh_token: str, client_id: str) -> None:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to revoke token"
         ) from e
-
-
-def get_user_role_data(
-    paging_info: PagingInfo,
-    users: list[CognitoUser],
-    session: Session,
-) -> list[IUser]:
-    """
-    Get user role data with pagination and filtering.
-
-    Args:
-        paging_info (PagingInfo): Pagination and filtering information.
-        users (list[CognitoUser]): List of Cognito users.
-        session (Session): Database session.
-
-    Returns:
-        list[IUser]: List of IUser objects with roles.
-    """
-    # Fetch roles for users
-    user_ids = [user.id for user in users]
-    statement = (
-        select(col(UserRole.user_id), Role)
-        .join(Role, col(Role.id) == col(UserRole.role_id))
-        .where(col(UserRole.user_id).in_(user_ids))
-    )
-    role_results = session.exec(statement).all()
-    profiles = session.exec(select(UserProfile).where(col(UserProfile.user_id).in_(user_ids))).all()
-    user_profiles_map = {str(profile.user_id): profile for profile in profiles}
-
-    # Group roles by user_id
-    user_roles_map: dict[str, list[IRole]] = defaultdict(list)
-    for user_id, role in role_results:
-        if role and role.id is not None:
-            user_roles_map[str(user_id)].append(
-                IRole(
-                    id=role.id,
-                    rolename=role.name,
-                    roledescription=role.description,
-                )
-            )
-
-    # Filter by email and apply pagination
-    search_str = paging_info.search_str.lower()
-    filtered_users = [
-        user
-        for user in users
-        if search_str in user.email.lower()
-        or search_str in user_profiles_map.get(str(user.id), UserProfile(user_id=user.id)).name.lower()
-        or search_str in user_profiles_map.get(str(user.id), UserProfile(user_id=user.id)).organisation.lower()
-    ]
-    sorted_users = sorted(filtered_users, key=lambda u: u.email)
-    paged_users = sorted_users[paging_info.offset : paging_info.offset + paging_info.page_size]
-
-    # Reconstruct IUser objects with roles
-    final_users = [
-        IUser(
-            id=user.id,
-            email=user.email,
-            name=user_profiles_map.get(str(user.id), UserProfile(user_id=user.id)).name,
-            organisation=user_profiles_map.get(str(user.id), UserProfile(user_id=user.id)).organisation,
-            is_disabled=user.is_disabled,
-            roles=user_roles_map.get(str(user.id), []),
-        )  # type: ignore[call-arg]
-        for user in paged_users
-    ]
-
-    return final_users
-
-
-def get_all_roles(db: Session) -> list[UUID]:
-    """
-    Get all role IDs from the database.
-
-    Args:
-        db (Session): Database session
-
-    Returns:
-        list[UUID]: List of role IDs
-    """
-    logger.debug("Attempting to get the list of roles from the database...")
-
-    result = db.exec(select(Role.id)).all()
-
-    role_ids = [role_id for role_id in result]
-
-    logger.info(f"Found {len(role_ids)} roles: {role_ids}")
-
-    return role_ids
-
-
-def validate_roles(user_roles: list[UUID], roles_from_db: list[UUID]) -> None:
-    """
-    Validate that all user roles exist in the database.
-
-    Args:
-        user_roles (list[UUID]): List of role IDs to validate
-        roles_from_db (list[UUID]): List of valid role IDs from the database
-
-    Returns:
-        None
-
-    Raises:
-        HTTPException: If any role is invalid
-    """
-    logger.debug(f"Attempting to validate user roles: {user_roles}")
-
-    invalid_roles = [role for role in user_roles if role not in roles_from_db]
-
-    if invalid_roles:
-        logger.error(f"Invalid role(s): {invalid_roles}. They do not match the roles in the database: {roles_from_db}")
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Invalid role(s): {invalid_roles}")
 
 
 def create_cognito_user(email: str, user_pool_id: str) -> UUID:

--- a/flip-api/src/flip_api/utils/cors.py
+++ b/flip-api/src/flip_api/utils/cors.py
@@ -1,0 +1,72 @@
+# Copyright (c) Guy's and St Thomas' NHS Foundation Trust & King's College London
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""CORS allowlist derivation for the FLIP API.
+
+The allowlist is sourced from the Cognito app client's ``CallbackURLs`` rather than a
+dedicated env var, so "where users can sign in" and "where the UI may call this API"
+cannot drift apart. This is the only reason application startup contacts the identity
+provider — see ``main.py``'s lifespan.
+"""
+
+from urllib.parse import urlparse
+
+from flip_api.config import get_settings
+from flip_api.utils.cognito_helpers import _cognito_client
+
+_DEFAULT_PORTS = {"http": 80, "https": 443}
+
+
+def _origin_from_url(url: str) -> str | None:
+    """Return ``scheme://host[:port]`` for ``url``, omitting ports that match the scheme default.
+
+    Browsers strip default ports from the ``Origin`` header (RFC 6454), so an allowlist entry
+    like ``https://localhost:443`` would never match an actual request — normalize before use.
+    Returns ``None`` for URLs without a usable scheme/host.
+    """
+    parsed = urlparse(url)
+    if not parsed.scheme or not parsed.hostname:
+        return None
+    host = parsed.hostname
+    port = parsed.port
+    if port is None or port == _DEFAULT_PORTS.get(parsed.scheme):
+        return f"{parsed.scheme}://{host}"
+    return f"{parsed.scheme}://{host}:{port}"
+
+
+def get_cors_allowed_origins() -> list[str]:
+    """Derive the CORS allowlist from the Cognito user pool client's CallbackURLs.
+
+    The same Cognito app client that authenticates UI logins already enumerates the trusted UI
+    origins per environment (see ``deploy/providers/AWS/services.tf``). Reusing it as the CORS
+    allowlist keeps "where users can sign in" and "where the UI may call this API" in lockstep,
+    without a separate env var.
+
+    Returns:
+        list[str]: Unique normalized origins (``scheme://host[:port]``) suitable for
+        ``CORSMiddleware(allow_origins=...)``.
+    """
+    settings = get_settings()
+    response = _cognito_client().describe_user_pool_client(
+        UserPoolId=settings.AWS_COGNITO_USER_POOL_ID,
+        ClientId=settings.AWS_COGNITO_APP_CLIENT_ID,
+    )
+    callback_urls: list[str] = response.get("UserPoolClient", {}).get("CallbackURLs", []) or []
+
+    seen: set[str] = set()
+    origins: list[str] = []
+    for url in callback_urls:
+        origin = _origin_from_url(url)
+        if origin and origin not in seen:
+            seen.add(origin)
+            origins.append(origin)
+    return origins

--- a/flip-api/src/flip_api/utils/cors.py
+++ b/flip-api/src/flip_api/utils/cors.py
@@ -12,10 +12,15 @@
 
 """CORS allowlist derivation for the FLIP API.
 
-The allowlist is sourced from the Cognito app client's ``CallbackURLs`` rather than a
-dedicated env var, so "where users can sign in" and "where the UI may call this API"
-cannot drift apart. This is the only reason application startup contacts the identity
-provider — see ``main.py``'s lifespan.
+Sourced from the Cognito app client's ``CallbackURLs`` so there is one Terraform-owned
+list of trusted UI origins per environment rather than two config surfaces that can
+drift. The UI authenticates with ``USER_SRP_AUTH`` rather than an OAuth2 redirect, so
+those URLs are never used as a login callback — flip-api reads them purely as the
+declared UI-origin list.
+
+This is the only Cognito call the ASGI app itself makes at startup (``main.py``'s
+lifespan). The container contacts Cognito earlier too, from the separate seeding
+process ``entrypoint.sh`` runs before uvicorn — see ``db/seed/main_users.py``.
 """
 
 from urllib.parse import urlparse

--- a/flip-api/src/flip_api/utils/user_roles.py
+++ b/flip-api/src/flip_api/utils/user_roles.py
@@ -1,0 +1,158 @@
+# Copyright (c) Guy's and St Thomas' NHS Foundation Trust & King's College London
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Database-backed user profile and role helpers.
+
+Pure Postgres reads over ``user_profile``, ``roles`` and ``user_role``. Nothing here
+touches AWS — these functions were split out of ``cognito_helpers`` so the Cognito
+module names only code that actually talks to the identity provider.
+"""
+
+from collections import defaultdict
+from uuid import UUID
+
+from fastapi import HTTPException, status
+from sqlmodel import Session, col, select
+
+from flip_api.db.models.user_models import Role, UserProfile, UserRole
+from flip_api.domain.schemas.users import CognitoUser, IRole, IUser
+from flip_api.utils.logger import logger
+from flip_api.utils.paging_utils import PagingInfo
+
+
+def apply_user_profile(user: CognitoUser, session: Session) -> CognitoUser:
+    """Attach DB-backed profile fields to a Cognito user response."""
+    if not hasattr(session, "get"):
+        return user
+
+    profile = session.get(UserProfile, user.id)
+    if not profile:
+        return user
+
+    return CognitoUser(
+        id=user.id,
+        email=user.email,
+        name=profile.name,
+        organisation=profile.organisation,
+        is_disabled=user.is_disabled,
+    )  # type: ignore[call-arg]
+
+
+def get_user_role_data(
+    paging_info: PagingInfo,
+    users: list[CognitoUser],
+    session: Session,
+) -> list[IUser]:
+    """
+    Get user role data with pagination and filtering.
+
+    Args:
+        paging_info (PagingInfo): Pagination and filtering information.
+        users (list[CognitoUser]): List of Cognito users.
+        session (Session): Database session.
+
+    Returns:
+        list[IUser]: List of IUser objects with roles.
+    """
+    # Fetch roles for users
+    user_ids = [user.id for user in users]
+    statement = (
+        select(col(UserRole.user_id), Role)
+        .join(Role, col(Role.id) == col(UserRole.role_id))
+        .where(col(UserRole.user_id).in_(user_ids))
+    )
+    role_results = session.exec(statement).all()
+    profiles = session.exec(select(UserProfile).where(col(UserProfile.user_id).in_(user_ids))).all()
+    user_profiles_map = {str(profile.user_id): profile for profile in profiles}
+
+    # Group roles by user_id
+    user_roles_map: dict[str, list[IRole]] = defaultdict(list)
+    for user_id, role in role_results:
+        if role and role.id is not None:
+            user_roles_map[str(user_id)].append(
+                IRole(
+                    id=role.id,
+                    rolename=role.name,
+                    roledescription=role.description,
+                )
+            )
+
+    # Filter by email and apply pagination
+    search_str = paging_info.search_str.lower()
+    filtered_users = [
+        user
+        for user in users
+        if search_str in user.email.lower()
+        or search_str in user_profiles_map.get(str(user.id), UserProfile(user_id=user.id)).name.lower()
+        or search_str in user_profiles_map.get(str(user.id), UserProfile(user_id=user.id)).organisation.lower()
+    ]
+    sorted_users = sorted(filtered_users, key=lambda u: u.email)
+    paged_users = sorted_users[paging_info.offset : paging_info.offset + paging_info.page_size]
+
+    # Reconstruct IUser objects with roles
+    final_users = [
+        IUser(
+            id=user.id,
+            email=user.email,
+            name=user_profiles_map.get(str(user.id), UserProfile(user_id=user.id)).name,
+            organisation=user_profiles_map.get(str(user.id), UserProfile(user_id=user.id)).organisation,
+            is_disabled=user.is_disabled,
+            roles=user_roles_map.get(str(user.id), []),
+        )  # type: ignore[call-arg]
+        for user in paged_users
+    ]
+
+    return final_users
+
+
+def get_all_roles(db: Session) -> list[UUID]:
+    """
+    Get all role IDs from the database.
+
+    Args:
+        db (Session): Database session
+
+    Returns:
+        list[UUID]: List of role IDs
+    """
+    logger.debug("Attempting to get the list of roles from the database...")
+
+    result = db.exec(select(Role.id)).all()
+
+    role_ids = [role_id for role_id in result]
+
+    logger.info(f"Found {len(role_ids)} roles: {role_ids}")
+
+    return role_ids
+
+
+def validate_roles(user_roles: list[UUID], roles_from_db: list[UUID]) -> None:
+    """
+    Validate that all user roles exist in the database.
+
+    Args:
+        user_roles (list[UUID]): List of role IDs to validate
+        roles_from_db (list[UUID]): List of valid role IDs from the database
+
+    Returns:
+        None
+
+    Raises:
+        HTTPException: If any role is invalid
+    """
+    logger.debug(f"Attempting to validate user roles: {user_roles}")
+
+    invalid_roles = [role for role in user_roles if role not in roles_from_db]
+
+    if invalid_roles:
+        logger.error(f"Invalid role(s): {invalid_roles}. They do not match the roles in the database: {roles_from_db}")
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Invalid role(s): {invalid_roles}")

--- a/flip-api/src/flip_api/utils/user_roles.py
+++ b/flip-api/src/flip_api/utils/user_roles.py
@@ -10,11 +10,14 @@
 # limitations under the License.
 #
 
-"""Database-backed user profile and role helpers.
+"""User profile and role helpers.
 
-Pure Postgres reads over ``user_profile``, ``roles`` and ``user_role``. Nothing here
-touches AWS — these functions were split out of ``cognito_helpers`` so the Cognito
-module names only code that actually talks to the identity provider.
+Postgres reads over ``user_profile``, ``roles`` and ``user_role``, plus the in-memory
+``validate_roles`` guard that callers apply to what those reads return (it takes the
+role IDs as an argument and queries nothing itself).
+
+Nothing here touches AWS: no ``boto3`` import, and every transitive import is AWS-free.
+Split out of ``cognito_helpers`` so that module stays about the Cognito user directory.
 """
 
 from collections import defaultdict

--- a/flip-api/tests/unit/utils/conftest.py
+++ b/flip-api/tests/unit/utils/conftest.py
@@ -1,0 +1,37 @@
+# Copyright (c) Guy's and St Thomas' NHS Foundation Trust & King's College London
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Shared fixtures for `flip_api.utils` unit tests."""
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _reset_cognito_client_cache():
+    """Clear the `_cognito_client` lru_cache around every test in this directory.
+
+    `_cognito_client` is `@lru_cache(maxsize=1)`, so a boto3 client is built once per
+    process and the cache object is *shared* — `cors.py` binds the same function, and
+    `test_cognito_helpers.py` and `test_cors.py` both exercise it. Tests patch
+    `boto3.client` and assume each starts fresh, so without this a mock warmed by one
+    test is silently served to the next, and the second test's patch is never consulted.
+
+    It lives here rather than in the individual modules so a new test file that touches
+    `_cognito_client` inherits the guard structurally instead of having to remember to
+    copy it (FLIP#1087). Clearing on both setup and teardown closes the leak in both
+    directions, so no module depends on another's teardown discipline.
+    """
+    from flip_api.utils.cognito_helpers import _cognito_client
+
+    _cognito_client.cache_clear()
+    yield
+    _cognito_client.cache_clear()

--- a/flip-api/tests/unit/utils/test_cognito_helpers.py
+++ b/flip-api/tests/unit/utils/test_cognito_helpers.py
@@ -46,21 +46,6 @@ class CognitoUserFactory(factory.Factory):
     is_disabled = factory.Faker("boolean")
 
 
-@pytest.fixture(autouse=True)
-def _reset_cognito_client_cache():
-    """
-    `_cognito_client` is lru_cached so a boto3 client is built once per
-    process. Tests patch `boto3.client` and assume each test starts fresh;
-    clear the cache between tests so a mock from one test doesn't leak
-    into the next.
-    """
-    from flip_api.utils.cognito_helpers import _cognito_client
-
-    _cognito_client.cache_clear()
-    yield
-    _cognito_client.cache_clear()
-
-
 @pytest.fixture
 def mock_logger():
     """Mock logger for testing."""

--- a/flip-api/tests/unit/utils/test_cognito_helpers.py
+++ b/flip-api/tests/unit/utils/test_cognito_helpers.py
@@ -21,12 +21,9 @@ from starlette.status import HTTP_400_BAD_REQUEST, HTTP_500_INTERNAL_SERVER_ERRO
 
 from flip_api.domain.schemas.users import CognitoUser
 from flip_api.utils.cognito_helpers import (
-    _origin_from_url,
-    apply_user_profile,
     create_cognito_user,
     filter_enabled_users,
     get_cognito_users,
-    get_cors_allowed_origins,
     get_pool_id,
     get_user_by_email_or_id,
     is_mfa_enabled,
@@ -1295,75 +1292,6 @@ class TestGetCognitoUsers:
         mock_client_instance.get_paginator.assert_called_once_with("list_users")
 
 
-class TestOriginFromUrl:
-    """Tests for the _origin_from_url normalizer used by the CORS allowlist builder."""
-
-    @pytest.mark.parametrize(
-        ("url", "expected"),
-        [
-            # Default ports must be stripped — browsers omit them from the Origin header.
-            ("https://localhost:443", "https://localhost"),
-            ("http://example.com:80/path", "http://example.com"),
-            # Non-default ports must be preserved.
-            ("http://localhost:8080", "http://localhost:8080"),
-            ("https://localhost:8443/", "https://localhost:8443"),
-            # Path / query / fragment are dropped.
-            ("https://app.flip.aicentre.co.uk/login?x=1#frag", "https://app.flip.aicentre.co.uk"),
-            # Hostname is lowercased by urlparse.
-            ("https://APP.FLIP.aicentre.co.uk", "https://app.flip.aicentre.co.uk"),
-        ],
-    )
-    def test_normalizes_origin(self, url, expected):
-        assert _origin_from_url(url) == expected
-
-    @pytest.mark.parametrize("url", ["", "not-a-url", "/just/a/path"])
-    def test_returns_none_for_unusable_input(self, url):
-        assert _origin_from_url(url) is None
-
-
-class TestGetCorsAllowedOrigins:
-    """Tests for get_cors_allowed_origins (Cognito-derived CORS allowlist)."""
-
-    @pytest.fixture
-    def mock_boto3_client(self):
-        with patch("flip_api.utils.cognito_helpers.boto3.client") as mock_client:
-            yield mock_client
-
-    @pytest.fixture
-    def mock_settings(self):
-        with patch("flip_api.utils.cognito_helpers.get_settings") as mock_get_settings:
-            settings = mock_get_settings.return_value
-            settings.AWS_REGION = "eu-west-2"
-            settings.AWS_COGNITO_USER_POOL_ID = "pool-id"
-            settings.AWS_COGNITO_APP_CLIENT_ID = "client-id"
-            yield mock_get_settings
-
-    def test_returns_normalized_unique_origins(self, mock_boto3_client, mock_settings):
-        """CallbackURLs are normalized to origins and deduplicated, preserving order."""
-        mock_boto3_client.return_value.describe_user_pool_client.return_value = {
-            "UserPoolClient": {
-                "CallbackURLs": [
-                    "https://app.flip.aicentre.co.uk",
-                    "https://localhost:443",
-                    # Duplicate after normalization (default port stripped) — must be deduped.
-                    "https://app.flip.aicentre.co.uk/callback",
-                ]
-            }
-        }
-
-        origins = get_cors_allowed_origins()
-
-        assert origins == ["https://app.flip.aicentre.co.uk", "https://localhost"]
-        mock_boto3_client.assert_called_once_with("cognito-idp", region_name="eu-west-2")
-        mock_boto3_client.return_value.describe_user_pool_client.assert_called_once_with(
-            UserPoolId="pool-id", ClientId="client-id"
-        )
-
-    def test_returns_empty_list_when_no_callback_urls(self, mock_boto3_client, mock_settings):
-        mock_boto3_client.return_value.describe_user_pool_client.return_value = {"UserPoolClient": {}}
-        assert get_cors_allowed_origins() == []
-
-
 class TestResetUserMfa:
     """Tests for the reset_user_mfa function."""
 
@@ -1911,56 +1839,3 @@ class TestGetUserByEmailOrId:
 
             params = mock_list.call_args.args[0]
             assert params["Filter"] == f'sub = "{user1}"'
-
-
-class TestApplyUserProfile:
-    """`apply_user_profile` merges DB profile fields onto a Cognito user."""
-
-    def _make_user(self):
-        return CognitoUser(
-            id=uuid4(),
-            email="alice@example.com",
-            is_disabled=False,
-        )  # type: ignore[call-arg]
-
-    def test_returns_user_unchanged_when_session_has_no_get(self):
-        """Duck-typed guard: list-listing call-sites pass `None` for `session`
-        when they don't have one. Don't blow up — just return the input.
-        """
-        user = self._make_user()
-
-        result = apply_user_profile(user, session=None)  # type: ignore[arg-type]
-
-        assert result is user
-
-    def test_returns_user_unchanged_when_no_profile_row_exists(self):
-        """No UserProfile row → no fields to apply; return the input verbatim."""
-        user = self._make_user()
-        session = Mock()
-        session.get.return_value = None
-
-        result = apply_user_profile(user, session=session)
-
-        # session.get was probed with the user id under UserProfile.
-        assert session.get.call_count == 1
-        assert result is user
-
-    def test_merges_profile_fields_when_available(self):
-        """A matching UserProfile row supplies the name + organisation that
-        Cognito doesn't carry. is_disabled is preserved verbatim.
-        """
-        user = self._make_user()
-        profile = Mock(name="…", organisation="London AI Centre")
-        # Mock(name=…) on a stock Mock is reserved — use side-effect attrs.
-        profile.name = "Alice Example"
-        profile.organisation = "London AI Centre"
-        session = Mock()
-        session.get.return_value = profile
-
-        result = apply_user_profile(user, session=session)
-
-        assert result.id == user.id
-        assert result.email == user.email
-        assert result.is_disabled is False
-        assert result.name == "Alice Example"
-        assert result.organisation == "London AI Centre"

--- a/flip-api/tests/unit/utils/test_cors.py
+++ b/flip-api/tests/unit/utils/test_cors.py
@@ -22,10 +22,12 @@ from flip_api.utils.cors import _origin_from_url, get_cors_allowed_origins
 @pytest.fixture(autouse=True)
 def _reset_cognito_client_cache():
     """
-    `get_cors_allowed_origins` builds its client through the lru_cached
-    `_cognito_client`, so a boto3 client is built once per process. Tests patch
-    `boto3.client` and assume each test starts fresh; clear the cache between
-    tests so a mock from one test doesn't leak into the next.
+    `TestGetCorsAllowedOrigins` builds its client through the lru_cached
+    `_cognito_client`, whose cache is shared with `cognito_helpers` and so with
+    `test_cognito_helpers.py` — the leak this guards is cross-module, not just
+    within this file. Tests patch `boto3.client` and assume each test starts
+    fresh, so clear the cache around every test. (`TestOriginFromUrl` builds no
+    client; autouse simply keeps the guard unconditional.)
     """
     from flip_api.utils.cognito_helpers import _cognito_client
 
@@ -75,7 +77,9 @@ class TestGetCorsAllowedOrigins:
         `get_cors_allowed_origins` reads the pool/client IDs via `cors.get_settings`,
         but the client it calls them on is built by `cognito_helpers._cognito_client`,
         which reads `AWS_REGION` via `cognito_helpers.get_settings`. Patching only one
-        leaves the other resolving real environment config.
+        leaves the other resolving real environment config — green on a dev machine
+        with a real `AWS_REGION`, red only in CI where it is the `<your-aws-region>`
+        placeholder from `.env.development.example`.
         """
         with (
             patch("flip_api.utils.cors.get_settings") as mock_get_settings,

--- a/flip-api/tests/unit/utils/test_cors.py
+++ b/flip-api/tests/unit/utils/test_cors.py
@@ -1,0 +1,103 @@
+# Copyright (c) Guy's and St Thomas' NHS Foundation Trust & King's College London
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Unit tests for the Cognito-derived CORS allowlist (`flip_api.utils.cors`)."""
+
+from unittest.mock import patch
+
+import pytest
+
+from flip_api.utils.cors import _origin_from_url, get_cors_allowed_origins
+
+
+@pytest.fixture(autouse=True)
+def _reset_cognito_client_cache():
+    """
+    `get_cors_allowed_origins` builds its client through the lru_cached
+    `_cognito_client`, so a boto3 client is built once per process. Tests patch
+    `boto3.client` and assume each test starts fresh; clear the cache between
+    tests so a mock from one test doesn't leak into the next.
+    """
+    from flip_api.utils.cognito_helpers import _cognito_client
+
+    _cognito_client.cache_clear()
+    yield
+    _cognito_client.cache_clear()
+
+
+class TestOriginFromUrl:
+    """Tests for the _origin_from_url normalizer used by the CORS allowlist builder."""
+
+    @pytest.mark.parametrize(
+        ("url", "expected"),
+        [
+            # Default ports must be stripped — browsers omit them from the Origin header.
+            ("https://localhost:443", "https://localhost"),
+            ("http://example.com:80/path", "http://example.com"),
+            # Non-default ports must be preserved.
+            ("http://localhost:8080", "http://localhost:8080"),
+            ("https://localhost:8443/", "https://localhost:8443"),
+            # Path / query / fragment are dropped.
+            ("https://app.flip.aicentre.co.uk/login?x=1#frag", "https://app.flip.aicentre.co.uk"),
+            # Hostname is lowercased by urlparse.
+            ("https://APP.FLIP.aicentre.co.uk", "https://app.flip.aicentre.co.uk"),
+        ],
+    )
+    def test_normalizes_origin(self, url, expected):
+        assert _origin_from_url(url) == expected
+
+    @pytest.mark.parametrize("url", ["", "not-a-url", "/just/a/path"])
+    def test_returns_none_for_unusable_input(self, url):
+        assert _origin_from_url(url) is None
+
+
+class TestGetCorsAllowedOrigins:
+    """Tests for get_cors_allowed_origins (Cognito-derived CORS allowlist)."""
+
+    @pytest.fixture
+    def mock_boto3_client(self):
+        with patch("flip_api.utils.cognito_helpers.boto3.client") as mock_client:
+            yield mock_client
+
+    @pytest.fixture
+    def mock_settings(self):
+        with patch("flip_api.utils.cors.get_settings") as mock_get_settings:
+            settings = mock_get_settings.return_value
+            settings.AWS_REGION = "eu-west-2"
+            settings.AWS_COGNITO_USER_POOL_ID = "pool-id"
+            settings.AWS_COGNITO_APP_CLIENT_ID = "client-id"
+            yield mock_get_settings
+
+    def test_returns_normalized_unique_origins(self, mock_boto3_client, mock_settings):
+        """CallbackURLs are normalized to origins and deduplicated, preserving order."""
+        mock_boto3_client.return_value.describe_user_pool_client.return_value = {
+            "UserPoolClient": {
+                "CallbackURLs": [
+                    "https://app.flip.aicentre.co.uk",
+                    "https://localhost:443",
+                    # Duplicate after normalization (default port stripped) — must be deduped.
+                    "https://app.flip.aicentre.co.uk/callback",
+                ]
+            }
+        }
+
+        origins = get_cors_allowed_origins()
+
+        assert origins == ["https://app.flip.aicentre.co.uk", "https://localhost"]
+        mock_boto3_client.assert_called_once_with("cognito-idp", region_name="eu-west-2")
+        mock_boto3_client.return_value.describe_user_pool_client.assert_called_once_with(
+            UserPoolId="pool-id", ClientId="client-id"
+        )
+
+    def test_returns_empty_list_when_no_callback_urls(self, mock_boto3_client, mock_settings):
+        mock_boto3_client.return_value.describe_user_pool_client.return_value = {"UserPoolClient": {}}
+        assert get_cors_allowed_origins() == []

--- a/flip-api/tests/unit/utils/test_cors.py
+++ b/flip-api/tests/unit/utils/test_cors.py
@@ -70,7 +70,17 @@ class TestGetCorsAllowedOrigins:
 
     @pytest.fixture
     def mock_settings(self):
-        with patch("flip_api.utils.cors.get_settings") as mock_get_settings:
+        """Patch `get_settings` in *both* modules this path crosses.
+
+        `get_cors_allowed_origins` reads the pool/client IDs via `cors.get_settings`,
+        but the client it calls them on is built by `cognito_helpers._cognito_client`,
+        which reads `AWS_REGION` via `cognito_helpers.get_settings`. Patching only one
+        leaves the other resolving real environment config.
+        """
+        with (
+            patch("flip_api.utils.cors.get_settings") as mock_get_settings,
+            patch("flip_api.utils.cognito_helpers.get_settings", mock_get_settings),
+        ):
             settings = mock_get_settings.return_value
             settings.AWS_REGION = "eu-west-2"
             settings.AWS_COGNITO_USER_POOL_ID = "pool-id"

--- a/flip-api/tests/unit/utils/test_cors.py
+++ b/flip-api/tests/unit/utils/test_cors.py
@@ -19,23 +19,6 @@ import pytest
 from flip_api.utils.cors import _origin_from_url, get_cors_allowed_origins
 
 
-@pytest.fixture(autouse=True)
-def _reset_cognito_client_cache():
-    """
-    `TestGetCorsAllowedOrigins` builds its client through the lru_cached
-    `_cognito_client`, whose cache is shared with `cognito_helpers` and so with
-    `test_cognito_helpers.py` — the leak this guards is cross-module, not just
-    within this file. Tests patch `boto3.client` and assume each test starts
-    fresh, so clear the cache around every test. (`TestOriginFromUrl` builds no
-    client; autouse simply keeps the guard unconditional.)
-    """
-    from flip_api.utils.cognito_helpers import _cognito_client
-
-    _cognito_client.cache_clear()
-    yield
-    _cognito_client.cache_clear()
-
-
 class TestOriginFromUrl:
     """Tests for the _origin_from_url normalizer used by the CORS allowlist builder."""
 

--- a/flip-api/tests/unit/utils/test_user_roles.py
+++ b/flip-api/tests/unit/utils/test_user_roles.py
@@ -20,8 +20,10 @@ where they were only exercised via mocked patches in ``tests/unit/user_services/
 from unittest.mock import Mock
 from uuid import uuid4
 
+from flip_api.db.models.user_models import Role, UserProfile
 from flip_api.domain.schemas.users import CognitoUser
-from flip_api.utils.user_roles import apply_user_profile
+from flip_api.utils.paging_utils import PagingInfo
+from flip_api.utils.user_roles import apply_user_profile, get_all_roles, get_user_role_data
 
 
 class TestApplyUserProfile:
@@ -75,3 +77,129 @@ class TestApplyUserProfile:
         assert result.is_disabled is False
         assert result.name == "Alice Example"
         assert result.organisation == "London AI Centre"
+
+
+def _exec_result(rows):
+    """Stand in for the object `session.exec()` returns (only `.all()` is used)."""
+    result = Mock()
+    result.all.return_value = rows
+    return result
+
+
+def _session(role_rows, profile_rows):
+    """`get_user_role_data` calls `session.exec` twice: roles first, then profiles."""
+    session = Mock()
+    session.exec.side_effect = [_exec_result(role_rows), _exec_result(profile_rows)]
+    return session
+
+
+def _paging(offset=0, page_size=10, search_str=""):
+    return PagingInfo(offset=offset, page_number=1, page_size=page_size, search_str=search_str)
+
+
+def _user(email, user_id=None):
+    return CognitoUser(id=user_id or uuid4(), email=email, is_disabled=False)  # type: ignore[call-arg]
+
+
+class TestGetUserRoleData:
+    """`get_user_role_data` joins Cognito users to their DB roles and profiles.
+
+    This is the only path that attaches roles to a user in the admin `GET /users`
+    listing, so a regression here renders every user with zero roles.
+    """
+
+    def test_attaches_roles_to_each_user(self):
+        """Roles are grouped per user; a user with no role rows gets an empty list."""
+        alice, bob = _user("alice@example.com"), _user("bob@example.com")
+        admin = Role(name="admin", description="Administrator")
+        researcher = Role(name="researcher", description="Researcher")
+        session = _session(
+            role_rows=[(alice.id, admin), (alice.id, researcher)],
+            profile_rows=[],
+        )
+
+        result = get_user_role_data(_paging(), [alice, bob], session)
+
+        by_email = {u.email: u for u in result}
+        assert [(r.rolename, r.roledescription) for r in by_email["alice@example.com"].roles] == [
+            ("admin", "Administrator"),
+            ("researcher", "Researcher"),
+        ]
+        assert [r.id for r in by_email["alice@example.com"].roles] == [admin.id, researcher.id]
+        # Bob has no role rows — he must still appear, with no roles.
+        assert by_email["bob@example.com"].roles == []
+
+    def test_skips_role_rows_with_no_usable_role(self):
+        """The `if role and role.id is not None` guard drops unjoinable rows."""
+        alice = _user("alice@example.com")
+        orphaned = Role(name="orphan", description="No id")
+        orphaned.id = None  # type: ignore[assignment]
+        session = _session(role_rows=[(alice.id, None), (alice.id, orphaned)], profile_rows=[])
+
+        result = get_user_role_data(_paging(), [alice], session)
+
+        assert result[0].roles == []
+
+    def test_merges_profile_fields_and_defaults_when_absent(self):
+        """Profile rows supply name/organisation; users without one get empty strings."""
+        alice, bob = _user("alice@example.com"), _user("bob@example.com")
+        session = _session(
+            role_rows=[],
+            profile_rows=[UserProfile(user_id=alice.id, name="Alice Example", organisation="London AI Centre")],
+        )
+
+        result = get_user_role_data(_paging(), [alice, bob], session)
+
+        by_email = {u.email: u for u in result}
+        assert (by_email["alice@example.com"].name, by_email["alice@example.com"].organisation) == (
+            "Alice Example",
+            "London AI Centre",
+        )
+        assert (by_email["bob@example.com"].name, by_email["bob@example.com"].organisation) == ("", "")
+
+    def test_search_matches_email_name_or_organisation_case_insensitively(self):
+        """Any of the three fields may satisfy the search; non-matches are dropped."""
+        by_email_match = _user("kingsteam@example.com")
+        by_name = _user("b@example.com")
+        by_org = _user("c@example.com")
+        excluded = _user("d@example.com")
+        session = _session(
+            role_rows=[],
+            profile_rows=[
+                UserProfile(user_id=by_name.id, name="Kings Person", organisation="Elsewhere"),
+                UserProfile(user_id=by_org.id, name="Someone", organisation="KINGS College"),
+                UserProfile(user_id=excluded.id, name="Nobody", organisation="Other"),
+            ],
+        )
+
+        result = get_user_role_data(
+            _paging(search_str="KiNgS"), [by_email_match, by_name, by_org, excluded], session
+        )
+
+        assert {u.email for u in result} == {"kingsteam@example.com", "b@example.com", "c@example.com"}
+
+    def test_applies_offset_and_page_size_after_sorting_by_email(self):
+        """Paging slices the email-sorted list, not the caller's order."""
+        users = [_user(e) for e in ("d@example.com", "b@example.com", "a@example.com", "c@example.com")]
+        session = _session(role_rows=[], profile_rows=[])
+
+        result = get_user_role_data(_paging(offset=1, page_size=2), users, session)
+
+        assert [u.email for u in result] == ["b@example.com", "c@example.com"]
+
+
+class TestGetAllRoles:
+    """`get_all_roles` returns the role IDs used to validate a user's requested roles."""
+
+    def test_returns_role_ids_from_the_database(self):
+        role_ids = [uuid4(), uuid4()]
+        db = Mock()
+        db.exec.return_value = _exec_result(role_ids)
+
+        assert get_all_roles(db) == role_ids
+
+    def test_returns_empty_list_when_no_roles_exist(self):
+        db = Mock()
+        db.exec.return_value = _exec_result([])
+
+        assert get_all_roles(db) == []

--- a/flip-api/tests/unit/utils/test_user_roles.py
+++ b/flip-api/tests/unit/utils/test_user_roles.py
@@ -1,0 +1,72 @@
+# Copyright (c) Guy's and St Thomas' NHS Foundation Trust & King's College London
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Unit tests for the DB-backed user profile/role helpers (`flip_api.utils.user_roles`)."""
+
+from unittest.mock import Mock
+from uuid import uuid4
+
+from flip_api.domain.schemas.users import CognitoUser
+from flip_api.utils.user_roles import apply_user_profile
+
+
+class TestApplyUserProfile:
+    """`apply_user_profile` merges DB profile fields onto a Cognito user."""
+
+    def _make_user(self):
+        return CognitoUser(
+            id=uuid4(),
+            email="alice@example.com",
+            is_disabled=False,
+        )  # type: ignore[call-arg]
+
+    def test_returns_user_unchanged_when_session_has_no_get(self):
+        """Duck-typed guard: list-listing call-sites pass `None` for `session`
+        when they don't have one. Don't blow up — just return the input.
+        """
+        user = self._make_user()
+
+        result = apply_user_profile(user, session=None)  # type: ignore[arg-type]
+
+        assert result is user
+
+    def test_returns_user_unchanged_when_no_profile_row_exists(self):
+        """No UserProfile row → no fields to apply; return the input verbatim."""
+        user = self._make_user()
+        session = Mock()
+        session.get.return_value = None
+
+        result = apply_user_profile(user, session=session)
+
+        # session.get was probed with the user id under UserProfile.
+        assert session.get.call_count == 1
+        assert result is user
+
+    def test_merges_profile_fields_when_available(self):
+        """A matching UserProfile row supplies the name + organisation that
+        Cognito doesn't carry. is_disabled is preserved verbatim.
+        """
+        user = self._make_user()
+        profile = Mock(name="…", organisation="London AI Centre")
+        # Mock(name=…) on a stock Mock is reserved — use side-effect attrs.
+        profile.name = "Alice Example"
+        profile.organisation = "London AI Centre"
+        session = Mock()
+        session.get.return_value = profile
+
+        result = apply_user_profile(user, session=session)
+
+        assert result.id == user.id
+        assert result.email == user.email
+        assert result.is_disabled is False
+        assert result.name == "Alice Example"
+        assert result.organisation == "London AI Centre"

--- a/flip-api/tests/unit/utils/test_user_roles.py
+++ b/flip-api/tests/unit/utils/test_user_roles.py
@@ -10,7 +10,12 @@
 # limitations under the License.
 #
 
-"""Unit tests for the DB-backed user profile/role helpers (`flip_api.utils.user_roles`)."""
+"""Unit tests for ``apply_user_profile`` (``flip_api.utils.user_roles``).
+
+The module's other three helpers (``get_user_role_data``, ``get_all_roles``,
+``validate_roles``) have no direct unit tests — a gap inherited from before the split,
+where they were only exercised via mocked patches in ``tests/unit/user_services/``.
+"""
 
 from unittest.mock import Mock
 from uuid import uuid4


### PR DESCRIPTION
Closes #1084. Closes #1087.

> **Scope note:** this started as a strictly behaviour-preserving move. It now also carries the
> test work from #1087, pulled in deliberately. The **production** diff is still a pure move —
> every function body byte-identical — but the PR is no longer test-neutral: it adds 7 tests and a
> `conftest.py`. See "Test coverage (#1087)" below.

## What

`flip-api/src/flip_api/utils/cognito_helpers.py` was 757 lines covering three unrelated concerns. This splits it in three, **without changing any behaviour**:

| Destination | Moved | Touches AWS? |
|---|---|---|
| `utils/user_roles.py` *(new)* | `apply_user_profile`, `get_user_role_data`, `get_all_roles`, `validate_roles` | No — pure Postgres |
| `utils/cors.py` *(new)* | `_origin_from_url`, `get_cors_allowed_origins` | Yes, but its concern is CORS config |
| `utils/cognito_helpers.py` *(kept)* | the 11-call `cognito-idp` admin plane | Yes |

## Why the module keeps its name

Renaming it would have churned every importer and every patch target. Keeping it means **9 of its 14 importing modules need no edit at all**, and the 1,966-line `test_cognito_helpers.py` keeps its patch targets (`...cognito_helpers.boto3.client`, `.get_settings`, `.get_cognito_users`, `.logger`, `._mfa_state_cache`) for everything that stayed. Only 5 modules change, and every one of those changes is an import line.

The clearest signal the seam was in the right place: **after the split `cognito_helpers.py` imports no sqlmodel and no DB models at all.** `Session`, `col`, `select`, `Role`, `UserProfile`, `UserRole`, `IRole`, `IUser`, `PagingInfo`, `defaultdict` and `urlparse` all dropped out as unused.

## Judgement calls worth a reviewer's attention

- **`get_pool_id` / `get_user_pool_id` stay in `cognito_helpers.py`.** They make no boto3 call, so a strict "no AWS" rule would move them — but they answer *which Cognito pool does this request target*, which is Cognito-domain config. Moving them would separate pool resolution from its only consumers.
- **`utils/cors.py` imports `_cognito_client`**, so it is not AWS-free either. It is split out because it is the only reason app *startup* contacts the identity provider (`main.py`'s lifespan), which is worth being able to see in one file.
- `utils/` already hosts DB-touching helpers (`project_manager.py`, `site_manager.py`), so `utils/user_roles.py` follows existing convention.

## Why now

This is step one of a Cognito-free identity provider for local dev + CI (moto server as a Cognito-compatible endpoint). That change adds an `endpoint_url` override to `_cognito_client()` — much easier to review landing in a module that does nothing but talk to Cognito. This PR is deliberately separate so the mechanical move and the behavioural change never share a diff.

## Test coverage (#1087)

Two gaps the review surfaced, both pre-existing, now closed in this PR at your request:

**`get_user_role_data` was untested where it matters.** Its role-attachment lines were dark in
*both* suites — the integration test covering the surrounding code uses a role-less fixture. That
is the only path attaching roles to a user in the admin `GET /users` listing, so a regression
would render every user with zero roles: user-visible, non-destructive, and invisible to the whole
suite. Added tests for role grouping, the `if role and role.id is not None` guard, profile merging
and its empty-string fallback, the search filter across email/name/organisation, and offset +
page_size slicing of the email-sorted list — the filter and paging branches had only ever been
exercised with degenerate data. Two small `get_all_roles` tests close the remainder.

`flip_api.utils.user_roles` goes **53% → 100%** unit coverage (`cors.py` was already 100%).

**The tests were mutation-checked, not just run.** Breaking the source four ways each fails exactly
one test, so they can actually fail:

| Mutation | Result |
|---|---|
| `if role and role.id is not None:` → `if False:` | 1 failed |
| remove the `sorted(..., key=lambda u: u.email)` | 1 failed |
| ignore `offset`/`page_size` when slicing | 1 failed |
| drop `organisation` from the search filter | 1 failed |

**`_reset_cognito_client_cache` hoisted to `tests/unit/utils/conftest.py`.** It was duplicated
verbatim in two modules, so a third file touching the lru_cached `_cognito_client` would silently
inherit the stale-cache bug. Confirmed still load-bearing — deleting the conftest fails a test in
`test_cors.py`.

## Verification

- `uv run ruff check .` and `uv run mypy src/` — clean.
- `uv run pytest tests/unit` — **1591 passed** (1584 before the #1087 tests).
- **Byte-identity check**: all 22 top-level functions present after the split, every body byte-identical to `origin/develop`, none added or removed (AST comparison).
- **No tests lost**: 84 test functions and 14 test classes before and after.
- The only test edits are two `get_settings` patch targets rebased onto `flip_api.utils.cors`, plus a copy of the `_cognito_client` lru_cache-clearing fixture into `test_cors.py`.

CI is green: **25 success, 1 skipped, 0 failures**, with the `flip-api` job running both
"Run unit tests" and "Run integration tests (Testcontainers-managed Postgres)".

CI earned its keep here. The first push failed on a bug this kind of split invites: `mock_settings`
in `test_cors.py` patched only `flip_api.utils.cors.get_settings`, but `_cognito_client()` stayed in
`cognito_helpers` and reads `AWS_REGION` from *its own* module's `get_settings`. Before the split one
patch covered both. It was green locally (dev machine has a real `AWS_REGION`) and red only in CI
(placeholder `<your-aws-region>`). Fixed in 4979ca91 by patching both, with the reason recorded in the
fixture docstring so it does not get "simplified" back.

## Review pass

Reviewed for code quality, test coverage and comment accuracy. No blocking findings. Fixes applied in
014c5927:

- Four inaccuracies in docstrings **this branch wrote** (moved docstrings untouched): `cors.py` claimed
  the lifespan call was the only startup Cognito contact — the container also seeds via Cognito before
  uvicorn (`entrypoint.sh` → `db/seed/main_users.py`); `cors.py` framed `CallbackURLs` as "where users
  sign in" when the UI uses `USER_SRP_AUTH` and never redirects to them; `user_roles.py` said "pure
  Postgres reads" when `validate_roles` queries nothing; and it claimed `cognito_helpers` now holds only
  Cognito-calling code, which is untrue in both directions.
- `deploy/providers/AWS/dev/variables.tf` pointed at `cognito_helpers.py:get_cors_allowed_origins` — a
  pointer this move broke. The other tracked references (`deploy/README.md`, `flip-api/README.md`) name
  `reset_user_mfa` and the boto3 client, both of which stayed put, so they remain accurate.

Two findings were out of scope for a pure move and are filed instead: **#1086** (`callback_urls` are the
live CORS allowlist, not "hygiene only" as `services.tf` claims — and prod includes `https://localhost`)
and **#1087** (`get_user_role_data`'s role-attachment path is untested; the lru_cache fixture is
duplicated rather than in a `conftest.py`).

One thing deliberately *not* changed: `cors.py` imports the private `_cognito_client`. Renaming it would
churn three test sites and `flip-api/README.md` for no behavioural gain. The gotcha to know is that a
future `patch("flip_api.utils.cognito_helpers._cognito_client")` would not affect `cors`, which holds the
original binding — it would need `patch("flip_api.utils.cors._cognito_client")`.


## Acceptance Criteria

*Imported from issue #1084*

- [ ] The four pure-DB functions move to a new `flip_api/utils/user_roles.py`.
- [ ] `get_cors_allowed_origins` + `_origin_from_url` move to a new `flip_api/utils/cors.py`.
- [ ] `cognito_helpers.py` **keeps its name** and retains only Cognito-facing code.
- [ ] Unit tests for the moved functions move to matching test modules, with patch targets rebased.
- [ ] `make -C flip-api test` passes with only import-path changes in the production diff.
- [ ] No behaviour change: no signatures, logic, or error handling altered.

