### PR TITLE
fix(deploy): callback_urls are the live CORS allowlist, not 'hygiene only' — and prod includes localhost

### DIFF
--- a/.github/workflows/validate_terraform.yml
+++ b/.github/workflows/validate_terraform.yml
@@ -81,6 +81,32 @@ jobs:
       - name: Run checkov_lint.sh test harness
         run: bash deploy/providers/AWS/scripts/tests/test_checkov_lint.sh
 
+  # Credential-free pytest checks over the stack's static artefacts: rendered
+  # Jinja templates, the deploy helper scripts, and Terraform source itself
+  # (e.g. the Cognito callback_urls / CORS allowlist invariants, which no runtime
+  # suite can see — flip-api reads that list from live Cognito, not from this
+  # tree). No AWS calls, no init, no plan. Deps are named explicitly rather than
+  # synced from the lockfile: the tests need only pytest, jinja2 and click,
+  # while the project's dev group pulls ansible-core and pyqt5.
+  python-tests:
+    name: AWS deploy tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        run: pip install uv
+
+      - name: Run AWS deploy test suite
+        working-directory: deploy/providers/AWS
+        run: uv run --no-project --with pytest --with jinja2 --with click pytest tests/ -v
+
   # Static checkov security lint (FLIP#1052 + the FLIP#1058 triage): a curated
   # check list over the whole AWS tree — IAM policy content (overly-broad
   # statements fmt/validate can't see) plus promoted infrastructure-posture

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -447,7 +447,7 @@ After changes, evaluate if docs need updating:
 
 ## CI/CD
 
-GitHub Actions: `test_flip_api.yml`, `test_flip_ui.yml`, `test_trust_*.yml`, `fl-tutorials-tests.yml`, `test_map_apps.yml`, `docker_build_*.yml`, `validate_terraform.yml` (fmt/validate + a checkov security lint over `deploy/providers/AWS/**` — IAM policy content plus promoted posture checks; static, credential-free; local run `make checkov-lint` **from the repo root** (the AWS Makefile's parse-time env guard blocks the `-C` form for contributors), deliberate breadth/posture suppressed in-code with `# checkov:skip=<ID>:<rationale>` — FLIP#1052, FLIP#1058), `secret-scanning.yml`, `docs.yml`, `pr_acceptance_criteria.yml`. Run locally: `make ci` (uses `act`).
+GitHub Actions: `test_flip_api.yml`, `test_flip_ui.yml`, `test_trust_*.yml`, `fl-tutorials-tests.yml`, `test_map_apps.yml`, `docker_build_*.yml`, `validate_terraform.yml` (fmt/validate + a checkov security lint over `deploy/providers/AWS/**` — IAM policy content plus promoted posture checks; static, credential-free; local run `make checkov-lint` **from the repo root** (the AWS Makefile's parse-time env guard blocks the `-C` form for contributors), deliberate breadth/posture suppressed in-code with `# checkov:skip=<ID>:<rationale>` — FLIP#1052, FLIP#1058; plus an `AWS deploy tests` job running the credential-free pytest suite in `deploy/providers/AWS/tests/` over the stack's static artefacts — rendered templates, deploy scripts, and Terraform source itself, including the Cognito `callback_urls` = browser CORS allowlist invariants), `secret-scanning.yml`, `docs.yml`, `pr_acceptance_criteria.yml`. Run locally: `make ci` (uses `act`).
 
 ### Docker image builds: gated on tests, manual trigger for branches
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -447,7 +447,7 @@ After changes, evaluate if docs need updating:
 
 ## CI/CD
 
-GitHub Actions: `test_flip_api.yml`, `test_flip_ui.yml`, `test_trust_*.yml`, `fl-tutorials-tests.yml`, `test_map_apps.yml`, `docker_build_*.yml`, `validate_terraform.yml` (fmt/validate + a checkov security lint over `deploy/providers/AWS/**` — IAM policy content plus promoted posture checks; static, credential-free; local run `make checkov-lint` **from the repo root** (the AWS Makefile's parse-time env guard blocks the `-C` form for contributors), deliberate breadth/posture suppressed in-code with `# checkov:skip=<ID>:<rationale>` — FLIP#1052, FLIP#1058), `secret-scanning.yml`, `docs.yml`, `pr_acceptance_criteria.yml`. Run locally: `make ci` (uses `act`).
+GitHub Actions: `test_flip_api.yml`, `test_flip_ui.yml`, `test_trust_*.yml`, `fl-tutorials-tests.yml`, `test_map_apps.yml`, `docker_build_*.yml`, `validate_terraform.yml` (fmt/validate + a checkov security lint over `deploy/providers/AWS/**` — IAM policy content plus promoted posture checks; static, credential-free; local run `make checkov-lint` **from the repo root** (the AWS Makefile's parse-time env guard blocks the `-C` form for contributors), deliberate breadth/posture suppressed in-code with `# checkov:skip=<ID>:<rationale>` — FLIP#1052, FLIP#1058; plus an `AWS deploy tests` job running the credential-free pytest suite in `deploy/providers/AWS/tests/` over the stack's static artefacts — rendered templates, deploy scripts, and Terraform source itself, including the Cognito `callback_urls` = browser CORS allowlist invariants), `secret-scanning.yml`, `docs.yml`, `pr_acceptance_criteria.yml`. Run locally: `make ci` (uses `act`).
 
 ### Docker image builds: gated on tests, manual trigger for branches
 

--- a/deploy/providers/AWS/AGENTS.md
+++ b/deploy/providers/AWS/AGENTS.md
@@ -54,6 +54,7 @@ make apply-fl-kit-slots                       # Targeted plan/apply of the /flip
 make destroy                                  # Selective destroy (preserves Cognito, Secrets, S3)
 make aws-login                                # AWS SSO login
 make checkov-lint                             # Static checkov security lint (IAM policy content + promoted posture checks) — CI counterpart is the Checkov Security Lint job in validate_terraform.yml (FLIP#1052, FLIP#1058); suppress deliberate breadth/posture in-code with `# checkov:skip=<ID>:<rationale>`. NB this Makefile's parse-time env guard needs the deploy env file — the REPO-ROOT `make checkov-lint` (or `bash scripts/checkov_lint.sh`) runs env-free
+uv run --no-project --with pytest --with jinja2 --with click pytest tests/   # Credential-free static checks over the stack's artefacts (rendered templates, deploy scripts, and Terraform source itself — incl. the Cognito `callback_urls` = browser CORS allowlist invariants). CI counterpart: the AWS deploy tests job in validate_terraform.yml. Deps named explicitly rather than `uv sync`d: the dev group pulls ansible-core + pyqt5, the tests need three packages
 ```
 
 ## Infrastructure

--- a/deploy/providers/AWS/CLAUDE.md
+++ b/deploy/providers/AWS/CLAUDE.md
@@ -54,6 +54,7 @@ make apply-fl-kit-slots                       # Targeted plan/apply of the /flip
 make destroy                                  # Selective destroy (preserves Cognito, Secrets, S3)
 make aws-login                                # AWS SSO login
 make checkov-lint                             # Static checkov security lint (IAM policy content + promoted posture checks) — CI counterpart is the Checkov Security Lint job in validate_terraform.yml (FLIP#1052, FLIP#1058); suppress deliberate breadth/posture in-code with `# checkov:skip=<ID>:<rationale>`. NB this Makefile's parse-time env guard needs the deploy env file — the REPO-ROOT `make checkov-lint` (or `bash scripts/checkov_lint.sh`) runs env-free
+uv run --no-project --with pytest --with jinja2 --with click pytest tests/   # Credential-free static checks over the stack's artefacts (rendered templates, deploy scripts, and Terraform source itself — incl. the Cognito `callback_urls` = browser CORS allowlist invariants). CI counterpart: the AWS deploy tests job in validate_terraform.yml. Deps named explicitly rather than `uv sync`d: the dev group pulls ansible-core + pyqt5, the tests need three packages
 ```
 
 ## Infrastructure

--- a/deploy/providers/AWS/README.md
+++ b/deploy/providers/AWS/README.md
@@ -519,6 +519,58 @@ the image back — re-run `make plan` after any `make deploy-centralhub`.
 > **Prod rollout note:** switch *production* deploys to this flow only after the 24 Jul 2026 DECAF
 > deadline (BDMS is live on legacy prod until then). Staging can adopt it immediately.
 
+### Changing the browser CORS allowlist (Cognito `callback_urls`)
+
+The Cognito app client's `callback_urls` **is** this environment's browser CORS allowlist. The UI
+signs in with `USER_SRP_AUTH`, so Cognito never redirects to these URLs; flip-api reads them back
+instead — `get_cors_allowed_origins()` (`flip_api/utils/cors.py`) calls `describe_user_pool_client`,
+normalizes each entry to `scheme://host[:port]`, and `CORSMiddleware` serves that list with
+`allow_credentials=true`. Every browser origin that must call the API has to be listed, and removing
+one silently blocks that origin — in the browser only, with nothing red in CI or in the ECS console.
+
+The value is set per Terraform root: `module "cognito"` in `services.tf` for stag/prod,
+`var.cognito_callback_urls` in `dev/variables.tf` for the dev account. **Deleting the argument does
+not empty the list** — `modules/cognito` defaults it to `["https://localhost:443"]`, so an omission
+puts a localhost origin into the production allowlist. `tests/test_cognito_callback_urls.py` guards
+both directions, and runs in CI as the `AWS deploy tests` job of `validate_terraform.yml`.
+
+To change it:
+
+```bash
+# 1. Edit the list for the environment's root:
+#      stag/prod → services.tf, module "cognito" → callback_urls
+#      dev       → dev/variables.tf, var.cognito_callback_urls
+# 2. Apply — TARGETED at the app client. Never run a full `make apply` on stag/prod for
+#    this: AMI drift in the same plan can force-replace the trust EC2s. Same reasoning
+#    as `apply-fl-kit-slots` above. The apply updates Cognito immediately …
+make init PROD=stag
+terraform plan -target=module.cognito.aws_cognito_user_pool_client.client -out=cognito.tfplan
+terraform apply cognito.tfplan
+
+# 3. … but flip-api does NOT pick it up until it restarts: main.py's lifespan reads the
+#    list once at start-up and CORSMiddleware holds it by reference. Restart flip-api.
+#    Quiesce FIRST if the deploy will also replace fl-server-net-1 — see "Central Hub
+#    deploys and rollback" above (Admin → Deployments, then GET /fl/quiesce).
+make deploy-centralhub PROD=stag
+#    Or, to restart flip-api alone without moving any image tag:
+aws ecs update-service --cluster flip-cluster --service flip-api --force-new-deployment
+
+# 4. Confirm Cognito actually carries the new list …
+aws cognito-idp describe-user-pool-client \
+  --user-pool-id "$AWS_COGNITO_USER_POOL_ID" --client-id "$AWS_COGNITO_APP_CLIENT_ID" \
+  --query 'UserPoolClient.CallbackURLs'
+
+# 5. … and that the running API serves it, with a preflight from the canonical origin.
+#    A correct response echoes access-control-allow-origin for that origin; a blocked
+#    origin simply omits the header (it is not an error status).
+curl -sSi -X OPTIONS "https://<api-host>/api/projects" \
+  -H "Origin: https://<ui-host>" \
+  -H "Access-Control-Request-Method: GET" | grep -i "^access-control-allow-origin"
+```
+
+Step 5 is the one that matters: steps 2–4 can all look right while the browser is still blocked,
+because the allowlist the API is *serving* only changes at the restart in step 3.
+
 ### Growing the FL kit-slot pool (`add-fl-kits`)
 
 When trust registration fails with `NoFreeKitSlotError` ("No FL kit slots available…"),

--- a/deploy/providers/AWS/pyproject.toml
+++ b/deploy/providers/AWS/pyproject.toml
@@ -59,10 +59,6 @@ python_files = ["test_*.py", "*_test.py"]
 addopts = []
 filterwarnings = ["ignore::DeprecationWarning", "ignore::FutureWarning"]
 
-[tool.pytest.ini_options_debug]
-python_files = ["test_*.py", "*_test.py"]
-filterwarnings = ["ignore::DeprecationWarning", "ignore::FutureWarning"]
-
 [tool.ruff]
 line-length = 120
 target-version = "py312"

--- a/deploy/providers/AWS/services.tf
+++ b/deploy/providers/AWS/services.tf
@@ -208,12 +208,16 @@ module "cognito" {
   # scheme://host[:port] origin, and CORSMiddleware serves that list with
   # allow_credentials=true. Every browser origin that must call the API in
   # stag/prod therefore has to be listed here, and removing one silently blocks
-  # that origin. Nothing in the test suite catches it — the value is read from
-  # live Cognito at runtime, not from this file.
+  # that origin. No runtime test can catch it — the API reads the list from live
+  # Cognito at start-up, not from this file — so the guard is static, over this
+  # source (see tests/test_cognito_callback_urls.py).
   #
   # Operationally: a change here takes effect at the NEXT flip-api start, not at
   # apply time. main.py's lifespan reads the list once and CORSMiddleware holds
-  # it by reference, so restart the flip-api service after applying.
+  # it by reference, so restart the flip-api service after applying. The full
+  # runbook — targeted apply (never a full stag/prod apply), restart, and the two
+  # verification steps — is in README.md, "Changing the browser CORS allowlist
+  # (Cognito callback_urls)".
   #
   # localhost is deliberately absent: this root stack is stag/prod only. Local
   # development uses the separate ./dev root, whose var.cognito_callback_urls

--- a/deploy/providers/AWS/services.tf
+++ b/deploy/providers/AWS/services.tf
@@ -203,8 +203,7 @@ module "cognito" {
   #
   # The UI signs in with USER_SRP_AUTH (Cognito's native flow, not an OAuth2
   # redirect), so Cognito itself never redirects to these URLs. flip-api reads
-  # them back instead: get_cors_allowed_origins()
-  # (flip-api/src/flip_api/utils/cognito_helpers.py) calls
+  # them back instead: its get_cors_allowed_origins() calls
   # describe_user_pool_client, normalizes each CallbackURL to a
   # scheme://host[:port] origin, and CORSMiddleware serves that list with
   # allow_credentials=true. Every browser origin that must call the API in

--- a/deploy/providers/AWS/services.tf
+++ b/deploy/providers/AWS/services.tf
@@ -198,11 +198,37 @@ module "cognito" {
   researcher_email   = var.flip_cognito_researcher_email
   seed_user_password = var.ADMIN_USER_PASSWORD
   templates_dir      = "${path.module}/templates/cognito"
-  # The UI uses USER_SRP_AUTH (Cognito's native auth flow, not OAuth2 redirect),
-  # so callback_urls are hygiene only — keep the canonical subdomain + localhost
-  # for dev.
-  callback_urls = ["https://${var.flip_alb_subdomain}", "https://localhost:443"]
-  logout_urls   = ["https://${var.flip_alb_subdomain}", "https://localhost:443"]
+  # callback_urls is NOT cosmetic — it is this environment's live browser CORS
+  # allowlist. Do not trim it without reading the following.
+  #
+  # The UI signs in with USER_SRP_AUTH (Cognito's native flow, not an OAuth2
+  # redirect), so Cognito itself never redirects to these URLs. flip-api reads
+  # them back instead: get_cors_allowed_origins()
+  # (flip-api/src/flip_api/utils/cognito_helpers.py) calls
+  # describe_user_pool_client, normalizes each CallbackURL to a
+  # scheme://host[:port] origin, and CORSMiddleware serves that list with
+  # allow_credentials=true. Every browser origin that must call the API in
+  # stag/prod therefore has to be listed here, and removing one silently blocks
+  # that origin. Nothing in the test suite catches it — the value is read from
+  # live Cognito at runtime, not from this file.
+  #
+  # Operationally: a change here takes effect at the NEXT flip-api start, not at
+  # apply time. main.py's lifespan reads the list once and CORSMiddleware holds
+  # it by reference, so restart the flip-api service after applying.
+  #
+  # localhost is deliberately absent: this root stack is stag/prod only. Local
+  # development uses the separate ./dev root, whose var.cognito_callback_urls
+  # carries the localhost origins.
+  callback_urls = ["https://${var.flip_alb_subdomain}"]
+
+  # Not read by flip-api; only Cognito's hosted UI would honour these as
+  # post-logout redirect targets, and allowed_oauth_flows_user_pool_client is
+  # unset (provider default false), so the hosted UI is not enabled for this
+  # client. Kept non-empty and localhost-free so the stag/prod client advertises
+  # no redirect target that isn't a real FLIP origin. logout_urls is Optional in
+  # the provider schema and need not mirror callback_urls — the ./dev root
+  # already passes lists of differing length.
+  logout_urls = ["https://${var.flip_alb_subdomain}"]
 }
 
 # State migration: Cognito resources used to live at the root of this stack and

--- a/deploy/providers/AWS/tests/test_cognito_callback_urls.py
+++ b/deploy/providers/AWS/tests/test_cognito_callback_urls.py
@@ -1,0 +1,128 @@
+# Copyright (c) 2026 Guy's and St Thomas' NHS Foundation Trust & King's College London
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Static guards on the Cognito app client's ``callback_urls`` per Terraform root.
+
+``callback_urls`` is not cosmetic: flip-api reads it back from live Cognito with
+``describe_user_pool_client`` and serves the normalized origins as the browser CORS
+allowlist with ``allow_credentials=true`` (see ``flip_api/utils/cors.py``). Nothing
+in the runtime test suites can catch a bad value — it is read from AWS at start-up,
+not from this tree — so the invariant is asserted here, over the ``.tf`` source.
+
+Two failure modes are guarded, and both are silent in a plan diff:
+
+* **Deletion.** ``modules/cognito`` defaults ``callback_urls`` to
+  ``["https://localhost:443"]``, so dropping the explicit argument from the stag/prod
+  root does not empty the list — it puts a localhost origin back into the production
+  CORS allowlist.
+* **Addition.** A localhost origin added to the stag/prod root for a debugging session
+  and left behind has the same effect.
+
+The dev root is asserted in the opposite direction: it *must* keep localhost, so that
+a well-meant "no localhost in Terraform" sweep cannot break local development instead.
+"""
+
+import re
+from pathlib import Path
+
+AWS_PROVIDER_DIR = Path(__file__).resolve().parent.parent
+STAG_PROD_SERVICES_TF = AWS_PROVIDER_DIR / "services.tf"
+DEV_VARIABLES_TF = AWS_PROVIDER_DIR / "dev" / "variables.tf"
+
+
+def _block(source: str, header: str) -> str:
+    """Extract a brace-balanced HCL block by its opening header.
+
+    Args:
+        source (str): Full contents of a Terraform file.
+        header (str): The block header to find, e.g. ``module "cognito"``.
+
+    Returns:
+        str: The block body, without the enclosing braces.
+    """
+    start = source.index(header)
+    open_brace = source.index("{", start)
+    depth = 0
+    for index in range(open_brace, len(source)):
+        if source[index] == "{":
+            depth += 1
+        elif source[index] == "}":
+            depth -= 1
+            if depth == 0:
+                return source[open_brace + 1 : index]
+    raise AssertionError(f"unbalanced braces after {header!r}")
+
+
+def _string_list(block: str, argument: str) -> list[str]:
+    """Read a single-line list-of-strings argument out of an HCL block.
+
+    Args:
+        block (str): An HCL block body.
+        argument (str): The argument name, e.g. ``callback_urls``.
+
+    Returns:
+        list[str]: The quoted entries, with any ``${...}`` interpolation left verbatim.
+    """
+    match = re.search(rf"^\s*{re.escape(argument)}\s*=\s*\[(.*?)\]", block, re.MULTILINE | re.DOTALL)
+    assert match is not None, f"{argument} is not set as a literal list — the guard below cannot see it"
+    return re.findall(r'"([^"]*)"', match.group(1))
+
+
+def _cognito_module_argument(argument: str) -> list[str]:
+    """Read one argument passed to the stag/prod root's ``module "cognito"`` block.
+
+    Args:
+        argument (str): The argument name.
+
+    Returns:
+        list[str]: The argument's entries.
+    """
+    block = _block(STAG_PROD_SERVICES_TF.read_text(), 'module "cognito"')
+    return _string_list(block, argument)
+
+
+def test_stag_prod_passes_callback_urls_explicitly() -> None:
+    """The stag/prod root must set callback_urls rather than inherit the module default.
+
+    The module default is ``["https://localhost:443"]``, so an omitted argument is not an
+    empty allowlist — it is a localhost origin in production.
+    """
+    assert _cognito_module_argument("callback_urls"), "stag/prod callback_urls must be non-empty"
+
+
+def test_stag_prod_callback_urls_carry_no_localhost() -> None:
+    """No stag/prod callback URL may name localhost."""
+    offenders = [url for url in _cognito_module_argument("callback_urls") if "localhost" in url.lower()]
+    assert not offenders, f"localhost is not a stag/prod browser origin: {offenders}"
+
+
+def test_stag_prod_logout_urls_carry_no_localhost() -> None:
+    """No stag/prod logout URL may name localhost.
+
+    flip-api does not read these, but the client should advertise no redirect target
+    that isn't a real FLIP origin.
+    """
+    offenders = [url for url in _cognito_module_argument("logout_urls") if "localhost" in url.lower()]
+    assert not offenders, f"localhost is not a stag/prod redirect target: {offenders}"
+
+
+def test_dev_root_keeps_localhost_callback_urls() -> None:
+    """The dev root must keep its localhost origins.
+
+    This is the other half of the asymmetry: local development serves the UI from
+    localhost, so stripping it here would break dev sign-in via the same CORS path.
+    """
+    block = _block(DEV_VARIABLES_TF.read_text(), 'variable "cognito_callback_urls"')
+    urls = _string_list(block, "default")
+    assert any("localhost" in url.lower() for url in urls), f"dev callback_urls lost its localhost origins: {urls}"


### PR DESCRIPTION
Closes #1086

## Problem 1 — the comment said `callback_urls` are cosmetic; they are load-bearing

`deploy/providers/AWS/services.tf` described the stag/prod Cognito app client's `callback_urls` as **"hygiene only"**. The first half of that comment is still true — the UI signs in with `USER_SRP_AUTH` (`explicit_auth_flows` in `modules/cognito/main.tf`), never an OAuth2 redirect, so Cognito itself never redirects to these URLs.

But "hygiene only" stopped being true once flip-api began deriving its **CORS allowlist** from them:

- `get_cors_allowed_origins()` (`flip-api/src/flip_api/utils/cognito_helpers.py`) calls `describe_user_pool_client` and normalises each `CallbackURL` into a `scheme://host[:port]` origin.
- `main.py`'s lifespan extends the module-level `_cors_allowed_origins` with the result, and `CORSMiddleware` is registered with `allow_origins=_cors_allowed_origins, allow_credentials=True`.

So `callback_urls` **is** the live browser CORS allowlist for stag/prod. An operator trimming a "hygiene only" entry would silently block that origin from calling the API, and **nothing in the test suite would catch it** — the value is read from live Cognito at runtime, not from the repo.

The comment is rewritten to state the coupling, name the deriving function, and warn against trimming. `deploy/providers/AWS/dev/variables.tf` already documented this correctly for the dev root; `services.tf` was the one that did not.

## Problem 2 — `https://localhost` was in the production CORS allowlist

`services.tf` is the **root** stack used by stag/prod. Dev is a *separate* root (`deploy/providers/AWS/dev/`) that takes `var.cognito_callback_urls`. The hardcoded `https://localhost:443` entry was therefore not dev-only.

`_origin_from_url` strips the scheme-default port (RFC 6454 — browsers do the same), so `https://localhost:443` normalised to `https://localhost` and landed in the **production** allowlist. This is covered directly by an existing unit test: `("https://localhost:443", "https://localhost")` in `test_cognito_helpers.py`.

Impact is **low, not critical** (as the issue notes): the API takes bearer tokens from the `Authorization` header rather than cookies, so a page on `https://localhost` has no token to send. It is defence-in-depth weakening and an unnecessary production-surface entry, not a directly exploitable hole.

Both `callback_urls` and `logout_urls` now carry only `https://${var.flip_alb_subdomain}`.

## Why `logout_urls` gets the same treatment

Decided rather than assumed, and verified against the provider schema rather than from memory:

- **Not a CORS input.** `get_cors_allowed_origins()` reads `CallbackURLs` only — there is no `LogoutURLs` read anywhere in flip-api. So this half of the change has no CORS effect either way.
- **No schema constraint forces it to be non-empty or to mirror `callback_urls`.** Checked directly against `hashicorp/aws ~> 6.0` with `terraform providers schema -json`: `logout_urls` is `optional=true, required=false` (as are `callback_urls`, `allowed_oauth_flows` and `allowed_oauth_flows_user_pool_client`). The repo already proves the two lists need not match — the `./dev` root passes two callback URLs and one logout URL.
- **Both lists stay non-empty anyway**, keeping the canonical subdomain, so the change is safe even against Cognito's API-side rule that OAuth-enabled clients need at least one callback URL.
- **The hosted UI is not even enabled** for this client: `allowed_oauth_flows_user_pool_client` is unset repo-wide (provider default `false`), so `logout_urls` is dead config today.
- **Symmetry.** Leaving localhost in `logout_urls` alone would preserve exactly the "is this load-bearing or not?" ambiguity this PR exists to remove, and would keep the prod client advertising a redirect target that is not a real FLIP origin.

## Nothing depends on the removed entry

`grep -rn "localhost:443"` over the repo — every other hit is dev-scoped or test-scoped:

| Location | Verdict |
|---|---|
| `deploy/providers/AWS/dev/variables.tf` (callback, logout, `s3_cors_allowed_origins`) | dev root — untouched, keeps localhost |
| `deploy/providers/AWS/modules/cognito/variables.tf` defaults | module defaults only; both roots pass explicit values |
| `flip-api/.../cognito_helpers.py` docstring + `test_cognito_helpers.py` | documents/tests the normalisation itself |
| `flip-ui/.vscode/launch.json`, `.vscode/launch.json` | local editor debug configs |

There is also no `validation {}` block or `nullable` constraint on `callback_urls`/`logout_urls` in `modules/cognito/` (the module's only `validation` block is on `mfa_configuration`).

Worth noting the local UI dev server runs on **`http://localhost:44357`**, not `https://localhost:443` — so the removed entry did not correspond to any real local workflow even before this change, and dev keeps both origins regardless.

### This also makes `services.tf` internally consistent

The same file already treats `https://${var.flip_alb_subdomain}` as the *only* legitimate browser origin for stag/prod everywhere else it declares one:

```
services.tf:56   cors_allowed_origins  = ["https://${var.flip_alb_subdomain}"]
services.tf:77   cors_allowed_origins  = ["https://${var.flip_alb_subdomain}"]
services.tf:138    allowed_origins = ["https://${var.flip_alb_subdomain}"]
```

Those are the S3 bucket CORS surfaces (a separate surface from the API allowlist, and not otherwise touched by this PR). The Cognito block was the sole outlier carrying localhost — after this change the file declares one consistent stag/prod browser origin throughout.

## ⚠️ Operational consequence — a restart is required after apply

**Changing `callback_urls` changes the CORS allowlist only at the *next* flip-api start, not at apply time.**

`main.py`'s lifespan calls `get_cors_allowed_origins()` **once** and `CORSMiddleware` holds `_cors_allowed_origins` **by reference**. Terraform updating the Cognito client has no effect on a running flip-api task — it keeps serving the allowlist it read at boot.

So the rollout for this PR is **apply, then restart flip-api**, and per the issue's acceptance criteria the allowlist should be confirmed afterwards against a live `describe_user_pool_client` plus a real preflight from the canonical UI origin. Since an FL-server replacement kills an in-flight training run, follow the usual quiesce workflow if the restart goes through `make deploy-centralhub` (enable deployment mode → wait for `GET /fl/quiesce` → deploy → disable).

## Verification

No infrastructure was mutated — no `apply` of any kind was run.

```
$ terraform fmt -check -recursive -diff deploy/providers/AWS
fmt-exit=0

$ terraform -chdir=deploy/providers/AWS init -backend=false -input=false
Terraform has been successfully initialized!

$ terraform -chdir=deploy/providers/AWS validate
Success! The configuration is valid, but there were some validation warnings
  (3 pre-existing `failure_threshold is deprecated` warnings on
   aws_service_discovery_service, unrelated to this change)
validate-exit=0

$ make checkov-lint          # from the repo root
Canary OK: checkov flags the deliberately broad fixture (both check families live).
Passed checks: 113, Failed checks: 0, Skipped checks: 14
```

`validate` was run with `-backend=false` so it never touched remote state or needed AWS credentials. The provider schema check used a throwaway scratch directory, also `-backend=false`.

## Out of scope

The issue's own suggestion stands and is deliberately **not** done here: deriving CORS from `CallbackURLs` at all is arguably the wrong coupling given the UI never uses them as callbacks, and an explicit `allowed_origins` variable would be more honest. That is a larger change across Terraform and flip-api. This PR only makes the existing coupling visible and removes the localhost entry.


## Applied and verified on stag

This has been applied to the live stag account and the CORS behaviour confirmed end to end — full detail in the verification comment below. Summary:

- Applied with a **targeted** `-target=module.cognito.aws_cognito_user_pool_client.client` apply: **1 to change, 0 to add, 0 to destroy**. A full `make apply` was deliberately avoided — its plan was `6 to add, 5 to change, 1 to destroy`, the destroy being an EC2 force-replaced by Ubuntu-AMI drift, plus five unrelated pre-existing drift items.
- Live client before → after: `CallbackURLs` and `LogoutURLs` both `[localhost:443, stag.flip.aicentre.co.uk]` → `[stag.flip.aicentre.co.uk]`.
- **The restart requirement in this PR is now empirically demonstrated, not just asserted**: immediately after apply, flip-api still answered `access-control-allow-origin: https://localhost`. Only after an ECS force-new-deployment did it refuse that origin while continuing to allow `https://stag.flip.aicentre.co.uk`, with `/api/health` 200.

**Note for whoever merges:** stag is currently *ahead* of `develop`. Until this merges, a full apply from `develop` would re-add `https://localhost:443` and silently undo it.

## Acceptance Criteria

*Imported from issue #1086*

- [x] The `services.tf` comment states that `callback_urls` are read at flip-api startup as the CORS allowlist and are therefore not free to trim.
- [x] `https://localhost:443` is removed from the stag/prod `callback_urls` (and `logout_urls` reviewed alongside), with dev keeping its localhost entries via `deploy/providers/AWS/dev/`.
- [x] Confirm no stag/prod UI origin regresses — the allowlist is derived at runtime, so verify against a live `describe_user_pool_client` after apply. **Done on stag** (see the verification comment): targeted apply, live client confirmed, flip-api restarted, `https://localhost` refused while the canonical origin still passes, `/api/health` 200.
