### PR TITLE
fix(imaging-api): dcm2niix command mismatch reports a missing Container Service plugin

### DIFF
--- a/deploy/providers/kubernetes/TROUBLESHOOTING.md
+++ b/deploy/providers/kubernetes/TROUBLESHOOTING.md
@@ -14,6 +14,7 @@ services, with a focus on the XNAT DICOM import pipeline.
    - [2.3 imaging-api Gets 401 from XNAT (flipServiceAccount)](#23-imaging-api-gets-401-from-xnat-flipserviceaccount)
    - [2.3a dcm2niix Never Registered (admin missing ContainerManager)](#23a-dcm2niix-never-registered-admin-missing-containermanager)
    - [2.3b dcm2niix Runs but Produces No NIfTI (Container Service PVC mounts)](#23b-dcm2niix-runs-but-produces-no-nifti-container-service-pvc-mounts)
+   - [2.3c dcm2niix Registered Against a Stale Image](#23c-dcm2niix-registered-against-a-stale-image)
    - [2.4 Forcing a Re-pull (status stuck on "Processing")](#24-forcing-a-re-pull-status-stuck-on-processing)
    - [2.5 C-MOVE Testing from the DCMTK Pod](#25-c-move-testing-from-the-dcmtk-pod)
    - [2.6 Checking DICOM Connectivity](#26-checking-dicom-connectivity)
@@ -354,6 +355,43 @@ xnat:
       accessMode: ReadWriteMany
       storageClassName: efs-sc        # any RWX-capable provisioner
 ```
+
+### 2.3c dcm2niix Registered Against a Stale Image
+
+**Symptom:** studies pull and archive fine, conversion never runs, and
+imaging-api reports the mismatch by listing what *is* registered, e.g.
+
+```
+No commands found for container 'ghcr.io/londonaicentre/xnat-dcm2niix:v1.0.20260724'.
+The Container Service is installed and has 1 command(s) registered:
+'dcm2niix' -> 'xnat/dcm2niix:latest'. If one of those is the same tool on an older
+image, this XNAT's registration predates the current pin ...
+```
+
+The Container Service is healthy and the command is enabled; it is simply bound
+to the image this XNAT was provisioned with.
+
+**Root Cause:** the registration lives in XNAT's database, not derived from the
+chart at run time, so an XNAT provisioned before the FLIP#980 pin keeps
+converting with the 2021 `xnat/dcm2niix:latest` image and looks perfectly
+healthy. FLIP#980 changed the *repository* as well as the tag, so comparing
+tags alone does not reveal it. `trust/xnat/dcm2niix/check_image_pin_sync.sh`
+cannot catch it either: it compares files in the repository and never calls a
+running XNAT, so a live registration that disagrees with the pin is invisible
+to it. Both staging trusts sat in this state.
+
+**Check:**
+
+```bash
+kubectl exec -n flip-trust "$XNAT_POD" -- \
+  curl -s -u admin:<admin-pass> http://localhost:8080/xapi/commands \
+  | jq -r '.[] | "\(.name) -> \(.image)"'
+```
+
+**Fix:** re-register against the pinned image — re-run the `xnat-init` Job
+(`helm upgrade` re-fires the post-install hook) on Kubernetes, or
+`configure-dcm2niix.sh` on Compose. Then confirm the listing above names the
+image the trust's imaging-api requests.
 
 ### 2.4 Forcing a Re-pull (status stuck on "Processing")
 

--- a/docs/source/components/component-xnat.rst
+++ b/docs/source/components/component-xnat.rst
@@ -204,6 +204,8 @@ DICOM to NIfTI Conversion
 
 XNAT can automatically convert DICOM images to NIfTI format using the ``dcm2niix`` tool via the Container Service plugin. The converter runs from FLIP's version-pinned image ``ghcr.io/londonaicentre/xnat-dcm2niix`` (built from ``trust/xnat/dcm2niix/``; never a mutable ``latest`` tag — the previously used Docker Hub ``xnat/dcm2niix:latest`` resolved to a stale 2021 build that silently dropped slices from valid series). On the Docker/swarm backend the setup script also registers ``ghcr.io`` as a credential-less Container Service *image host*: without an image-host entry matching the image's registry hostname, container-service 3.8.1's swarm launch path fails with a ``NullPointerException`` before any container exists, even for a public image (the Kubernetes backend pulls via kubelet and does not need the entry). FLIP controls this conversion on a per-project basis through two XNAT mechanisms:
 
+The pinned image is recorded in XNAT's own database when the command is registered, not read from the repository at run time, so an XNAT provisioned before a pin bump keeps converting with the superseded image and reports itself healthy. The pin-sync check compares repository files only and cannot detect this. ``GET /xapi/commands`` lists the ``name -> image`` pairs a deployment actually holds — the same listing imaging-api returns when no command matches the image it requests — and re-running ``configure-dcm2niix.sh`` (or the ``xnat-init`` job on Kubernetes) re-registers against the current pin.
+
 Commands vs Event Subscriptions
 ================================
 

--- a/trust/imaging-api/imaging_api/services/projects.py
+++ b/trust/imaging-api/imaging_api/services/projects.py
@@ -263,6 +263,47 @@ def set_project_prearchive_settings(project_id: str, headers: dict[str, str]) ->
         )
 
 
+def _no_command_message(container: str, headers: dict[str, str]) -> str:
+    """Explain why no XNAT command matched ``container``.
+
+    ``get_command_info`` queries ``/xapi/commands?image=<container>``, so an empty
+    result has two very different causes with opposite fixes: the Container Service
+    genuinely has no commands, or it has one registered against a *different* image.
+    The latter is the common case — an XNAT provisioned before ``DCM2NIIX_IMAGE`` was
+    pinned (FLIP#980) still carries ``xnat/dcm2niix:latest`` — and blaming a missing
+    plugin sends the reader to the wrong place entirely.
+
+    Re-queries XNAT unfiltered to say which it is. The diagnostic call runs only on
+    the error path, and is never allowed to mask the original failure.
+
+    Args:
+        container (str): Image that was requested and did not match.
+        headers (dict[str, str]): XNAT authentication headers.
+
+    Returns:
+        str: Message naming the registered images when there are any, otherwise
+        falling back to the Container Service hypothesis.
+    """
+    try:
+        probe = requests.get(f"{XNAT_URL}/xapi/commands", headers=headers)
+        registered = probe.json() if probe.status_code == 200 else []
+    except Exception:  # noqa: BLE001 - diagnostics must never replace the real error
+        registered = []
+
+    images = sorted({c.get("image") for c in registered if c.get("image")})
+    if not images:
+        return (
+            f"No commands found for container '{container}' and no commands are registered at all "
+            "- the XNAT Container Service may not be installed or configured"
+        )
+    return (
+        f"No commands found for container '{container}'. XNAT has command(s) registered against "
+        f"{', '.join(repr(i) for i in images)} instead - this XNAT's registration predates the "
+        "current DCM2NIIX_IMAGE pin. Re-run configure-dcm2niix.sh (compose) or the xnat-init job "
+        "(k8s) to re-register it, and check the trust's imaging-api image is current."
+    )
+
+
 def get_command_info(container: str, headers: dict[str, str]) -> tuple[int, str]:
     """
     Fetches the XNAT command ID and wrapper name for a given container image.
@@ -284,9 +325,7 @@ def get_command_info(container: str, headers: dict[str, str]) -> tuple[int, str]
 
     commands = response.json()
     if not commands:
-        raise Exception(
-            f"No commands found for container '{container}' - Container Service plugin may not be installed"
-        )
+        raise Exception(_no_command_message(container, headers))
     command = commands[0]
     return command["id"], command["xnat"][0]["name"]
 

--- a/trust/imaging-api/imaging_api/services/projects.py
+++ b/trust/imaging-api/imaging_api/services/projects.py
@@ -267,22 +267,28 @@ def _no_command_message(container: str, headers: dict[str, str]) -> str:
     """Explain why no XNAT command matched ``container``.
 
     ``get_command_info`` queries ``/xapi/commands?image=<container>``, so an empty
-    result has two very different causes with opposite fixes: the Container Service
-    genuinely has no commands, or it has one registered against a *different* image.
-    The latter is the common case — an XNAT provisioned before ``DCM2NIIX_IMAGE`` was
-    pinned (FLIP#980) still carries ``xnat/dcm2niix:latest`` — and blaming a missing
-    plugin sends the reader to the wrong place entirely.
+    result means only that no command is registered against *that exact image*. The
+    previous message asserted a single cause — a missing Container Service plugin —
+    which is the least likely one (FLIP#1093). In practice the plugin is healthy and
+    the command is registered against a different image: an XNAT provisioned before
+    FLIP#980 still carries ``xnat/dcm2niix:latest``.
 
-    Re-queries XNAT unfiltered to say which it is. The diagnostic call runs only on
-    the error path, and is never allowed to mask the original failure.
+    Rather than guess at the cause, list what *is* registered as name→image pairs.
+    That is the datum an operator needs and it cannot be wrong: it neither implies
+    unrelated containers are stale versions of this one, nor hides a same-named
+    command sitting on an older image. Note FLIP#980 changed the repository as well
+    as the tag, so comparing repositories would miss the very case this exists for.
+
+    Re-queries XNAT unfiltered on the error path only, and never lets that
+    diagnostic call mask the original failure.
 
     Args:
         container (str): Image that was requested and did not match.
         headers (dict[str, str]): XNAT authentication headers.
 
     Returns:
-        str: Message naming the registered images when there are any, otherwise
-        falling back to the Container Service hypothesis.
+        str: A message naming what is registered, or the Container Service
+        hypothesis when genuinely nothing is.
     """
     try:
         probe = requests.get(f"{XNAT_URL}/xapi/commands", headers=headers)
@@ -290,17 +296,22 @@ def _no_command_message(container: str, headers: dict[str, str]) -> str:
     except Exception:  # noqa: BLE001 - diagnostics must never replace the real error
         registered = []
 
-    images = sorted({c.get("image") for c in registered if c.get("image")})
-    if not images:
+    if not registered:
         return (
             f"No commands found for container '{container}' and no commands are registered at all "
             "- the XNAT Container Service may not be installed or configured"
         )
+
+    listed = ", ".join(
+        f"{c.get('name', '?')!r} -> {c.get('image', '?')!r}"
+        for c in sorted(registered, key=lambda c: (c.get("name") or "", c.get("image") or ""))
+    )
     return (
-        f"No commands found for container '{container}'. XNAT has command(s) registered against "
-        f"{', '.join(repr(i) for i in images)} instead - this XNAT's registration predates the "
-        "current DCM2NIIX_IMAGE pin. Re-run configure-dcm2niix.sh (compose) or the xnat-init job "
-        "(k8s) to re-register it, and check the trust's imaging-api image is current."
+        f"No commands found for container '{container}'. The Container Service is working and has "
+        f"{len(registered)} command(s) registered: {listed}. If one of those is the same tool on an "
+        "older image, this XNAT's registration predates the current pin - re-run configure-dcm2niix.sh "
+        "(compose) or the xnat-init job (k8s) to re-register it, and check the trust's imaging-api "
+        "image is current."
     )
 
 

--- a/trust/imaging-api/imaging_api/services/projects.py
+++ b/trust/imaging-api/imaging_api/services/projects.py
@@ -263,6 +263,29 @@ def set_project_prearchive_settings(project_id: str, headers: dict[str, str]) ->
         )
 
 
+# Cap on the name->image pairs embedded in the raised message. That string becomes an
+# imaging-api 500 detail, and trust-api truncates the relayed body at 1000 characters before it
+# reaches the hub as the task's error. A 40-command registry renders ~2600 characters, so the cut
+# lands mid-image-name and drops the remediation sentence entirely - the actionable half never
+# arrives. Cap the raised message here and log the full listing trust-side, where nothing truncates.
+_MAX_LISTED_COMMANDS = 10
+
+
+def _sorted_command_pairs(commands: list[dict[str, Any]]) -> list[str]:
+    """Renders each registered command as a ``'name' -> 'image'`` pair, name-ordered.
+
+    Args:
+        commands (list[dict[str, Any]]): Command objects as returned by ``/xapi/commands``.
+
+    Returns:
+        list[str]: One rendered pair per command, ordered by name then image.
+    """
+    return [
+        f"{c.get('name', '?')!r} -> {c.get('image', '?')!r}"
+        for c in sorted(commands, key=lambda c: (c.get("name") or "", c.get("image") or ""))
+    ]
+
+
 def _no_command_message(container: str, headers: dict[str, str]) -> str:
     """Explain why no XNAT command matched ``container``.
 
@@ -282,19 +305,60 @@ def _no_command_message(container: str, headers: dict[str, str]) -> str:
     Re-queries XNAT unfiltered on the error path only, and never lets that
     diagnostic call mask the original failure.
 
+    Three outcomes are reported distinctly, because collapsing them is how the
+    previous message misdiagnosed. A 200 carrying an empty array is the only one
+    that supports the Container-Service hypothesis. A non-200 or a transport
+    error means the listing could not be *obtained*, which establishes nothing
+    about the plugin: XNAT answers ``/xapi/commands`` with 401 and an HTML body
+    when the service account's credentials are wrong or its session has expired,
+    and reporting that as a missing plugin sends the operator to reinstall a
+    plugin that is present and healthy.
+
     Args:
         container (str): Image that was requested and did not match.
         headers (dict[str, str]): XNAT authentication headers.
 
     Returns:
-        str: A message naming what is registered, or the Container Service
-        hypothesis when genuinely nothing is.
+        str: A message naming what is registered, the Container Service
+        hypothesis when the registry is genuinely empty, or a statement that the
+        listing could not be obtained when it could not.
     """
     try:
         probe = requests.get(f"{XNAT_URL}/xapi/commands", headers=headers)
-        registered = probe.json() if probe.status_code == 200 else []
-    except Exception:  # noqa: BLE001 - diagnostics must never replace the real error
+        if probe.status_code != 200:
+            listing_failure: str | None = f"HTTP {probe.status_code}"
+            registered: Any = []
+        else:
+            listing_failure = None
+            registered = probe.json()
+    except Exception as exc:  # diagnostics must never replace the real error
+        listing_failure = f"{type(exc).__name__}: {exc}"
         registered = []
+
+    # A 200 whose body is not an array of objects must not crash this helper. The formatting
+    # below assumes mappings, and `sorted()` over a dict yields its string keys, so `c.get(...)`
+    # would raise AttributeError out of a function whose whole contract is never to replace the
+    # underlying error. Live XNAT answers this endpoint with a JSON array and signals faults with
+    # a non-200, so this is defensive: it is reachable through an intermediary that rewrites the
+    # body (the Helm chart's nginx, a site proxy), not from XNAT itself. Treat it as "could not
+    # list" rather than "nothing registered" - an unparseable body is not evidence of an empty
+    # registry.
+    if not isinstance(registered, list):
+        listing_failure = listing_failure or "unexpected response body"
+        registered = []
+    else:
+        usable = [c for c in registered if isinstance(c, dict)]
+        if registered and not usable:
+            listing_failure = listing_failure or "unexpected response body"
+        registered = usable
+
+    if listing_failure is not None:
+        return (
+            f"No commands found for container '{container}', and the registered commands could not "
+            f"be listed to narrow it down ({listing_failure}). This says nothing about whether the "
+            "XNAT Container Service is installed - check the service account's XNAT credentials and "
+            "that /xapi/commands is reachable, then retry."
+        )
 
     if not registered:
         return (
@@ -302,12 +366,30 @@ def _no_command_message(container: str, headers: dict[str, str]) -> str:
             "- the XNAT Container Service may not be installed or configured"
         )
 
-    listed = ", ".join(
-        f"{c.get('name', '?')!r} -> {c.get('image', '?')!r}"
-        for c in sorted(registered, key=lambda c: (c.get("name") or "", c.get("image") or ""))
+    pairs = _sorted_command_pairs(registered)
+    # Trust-side the full listing is never truncated, so keep it where an operator can read it.
+    logger.error(
+        "No XNAT command matched image %r; %d command(s) registered: %s",
+        container,
+        len(registered),
+        ", ".join(pairs),
     )
+    listed = ", ".join(pairs[:_MAX_LISTED_COMMANDS])
+    if len(pairs) > _MAX_LISTED_COMMANDS:
+        listed += f", and {len(pairs) - _MAX_LISTED_COMMANDS} more"
+
+    if any(c.get("image") == container for c in registered):
+        return (
+            f"No commands found for container '{container}', yet that exact image is registered: "
+            f"{listed}. The filtered lookup (/xapi/commands?image=<image>) returned nothing while "
+            "the unfiltered listing shows it, so the registration is not stale and re-registering "
+            "the same image will not change anything - suspect the lookup instead: a case or "
+            "encoding difference in the image string, an 'image' field carrying a digest, or a "
+            "command with no 'xnat' wrapper."
+        )
+
     return (
-        f"No commands found for container '{container}'. The Container Service is working and has "
+        f"No commands found for container '{container}'. The Container Service is installed and has "
         f"{len(registered)} command(s) registered: {listed}. If one of those is the same tool on an "
         "older image, this XNAT's registration predates the current pin - re-run configure-dcm2niix.sh "
         "(compose) or the xnat-init job (k8s) to re-register it, and check the trust's imaging-api "

--- a/trust/imaging-api/imaging_api/services/projects.py
+++ b/trust/imaging-api/imaging_api/services/projects.py
@@ -13,6 +13,7 @@
 import urllib.parse
 import uuid
 import xml.etree.ElementTree as ET
+from collections.abc import Callable
 from typing import Any
 
 import requests
@@ -263,12 +264,43 @@ def set_project_prearchive_settings(project_id: str, headers: dict[str, str]) ->
         )
 
 
-# Cap on the name->image pairs embedded in the raised message. That string becomes an
-# imaging-api 500 detail, and trust-api truncates the relayed body at 1000 characters before it
-# reaches the hub as the task's error. A 40-command registry renders ~2600 characters, so the cut
-# lands mid-image-name and drops the remediation sentence entirely - the actionable half never
-# arrives. Cap the raised message here and log the full listing trust-side, where nothing truncates.
-_MAX_LISTED_COMMANDS = 10
+# Budget for the name->image listing embedded in the raised message, in CHARACTERS rather than
+# items. That string becomes an imaging-api 500 detail, and trust-api truncates the relayed body at
+# 1000 characters (see trust_api/utils/http.py) before it reaches the hub as the task's error. An
+# item cap cannot hold that bound: a realistic 'dcm2niix' -> 'ghcr.io/londonaicentre/xnat-dcm2niix:
+# <pin>' pair is ~66 characters against a ~40-character synthetic one, so ten of the former render
+# ~1075 characters and push the remediation sentence past the cut - exactly the outcome a cap is
+# here to prevent, and an item cap that passes only on short test fixtures hides it. Fit pairs to
+# the budget instead, and log the full listing trust-side where nothing truncates.
+_MAX_MESSAGE_CHARS = 950
+
+# Bound on an XNAT error body interpolated into a raised message. XNAT answers an unauthenticated
+# /xapi call with a Tomcat error page whose entire signal is its <title> (~84 characters); the
+# remaining ~600 are a CSS block and boilerplate that would eat most of the budget above. The full
+# body goes to the log instead.
+_MAX_BODY_CHARS = 200
+
+# The unfiltered re-query runs only once the real error is already in hand, so a hang there delays a
+# failure that is already determined. Explicit here for that reason; a file-wide convention for the
+# other calls is a separate change.
+_DIAGNOSTIC_TIMEOUT_SECONDS = 10
+
+
+def _bounded_body(text: str) -> str:
+    """Trims an XNAT error body to its informative head for embedding in a raised message.
+
+    Args:
+        text (str): Raw response body from XNAT.
+
+    Returns:
+        str: The body unchanged when it is already short, otherwise its first ``_MAX_BODY_CHARS``
+        characters with a pointer to the trust-side log for the remainder.
+    """
+    body = (text or "").strip()
+    if len(body) <= _MAX_BODY_CHARS:
+        return body
+    omitted = len(body) - _MAX_BODY_CHARS
+    return f"{body[:_MAX_BODY_CHARS]}... (+{omitted} more characters, full body in the imaging-api log)"
 
 
 def _sorted_command_pairs(commands: list[dict[str, Any]]) -> list[str]:
@@ -284,6 +316,89 @@ def _sorted_command_pairs(commands: list[dict[str, Any]]) -> list[str]:
         f"{c.get('name', '?')!r} -> {c.get('image', '?')!r}"
         for c in sorted(commands, key=lambda c: (c.get("name") or "", c.get("image") or ""))
     ]
+
+
+def _render_listing(kept: list[str], omitted: int) -> str:
+    """Renders the listing fragment of a message, naming whatever did not fit.
+
+    Args:
+        kept (list[str]): Rendered pairs that fit inside the budget.
+        omitted (int): How many further pairs were dropped.
+
+    Returns:
+        str: The comma-joined pairs with an "and N more" tail, or a pointer to the log when the
+        budget could not accommodate even one pair.
+    """
+    if not kept:
+        return f"{omitted} command(s), too long to list here - see the imaging-api log"
+    listed = ", ".join(kept)
+    if omitted:
+        listed += f", and {omitted} more"
+    return listed
+
+
+def _fit_listing(render: Callable[[str], str], pairs: list[str]) -> str:
+    """Renders a message with as many of ``pairs`` as fit inside ``_MAX_MESSAGE_CHARS``.
+
+    Appends pairs one at a time and stops on the first that would put the *rendered message* over
+    budget, so the bound holds against real image names rather than short ones. The remediation
+    sentence lives in the fixed prose, so keeping the whole message under the truncation is what
+    keeps the actionable half of it alive.
+
+    Args:
+        render (Callable[[str], str]): Builds the full message from a listing fragment.
+        pairs (list[str]): Rendered ``'name' -> 'image'`` pairs, most relevant first.
+
+    Returns:
+        str: The rendered message, trimmed to the budget.
+    """
+    kept: list[str] = []
+    for pair in pairs:
+        candidate = [*kept, pair]
+        if len(render(_render_listing(candidate, len(pairs) - len(candidate)))) > _MAX_MESSAGE_CHARS:
+            break
+        kept = candidate
+    return render(_render_listing(kept, len(pairs) - len(kept)))
+
+
+def _listing_failure_message(container: str, listing_failure: str, status: int | None) -> str:
+    """Explains a failure to *obtain* the command listing, by what the status actually implies.
+
+    401 and 403 reach here with different documented causes and must not be collapsed: 401 is a
+    credential or session fault, while Container Service 3.7.0+ answers 403 on ``/xapi/commands``
+    when the caller lacks the ``ContainerManager`` role (TROUBLESHOOTING 2.3a). Sending an operator
+    to re-check working credentials for a 403 is a smaller version of the misdiagnosis FLIP#1093 is
+    about.
+
+    Args:
+        container (str): Image that was requested and did not match.
+        listing_failure (str): Short description of why the listing could not be obtained.
+        status (int | None): HTTP status of the diagnostic call, or None for a transport failure.
+
+    Returns:
+        str: A message reporting the failure and the remedy its status implies.
+    """
+    if status == 401:
+        remedy = (
+            "XNAT answers 401 when the service account's credentials are wrong or its session has "
+            "expired - check this trust's XNAT_SERVICE_USER/XNAT_SERVICE_PASSWORD, then retry."
+        )
+    elif status == 403:
+        remedy = (
+            "XNAT answers 403 on /xapi/commands when the service account lacks the ContainerManager "
+            "role, which Container Service 3.7.0+ requires - grant the role rather than re-checking "
+            "credentials (see TROUBLESHOOTING 2.3a), then retry."
+        )
+    else:
+        remedy = (
+            "Check the service account's XNAT credentials and its ContainerManager role, and that "
+            "/xapi/commands is reachable, then retry."
+        )
+    return (
+        f"No commands found for container '{container}', and the registered commands could not be "
+        f"listed to narrow it down ({listing_failure}). This says nothing about whether the XNAT "
+        f"Container Service is installed - {remedy}"
+    )
 
 
 def _no_command_message(container: str, headers: dict[str, str]) -> str:
@@ -307,24 +422,27 @@ def _no_command_message(container: str, headers: dict[str, str]) -> str:
 
     Three outcomes are reported distinctly, because collapsing them is how the
     previous message misdiagnosed. A 200 carrying an empty array is the only one
-    that supports the Container-Service hypothesis. A non-200 or a transport
-    error means the listing could not be *obtained*, which establishes nothing
-    about the plugin: XNAT answers ``/xapi/commands`` with 401 and an HTML body
-    when the service account's credentials are wrong or its session has expired,
-    and reporting that as a missing plugin sends the operator to reinstall a
-    plugin that is present and healthy.
+    that supports the Container-Service hypothesis — and only weakly, since XNAT
+    answers a path with no plugin behind it with 404, not an empty list, so a
+    readable registry is itself evidence the service is installed. A non-200 or a
+    transport error means the listing could not be *obtained*, which establishes
+    nothing about the plugin.
 
     Args:
         container (str): Image that was requested and did not match.
         headers (dict[str, str]): XNAT authentication headers.
 
     Returns:
-        str: A message naming what is registered, the Container Service
-        hypothesis when the registry is genuinely empty, or a statement that the
-        listing could not be obtained when it could not.
+        str: A message naming what is registered, the registration remedy when the
+        registry is readable and empty, or a statement that the listing could not be
+        obtained when it could not.
     """
+    probe_text = ""
+    status: int | None = None
     try:
-        probe = requests.get(f"{XNAT_URL}/xapi/commands", headers=headers)
+        probe = requests.get(f"{XNAT_URL}/xapi/commands", headers=headers, timeout=_DIAGNOSTIC_TIMEOUT_SECONDS)
+        probe_text = probe.text
+        status = probe.status_code
         if probe.status_code != 200:
             listing_failure: str | None = f"HTTP {probe.status_code}"
             registered: Any = []
@@ -334,6 +452,14 @@ def _no_command_message(container: str, headers: dict[str, str]) -> str:
     except Exception as exc:  # diagnostics must never replace the real error
         listing_failure = f"{type(exc).__name__}: {exc}"
         registered = []
+        # The raised message carries only a short description and nothing downstream sees the
+        # exception, so this is the only trust-side record of what actually failed.
+        logger.error(
+            "Could not list XNAT commands while diagnosing a lookup miss for image %r (%s)",
+            container,
+            listing_failure,
+            exc_info=True,
+        )
 
     # A 200 whose body is not an array of objects must not crash this helper. The formatting
     # below assumes mappings, and `sorted()` over a dict yields its string keys, so `c.get(...)`
@@ -353,17 +479,26 @@ def _no_command_message(container: str, headers: dict[str, str]) -> str:
         registered = usable
 
     if listing_failure is not None:
-        return (
-            f"No commands found for container '{container}', and the registered commands could not "
-            f"be listed to narrow it down ({listing_failure}). This says nothing about whether the "
-            "XNAT Container Service is installed - check the service account's XNAT credentials and "
-            "that /xapi/commands is reachable, then retry."
-        )
+        if status is not None:
+            # The raised message deliberately omits the body - an XNAT login page is ~683
+            # characters of Tomcat boilerplate - so keep it here, where nothing truncates it.
+            logger.error(
+                "Could not list XNAT commands while diagnosing a lookup miss for image %r: %s; body: %s",
+                container,
+                listing_failure,
+                probe_text,
+            )
+        return _listing_failure_message(container, listing_failure, status)
 
     if not registered:
         return (
-            f"No commands found for container '{container}' and no commands are registered at all "
-            "- the XNAT Container Service may not be installed or configured"
+            f"No commands found for container '{container}': the command registry is readable and "
+            "empty, so no command is registered on this XNAT. Re-run configure-dcm2niix.sh (compose) "
+            "or the xnat-init job (k8s) to register it, and check the service account holds the "
+            "ContainerManager role - Container Service 3.7.0+ requires it, and without it "
+            "registration reports success having registered nothing (see TROUBLESHOOTING 2.3a). A "
+            "readable registry means the Container Service answered, so a missing plugin is the "
+            "least likely cause here; rule it out last."
         )
 
     pairs = _sorted_command_pairs(registered)
@@ -374,26 +509,34 @@ def _no_command_message(container: str, headers: dict[str, str]) -> str:
         len(registered),
         ", ".join(pairs),
     )
-    listed = ", ".join(pairs[:_MAX_LISTED_COMMANDS])
-    if len(pairs) > _MAX_LISTED_COMMANDS:
-        listed += f", and {len(pairs) - _MAX_LISTED_COMMANDS} more"
 
-    if any(c.get("image") == container for c in registered):
-        return (
-            f"No commands found for container '{container}', yet that exact image is registered: "
-            f"{listed}. The filtered lookup (/xapi/commands?image=<image>) returned nothing while "
-            "the unfiltered listing shows it, so the registration is not stale and re-registering "
-            "the same image will not change anything - suspect the lookup instead: a case or "
-            "encoding difference in the image string, an 'image' field carrying a digest, or a "
-            "command with no 'xnat' wrapper."
+    matching = [c for c in registered if c.get("image") == container]
+    if matching:
+        # Lead with the matching entries. This branch asserts the exact image *is* registered, and
+        # a budget-trimmed listing that dropped it would contradict the very claim it is evidence
+        # for - the failure mode this whole helper exists to remove.
+        others = [c for c in registered if c.get("image") != container]
+        return _fit_listing(
+            lambda listed: (
+                f"No commands found for container '{container}', yet that exact image is registered: "
+                f"{listed}. The filtered lookup (/xapi/commands?image=<image>) returned nothing while "
+                "the unfiltered listing shows it, so the registration is not stale and re-registering "
+                "the same image will not change anything - suspect the lookup instead: a case or "
+                "encoding difference in the image string, an 'image' field carrying a digest, or a "
+                "command with no 'xnat' wrapper."
+            ),
+            _sorted_command_pairs(matching) + _sorted_command_pairs(others),
         )
 
-    return (
-        f"No commands found for container '{container}'. The Container Service is installed and has "
-        f"{len(registered)} command(s) registered: {listed}. If one of those is the same tool on an "
-        "older image, this XNAT's registration predates the current pin - re-run configure-dcm2niix.sh "
-        "(compose) or the xnat-init job (k8s) to re-register it, and check the trust's imaging-api "
-        "image is current."
+    return _fit_listing(
+        lambda listed: (
+            f"No commands found for container '{container}'. The Container Service is installed and "
+            f"has {len(registered)} command(s) registered: {listed}. If one of those is the same tool "
+            "on an older image, this XNAT's registration predates the current pin - re-run "
+            "configure-dcm2niix.sh (compose) or the xnat-init job (k8s) to re-register it, and check "
+            "the trust's imaging-api image is current."
+        ),
+        pairs,
     )
 
 
@@ -409,18 +552,47 @@ def get_command_info(container: str, headers: dict[str, str]) -> tuple[int, str]
         tuple[int, str]: A tuple of (command_id, wrapper_name).
 
     Raises:
-        Exception: If the command cannot be fetched from XNAT.
+        Exception: If the command cannot be fetched from XNAT, or the command that matches carries
+            no ``xnat`` wrapper to launch.
     """
     container_name_formatted = urllib.parse.quote(container)
     response = requests.get(f"{XNAT_URL}/xapi/commands?image={container_name_formatted}", headers=headers)
     if response.status_code != 200:
-        raise Exception(f"Error: XNAT command fetch failed: {response.status_code} - {response.text}")
+        # Credentials that are wrong from the start fail here, before the diagnostic helper below is
+        # ever reached, and XNAT answers with a whole Tomcat error page. Bound it in the raised
+        # message - that string travels to the hub through trust-api's 1000-character truncation -
+        # and keep the full body in the log.
+        logger.error(
+            "XNAT command lookup for image %r failed: HTTP %s; body: %s",
+            container,
+            response.status_code,
+            response.text,
+        )
+        raise Exception(f"Error: XNAT command fetch failed: {response.status_code} - {_bounded_body(response.text)}")
 
     commands = response.json()
     if not commands:
         raise Exception(_no_command_message(container, headers))
     command = commands[0]
-    return command["id"], command["xnat"][0]["name"]
+
+    # The mismatch message above teaches "a command with no 'xnat' wrapper" as a hypothesis to
+    # check. Without this guard that exact state raises a bare KeyError('xnat') - or IndexError on
+    # an empty wrapper list - two lines from the text recommending it, and travels to the hub as a
+    # task error with nothing in it. 2.3a's verification step checks for the wrapper, so it is a
+    # real state rather than a theoretical one.
+    wrappers = command.get("xnat")
+    wrapper_name = None
+    if isinstance(wrappers, list) and wrappers and isinstance(wrappers[0], dict):
+        wrapper_name = wrappers[0].get("name")
+    if not wrapper_name:
+        raise Exception(
+            f"XNAT command {command.get('name', '?')!r} (id {command.get('id', '?')}) matches image "
+            f"'{container}' but carries no 'xnat' wrapper, so there is no wrapper name to launch. "
+            "Re-run configure-dcm2niix.sh (compose) or the xnat-init job (k8s) to re-register it, and "
+            "verify with GET /xapi/commands?name=dcm2niix that the entry has a 'dcm2niix-scan' "
+            "wrapper (see TROUBLESHOOTING 2.3a)."
+        )
+    return command["id"], wrapper_name
 
 
 def create_project_event_subscription(project_id: str, container: str, active: bool, headers: dict[str, str]) -> None:

--- a/trust/imaging-api/tests/services/test_projects.py
+++ b/trust/imaging-api/tests/services/test_projects.py
@@ -355,13 +355,29 @@ def test_get_command_info_lists_unrelated_commands_without_claiming_a_mismatch(m
 
 
 @patch("imaging_api.services.projects.requests.get")
-def test_get_command_info_no_commands_at_all_keeps_plugin_hypothesis(mock_get, headers):
-    """With nothing registered, the Container Service hypothesis is the accurate one."""
+def test_get_command_info_empty_registry_leads_with_the_registration_fix(mock_get, headers):
+    """A readable, empty registry means "never registered", not "plugin missing".
+
+    XNAT answers a path with no plugin behind it with 404, so a 200 carrying an empty array is
+    evidence the Container Service *is* installed. TROUBLESHOOTING 2.3a documents the cause this
+    branch actually has: the service account lacked ContainerManager, so registration reported
+    success having registered nothing. Lead with that remedy, not with the plugin hypothesis.
+    """
     empty = MagicMock(status_code=200, json=MagicMock(return_value=[]))
     mock_get.side_effect = [empty, empty]
 
-    with pytest.raises(Exception, match="may not be installed or configured"):
+    with pytest.raises(Exception, match="No commands found for container") as excinfo:
         get_command_info("ghcr.io/londonaicentre/xnat-dcm2niix:v1.0.20260724", headers)
+
+    message = str(excinfo.value)
+    # The fact the response supports, and the action that follows from it.
+    assert "readable and empty" in message
+    assert "configure-dcm2niix.sh" in message
+    assert "ContainerManager" in message
+    assert "2.3a" in message
+    # The plugin hypothesis survives only as a trailing note, never as the headline.
+    assert not message.startswith("No commands found for container '...' - Container Service")
+    assert message.index("configure-dcm2niix.sh") < message.index("missing plugin")
 
 
 @patch("imaging_api.services.projects.requests.get")
@@ -459,14 +475,26 @@ def test_get_command_info_exact_image_match_drops_the_stale_pin_advice(mock_get,
 
 
 @patch("imaging_api.services.projects.requests.get")
-def test_get_command_info_caps_the_listed_commands(mock_get, headers):
-    """The raised string reaches the hub through a 1000-character truncation.
+@pytest.mark.parametrize(
+    "image_for",
+    [
+        lambda i: f"ghcr.io/example/tool-{i:02d}:v1",
+        # The shape an operator actually has. An item cap sized against the short fixture above
+        # lets ten of these render ~1075 characters, putting the remediation past the hub-side cut.
+        lambda i: f"ghcr.io/londonaicentre/xnat-dcm2niix-variant-{i:02d}:v1.0.20260724",
+    ],
+    ids=["short-images", "realistic-long-images"],
+)
+def test_get_command_info_listing_stays_inside_the_truncation_budget(mock_get, headers, image_for):
+    """The raised string reaches the hub through trust-api's 1000-character truncation.
 
-    A large registry otherwise pushes the remediation sentence past the cut, so the hub-side error
-    ends mid-image-name with nothing actionable in it.
+    The budget has to be in characters, not items: the invariant that matters is that the
+    remediation sentence survives the cut, and that is a property of the rendered length, not of
+    how many pairs were appended. Parametrised over a short and a realistic image shape so the
+    bound is held by the code rather than by the brevity of a fixture.
     """
     filtered = MagicMock(status_code=200, json=MagicMock(return_value=[]))
-    many = [{"id": i, "name": f"tool-{i:02d}", "image": f"ghcr.io/example/tool-{i:02d}:v1"} for i in range(40)]
+    many = [{"id": i, "name": f"tool-{i:02d}", "image": image_for(i)} for i in range(40)]
     unfiltered = MagicMock(status_code=200, json=MagicMock(return_value=many))
     mock_get.side_effect = [filtered, unfiltered]
 
@@ -474,13 +502,136 @@ def test_get_command_info_caps_the_listed_commands(mock_get, headers):
         get_command_info("ghcr.io/londonaicentre/xnat-dcm2niix:v1.0.20260724", headers)
 
     message = str(excinfo.value)
-    assert "and 30 more" in message
-    assert "'tool-09' -> 'ghcr.io/example/tool-09:v1'" in message
-    assert "tool-10" not in message
-    # The count still reports the whole registry, and the remediation survives the truncation.
-    assert "40 command(s) registered" in message
-    assert "configure-dcm2niix.sh" in message
+    # The whole message survives the truncation, remediation included - the point of the budget.
     assert len(message) < 1000
+    assert "configure-dcm2niix.sh" in message
+    assert message.endswith("image is current.")
+    # The count still reports the whole registry, and the tail names what was dropped.
+    assert "40 command(s) registered" in message
+    assert "more" in message
+    # Whatever was listed was listed whole - never cut mid-pair.
+    listed = message.split("registered: ", 1)[1].split(". If one of those", 1)[0]
+    shown = [p for p in listed.split(", ") if p.startswith("'")]
+    assert shown, "at least one pair should fit"
+    for pair in shown:
+        assert pair.endswith("'"), f"pair rendered incomplete: {pair!r}"
+
+
+@patch("imaging_api.services.projects.requests.get")
+def test_get_command_info_forbidden_listing_points_at_the_role_not_credentials(mock_get, headers):
+    """403 shares this branch with 401 but has a different documented remedy.
+
+    Container Service 3.7.0+ answers /xapi/commands with 401/403 when the caller lacks the
+    ContainerManager role (TROUBLESHOOTING 2.3a); the fix is a role grant. Sending an operator to
+    re-check credentials that are working is the same misdirection FLIP#1093 is about.
+    """
+    filtered = MagicMock(status_code=200, json=MagicMock(return_value=[]))
+    forbidden = MagicMock(status_code=403, text="<html>forbidden</html>")
+    mock_get.side_effect = [filtered, forbidden]
+
+    with pytest.raises(Exception, match="No commands found for container") as excinfo:
+        get_command_info("ghcr.io/londonaicentre/xnat-dcm2niix:v1.0.20260724", headers)
+
+    message = str(excinfo.value)
+    assert "HTTP 403" in message
+    assert "ContainerManager" in message
+    assert "2.3a" in message
+    assert "may not be installed" not in message
+    # The 401 remedy must not be what a 403 is told to do.
+    assert "credentials are wrong" not in message
+
+
+@patch("imaging_api.services.projects.requests.get")
+def test_get_command_info_listing_failure_never_carries_the_html_body(mock_get, headers):
+    """XNAT's 401 page is ~683 characters of Tomcat boilerplate.
+
+    It must not travel to the hub inside the raised message, where it would consume most of the
+    1000-character budget; the body belongs in the trust-side log.
+    """
+    filtered = MagicMock(status_code=200, json=MagicMock(return_value=[]))
+    unauthorised = MagicMock(status_code=401, text="<html><body>" + "x" * 2000 + "</body></html>")
+    mock_get.side_effect = [filtered, unauthorised]
+
+    with pytest.raises(Exception, match="No commands found for container") as excinfo:
+        get_command_info("ghcr.io/londonaicentre/xnat-dcm2niix:v1.0.20260724", headers)
+
+    message = str(excinfo.value)
+    assert "xxxx" not in message
+    assert "<html>" not in message
+    assert len(message) < 1000
+
+
+@patch("imaging_api.services.projects.requests.get")
+def test_get_command_info_exact_match_is_listed_even_beyond_the_budget(mock_get, headers):
+    """The claim and its evidence must not disagree.
+
+    This branch asserts the exact image *is* registered. Ordered by name, a matching entry sorting
+    late would be trimmed away by the budget, leaving a message that asserts a registration and
+    shows a listing without it - the claim-without-support shape this helper exists to remove.
+    """
+    target = "ghcr.io/londonaicentre/xnat-dcm2niix:v1.0.20260724"
+    filtered = MagicMock(status_code=200, json=MagicMock(return_value=[]))
+    many = [{"id": i, "name": f"tool-{i:02d}", "image": f"ghcr.io/example/tool-{i:02d}:v1"} for i in range(40)]
+    # Sorts last by name, so a naive name-ordered trim would drop it.
+    many.append({"id": 99, "name": "zzz-dcm2niix", "image": target})
+    unfiltered = MagicMock(status_code=200, json=MagicMock(return_value=many))
+    mock_get.side_effect = [filtered, unfiltered]
+
+    with pytest.raises(Exception, match="No commands found for container") as excinfo:
+        get_command_info(target, headers)
+
+    message = str(excinfo.value)
+    assert "that exact image is registered" in message
+    assert f"'zzz-dcm2niix' -> '{target}'" in message, "the entry the message claims is registered must be shown"
+    assert len(message) < 1000
+
+
+@patch("imaging_api.services.projects.requests.get")
+@pytest.mark.parametrize(
+    "command",
+    [
+        {"id": 1, "name": "dcm2niix"},
+        {"id": 1, "name": "dcm2niix", "xnat": []},
+        {"id": 1, "name": "dcm2niix", "xnat": [{}]},
+    ],
+    ids=["no-xnat-key", "empty-wrapper-list", "wrapper-without-name"],
+)
+def test_get_command_info_wrapperless_command_is_a_legible_error(mock_get, headers, command):
+    """The mismatch message teaches "a command with no 'xnat' wrapper" as a hypothesis to check.
+
+    Unguarded, that exact state raises a bare KeyError('xnat') - or IndexError on an empty wrapper
+    list - and reaches the hub as a task error with nothing in it, which is the opaque failure class
+    this change is narrowing. 2.3a's verification step checks for the wrapper, so it is a real state.
+    """
+    mock_get.return_value = MagicMock(status_code=200, json=MagicMock(return_value=[command]))
+
+    with pytest.raises(Exception, match="no 'xnat' wrapper") as excinfo:
+        get_command_info("ghcr.io/londonaicentre/xnat-dcm2niix:v1.0.20260724", headers)
+
+    assert not isinstance(excinfo.value, KeyError | IndexError), "must not surface as a bare lookup error"
+    message = str(excinfo.value)
+    assert "no 'xnat' wrapper" in message
+    assert "dcm2niix" in message
+    assert "configure-dcm2niix.sh" in message
+
+
+@patch("imaging_api.services.projects.requests.get")
+def test_get_command_info_fetch_failure_bounds_the_error_body(mock_get, headers):
+    """Wrong credentials fail on the filtered lookup, before the diagnostic helper is reached.
+
+    XNAT answers with a whole Tomcat error page; interpolating it whole leaves the hub-side error
+    almost entirely login-page markup, and subject to the same truncation the message below
+    respects. Bound it here and keep the full body in the log.
+    """
+    mock_get.return_value = MagicMock(status_code=401, text="<html>" + "y" * 5000 + "</html>")
+
+    with pytest.raises(Exception, match="XNAT command fetch failed") as excinfo:
+        get_command_info("ghcr.io/londonaicentre/xnat-dcm2niix:v1.0.20260724", headers)
+
+    message = str(excinfo.value)
+    assert "401" in message
+    assert len(message) < 1000
+    assert "more characters, full body in the imaging-api log" in message
 
 
 # ===========================================================================

--- a/trust/imaging-api/tests/services/test_projects.py
+++ b/trust/imaging-api/tests/services/test_projects.py
@@ -300,6 +300,47 @@ def test_get_command_info_fetch_failure(mock_get, headers):
         get_command_info("ghcr.io/londonaicentre/xnat-dcm2niix:v1.0.20260724", headers)
 
 
+@patch("imaging_api.services.projects.requests.get")
+def test_get_command_info_mismatch_names_registered_image(mock_get, headers):
+    """A stale registration must name both images, not blame the plugin (FLIP#1093)."""
+    filtered = MagicMock(status_code=200, json=MagicMock(return_value=[]))
+    unfiltered = MagicMock(
+        status_code=200,
+        json=MagicMock(return_value=[{"id": 6, "name": "dcm2niix", "image": "xnat/dcm2niix:latest"}]),
+    )
+    mock_get.side_effect = [filtered, unfiltered]
+
+    with pytest.raises(Exception, match="No commands found for container") as excinfo:
+        get_command_info("ghcr.io/londonaicentre/xnat-dcm2niix:v1.0.20260724", headers)
+
+    message = str(excinfo.value)
+    assert "ghcr.io/londonaicentre/xnat-dcm2niix:v1.0.20260724" in message
+    assert "xnat/dcm2niix:latest" in message
+    assert "configure-dcm2niix.sh" in message
+    # The misleading hypothesis must not appear when commands plainly exist.
+    assert "may not be installed" not in message
+
+
+@patch("imaging_api.services.projects.requests.get")
+def test_get_command_info_no_commands_at_all_keeps_plugin_hypothesis(mock_get, headers):
+    """With nothing registered, the Container Service hypothesis is the accurate one."""
+    empty = MagicMock(status_code=200, json=MagicMock(return_value=[]))
+    mock_get.side_effect = [empty, empty]
+
+    with pytest.raises(Exception, match="may not be installed or configured"):
+        get_command_info("ghcr.io/londonaicentre/xnat-dcm2niix:v1.0.20260724", headers)
+
+
+@patch("imaging_api.services.projects.requests.get")
+def test_get_command_info_diagnostic_failure_does_not_mask_error(mock_get, headers):
+    """If the diagnostic re-query blows up, still raise the real mismatch error."""
+    filtered = MagicMock(status_code=200, json=MagicMock(return_value=[]))
+    mock_get.side_effect = [filtered, ConnectionError("xnat unreachable")]
+
+    with pytest.raises(Exception, match="No commands found for container"):
+        get_command_info("ghcr.io/londonaicentre/xnat-dcm2niix:v1.0.20260724", headers)
+
+
 # ===========================================================================
 # create_project_event_subscription
 # ===========================================================================

--- a/trust/imaging-api/tests/services/test_projects.py
+++ b/trust/imaging-api/tests/services/test_projects.py
@@ -319,6 +319,13 @@ def test_get_command_info_lists_registered_commands_on_mismatch(mock_get, header
     assert "configure-dcm2niix.sh" in message
     # The misleading hypothesis must not appear when commands plainly exist.
     assert "may not be installed" not in message
+    # The second call must be the UNFILTERED listing. Driving these tests purely by side_effect
+    # ordering would stay green if a regression re-queried the filtered URL, which always comes
+    # back empty and would silently degrade every mismatch into the plugin hypothesis.
+    first_url, second_url = (call.args[0] for call in mock_get.call_args_list)
+    assert "image=" in first_url
+    assert second_url.endswith("/xapi/commands")
+    assert "image=" not in second_url
 
 
 @patch("imaging_api.services.projects.requests.get")
@@ -359,12 +366,121 @@ def test_get_command_info_no_commands_at_all_keeps_plugin_hypothesis(mock_get, h
 
 @patch("imaging_api.services.projects.requests.get")
 def test_get_command_info_diagnostic_failure_does_not_mask_error(mock_get, headers):
-    """If the diagnostic re-query blows up, still raise the real mismatch error."""
+    """A failed re-query must raise the real mismatch error AND not invent a cause.
+
+    Asserting only the generic prefix left this test passing even when the code claimed an empty
+    registry, so it could not hold the branch it exists for.
+    """
     filtered = MagicMock(status_code=200, json=MagicMock(return_value=[]))
     mock_get.side_effect = [filtered, ConnectionError("xnat unreachable")]
 
-    with pytest.raises(Exception, match="No commands found for container"):
+    with pytest.raises(Exception, match="No commands found for container") as excinfo:
         get_command_info("ghcr.io/londonaicentre/xnat-dcm2niix:v1.0.20260724", headers)
+
+    message = str(excinfo.value)
+    assert "could not be listed" in message
+    assert "ConnectionError" in message
+    # A failure to list is not evidence about the plugin.
+    assert "may not be installed" not in message
+    assert "registered at all" not in message
+
+
+@patch("imaging_api.services.projects.requests.get")
+def test_get_command_info_unauthorised_listing_is_not_a_missing_plugin(mock_get, headers):
+    """The live failure this distinction exists for.
+
+    XNAT answers /xapi/commands with 401 and an HTML body when the service account's credentials
+    are wrong or its session expired. Reporting that as a missing Container Service sends the
+    operator to reinstall a plugin that is installed and healthy.
+    """
+    filtered = MagicMock(status_code=200, json=MagicMock(return_value=[]))
+    unauthorised = MagicMock(status_code=401, text="<html>login</html>")
+    mock_get.side_effect = [filtered, unauthorised]
+
+    with pytest.raises(Exception, match="No commands found for container") as excinfo:
+        get_command_info("ghcr.io/londonaicentre/xnat-dcm2niix:v1.0.20260724", headers)
+
+    message = str(excinfo.value)
+    assert "HTTP 401" in message
+    assert "may not be installed" not in message
+
+
+@patch("imaging_api.services.projects.requests.get")
+@pytest.mark.parametrize(
+    "body",
+    [
+        {"detail": "not an array"},
+        ["a bare string", 42],
+    ],
+    ids=["object-body", "list-of-non-objects"],
+)
+def test_get_command_info_malformed_listing_body_still_reports_the_mismatch(mock_get, headers, body):
+    """A 200 that is not an array of objects must not raise out of the diagnostic helper.
+
+    `sorted()` over a dict yields its string keys, so formatting would hit
+    `AttributeError: 'str' object has no attribute 'get'` and replace the mismatch message with a
+    crash on its way to the hub. Live XNAT does not emit this shape (faults come back as non-200),
+    so it guards against an intermediary that rewrites the body.
+    """
+    filtered = MagicMock(status_code=200, json=MagicMock(return_value=[]))
+    malformed = MagicMock(status_code=200, json=MagicMock(return_value=body))
+    mock_get.side_effect = [filtered, malformed]
+
+    with pytest.raises(Exception, match="No commands found for container") as excinfo:
+        get_command_info("ghcr.io/londonaicentre/xnat-dcm2niix:v1.0.20260724", headers)
+
+    message = str(excinfo.value)
+    assert "unexpected response body" in message
+    assert "may not be installed" not in message
+
+
+@patch("imaging_api.services.projects.requests.get")
+def test_get_command_info_exact_image_match_drops_the_stale_pin_advice(mock_get, headers):
+    """Re-registering cannot help when the requested image is already registered.
+
+    The filtered lookup returning nothing while the unfiltered listing shows the same image means
+    the lookup is at fault, not the registration.
+    """
+    container = "ghcr.io/londonaicentre/xnat-dcm2niix:v1.0.20260724"
+    filtered = MagicMock(status_code=200, json=MagicMock(return_value=[]))
+    unfiltered = MagicMock(
+        status_code=200,
+        json=MagicMock(return_value=[{"id": 6, "name": "dcm2niix", "image": container}]),
+    )
+    mock_get.side_effect = [filtered, unfiltered]
+
+    with pytest.raises(Exception, match="No commands found for container") as excinfo:
+        get_command_info(container, headers)
+
+    message = str(excinfo.value)
+    assert "that exact image is registered" in message
+    assert "configure-dcm2niix.sh" not in message
+    assert "predates the current pin" not in message
+
+
+@patch("imaging_api.services.projects.requests.get")
+def test_get_command_info_caps_the_listed_commands(mock_get, headers):
+    """The raised string reaches the hub through a 1000-character truncation.
+
+    A large registry otherwise pushes the remediation sentence past the cut, so the hub-side error
+    ends mid-image-name with nothing actionable in it.
+    """
+    filtered = MagicMock(status_code=200, json=MagicMock(return_value=[]))
+    many = [{"id": i, "name": f"tool-{i:02d}", "image": f"ghcr.io/example/tool-{i:02d}:v1"} for i in range(40)]
+    unfiltered = MagicMock(status_code=200, json=MagicMock(return_value=many))
+    mock_get.side_effect = [filtered, unfiltered]
+
+    with pytest.raises(Exception, match="No commands found for container") as excinfo:
+        get_command_info("ghcr.io/londonaicentre/xnat-dcm2niix:v1.0.20260724", headers)
+
+    message = str(excinfo.value)
+    assert "and 30 more" in message
+    assert "'tool-09' -> 'ghcr.io/example/tool-09:v1'" in message
+    assert "tool-10" not in message
+    # The count still reports the whole registry, and the remediation survives the truncation.
+    assert "40 command(s) registered" in message
+    assert "configure-dcm2niix.sh" in message
+    assert len(message) < 1000
 
 
 # ===========================================================================

--- a/trust/imaging-api/tests/services/test_projects.py
+++ b/trust/imaging-api/tests/services/test_projects.py
@@ -301,8 +301,8 @@ def test_get_command_info_fetch_failure(mock_get, headers):
 
 
 @patch("imaging_api.services.projects.requests.get")
-def test_get_command_info_mismatch_names_registered_image(mock_get, headers):
-    """A stale registration must name both images, not blame the plugin (FLIP#1093)."""
+def test_get_command_info_lists_registered_commands_on_mismatch(mock_get, headers):
+    """The real FLIP#980 case: same tool, different repo AND tag (FLIP#1093)."""
     filtered = MagicMock(status_code=200, json=MagicMock(return_value=[]))
     unfiltered = MagicMock(
         status_code=200,
@@ -315,10 +315,36 @@ def test_get_command_info_mismatch_names_registered_image(mock_get, headers):
 
     message = str(excinfo.value)
     assert "ghcr.io/londonaicentre/xnat-dcm2niix:v1.0.20260724" in message
-    assert "xnat/dcm2niix:latest" in message
+    assert "'dcm2niix' -> 'xnat/dcm2niix:latest'" in message
     assert "configure-dcm2niix.sh" in message
     # The misleading hypothesis must not appear when commands plainly exist.
     assert "may not be installed" not in message
+
+
+@patch("imaging_api.services.projects.requests.get")
+def test_get_command_info_lists_unrelated_commands_without_claiming_a_mismatch(mock_get, headers):
+    """Unrelated containers must be shown as-is, not implied to be stale versions."""
+    filtered = MagicMock(status_code=200, json=MagicMock(return_value=[]))
+    unfiltered = MagicMock(
+        status_code=200,
+        json=MagicMock(
+            return_value=[
+                {"id": 2, "name": "some-other-tool", "image": "ghcr.io/someone/other-tool:v3"},
+                {"id": 3, "name": "another", "image": "docker.io/library/busybox:1.36"},
+            ]
+        ),
+    )
+    mock_get.side_effect = [filtered, unfiltered]
+
+    with pytest.raises(Exception, match="No commands found for container") as excinfo:
+        get_command_info("ghcr.io/londonaicentre/xnat-dcm2niix:v1.0.20260724", headers)
+
+    message = str(excinfo.value)
+    assert "2 command(s) registered" in message
+    assert "'some-other-tool' -> 'ghcr.io/someone/other-tool:v3'" in message
+    assert "'another' -> 'docker.io/library/busybox:1.36'" in message
+    # It is conditional ("If one of those..."), never an assertion about these images.
+    assert "If one of those" in message
 
 
 @patch("imaging_api.services.projects.requests.get")

--- a/trust/xnat/README.md
+++ b/trust/xnat/README.md
@@ -104,6 +104,13 @@ a stale 2021 build that silently dropped slices from valid series).
 sync — it runs as a pre-commit hook and as the `dcm2niix-pin-sync` CI job — because a half-bumped set
 is otherwise silent: the old immutable tag simply keeps being pulled.
 
+That check compares files in this repository and never calls a running XNAT, so it cannot see the
+*live* registration. An XNAT provisioned before a bump keeps its old command in the XNAT database and
+goes on converting with the superseded image while looking perfectly healthy — both staging trusts sat
+in that state. Confirm a deployment with `GET /xapi/commands` (the `name -> image` pairs it returns are
+what imaging-api reports when nothing matches) and re-register with `configure-dcm2niix.sh`, or the
+`xnat-init` job on Kubernetes, if the image named there is not the current pin.
+
 #### Operator action: the GHCR package must be public
 
 **After the first publish, and again after any delete-and-recreate of the package, set


### PR DESCRIPTION
Closes #1093.

## The problem

`get_command_info` queries `/xapi/commands?image=<container>` — filtered by image. An empty result therefore means only that no command is registered against *that exact image*, but the error asserted a single, and the least likely, cause:

```
No commands found for container '...' - Container Service plugin may not be installed
```

In practice the Container Service is installed and healthy, and the command is registered against a different image: an XNAT provisioned before FLIP#980 pinned `DCM2NIIX_IMAGE` still carries `xnat/dcm2niix:latest`, the 2021 Docker Hub build that silently drops slices from valid series.

## What changed

On the **error path only**, re-query XNAT unfiltered and report what *is* registered, as `name -> image` pairs:

```
No commands found for container 'ghcr.io/londonaicentre/xnat-dcm2niix:v1.0.20260724'.
The Container Service is installed and has 1 command(s) registered:
'dcm2niix' -> 'xnat/dcm2niix:latest'. If one of those is the same tool on an older
image, this XNAT's registration predates the current pin - re-run
configure-dcm2niix.sh (compose) or the xnat-init job (k8s) to re-register it, and
check the trust's imaging-api image is current.
```

Three response shapes are reported distinctly, because collapsing them is how the original message misdiagnosed:

| Response | What it supports | What the message says |
| --- | --- | --- |
| 200, commands registered | A mismatch, or a lookup fault | Lists the pairs; if the exact image *is* present, says so and points at the lookup instead |
| 200, empty array | Never registered — and the service **is** installed | Names that fact, then the re-register step and the `ContainerManager` role (2.3a) |
| non-200 / transport error | Nothing about the plugin | Says the listing could not be obtained; 401 → credentials, 403 → role grant |

### Why it reports rather than diagnoses

Two earlier drafts of this fix tried to infer the cause, and review found both wrong:

1. **Listing every registered image as the culprit.** On an XNAT carrying unrelated containers, that reads as though those are stale dcm2niix registrations.
2. **Partitioning by image repository** and calling a same-repo/different-tag entry a version mismatch. This fails on the exact case the fix exists for: FLIP#980 moved `xnat/dcm2niix:latest` → `ghcr.io/londonaicentre/xnat-dcm2niix:<pin>`, changing the **repository as well as the tag**, so the real stale registration on both stag trusts would have been classified "unrelated" and reported as nothing useful.

Both failures came from inferring a cause the API response cannot support. The shipped version states the fact and offers the explanation conditionally ("If one of those is the same tool on an older image"), which can neither mislabel unrelated containers nor hide a same-named command on an older image.

Two constraints held throughout:
- The diagnostic call runs **only** when the first lookup already failed — no extra request in normal operation.
- It is wrapped so a failure there can never replace the real error.

## Review follow-ups (95d519a5)

- **The listing budget is in characters, not items.** A ten-item cap did not deliver its stated purpose: the fixed prose is 397 characters, and ten realistic `'dcm2niix' -> 'ghcr.io/londonaicentre/xnat-dcm2niix:<pin>'` pairs render 1075, pushing the remediation sentence past trust-api's 1000-character truncation (`trust_api/utils/http.py:69`). `_fit_listing` now appends pairs while the *rendered message* stays under budget.
- **The exact-image branch leads with the matching entry**, so it can no longer assert a registration and then print a capped listing that does not contain it.
- **The empty-registry branch leads with the fix, not the plugin.** A live XNAT answers a path with no plugin behind it with **404**, not an empty array, so a readable empty registry is evidence the Container Service *is* installed. It now names the re-register step and the `ContainerManager` role (2.3a), keeping the plugin possibility as a trailing note.
- **401 and 403 are split** — 403 on `/xapi/commands` means the caller lacks `ContainerManager`, so a credential check is the wrong advice — and **both failure branches now log** status and body trust-side, where nothing truncates. Previously only the success path logged.
- **A command with no `xnat` wrapper raises a legible error** instead of a bare `KeyError('xnat')` / `IndexError`. That state is the very hypothesis the mismatch message tells an operator to check.
- **The filtered lookup bounds XNAT's error body.** Wrong credentials fail there, *before* the diagnostic helper is reached, and XNAT answers with a 683-character Tomcat page whose whole signal is its `<title>`. It was interpolated whole into the hub-side error; it is now bounded in the message and logged in full.
- **An explicit timeout on the diagnostic re-query**, which runs only once the real error is already in hand. Scoped to that one call; the other five `requests.get` in the file are untouched.

## Verification

- `uv run ruff check`, `uv run ruff format --check` and `uv run mypy imaging_api/` — clean.
- `uv run pytest tests/` — **330 passed**.
- **13 new tests** (19 cases with parametrisation) covering: the real FLIP#980 case (same tool, new repo *and* tag), unrelated-commands-only (asserting it does **not** claim a mismatch), the empty registry, 401 and 403 listing failures, a malformed body, the character budget under both short and realistic image names, the hoisted exact match, all three wrapper-less shapes, and the bounded fetch-failure body.
- **Mutation-checked** (with bytecode caching disabled): reverting each of the seven behaviours above fails exactly the test that covers it and nothing else. Notably, reverting the character budget to `pairs[:10]` fails only the `realistic-long-images` case — the short fixture passes, which is how the item cap looked correct in the first place.

### Verified on live stacks

Both the failure and the fix were exercised against running XNATs, not only mocks:

- On dev trust 1, with the Container Service demonstrably healthy (it answered `/xapi/commands` and `get_command_info` succeeded for the pinned image), the `develop` code still reports `Container Service plugin may not be installed`.
- The `kind-flip-dev` k8s trust genuinely carries the stale `xnat/dcm2niix:latest` registration — its imaging-api predates the pin and has no `DCM2NIIX_IMAGE` setting at all. Asking that XNAT for the current pin reproduces the production failure exactly. `develop` blames the plugin; this branch returns the 432-character message quoted above, naming the stale registration and the remediation, well inside the truncation budget.

## Acceptance Criteria

- [x] When commands exist but none match the requested image, the error names the requested image and the command(s) actually registered, and points at the configure/init step.
- [x] When no commands are registered at all, the message leads with the registration remedy and the `ContainerManager` role, since a readable registry is evidence the Container Service is installed.
- [x] When the listing cannot be obtained, the message says so and distinguishes 401 from 403 rather than implying anything about the plugin.
- [x] The raised message survives trust-api's 1000-character truncation with its remediation intact, for realistic image names.
- [x] Unit tests cover every branch in `trust/imaging-api/tests/services/test_projects.py`.
- [x] `make -C trust/imaging-api test` passes.
