### PR TITLE
fix(xnat): provision XNAT bind mounts as the container uid, not 1000

### DIFF
--- a/.github/workflows/test_trust_xnat.yml
+++ b/.github/workflows/test_trust_xnat.yml
@@ -17,7 +17,12 @@ name: Trust - XNAT CI
 # file they assert on has to trigger this workflow — otherwise a change to a
 # guard (or to the credential minter) lands with the test that pins it unrun.
 # The dcm2niix-pin-sync job below likewise reads four files scattered across the
-# repo, so each of those triggers the workflow too.
+# repo, so each of those triggers the workflow too. The same rule covers the
+# bind-mount ownership drift tests (test_data_dir_ownership.py): they assert that
+# the XNAT Dockerfile's uid and both Ansible playbooks' ownership tasks still
+# agree with trust/xnat/Makefile, so all three of those files trigger this
+# workflow — otherwise a change to the uid in the image, or to the ownership task
+# in either playbook, lands with the drift test that exists to catch it unrun.
 on:
   push:
     branches: [main, develop]
@@ -40,6 +45,9 @@ on:
       - "trust/xnat/dcm2niix/**"
       - "trust/xnat/xnat/config/dcm2niix_command.json"
       - "deploy/providers/kubernetes/templates/xnat-init-job.yaml"
+      - "trust/xnat/xnat/Dockerfile"
+      - "deploy/providers/AWS/site.yml"
+      - "deploy/providers/local/site_local_trust.yml"
       - ".github/workflows/test_trust_xnat.yml"
   pull_request:
     branches: [main, develop]
@@ -62,6 +70,9 @@ on:
       - "trust/xnat/dcm2niix/**"
       - "trust/xnat/xnat/config/dcm2niix_command.json"
       - "deploy/providers/kubernetes/templates/xnat-init-job.yaml"
+      - "trust/xnat/xnat/Dockerfile"
+      - "deploy/providers/AWS/site.yml"
+      - "deploy/providers/local/site_local_trust.yml"
       - ".github/workflows/test_trust_xnat.yml"
 
 permissions:

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -329,13 +329,25 @@ storage archive (which `tar` writes as root). `make -C trust/xnat xnat-reset` is
 onto the same invariant and provisions the XNAT directories as UID 1001 too, verifying it
 afterwards and failing with the exact `chown` to run rather than leaving a host half-provisioned
 (FLIP#1095 — it previously used a hardcoded 1000 on its remote branch and the invoking user's UID
-on the others). If you provision a trust host outside all three, you must replicate this ownership
-or first-boot writes (archive ingest, SQLite index, log rotation) will fail with EACCES. That
+on the others). What the three paths share is the **UID, not the directory**: the playbooks
+provision `/opt/flip/xnat/**`, while `xnat-reset` and the compose stacks both read `XNAT_DATA_DIR`,
+which in stag/prod defaults to the per-slot `/opt/flip/xnat-trust<N>` so two trusts on one host stay
+isolated. `xnat-reset` is therefore the path that provisions the tree XNAT actually writes to, and
+an ownership change made against the playbooks' `/opt/flip/xnat` would not reach it. If you
+provision a trust host outside all three, you must replicate this ownership or first-boot writes
+(archive ingest, SQLite index, log rotation) will fail with EACCES. That
 failure is worth recognising because it does not look like a permissions problem: XNAT accepts the
 inbound DICOM association, fails the write and aborts it, so the PACS reports a *network* fault
 (`Peer aborted Association`), while the same EACCES stops XNAT writing the application logs that
 would name the cause. In dev, `trust/orthanc/update_orthanc_data.sh` instead `chmod`s the mock
 storage world-writable so a developer needs no `sudo` to re-seed it.
+
+XNAT's dev tree deliberately does **not** follow that convention. `xnat-reset` creates
+`trust/xnat/xnat-data-<KIT>/` under `sudo` and chowns it to UID 1001, so on a host whose developer
+is not themselves UID 1001 that tree is readable but not writable: deleting it, or running
+`git clean -fdx` over the checkout, needs `sudo`. Ownership is the whole of the fix here — it is
+what makes XNAT able to ingest at all — and the modes are left at their defaults rather than
+widened to buy back the convenience.
 
 ### Linux Capability Restrictions
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -325,9 +325,16 @@ longer run as root, the host-side bind-mount source directories must be owned by
 UID. The Ansible playbooks `deploy/providers/AWS/site.yml` and
 `deploy/providers/local/site_local_trust.yml` provision `/opt/flip/xnat/**` as UID 1001 and
 `/opt/flip/orthanc/**` as UID 999 — including a recursive `chown` after extracting the Orthanc
-storage archive (which `tar` writes as root). If you provision a trust host outside Ansible, you
-must replicate this ownership or first-boot writes (archive ingest, SQLite index, log rotation)
-will fail with EACCES. In dev, `trust/orthanc/update_orthanc_data.sh` instead `chmod`s the mock
+storage archive (which `tar` writes as root). `make -C trust/xnat xnat-reset` is the third path
+onto the same invariant and provisions the XNAT directories as UID 1001 too, verifying it
+afterwards and failing with the exact `chown` to run rather than leaving a host half-provisioned
+(FLIP#1095 — it previously used a hardcoded 1000 on its remote branch and the invoking user's UID
+on the others). If you provision a trust host outside all three, you must replicate this ownership
+or first-boot writes (archive ingest, SQLite index, log rotation) will fail with EACCES. That
+failure is worth recognising because it does not look like a permissions problem: XNAT accepts the
+inbound DICOM association, fails the write and aborts it, so the PACS reports a *network* fault
+(`Peer aborted Association`), while the same EACCES stops XNAT writing the application logs that
+would name the cause. In dev, `trust/orthanc/update_orthanc_data.sh` instead `chmod`s the mock
 storage world-writable so a developer needs no `sudo` to re-seed it.
 
 ### Linux Capability Restrictions

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -343,7 +343,7 @@ would name the cause. In dev, `trust/orthanc/update_orthanc_data.sh` instead `ch
 storage world-writable so a developer needs no `sudo` to re-seed it.
 
 XNAT's dev tree deliberately does **not** follow that convention. `xnat-reset` creates
-`trust/xnat/xnat-data-<KIT>/` under `sudo` and chowns it to UID 1001, so on a host whose developer
+`trust/xnat/xnat-data-trust<N>/` under `sudo` and chowns it to UID 1001, so on a host whose developer
 is not themselves UID 1001 that tree is readable but not writable: deleting it, or running
 `git clean -fdx` over the checkout, needs `sudo`. Ownership is the whole of the fix here — it is
 what makes XNAT able to ingest at all — and the modes are left at their defaults rather than

--- a/trust/xnat/Makefile
+++ b/trust/xnat/Makefile
@@ -158,15 +158,25 @@ XNAT_DATA_DIRS := $(addprefix $(XNAT_DATA_DIR)/xnat-data/,tomcat_logs archive bu
 # dir that is missing entirely, since stat then prints nothing for it.
 #
 # $(1) is a command printing "<uid>:<gid>" per source, one line each — run
-# locally, or over ssh when the swarm host is remote.
+# locally, or over ssh when the swarm host is remote. $(2) is the prefix that
+# makes the printed remedy runnable where the directories actually are: empty on
+# the local branches, `ssh <ctx>` on the remote-swarm one, where the paths live
+# on the trust host and an operator pasting a bare `sudo chown` would either get
+# "no such file or directory" or chown a same-named path on their own machine.
+#
+# stat's stderr is deliberately not discarded. A stat that fails for a reason
+# other than a missing directory — an unreadable parent, or a non-GNU stat that
+# rejects `-c` — otherwise counts zero and is reported as wrong ownership, which
+# sends the reader after the wrong fault. A missing directory still counts zero
+# and still fires the guard, now with stat naming the path it could not read.
 define check_xnat_dir_owner
-	owned="$$($(1) 2>/dev/null | grep -cx '$(XNAT_DIR_OWNER)' || true)"; \
+	owned="$$($(1) | grep -cx '$(XNAT_DIR_OWNER)' || true)"; \
 	if [ "$$owned" != "$(words $(XNAT_DATA_DIRS))" ]; then \
 		echo "❌  XNAT bind-mount sources under $(XNAT_DATA_DIR) are not all owned by $(XNAT_DIR_OWNER)."; \
 		echo "    xnat-web runs as uid $(XNAT_CONTAINER_UID) and cannot write them, so DICOM"; \
 		echo "    retrieval fails with the PACS reporting 'Peer aborted Association' and XNAT"; \
 		echo "    writes no logs to explain it (FLIP#1095)."; \
-		echo "    Fix: sudo chown -R $(XNAT_DIR_OWNER) $(XNAT_DATA_DIR)"; \
+		echo "    Fix: $(if $(2),$(2) ,)sudo chown -R $(XNAT_DIR_OWNER) $(XNAT_DATA_DIR)"; \
 		exit 1; \
 	fi
 endef
@@ -390,6 +400,21 @@ xnat-plugins-download:
 # (the second xnat-web otherwise crash-loops on a locked SQLite index).
 # Data dir defaults vary by PROD — see the XNAT_DATA_DIR comment above
 # for the resolution rule and how to override per-host.
+#
+# All three branches provision under sudo, development included. An unprivileged
+# `mkdir -p` creates the tree owned by the invoking user, and the chown to 1001
+# that follows then fails with EPERM on every host whose developer is not
+# themselves uid 1001 — so the ownership the guard requires could never be
+# reached, and `make up` would abort here. sudo costs nothing extra: the wipe on
+# the line above already needs it, so dev bring-up already prompts, and sudo's
+# credential cache means the mkdir and chown ride the same authentication.
+#
+# `set -e` also makes the two `docker context` probes fatal, which is deliberate.
+# Letting them fall through to the local branch (the pre-FLIP#1095 behaviour) means
+# a mistyped or unreachable DOCKER_CONTEXT silently runs `sudo rm -rf
+# $(XNAT_DATA_DIR)` against the *operator's own machine* while they believe they
+# are resetting a remote trust host. Aborting on an unresolvable context is the
+# safer failure.
 xnat-reset:
 	$(require_kit)
 	@case "$$(pwd)" in */trust/xnat) ;; *) \
@@ -408,7 +433,7 @@ xnat-reset:
 			ssh://*) \
 				echo "  🛰️  remote swarm deploy (context '$$xnat_ctx') — resetting XNAT dirs on the trust host via ssh"; \
 				ssh "$$xnat_ctx" "sudo rm -rf $(XNAT_DATA_DIR) && sudo mkdir -p $(XNAT_DATA_DIRS) && sudo chown -R $(XNAT_DIR_OWNER) $(XNAT_DATA_DIR)"; \
-				$(call check_xnat_dir_owner,ssh "$$xnat_ctx" "stat -c '%u:%g' $(XNAT_DATA_DIRS)"); \
+				$(call check_xnat_dir_owner,ssh "$$xnat_ctx" "stat -c '%u:%g' $(XNAT_DATA_DIRS)",ssh $$xnat_ctx); \
 				;; \
 			*) \
 				echo "  💻 local docker context '$$xnat_ctx' ($$xnat_endpoint) — resetting XNAT dirs on this host"; \
@@ -421,8 +446,8 @@ xnat-reset:
 	else \
 		echo "  📍 Using dev data dir: $(XNAT_DATA_DIR)/"; \
 		sudo rm -rf $(XNAT_DATA_DIR); \
-		mkdir -p $(XNAT_DATA_DIRS); \
-		chown $(XNAT_DIR_OWNER) $(XNAT_DATA_DIRS) 2>/dev/null || true; \
+		sudo mkdir -p $(XNAT_DATA_DIRS); \
+		sudo chown -R $(XNAT_DIR_OWNER) $(XNAT_DATA_DIR); \
 		$(call check_xnat_dir_owner,stat -c '%u:%g' $(XNAT_DATA_DIRS)); \
 	fi
 

--- a/trust/xnat/Makefile
+++ b/trust/xnat/Makefile
@@ -134,10 +134,21 @@ export XNAT_DATA_DIR
 # rather than at permissions. The same failure stops XNAT writing the application
 # logs that would name the real cause, so the evidence goes with it (FLIP#1095).
 #
-# xnat-db runs as root and is unaffected; its dir is included on stag/prod only
-# so the whole tree carries one owner, matching the playbooks.
+# xnat-db is unaffected, but not merely because it runs as root: trust/xnat/postgres/
+# Dockerfile sets no USER and the compose pins none, so the container starts as root
+# and the stock postgres entrypoint re-chowns PGDATA and drops to `postgres` itself.
+# That is what makes a 1001-owned xnat-db-data harmless, and it is what would go away
+# if someone pinned a `user:` on xnat-db. Its dir is included on stag/prod only, so
+# the whole tree carries one owner.
+#
 # deploy/providers/AWS/site.yml and deploy/providers/local/site_local_trust.yml
-# provision these same paths with this same id — keep the three in step.
+# provision XNAT's bind mounts with this same id: the uid is the invariant all three
+# paths share, and the one to keep in step. The directories deliberately are not —
+# both playbooks provision /opt/flip/xnat, while stag/prod resolves XNAT_DATA_DIR to
+# the per-slot /opt/flip/xnat-trust$(TRUST_NUM) above so two trusts sharing an EC2
+# host stay isolated. Compose and xnat-reset read that same variable, so this recipe
+# provisions the tree XNAT actually writes to and the playbooks' one is not it — an
+# ownership change made there would look right and reach nothing.
 XNAT_CONTAINER_UID := 1001
 XNAT_CONTAINER_GID := 1001
 XNAT_DIR_OWNER := $(XNAT_CONTAINER_UID):$(XNAT_CONTAINER_GID)
@@ -152,8 +163,13 @@ XNAT_DATA_DIRS := $(addprefix $(XNAT_DATA_DIR)/xnat-data/,tomcat_logs archive bu
 # symptom surfaces layers away from the cause (see above) and a warning is easy
 # to lose in long bring-up output — the same reasoning, and the same shape, as
 # $(ensure_net_dirs) in trust/Makefile. Checked after the chown rather than
-# instead of it: a non-root non-owner gets EPERM from chown even when the
-# metadata already matches, and that must not abort an already-correct host.
+# instead of it as defence in depth, not because the chown itself might be
+# refused: all three branches chown under sudo, and `set -e` aborts on one that
+# fails outright before the guard is reached. What is left for the guard is a
+# chown that did not cover what it was meant to — it applies recursively to
+# $(XNAT_DATA_DIR) while the guard stats each entry of $(XNAT_DATA_DIRS), so those
+# two drifting apart, or a later edit narrowing or dropping the chown on one
+# branch, surfaces here rather than at the first DICOM write.
 # Counting matches (rather than testing the chown's exit status) also catches a
 # dir that is missing entirely, since stat then prints nothing for it.
 #

--- a/trust/xnat/Makefile
+++ b/trust/xnat/Makefile
@@ -121,6 +121,56 @@ XNAT_DATA_DIR ?= $(if $(filter true stag,$(PROD)),/opt/flip/xnat-trust$(TRUST_NU
 XNAT_DATA_DIR := $(abspath $(XNAT_DATA_DIR))
 export XNAT_DATA_DIR
 
+# uid/gid every XNAT bind-mount source must be owned by. `xnat-web` runs as the
+# in-image `xnat` user, created with a fixed id in trust/xnat/xnat/Dockerfile
+# (`useradd --system --uid 1001 --gid xnat`). That is a property of the image,
+# not of the host, so it can neither be derived from $(USER) nor assumed to be
+# the conventional 1000 that the FLIP-built Python services use.
+#
+# XNAT ingests DICOM into archive/, stages it through build/ and cache/, and
+# rotates its logs into tomcat_logs/. If any of those is not writable it accepts
+# the inbound association, fails the write, and aborts it — so the PACS reports a
+# *network* fault ("Peer aborted Association"), pointing at ports and AE titles
+# rather than at permissions. The same failure stops XNAT writing the application
+# logs that would name the real cause, so the evidence goes with it (FLIP#1095).
+#
+# xnat-db runs as root and is unaffected; its dir is included on stag/prod only
+# so the whole tree carries one owner, matching the playbooks.
+# deploy/providers/AWS/site.yml and deploy/providers/local/site_local_trust.yml
+# provision these same paths with this same id — keep the three in step.
+XNAT_CONTAINER_UID := 1001
+XNAT_CONTAINER_GID := 1001
+XNAT_DIR_OWNER := $(XNAT_CONTAINER_UID):$(XNAT_CONTAINER_GID)
+
+# The bind-mount sources xnat-reset provisions. xnat-db-data is stag/prod-only:
+# the development stack gives xnat-db no persistent bind mount.
+XNAT_DATA_DIRS := $(addprefix $(XNAT_DATA_DIR)/xnat-data/,tomcat_logs archive build cache) \
+                  $(if $(filter true stag,$(PROD)),$(XNAT_DATA_DIR)/xnat-db-data)
+
+# Verify every bind-mount source is owned by the container uid, and fail naming
+# the exact remedy when it is not. Fatal rather than a warning because the
+# symptom surfaces layers away from the cause (see above) and a warning is easy
+# to lose in long bring-up output — the same reasoning, and the same shape, as
+# $(ensure_net_dirs) in trust/Makefile. Checked after the chown rather than
+# instead of it: a non-root non-owner gets EPERM from chown even when the
+# metadata already matches, and that must not abort an already-correct host.
+# Counting matches (rather than testing the chown's exit status) also catches a
+# dir that is missing entirely, since stat then prints nothing for it.
+#
+# $(1) is a command printing "<uid>:<gid>" per source, one line each — run
+# locally, or over ssh when the swarm host is remote.
+define check_xnat_dir_owner
+	owned="$$($(1) 2>/dev/null | grep -cx '$(XNAT_DIR_OWNER)' || true)"; \
+	if [ "$$owned" != "$(words $(XNAT_DATA_DIRS))" ]; then \
+		echo "❌  XNAT bind-mount sources under $(XNAT_DATA_DIR) are not all owned by $(XNAT_DIR_OWNER)."; \
+		echo "    xnat-web runs as uid $(XNAT_CONTAINER_UID) and cannot write them, so DICOM"; \
+		echo "    retrieval fails with the PACS reporting 'Peer aborted Association' and XNAT"; \
+		echo "    writes no logs to explain it (FLIP#1095)."; \
+		echo "    Fix: sudo chown -R $(XNAT_DIR_OWNER) $(XNAT_DATA_DIR)"; \
+		exit 1; \
+	fi
+endef
+
 # Path to the dev XNAT folder on the Docker host (bind mounts resolve there, not locally).
 export XNAT_PATH=$(realpath .)
 
@@ -348,7 +398,8 @@ xnat-reset:
 	@if ! echo "$(XNAT_PORT_EFFECTIVE)" | grep -qE '^[0-9]+$$'; then \
 		echo "ERROR: XNAT_PORT must be numeric for KIT=$(KIT), got '$(XNAT_PORT_EFFECTIVE)'"; exit 1; \
 	fi
-	@echo "Deleting previous XNAT data and creating new directories for $(KIT) ..."; \
+	@set -e; \
+	echo "Deleting previous XNAT data and creating new directories for $(KIT) ..."; \
 	if [ "$(PROD)" = "true" ] || [ "$(PROD)" = "stag" ]; then \
 		echo "  📍 Using prod data dir: $(XNAT_DATA_DIR)/"; \
 		xnat_ctx="$$(docker context show)"; \
@@ -356,26 +407,23 @@ xnat-reset:
 		case "$$xnat_endpoint" in \
 			ssh://*) \
 				echo "  🛰️  remote swarm deploy (context '$$xnat_ctx') — resetting XNAT dirs on the trust host via ssh"; \
-				ssh "$$xnat_ctx" "sudo rm -rf $(XNAT_DATA_DIR) && sudo mkdir -p $(XNAT_DATA_DIR)/xnat-data/tomcat_logs $(XNAT_DATA_DIR)/xnat-data/archive $(XNAT_DATA_DIR)/xnat-data/build $(XNAT_DATA_DIR)/xnat-data/cache $(XNAT_DATA_DIR)/xnat-db-data && sudo chown -R 1000:1000 $(XNAT_DATA_DIR)"; \
+				ssh "$$xnat_ctx" "sudo rm -rf $(XNAT_DATA_DIR) && sudo mkdir -p $(XNAT_DATA_DIRS) && sudo chown -R $(XNAT_DIR_OWNER) $(XNAT_DATA_DIR)"; \
+				$(call check_xnat_dir_owner,ssh "$$xnat_ctx" "stat -c '%u:%g' $(XNAT_DATA_DIRS)"); \
 				;; \
 			*) \
 				echo "  💻 local docker context '$$xnat_ctx' ($$xnat_endpoint) — resetting XNAT dirs on this host"; \
 				sudo rm -rf $(XNAT_DATA_DIR); \
-				sudo mkdir -p $(XNAT_DATA_DIR)/xnat-data/tomcat_logs; \
-				sudo mkdir -p $(XNAT_DATA_DIR)/xnat-data/archive; \
-				sudo mkdir -p $(XNAT_DATA_DIR)/xnat-data/build; \
-				sudo mkdir -p $(XNAT_DATA_DIR)/xnat-data/cache; \
-				sudo mkdir -p $(XNAT_DATA_DIR)/xnat-db-data; \
-				sudo chown -R $(USER):$$(id -gn) $(XNAT_DATA_DIR); \
+				sudo mkdir -p $(XNAT_DATA_DIRS); \
+				sudo chown -R $(XNAT_DIR_OWNER) $(XNAT_DATA_DIR); \
+				$(call check_xnat_dir_owner,stat -c '%u:%g' $(XNAT_DATA_DIRS)); \
 				;; \
 		esac; \
 	else \
 		echo "  📍 Using dev data dir: $(XNAT_DATA_DIR)/"; \
 		sudo rm -rf $(XNAT_DATA_DIR); \
-		mkdir -p $(XNAT_DATA_DIR)/xnat-data/tomcat_logs; \
-		mkdir -p $(XNAT_DATA_DIR)/xnat-data/archive; \
-		mkdir -p $(XNAT_DATA_DIR)/xnat-data/build; \
-		mkdir -p $(XNAT_DATA_DIR)/xnat-data/cache; \
+		mkdir -p $(XNAT_DATA_DIRS); \
+		chown $(XNAT_DIR_OWNER) $(XNAT_DATA_DIRS) 2>/dev/null || true; \
+		$(call check_xnat_dir_owner,stat -c '%u:%g' $(XNAT_DATA_DIRS)); \
 	fi
 
 # Configure an XNAT instance with initial settings and run dcm2niix setup.

--- a/trust/xnat/docker-compose-stack.production.yml
+++ b/trust/xnat/docker-compose-stack.production.yml
@@ -1,9 +1,10 @@
 # Production overlay for docker-compose-stack.yml
 # Mounts persistent data volumes on the host for XNAT data survival across restarts.
 # In development, XNAT stores data inside the container (ephemeral).
-# Host path comes from XNAT_DATA_DIR (set by trust/xnat/Makefile; defaults to
-# /opt/flip/xnat in stag/prod). Keep this in lockstep with the xnat-reset
-# recipe so the dirs Make creates and the dirs compose mounts match.
+# Host path comes from XNAT_DATA_DIR (set by trust/xnat/Makefile; defaults to the
+# per-slot /opt/flip/xnat-trust<N> in stag/prod — not the /opt/flip/xnat the Ansible
+# playbooks provision). Keep this in lockstep with the xnat-reset recipe so the dirs
+# Make creates and the dirs compose mounts match.
 services:
   xnat-web:
     environment:

--- a/trust/xnat/docker-compose-stack.production.yml
+++ b/trust/xnat/docker-compose-stack.production.yml
@@ -1,6 +1,8 @@
 # Production overlay for docker-compose-stack.yml
 # Mounts persistent data volumes on the host for XNAT data survival across restarts.
-# In development, XNAT stores data inside the container (ephemeral).
+# Development bind-mounts the same xnat-web dirs (see the development overlay); what it
+# does not persist is the database — xnat-db gets no PGDATA mount there, only the
+# init scripts, so a dev XNAT's Postgres is ephemeral while its archive is not.
 # Host path comes from XNAT_DATA_DIR (set by trust/xnat/Makefile; defaults to the
 # per-slot /opt/flip/xnat-trust<N> in stag/prod — not the /opt/flip/xnat the Ansible
 # playbooks provision). Keep this in lockstep with the xnat-reset recipe so the dirs

--- a/trust/xnat/tests/test_data_dir_ownership.py
+++ b/trust/xnat/tests/test_data_dir_ownership.py
@@ -31,6 +31,17 @@ extracting the shell the recipe will actually execute (via ``make -n``) and runn
 it against real directories. It needs neither root nor Docker: rather than
 chown-ing to a foreign id, it overrides ``XNAT_CONTAINER_UID``/``GID`` on the make
 command line, which is what the recipe compares against.
+
+That override is also its blind spot, and ``TestDevBranchProvisionsTheContainerUid``
+exists because of it. Expecting the invoker's own id, and running only the extracted
+``owned=`` line, together remove the one condition that matters — provisioning for a
+uid the caller is not. Those tests therefore pass whether or not the recipe can
+actually reach the ownership it demands. The second class runs the whole generated
+development branch (wipe, mkdir, chown, check) with a ``sudo`` shim that drops the
+privilege, so an unreachable owner fails there as it would on a developer's machine.
+Note that this host and the GitHub runner are both uid 1001, the same id the XNAT
+image uses, so any test written against that literal is vacuous in both places it
+runs; the uid is always derived from ``os.getuid()``.
 """
 
 from __future__ import annotations
@@ -94,7 +105,15 @@ class TestUidIsConsistent:
     def test_playbooks_provision_the_same_uid(self, playbook: Path) -> None:
         uid = _make_var("XNAT_CONTAINER_UID")
         text = playbook.read_text()
-        task = re.search(r"name:.*XNAT bind-mount directories.*?(?=\n    - name:)", text, re.DOTALL)
+        # Anchored on the task's own indent and ended by the next sibling at that indent (or EOF),
+        # so reindenting the play, reordering it, or making this the last task in the file does not
+        # turn a real drift check into "no XNAT bind-mount directory task" — a failure that accuses
+        # the playbook when the fault is in this regex.
+        task = re.search(
+            r"^(?P<indent>[ \t]*)- name:.*XNAT bind-mount directories.*?(?=^(?P=indent)- |\Z)",
+            text,
+            re.DOTALL | re.MULTILINE,
+        )
         assert task, f"no XNAT bind-mount directory task in {playbook}"
         assert re.search(rf'owner:\s*"{uid}"', task.group(0)), (
             f"{playbook.name} provisions the XNAT bind mounts as a different uid than "
@@ -182,3 +201,88 @@ class TestOwnershipGuardFires:
         (data / "xnat-data" / "cache").rmdir()
         guard = self._guard(data, os.getuid(), os.getgid())
         assert subprocess.run(["sh", "-c", guard], capture_output=True, timeout=TIMEOUT_SECONDS).returncode == 1
+
+
+class TestDevBranchProvisionsTheContainerUid:
+    """Execute the development branch end to end: mkdir, chown and check together.
+
+    ``TestOwnershipGuardFires`` runs only the extracted ``owned=`` line and overrides the expected
+    uid to the invoker's, so between them those two choices remove exactly the condition this issue
+    is about — provisioning directories for a uid that is *not* the caller's. That is why the suite
+    stayed green while the development branch could not reach the ownership it demands.
+
+    These run the whole generated sequence instead. Neither needs root: a ``sudo`` shim on PATH
+    ``exec``s its arguments unprivileged, which is precisely the constraint a normal developer runs
+    under, so a chown to a foreign id fails here exactly as it would on their machine.
+
+    The uid is derived as ``os.getuid() + 1`` rather than written as a literal. This host and the
+    GitHub runner both happen to be uid 1001 — the same id the XNAT image uses — so a literal would
+    make these vacuous in exactly the two places they run.
+    """
+
+    @staticmethod
+    def _sudo_shim(root: Path) -> Path:
+        """A PATH entry whose `sudo` runs the command unprivileged, modelling a non-root developer."""
+        bin_dir = root / "shim"
+        bin_dir.mkdir()
+        shim = bin_dir / "sudo"
+        shim.write_text('#!/bin/sh\nexec "$@"\n')
+        shim.chmod(0o755)
+        return bin_dir
+
+    @staticmethod
+    def _dev_recipe(data_dir: Path, expected_uid: int, expected_gid: int) -> str:
+        """The full shell the development branch of xnat-reset runs (PROD unset)."""
+        result = subprocess.run(
+            [
+                "make", "-n", "--no-print-directory", "xnat-reset",
+                "KIT=GSTT",
+                f"XNAT_DATA_DIR={data_dir}",
+                f"XNAT_CONTAINER_UID={expected_uid}",
+                f"XNAT_CONTAINER_GID={expected_gid}",
+            ],
+            cwd=XNAT_DIR,
+            capture_output=True,
+            text=True,
+            timeout=TIMEOUT_SECONDS,
+        )
+        assert result.returncode == 0, f"make -n xnat-reset failed:\n{result.stderr}"
+        lines = result.stdout.splitlines()
+        start = next((i for i, ln in enumerate(lines) if ln.strip().startswith("set -e;")), None)
+        assert start is not None, "xnat-reset emitted no `set -e` provisioning block"
+        return "\n".join(lines[start:])
+
+    def _run(self, tmp_path: Path, uid: int, gid: int) -> subprocess.CompletedProcess[str]:
+        env = dict(os.environ, PATH=f"{self._sudo_shim(tmp_path)}:{os.environ['PATH']}")
+        recipe = self._dev_recipe(tmp_path / "data", uid, gid)
+        return subprocess.run(
+            ["sh", "-c", recipe], capture_output=True, text=True, timeout=TIMEOUT_SECONDS, env=env
+        )
+
+    def test_provisions_a_tree_the_container_uid_owns(self, tmp_path: Path) -> None:
+        """The achievable case: the sequence creates the tree and its own guard then passes."""
+        result = self._run(tmp_path, os.getuid(), os.getgid())
+        assert result.returncode == 0, f"development branch failed on an achievable uid:\n{result.stdout}{result.stderr}"
+        for name in ("tomcat_logs", "archive", "build", "cache"):
+            created = tmp_path / "data" / "xnat-data" / name
+            assert created.is_dir(), f"{name} was not provisioned"
+            assert created.stat().st_uid == os.getuid()
+
+    def test_an_unreachable_owner_stops_at_the_chown_not_the_guard(self, tmp_path: Path) -> None:
+        """A chown the caller cannot perform must fail *as itself*, not as wrong ownership.
+
+        Both the suppressed and the fatal form exit non-zero, so the exit status alone proves
+        nothing — this asserts on *which* step reported. With ``chown ... 2>/dev/null || true`` the
+        EPERM was discarded and the recipe walked on to a guard that could never pass, so the
+        operator was told the directories had the wrong owner with no hint that the chown meant to
+        fix it had silently failed. Failing at the chown names the cause instead.
+        """
+        result = self._run(tmp_path, os.getuid() + 1, os.getgid() + 1)
+        assert result.returncode != 0, "a chown the developer cannot perform was swallowed"
+        assert "Operation not permitted" in result.stderr, (
+            "the chown's EPERM is being discarded; the recipe reports a symptom, not the cause"
+        )
+        assert "❌" not in result.stdout, (
+            "the recipe continued past a failed chown to the ownership guard, which reports the "
+            "wrong owner rather than the chown that could not set it"
+        )

--- a/trust/xnat/tests/test_data_dir_ownership.py
+++ b/trust/xnat/tests/test_data_dir_ownership.py
@@ -1,0 +1,184 @@
+# Copyright (c) 2026 Guy's and St Thomas' NHS Foundation Trust & King's College London
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""
+Tests for XNAT bind-mount ownership (FLIP#1095).
+
+``xnat-web`` runs as the in-image ``xnat`` user, whose id is fixed in
+``trust/xnat/xnat/Dockerfile``. Every host directory bind-mounted into it must be
+owned by that id. When one is not, XNAT accepts the inbound DICOM association,
+fails to write the object, and aborts — so the PACS reports a *network* fault
+("Peer aborted Association") and the same permission failure stops XNAT writing
+the application logs that would name the real cause.
+
+Three provisioning paths must therefore agree on one number: ``xnat-reset`` in
+``trust/xnat/Makefile``, and the two Ansible playbooks. They previously did not —
+``xnat-reset`` used a hardcoded 1000 on its remote branch and the invoking user's
+id on the others.
+
+The static tests pin that agreement. They cannot see whether the guard still
+*runs*, though: a branch that drops the check, or a check that can no longer fail,
+leaves every literal untouched. ``TestOwnershipGuardFires`` closes that half by
+extracting the shell the recipe will actually execute (via ``make -n``) and running
+it against real directories. It needs neither root nor Docker: rather than
+chown-ing to a foreign id, it overrides ``XNAT_CONTAINER_UID``/``GID`` on the make
+command line, which is what the recipe compares against.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+XNAT_DIR = Path(__file__).resolve().parents[1]
+REPO_ROOT = XNAT_DIR.parents[1]
+MAKEFILE = XNAT_DIR / "Makefile"
+DOCKERFILE = XNAT_DIR / "xnat" / "Dockerfile"
+AWS_PLAYBOOK = REPO_ROOT / "deploy" / "providers" / "AWS" / "site.yml"
+LOCAL_PLAYBOOK = REPO_ROOT / "deploy" / "providers" / "local" / "site_local_trust.yml"
+
+# Long enough for a `make -n` parse; short enough that a hang fails the suite
+# rather than wedging CI.
+TIMEOUT_SECONDS = 60
+
+
+def _make_var(name: str) -> str:
+    """Return the literal a `NAME := value` assignment in trust/xnat/Makefile binds."""
+    match = re.search(rf"^{re.escape(name)}\s*:?=\s*(\S+)\s*$", MAKEFILE.read_text(), re.MULTILINE)
+    assert match, f"{name} is not assigned in {MAKEFILE}"
+    return match.group(1)
+
+
+def _reset_recipe() -> str:
+    """Return the body of the `xnat-reset` recipe."""
+    text = MAKEFILE.read_text()
+    start = text.index("\nxnat-reset:")
+    # A recipe ends at the first line that is neither blank, a comment, nor indented.
+    body: list[str] = []
+    for line in text[start + 1 :].splitlines()[1:]:
+        if line and not line.startswith(("\t", " ", "#")):
+            break
+        body.append(line)
+    return "\n".join(body)
+
+
+class TestUidIsConsistent:
+    """The Makefile, the Dockerfile and both playbooks must name the same uid."""
+
+    def test_dockerfile_uid_matches_makefile(self) -> None:
+        match = re.search(r"useradd\b[^\n]*--uid\s+(\d+)[^\n]*\bxnat\b", DOCKERFILE.read_text())
+        assert match, "no `useradd --uid <N> … xnat` in the XNAT Dockerfile"
+        assert _make_var("XNAT_CONTAINER_UID") == match.group(1), (
+            "XNAT_CONTAINER_UID in trust/xnat/Makefile has drifted from the uid the "
+            "XNAT image actually creates. The Makefile provisions the bind mounts that "
+            "the image writes to, so a mismatch makes them unwritable."
+        )
+
+    def test_gid_matches_uid(self) -> None:
+        # The Dockerfile creates the group and the user with the same id.
+        assert _make_var("XNAT_CONTAINER_GID") == _make_var("XNAT_CONTAINER_UID")
+
+    @pytest.mark.parametrize("playbook", [AWS_PLAYBOOK, LOCAL_PLAYBOOK], ids=["aws", "on-prem"])
+    def test_playbooks_provision_the_same_uid(self, playbook: Path) -> None:
+        uid = _make_var("XNAT_CONTAINER_UID")
+        text = playbook.read_text()
+        task = re.search(r"name:.*XNAT bind-mount directories.*?(?=\n    - name:)", text, re.DOTALL)
+        assert task, f"no XNAT bind-mount directory task in {playbook}"
+        assert re.search(rf'owner:\s*"{uid}"', task.group(0)), (
+            f"{playbook.name} provisions the XNAT bind mounts as a different uid than "
+            f"trust/xnat/Makefile ({uid}). All three provisioning paths must agree."
+        )
+
+
+class TestResetRecipeDerivesTheOwner:
+    """`xnat-reset` must not reintroduce a hardcoded or host-derived owner."""
+
+    def test_no_hardcoded_foreign_uid(self) -> None:
+        uid = _make_var("XNAT_CONTAINER_UID")
+        stray = [n for n in re.findall(r"chown\s+(?:-R\s+)?(\d+):\d+", _reset_recipe()) if n != uid]
+        assert not stray, (
+            f"xnat-reset chowns the XNAT bind mounts to {stray}, but xnat-web runs as {uid}. "
+            "This is the FLIP#1095 regression: use $(XNAT_DIR_OWNER)."
+        )
+
+    def test_owner_is_not_derived_from_the_invoking_user(self) -> None:
+        assert "$(USER)" not in _reset_recipe(), (
+            "xnat-reset derives the bind-mount owner from the invoking host user. The uid "
+            "is a property of the XNAT image, not of whoever ran make, so this only works "
+            "on a host whose login account happens to share it."
+        )
+
+    def test_every_branch_verifies_ownership(self) -> None:
+        # remote-swarm, local-prod and development: each provisions dirs, so each must check.
+        assert _reset_recipe().count("check_xnat_dir_owner") == 3, (
+            "one of xnat-reset's three provisioning branches no longer verifies ownership. "
+            "An unchecked branch fails silently and the symptom surfaces in the PACS."
+        )
+
+
+class TestOwnershipGuardFires:
+    """Execute the generated guard: it must accept a correct tree and reject a broken one."""
+
+    @staticmethod
+    def _guard(data_dir: Path, expected_uid: int, expected_gid: int) -> str:
+        """Extract the shell the *local* branches of xnat-reset run to verify ownership."""
+        result = subprocess.run(
+            [
+                "make", "-n", "--no-print-directory", "xnat-reset",
+                "KIT=GSTT",
+                f"XNAT_DATA_DIR={data_dir}",
+                f"XNAT_CONTAINER_UID={expected_uid}",
+                f"XNAT_CONTAINER_GID={expected_gid}",
+            ],
+            cwd=XNAT_DIR,
+            capture_output=True,
+            text=True,
+            timeout=TIMEOUT_SECONDS,
+        )
+        assert result.returncode == 0, f"make -n xnat-reset failed:\n{result.stderr}"
+        # Both local branches emit the same check; the remote one wraps it in ssh.
+        local = [ln for ln in result.stdout.splitlines() if "owned=" in ln and "ssh " not in ln]
+        assert local, "xnat-reset emitted no local ownership check"
+        # Recipe lines carry make's trailing continuation; `sh` would read a lone
+        # backslash as a command and exit 127 before the guard ever ran.
+        return local[-1].rstrip().removesuffix("\\")
+
+    @staticmethod
+    def _make_tree(root: Path) -> Path:
+        data = root / "data"
+        for name in ("tomcat_logs", "archive", "build", "cache"):
+            (data / "xnat-data" / name).mkdir(parents=True)
+        return data
+
+    def test_accepts_a_correctly_owned_tree(self, tmp_path: Path) -> None:
+        data = self._make_tree(tmp_path)
+        guard = self._guard(data, os.getuid(), os.getgid())
+        assert subprocess.run(["sh", "-c", guard], timeout=TIMEOUT_SECONDS).returncode == 0
+
+    def test_rejects_a_wrongly_owned_tree(self, tmp_path: Path) -> None:
+        """The FLIP#1095 failure: dirs exist but belong to someone the container is not."""
+        data = self._make_tree(tmp_path)
+        # Expect an id the tree demonstrably is not, without needing root to chown.
+        guard = self._guard(data, os.getuid() + 1, os.getgid() + 1)
+        result = subprocess.run(["sh", "-c", guard], capture_output=True, text=True, timeout=TIMEOUT_SECONDS)
+        assert result.returncode == 1
+        assert "Fix: sudo chown -R" in result.stdout, "the guard must name the remedy, not just fail"
+
+    def test_rejects_a_missing_directory(self, tmp_path: Path) -> None:
+        """A dir absent entirely must fail too — `stat` prints nothing rather than erroring out."""
+        data = self._make_tree(tmp_path)
+        (data / "xnat-data" / "cache").rmdir()
+        guard = self._guard(data, os.getuid(), os.getgid())
+        assert subprocess.run(["sh", "-c", guard], capture_output=True, timeout=TIMEOUT_SECONDS).returncode == 1

--- a/trust/xnat/tests/test_data_dir_ownership.py
+++ b/trust/xnat/tests/test_data_dir_ownership.py
@@ -262,7 +262,9 @@ class TestDevBranchProvisionsTheContainerUid:
     def test_provisions_a_tree_the_container_uid_owns(self, tmp_path: Path) -> None:
         """The achievable case: the sequence creates the tree and its own guard then passes."""
         result = self._run(tmp_path, os.getuid(), os.getgid())
-        assert result.returncode == 0, f"development branch failed on an achievable uid:\n{result.stdout}{result.stderr}"
+        assert result.returncode == 0, (
+            f"development branch failed on an achievable uid:\n{result.stdout}{result.stderr}"
+        )
         for name in ("tomcat_logs", "archive", "build", "cache"):
             created = tmp_path / "data" / "xnat-data" / name
             assert created.is_dir(), f"{name} was not provisioned"

--- a/trust/xnat/tests/test_data_dir_ownership.py
+++ b/trust/xnat/tests/test_data_dir_ownership.py
@@ -13,11 +13,19 @@
 Tests for XNAT bind-mount ownership (FLIP#1095).
 
 ``xnat-web`` runs as the in-image ``xnat`` user, whose id is fixed in
-``trust/xnat/xnat/Dockerfile``. Every host directory bind-mounted into it must be
-owned by that id. When one is not, XNAT accepts the inbound DICOM association,
-fails to write the object, and aborts — so the PACS reports a *network* fault
-("Peer aborted Association") and the same permission failure stops XNAT writing
-the application logs that would name the real cause.
+``trust/xnat/xnat/Dockerfile``. The host directories XNAT writes at runtime —
+``archive``, ``build``, ``cache`` and ``tomcat_logs``, the ``XNAT_DATA_DIRS`` this
+suite guards — must be owned by that id. When one is not, XNAT accepts the inbound
+DICOM association, fails to write the object, and aborts — so the PACS reports a
+*network* fault ("Peer aborted Association") and the same permission failure stops
+XNAT writing the application logs that would name the real cause.
+
+The development stack also bind-mounts ``xnat/plugins`` and ``xnat/config`` from the
+checkout (``docker-compose-stack.development.yml``). Those keep the checkout's
+ownership on purpose — they hold plugin jars and config a developer edits directly —
+so they sit outside ``XNAT_DATA_DIRS`` and outside these tests. ``xnat-configure``
+absorbs the write friction that leaves, rather than the ownership being changed to
+remove it (see the ``rm -f`` before each ``tee`` in ``trust/xnat/Makefile``).
 
 Three provisioning paths must therefore agree on one number: ``xnat-reset`` in
 ``trust/xnat/Makefile``, and the two Ansible playbooks. They previously did not —
@@ -117,7 +125,10 @@ class TestUidIsConsistent:
         assert task, f"no XNAT bind-mount directory task in {playbook}"
         assert re.search(rf'owner:\s*"{uid}"', task.group(0)), (
             f"{playbook.name} provisions the XNAT bind mounts as a different uid than "
-            f"trust/xnat/Makefile ({uid}). All three provisioning paths must agree."
+            f"trust/xnat/Makefile ({uid}). All three provisioning paths must agree on the "
+            "uid. They deliberately do not share directories — both playbooks provision "
+            "/opt/flip/xnat while the Makefile resolves the per-slot XNAT_DATA_DIR — so the "
+            "uid is the whole of what this pins."
         )
 
 


### PR DESCRIPTION
## Linked Issues

Fixes #1095

## What

`make -C trust/xnat xnat-reset` created XNAT's bind-mount sources with the wrong owner:

- the **remote-swarm** branch hardcoded `sudo chown -R 1000:1000`
- the **local-prod** branch used `$(USER):$(id -gn)`
- the **development** branch did no `chown` at all, so ownership followed whoever ran `make`

`xnat-web` runs as the in-image `xnat` user, **uid 1001**, fixed in `trust/xnat/xnat/Dockerfile:49-50`. That is a property of the image, not of the host, so none of those three produce a writable tree unless the host account happens to share the id.

Both Ansible playbooks already get this right and say why:

```yaml
# XNAT containers run as the in-image `xnat` user (UID 1001) … Bind-mounted host
# paths must be writable by that UID or first-boot writes (archive ingest, build
# cache, Tomcat log rotation, prearchive moves) fail with EACCES.
owner: "1001"
```

`xnat-reset` was the one provisioning path that disagreed.

## Why it is worth fixing rather than working around

The symptom points away from the cause, and takes the evidence with it. XNAT accepts the inbound DICOM association, fails to write the object, and aborts — so the PACS reports a **network** fault:

```
DicomAssociation - C-STORE to AET "XNAT": Peer aborted Association (or never connected)
```

That sends you to ports, AE titles and firewalls, none of which are wrong. Meanwhile `/data/xnat/home/logs` is unwritable by the same EACCES, so XNAT writes **no application logs**: the one artefact that would name the cause does not exist.

Seen live on a trust stack: 600 queued PACS requests, 0 studies archived, 0 log files, all four data dirs `1000:1000` against a container running as 1001. After `chown -R 1001:1001`, the same queue drained to **600 `RECEIVED` / 153 MB archived** with zero C-STORE errors, and XNAT began writing logs for the first time.

## How

- One definition — `XNAT_CONTAINER_UID` / `XNAT_CONTAINER_GID` / `XNAT_DIR_OWNER` — with a comment tying it to the Dockerfile and to the two playbooks.
- `XNAT_DATA_DIRS` lists the sources once. `xnat-db-data` stays stag/prod-only, matching current behaviour (the dev stack gives `xnat-db` no persistent bind mount).
- All three branches apply that owner and then **verify** it, failing with the exact `chown` to run rather than leaving a host half-provisioned. Same shape and same reasoning as `$(ensure_net_dirs)` in `trust/Makefile`: a warning is easy to lose in long bring-up output, and continuing lands in a failure whose symptom is somewhere else entirely.
- **All three branches provision under `sudo`, development included.** An unprivileged `mkdir -p` creates the tree owned by the invoking user, and the `chown` to 1001 that follows then returns `EPERM` on every host whose developer is not themselves uid 1001 — so the ownership the guard requires could never be reached and `make up` aborted there. This costs no new privilege: the `sudo rm -rf` on the preceding line already needs it, so dev bring-up already prompts, and sudo's credential cache means the `mkdir` and `chown` ride that same authentication.
- Dropping the dev branch's `2>/dev/null || true` also changes **which step reports**. Previously the `EPERM` was discarded and the recipe walked on to a guard that could never pass, telling the operator the directories had the wrong owner with no hint that the `chown` meant to fix it had silently failed. It now stops at the cause.
- Verifying *after* the chown rather than instead of it, as **defence in depth** — not because the chown itself might be refused. Every branch chowns under `sudo`, and `set -e` aborts on one that fails outright before the guard is reached. What is left for the guard is a chown that did not cover what it was meant to: it applies recursively to `$(XNAT_DATA_DIR)` while the guard stats each entry of `$(XNAT_DATA_DIRS)`, so those drifting apart — or a later edit narrowing or dropping the chown on one branch — surfaces there rather than at the first DICOM write.
- The check counts matching sources rather than testing the `chown` exit status, so a directory that is missing entirely is caught too — `stat` then prints nothing for it.
- The printed remedy takes a **command prefix**, so the remote-swarm branch emits `ssh <ctx> sudo chown -R …`. Those paths live on the trust host, and an operator pasting the bare form either got "no such file or directory" or chowned a same-named path on their own machine.
- `stat`'s stderr is **no longer discarded**. A `stat` failing for any reason other than a missing directory counted zero and was reported as wrong ownership, sending the reader after the wrong fault. A missing directory still counts zero and still fires the guard, now with `stat` naming the path it could not read.
- Added `set -e` to the recipe: it is a single `;`-joined `if` block, so a failing `ssh` previously did not abort it. **This also makes the two `docker context` probes fatal, which is deliberate** — see Type of Change below.

## Tests

`trust/xnat/tests/test_data_dir_ownership.py` — 12 tests, three layers:

- **Static:** the uid agrees across `trust/xnat/Makefile`, `trust/xnat/xnat/Dockerfile` and both playbooks; the recipe reintroduces neither a hardcoded foreign uid nor a `$(USER)`-derived one; all three branches still call the check.
- **Guard behaviour:** extracts the shell the recipe will actually run (via `make -n`) and executes it against a correctly-owned tree, a wrongly-owned one, and one with a directory missing.
- **Development branch, end to end:** `TestDevBranchProvisionsTheContainerUid` runs the *whole* generated dev branch — wipe, `mkdir`, `chown`, check — with a `sudo` shim that drops the privilege, modelling a normal developer. The guard-behaviour layer above cannot see this failure: it overrides `XNAT_CONTAINER_UID` to the invoker's own id and runs only the extracted `owned=` line, which between them remove the one condition this issue is about — provisioning for a uid the caller is not. It therefore passed whether or not the recipe could reach the ownership it demands.

The uid in these tests is derived from `os.getuid()` rather than written as `1001`: this development host and the GitHub runner are **both uid 1001**, the same id the XNAT image uses, so a literal would be vacuous in both places the suite runs.

Mutation-checked: reverting the uid to 1000 fails 4 tests, deleting the guard from one branch fails 1, and restoring the dev branch's suppressed unprivileged `chown` fails `test_an_unreachable_owner_stops_at_the_chown_not_the_guard`. That last assertion deliberately checks *which* step reported rather than the exit status, because both the suppressed and the fatal form exit non-zero — the suppressed one prints the guard's ownership complaint with an empty stderr, the fatal one prints `chown: … Operation not permitted` and never reaches the guard.

```
208 passed, 1 skipped   (full trust/xnat suite; ruff + mypy clean)
```

## CI

The drift tests assert on `trust/xnat/xnat/Dockerfile`, `deploy/providers/AWS/site.yml` and `deploy/providers/local/site_local_trust.yml`, none of which appeared in this workflow's path filters. A PR changing only the container uid in the Dockerfile, or only the ownership task in either playbook, therefore did not run the tests that exist to catch exactly that drift. All three are added to both the `push` and `pull_request` filters, and the workflow's header comment now states the rule for them.

## Checklist

- [x] Follows the project's coding conventions and style guide
- [x] Updates documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Type of Change

- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [x] In-line docstrings updated.
- [ ] Documentation updated, tested `make -C docs/ docs`.

Non-breaking in the sense that no interface, variable or target changes, but **two dev-side behaviours do change** and are worth stating plainly:

1. **Development bind-mount directories are now created and owned by 1001 via `sudo`.** Previously they were owned by the invoking developer. On a host where that developer is uid 1001 nothing changes; on any other host this is what makes XNAT work rather than fail. No new password prompt: the recipe already runs `sudo rm -rf` immediately before.
2. **An unresolvable `DOCKER_CONTEXT` is now fatal instead of falling through to the local branch.** That fall-through was not benign — a mistyped or unreachable context silently ran `sudo rm -rf $(XNAT_DATA_DIR)` against the *operator's own machine* while they believed they were resetting a remote trust host. Aborting is the safer failure, and the recipe carries a comment saying so.

## Testing

I did the following tests to verify my changes:

- [x] Quick tests passed locally: `pytest` in `trust/xnat/tests` — 208 passed, 1 skipped (shellcheck not installed).
- [ ] Integration tests pass (if applicable) by running `make integration-test`.

Beyond the suite, the development branch was executed end to end inside a container running as uid 1000 with the XNAT uid left at its real 1001 — the configuration this host cannot represent, since its own user is 1001. Before the fix it exits 1 with all four directories left `1000:1000`; after it, exit 0 with all four `1001:1001`.

## Notes for the reviewer

- File modes are deliberately left alone — the defect is ownership, and changing modes would widen the diff without cause. `deploy/README.md` records that this makes the dev XNAT tree depart from the Orthanc mock's world-writable convention on purpose: on a host whose developer is not uid 1001, deleting the tree or running `git clean -fdx` needs `sudo`.
- **The three provisioning paths share the uid, not the directory.** Both playbooks provision `/opt/flip/xnat`, while `XNAT_DATA_DIR` resolves stag/prod to the per-slot `/opt/flip/xnat-trust<N>` that compose and `xnat-reset` both use. Nothing breaks — they agree with each other — but the Makefile comment, `deploy/README.md`, the drift test's assertion message and `docker-compose-stack.production.yml`'s header all claimed the paths converge, which would point an ownership fix at a tree XNAT never writes to. All four are corrected. Repointing the playbooks is a functional change to both providers and is left out of this PR.
- `deploy/README.md`'s existing "Bind-mount ownership" section is updated to name `xnat-reset` as the third path onto the invariant, and to describe the misleading symptom so the next person recognises it.
- No new Make targets, env vars or dependencies, so no `CLAUDE.md`/`AGENTS.md` change is required.
- The macOS `stat -c` portability question raised in review is **not addressed here**: `$(ensure_net_dirs)` in `trust/Makefile` runs `stat -c` earlier on the same `make up` path, so a BSD host is already blocked before `xnat-reset` is reached. A shim belongs with that helper, covering both call sites at once.
- This PR touches `.github/workflows/test_trust_xnat.yml`, which #994 also edits. Expect a conflict in the path-filter blocks depending on merge order.

## Acceptance Criteria

*Imported from issue #1095*

- [x] `xnat-reset` provisions XNAT's data directories owned by the uid the `xnat-web` image runs as (1001) on **both** the remote-swarm and the development branch — not the invoking user, and not a hardcoded 1000.
- [x] That uid is defined once in `trust/xnat/Makefile` and referenced, rather than repeated as a literal, so the two branches cannot drift apart.
- [x] `xnat-reset` re-checks ownership after applying it and **fails loudly**, naming the exact `sudo chown` to run — the same verify-then-fail idiom as `$(ensure_net_dirs)` in `trust/Makefile`, and for the same reason: a warning in long bring-up output is missed, and continuing lands in a failure whose symptom points somewhere else entirely.
- [x] A test pins the invariant so `trust/xnat/Makefile` and `trust/xnat/xnat/Dockerfile` cannot drift apart silently.
- [x] No behaviour change on a host that is already correctly owned: the recipe re-applies the same ownership under `sudo` and the guard then passes, so a correct host is left exactly as it was. (The criterion as imported justified this by a non-root `chown` returning `EPERM` — that no longer arises now every branch chowns under `sudo`. The guard is kept as defence in depth against a chown that did not cover `$(XNAT_DATA_DIRS)`; see the `How` section.)

