### PR TITLE
[Bug]: upload_spleen_labels_to_xnat.py resolves .data_version two directories above the repo since the datasets/ move

### DIFF
--- a/fl-tutorials/datasets/spleen/upload_spleen_labels_to_xnat.py
+++ b/fl-tutorials/datasets/spleen/upload_spleen_labels_to_xnat.py
@@ -64,7 +64,13 @@ MAPPING_CACHE_FILENAME = ".accession_map.csv"
 # trust/omop-db/.data_version, rather than a second copy that could silently drift from it.
 # Note this pins the *path*, not the bytes: HF_TRUST_DATA_REVISION above pins the revision those
 # bytes are read at, and defaults to a moving `main` like every other dataset read in this repo.
-OMOP_DATA_VERSION_FILE = Path(__file__).resolve().parents[5] / "trust" / "omop-db" / ".data_version"
+#
+# parents[3] is the repository root from fl-tutorials/datasets/spleen/<this file>. The index is
+# a depth assumption: it was parents[5] when this file lived under
+# fl-tutorials/nvflare/image_segmentation/3d_spleen_segmentation/utils/, and the move to
+# datasets/ (d6ce346b) left it pointing two directories above the repo (FLIP#1102).
+# tests/test_spleen_uploader_paths.py fails if this ever stops resolving to a real file.
+OMOP_DATA_VERSION_FILE = Path(__file__).resolve().parents[3] / "trust" / "omop-db" / ".data_version"
 
 DOWNLOAD_TIMEOUT_SECONDS = 60
 

--- a/fl-tutorials/tests/test_spleen_uploader_paths.py
+++ b/fl-tutorials/tests/test_spleen_uploader_paths.py
@@ -1,0 +1,46 @@
+# Copyright (c) 2026 Guy's and St Thomas' NHS Foundation Trust & King's College London
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""The spleen label uploader's repo-relative paths resolve from where the file actually lives.
+
+Pins FLIP#1102: a ``parents[N]`` index is a depth assumption, and moving the file (d6ce346b) broke
+it silently — nothing between the move and a live enrichment run reads the path.
+"""
+
+import importlib.util
+from pathlib import Path
+
+UPLOADER = Path(__file__).resolve().parents[1] / "datasets" / "spleen" / "upload_spleen_labels_to_xnat.py"
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _load_uploader():
+    spec = importlib.util.spec_from_file_location("upload_spleen_labels_to_xnat_under_test", UPLOADER)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_omop_data_version_file_is_the_repos_pin():
+    uploader = _load_uploader()
+
+    assert uploader.OMOP_DATA_VERSION_FILE == REPO_ROOT / "trust" / "omop-db" / ".data_version"
+    assert uploader.OMOP_DATA_VERSION_FILE.is_file(), (
+        "the parents[N] index in OMOP_DATA_VERSION_FILE no longer matches this file's depth"
+    )
+
+
+def test_omop_data_version_reads_the_pinned_value():
+    uploader = _load_uploader()
+
+    assert uploader.omop_data_version() == (REPO_ROOT / "trust" / "omop-db" / ".data_version").read_text().strip()


### PR DESCRIPTION
# Description

`upload_spleen_labels_to_xnat.py` read `trust/omop-db/.data_version` via `Path(__file__).resolve().parents[5]` — right when the file sat six levels deep, two directories above the repository since `d6ce346b` (#1069) moved it to `fl-tutorials/datasets/spleen/`. Every `e2e_smoke_spleen` on develop has been failing at the enrichment step:

```
❌ Could not read /home/<user>/sandbox/trust/omop-db/.data_version: [Errno 2] No such file or directory
❌ Smoke failed: Data-enrichment command failed (exit 1)
```

Index is now `parents[3]` with the depth assumption stated beside it, and a test asserts the resolved path is a real file and reads the pin — so the next move fails in CI, not in a smoke run. Negative-tested: with `parents[5]` restored both tests fail.

Found while verifying #1101: image pull reached 21/21 and 20/20 on the seeded trusts and the run died at the next step.

## Linked Issues

Closes #1102

## Type of Change

- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change.
- [x] New tests added to cover the changes.
- [x] In-line docstrings updated.
- [ ] Documentation updated.

## Testing

- `fl-tutorials/tests/test_spleen_uploader_paths.py`: 2 passed; 2 failed with the old index.
- ruff clean.

## Acceptance Criteria

*Imported from issue #1102*

- [ ] The uploader resolves `trust/omop-db/.data_version` from its actual location (`parents[3]`), with
      the depth assumption stated beside it
- [ ] A test in `fl-tutorials/tests/datasets/spleen/` asserts the resolved path exists, so the next move
      of this file fails in CI rather than in someone's smoke run
- [ ] `e2e_smoke_spleen`'s enrichment step runs again on develop