### PR TITLE
fix(fl): stop/abort succeeds when the FL server is unreachable (#735 C7)

### DIFF
--- a/flip-api/src/flip_api/fl_services/services/fl_service.py
+++ b/flip-api/src/flip_api/fl_services/services/fl_service.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from typing import Any, cast
 from uuid import UUID
 
+import httpx
 from fastapi import Request
 from sqlalchemy import Column
 from sqlmodel import Session, col, select
@@ -1057,13 +1058,28 @@ def abort_model_training(request: Request, model_id: UUID, session: Session) -> 
         add_log(model_id, "Training job aborted before start; training slot released.", session)
         return
 
-    server_status = fetch_server_status(net_endpoint)
-    logger.debug(f"Server status: {server_status}")
+    try:
+        server_status = fetch_server_status(net_endpoint)
+        logger.debug(f"Server status: {server_status}")
+    except httpx.RequestError as e:
+        # The FL server is unreachable (e.g. scaled to zero). The queue was already dequeued
+        # above, so there is nothing to abort — release the slot rather than failing the stop.
+        released = fl_scheduler_service.release_scheduler_for_model(model_id, session)
+        logger.info(
+            f"FL server unreachable for model {model_id} (endpoint={net_endpoint}); "
+            f"nothing to abort (released {released} scheduler(s)). Reason: {e}"
+        )
+        add_log(model_id, "FL server unreachable; nothing to abort — training slot released.", session)
+        return
 
     if not server_status:  # or server_status.status != FLStatus.SUCCESS.value:
-        error_msg = f"FL Server not running for {model_id=}. Server status: {server_status}"
-        logger.error(error_msg)
-        raise ValueError(error_msg)
+        released = fl_scheduler_service.release_scheduler_for_model(model_id, session)
+        logger.info(
+            f"FL server not running for model {model_id} (endpoint={net_endpoint}); "
+            f"nothing to abort (released {released} scheduler(s))."
+        )
+        add_log(model_id, "FL server unreachable; nothing to abort — training slot released.", session)
+        return
 
     # If there is no running job for this model, it is already terminal — abort is an
     # idempotent no-op. The jobs were just dequeued above, so free the net promptly instead of

--- a/flip-api/tests/unit/fl_services/services/test_fl_service.py
+++ b/flip-api/tests/unit/fl_services/services/test_fl_service.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 from uuid import UUID, uuid4
 
+import httpx
 import pytest
 
 from flip_api.config import Settings
@@ -1691,7 +1692,7 @@ def test_abort_model_training_db_error_propagates(
 @patch("flip_api.fl_services.services.fl_scheduler_service.get_net_by_model_id")
 @patch("flip_api.fl_services.services.fl_scheduler_service.remove_job_from_queue")
 @patch("flip_api.fl_services.services.fl_scheduler_service.release_scheduler_for_model")
-def test_abort_model_training_raises_when_server_not_running(
+def test_abort_model_training_server_not_running_frees_net(
     mock_release,
     mock_remove,
     mock_get_net,
@@ -1709,14 +1710,49 @@ def test_abort_model_training_raises_when_server_not_running(
     request = MagicMock()
     request.path_params = {"target": "server", "clients": None}
 
-    with pytest.raises(ValueError, match="FL Server not running"):
-        fl_service.abort_model_training(request, model_id, fake_session)
+    # Server down is the normal idle state under scale-to-zero: stop must succeed as a no-op.
+    fl_service.abort_model_training(request, model_id, fake_session)
 
     # The abort must short-circuit before consulting the job list or issuing an abort.
     mock_extract_current_job_data.assert_not_called()
     mock_abort.assert_not_called()
-    # The abort was never delivered, so the net must NOT be released — the job may still be live.
-    mock_release.assert_not_called()
+    # The job was dequeued and the slot released — nothing to abort on a down server.
+    mock_remove.assert_called_once_with(model_id, fake_session)
+    mock_release.assert_called_once_with(model_id, fake_session)
+
+
+@patch("flip_api.fl_services.services.fl_service.extract_current_job_data")
+@patch("flip_api.fl_services.services.fl_service.get_fl_backend_job_id_by_model_id")
+@patch("flip_api.fl_services.services.fl_service.fetch_server_status")
+@patch("flip_api.fl_services.services.fl_service.abort_job")
+@patch("flip_api.fl_services.services.fl_scheduler_service.get_net_by_model_id")
+@patch("flip_api.fl_services.services.fl_scheduler_service.remove_job_from_queue")
+@patch("flip_api.fl_services.services.fl_scheduler_service.release_scheduler_for_model")
+def test_abort_model_training_unreachable_server_frees_net(
+    mock_release,
+    mock_remove,
+    mock_get_net,
+    mock_abort,
+    mock_fetch_server_status,
+    mock_get_fl_backend_job_id_by_model_id,
+    mock_extract_current_job_data,
+    model_id,
+    fake_session,
+):
+    mock_get_fl_backend_job_id_by_model_id.return_value = "job123"
+    mock_get_net.return_value = MagicMock(endpoint="http://fl-api-endpoint", name="net1")
+    mock_fetch_server_status.side_effect = httpx.RequestError("connection refused")
+
+    request = MagicMock()
+    request.path_params = {"target": "server", "clients": None}
+
+    # An unreachable FL server must not fail the stop: treat it as nothing to abort.
+    fl_service.abort_model_training(request, model_id, fake_session)
+
+    mock_extract_current_job_data.assert_not_called()
+    mock_abort.assert_not_called()
+    mock_remove.assert_called_once_with(model_id, fake_session)
+    mock_release.assert_called_once_with(model_id, fake_session)
 
 
 @patch("flip_api.fl_services.services.fl_service.extract_current_job_data")


### PR DESCRIPTION
Closes #1132.
Part of #735 (per-job fl-server, C7).

## What
- `POST /fl/stop/{model_id}` returned HTTP 500 when the FL server was unreachable.
- `abort_model_training` now treats `httpx.RequestError` and a falsy server status as "nothing to abort": logs a clear message, releases the scheduler slot via `fl_scheduler_service.release_scheduler_for_model`, writes a model log entry, and returns instead of raising.
- This matches the existing pre-running-window branch (`except (NotFoundError, ValueError)`) so scale-to-zero idle servers no longer fail the stop.

## Tests
- Rewrote `test_abort_model_training_raises_when_server_not_running` → `test_abort_model_training_server_not_running_frees_net`: asserts no raise and scheduler release.
- Added `test_abort_model_training_unreachable_server_frees_net`: `fetch_server_status` raises `httpx.RequestError` → no raise and scheduler release.

## Verification
- `uv run pytest tests/unit/fl_services/services/test_fl_service.py -q` → 93 passed
- `uv run ruff check src/flip_api/fl_services/services/fl_service.py tests/unit/fl_services/services/test_fl_service.py` → All checks passed
- `uv run mypy src/flip_api/fl_services/services/fl_service.py` → Success: no issues found in 1 source file