### PR TITLE
fix(fl): /fl/status and /fl/{net}/status report offline instead of 500 (#735 C9)

### DIFF
--- a/flip-api/src/flip_api/fl_services/get_net_status.py
+++ b/flip-api/src/flip_api/fl_services/get_net_status.py
@@ -65,7 +65,13 @@ def get_net_status(
         if not clients:
             error_message = f"No response from FL API for net {net_name}"
             logger.error(error_message)
-            raise HTTPException(status_code=502, detail=error_message)
+            return INetStatus(
+                name=net_name,
+                fl_backend=net_info.fl_backend,
+                online=False,
+                registered_clients=0,
+                clients=[],
+            )
 
         # Match by FL kit slot name — the FL net never sees Trust.name. See the equivalent
         # comment in get_status.py for the rationale (an admin-chosen display name is

--- a/flip-api/src/flip_api/fl_services/services/fl_service.py
+++ b/flip-api/src/flip_api/fl_services/services/fl_service.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from typing import Any, cast
 from uuid import UUID
 
+import httpx
 from fastapi import Request
 from sqlalchemy import Column
 from sqlmodel import Session, col, select
@@ -240,7 +241,11 @@ def check_server_status(endpoint: str) -> IServerStatus | None:
     logger.debug(f"Checking server status at '{url}'")
     # Same generous timeout as check_client_status: the Flower FL API hits the SuperLink and can
     # be slower than httpx's 5s default.
-    response = http_get(url, timeout=30)
+    try:
+        response = http_get(url, timeout=30)
+    except httpx.RequestError as e:
+        logger.error(f"HTTP GET failed for {url}: {e}")
+        return None
     logger.debug(f"Server status response: {response}")
     if not response:
         logger.error(f"No response from FL API for server at endpoint {endpoint}")
@@ -264,7 +269,11 @@ def check_client_status(endpoint: str) -> list[IClientStatus] | None:
     # NOTE the Flower FL API queries the SuperLink (ControlServicer.ShowFederation) on each call,
     # which can take ~9s — past httpx's 5s default — so a single check would time out and fail the
     # whole run (run_jobs marks the model ERROR). Use the same generous timeout as Flower submit.
-    response = http_get(url, timeout=30)
+    try:
+        response = http_get(url, timeout=30)
+    except httpx.RequestError as e:
+        logger.error(f"HTTP GET failed for {url}: {e}")
+        return None
     logger.debug(f"Client status response: {response}")
     if not response:
         logger.error(f"No response from FL API for clients at endpoint {endpoint}")

--- a/flip-api/tests/unit/fl_services/services/test_fl_service.py
+++ b/flip-api/tests/unit/fl_services/services/test_fl_service.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 from uuid import UUID, uuid4
 
+import httpx
 import pytest
 
 from flip_api.config import Settings
@@ -1243,6 +1244,20 @@ def test_check_server_status_returns_none_when_no_response(mock_http_get):
     mock_http_get.return_value = None
 
     assert fl_service.check_server_status("endpoint") is None
+
+
+@patch("flip_api.fl_services.services.fl_service.http_get")
+def test_check_server_status_returns_none_when_request_fails(mock_http_get):
+    mock_http_get.side_effect = httpx.RequestError("connection refused")
+
+    assert fl_service.check_server_status("endpoint") is None
+
+
+@patch("flip_api.fl_services.services.fl_service.http_get")
+def test_check_client_status_returns_none_when_request_fails(mock_http_get):
+    mock_http_get.side_effect = httpx.RequestError("connection refused")
+
+    assert fl_service.check_client_status("endpoint") is None
 
 
 @patch("flip_api.fl_services.services.fl_service.http_get")

--- a/flip-api/tests/unit/fl_services/test_get_net_status.py
+++ b/flip-api/tests/unit/fl_services/test_get_net_status.py
@@ -151,9 +151,12 @@ def test_get_net_status_net_not_found(fake_request, mock_db):
 
 def test_get_net_status_status_missing(fake_request, mock_db, mock_get_net_by_name):
     with patch("flip_api.fl_services.get_net_status.fetch_client_status", return_value=None):
-        with pytest.raises(HTTPException) as exc:
-            get_net_status("net-name", fake_request, mock_db)
-        assert exc.value.status_code == 502
+        result = get_net_status("net-name", fake_request, mock_db)
+    assert result.name == "net-name"
+    assert result.fl_backend == FLBackend.NVFLARE
+    assert result.online is False
+    assert result.registered_clients == 0
+    assert result.clients == []
 
 
 def test_get_net_status_unexpected_error(fake_request, mock_db, mock_get_net_by_name):

--- a/flip-api/tests/unit/fl_services/test_get_status.py
+++ b/flip-api/tests/unit/fl_services/test_get_status.py
@@ -219,3 +219,41 @@ def test_get_status_endpoint_client_status_none(
     assert result[0].online is False
     assert result[0].fl_backend == FLBackend.NVFLARE
     assert result[0].clients == []
+
+
+def test_get_status_endpoint_reports_offline_net_without_failing_others(
+    fake_request,
+    mock_db,
+    mock_get_trusts,
+    mock_get_slot_names_by_trust_ids,
+):
+    class Net:
+        def __init__(self, name, endpoint, fl_backend):
+            self.name = name
+            self.endpoint = endpoint
+            self.fl_backend = fl_backend
+
+    with patch("flip_api.fl_services.get_status.get_nets") as mock_get_nets:
+        mock_get_nets.return_value = [
+            Net("down-net", "down-endpoint", FLBackend.NVFLARE),
+            Net("up-net", "up-endpoint", FLBackend.NVFLARE),
+        ]
+        with (
+            patch("flip_api.fl_services.get_status.fetch_server_status") as mock_fetch_server_status,
+            patch("flip_api.fl_services.get_status.fetch_client_status") as mock_fetch_client_status,
+        ):
+            mock_fetch_server_status.side_effect = lambda endpoint: (
+                None if endpoint == "down-endpoint" else IServerStatus(status="started")
+            )
+            mock_fetch_client_status.return_value = [IClientStatus(name="trust-1", status="no_jobs")]
+
+            result = get_status_endpoint(fake_request, mock_db, user_id="user-1")
+
+    assert len(result) == 2
+    down = next(net for net in result if net.name == "down-net")
+    up = next(net for net in result if net.name == "up-net")
+    assert down.online is False
+    assert down.fl_backend == FLBackend.NVFLARE
+    assert down.registered_clients == 0
+    assert down.clients == []
+    assert up.online is True


### PR DESCRIPTION
Closes #1134.
Part of #735 (per-job fl-server, C9).

## What

- `check_server_status` / `check_client_status` now catch `httpx.RequestError` from `http_get`, log at error, and return `None` — matching their documented "None when the FL API does not respond" contract.
- `GET /fl/{net}/status` now returns an offline `INetStatus` (`online=False`, `registered_clients=0`, `clients=[]`) instead of a 502 when the FL API is unreachable. A missing net still returns 404.
- `GET /fl/status` needed no change: its existing `if not server_status` branch already emits `online=False`, so a single down net no longer 500s the whole aggregate.

## Tests

- `check_server_status` / `check_client_status` return `None` when `http_get` raises `httpx.RequestError`.
- `get_net_status` returns an offline status instead of raising 502 when `fetch_client_status` returns `None`.
- `get_status_endpoint` reports a down net `online=False` while keeping other nets intact.