### PR TITLE
Blind SSRF into the admin-authenticated XNAT API via accession_id

### DIFF
--- a/trust/imaging-api/README.md
+++ b/trust/imaging-api/README.md
@@ -57,8 +57,11 @@ Download and unzip a XNAT dataset to a local folder.
 }
 ```
 
-Query parameters: `assessor_type` (`scan`, default, or `assessor`), `resource_type` (`NIFTI` default; `DICOM`, `ALL`,
-or a custom XNAT resource label) and `force_refresh` (default `false`).
+Query parameters: `assessor_type` (`scan`, default, or `assessor`), `resource_type` (`NIFTI` default; `DICOM`, `SEG`
+or `ALL` — a closed allow-list matching flip-utils' `ResourceType` enum, since the value is interpolated into the
+XNAT download URL; anything else is a 422) and `force_refresh` (default `false`). `accession_id`, like `scan_id` and
+`resource_id` on the upload route, must be a single RFC 3986 path segment (unreserved characters only, not `.` or
+`..`); other values are rejected with a 422 before any XNAT request is made (#908).
 
 Downloads are cached on the trust host. Extraction lands in
 `<BASE_IMAGES_DOWNLOAD_DIR>/<net_id>/<central_hub_project_id>/<accession_id>/` and a completeness sentinel

--- a/trust/imaging-api/imaging_api/routers/download.py
+++ b/trust/imaging-api/imaging_api/routers/download.py
@@ -14,7 +14,11 @@ from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException
 
-from imaging_api.routers.schemas import DownloadImagesRequestData, DownloadImagesResponse
+from imaging_api.routers.schemas import (
+    DownloadImagesRequestData,
+    DownloadImagesResponse,
+    ResourceType,
+)
 from imaging_api.services.download import download_and_unzip_images
 from imaging_api.utils.auth import get_xnat_auth_headers
 from imaging_api.utils.encryption import decrypt
@@ -34,7 +38,7 @@ async def download_images_by_accession_number(
     *,
     # TODO Make assessor_type an Enum with allowed values ("scan", "assessor")
     assessor_type: str = "scan",
-    resource_type: str = "NIFTI",
+    resource_type: ResourceType = "NIFTI",
     force_refresh: bool = False,
     headers: XNATAuthHeaders,
 ) -> DownloadImagesResponse:

--- a/trust/imaging-api/imaging_api/routers/schemas.py
+++ b/trust/imaging-api/imaging_api/routers/schemas.py
@@ -11,7 +11,7 @@
 #
 
 import uuid
-from typing import Annotated
+from typing import Annotated, Literal
 from uuid import UUID
 
 from pydantic import BaseModel, EmailStr, Field, field_validator, model_validator
@@ -29,6 +29,53 @@ XNAT_PORT = get_settings().XNAT_PORT
 # defence; this validator is the trust-boundary fail-fast that returns a 422
 # instead of letting the corrupted entity reach XNAT.
 _XML_FORBIDDEN_CHARS = ("<", ">", "&")
+
+# Accession IDs are interpolated directly into XNAT URLs issued with the XNAT
+# service-admin session, so a traversal payload ("../../") would reach XNAT
+# before any filesystem guard could run. Keep the charset conservative until
+# the production PACS accession distribution is confirmed (see #908): letters,
+# digits, dot, underscore and hyphen only — no path separators, percent escapes,
+# whitespace, query/fragment delimiters, or double-dot segments.
+_ACCESSION_ID_ALLOWED_CHARS = frozenset("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789._-")
+
+# Known XNAT resource labels accepted on the download route. Deliberately a
+# closed list for now — custom resource labels were previously accepted and
+# should be re-confirmed against production XNAT projects before widening.
+ResourceType = Literal["DICOM", "NIFTI", "SEG", "ALL"]
+
+
+def _validate_accession_id(value: str) -> str:
+    """Rejects accession IDs that could traverse or inject into an XNAT URL.
+
+    Args:
+        value (str): The caller-supplied accession ID.
+
+    Returns:
+        str: The unchanged accession ID when it is safe.
+
+    Raises:
+        ValueError: If the value is empty, contains a character outside the
+            conservative ``[A-Za-z0-9._-]`` set, or contains a double-dot
+            segment.
+    """
+    if not value:
+        raise ValueError("accession_id must not be empty")
+    if any(char not in _ACCESSION_ID_ALLOWED_CHARS for char in value):
+        raise ValueError("accession_id must contain only [A-Za-z0-9._-]")
+    if ".." in value:
+        raise ValueError("accession_id must not contain '..'")
+    return value
+
+
+class _AccessionIdRequest(BaseModel):
+    """Shared shape and validation for request bodies carrying a PACS accession ID."""
+
+    accession_id: str
+
+    @field_validator("accession_id")
+    @classmethod
+    def _reject_unsafe_accession_id(cls, v: str) -> str:
+        return _validate_accession_id(v)
 
 # #########################
 # Users
@@ -318,11 +365,10 @@ class ProjectRetrieval(BaseModel):
 # #########################
 
 
-class DownloadImagesRequestData(BaseModel):
+class DownloadImagesRequestData(_AccessionIdRequest):
     """Represents a request to download images."""
 
     encrypted_central_hub_project_id: str
-    accession_id: str
 
 
 class DownloadImagesResponse(BaseModel):
@@ -332,11 +378,10 @@ class DownloadImagesResponse(BaseModel):
 # ##########################
 # Upload
 # ##########################
-class UploadDataRequest(BaseModel):
+class UploadDataRequest(_AccessionIdRequest):
     """Represents a request to upload data."""
 
     encrypted_central_hub_project_id: str
-    accession_id: str
     scan_id: str
     resource_id: str
     files: list[str]

--- a/trust/imaging-api/imaging_api/routers/schemas.py
+++ b/trust/imaging-api/imaging_api/routers/schemas.py
@@ -10,6 +10,7 @@
 # limitations under the License.
 #
 
+import string
 import uuid
 from typing import Annotated, Literal
 from uuid import UUID
@@ -30,41 +31,49 @@ XNAT_PORT = get_settings().XNAT_PORT
 # instead of letting the corrupted entity reach XNAT.
 _XML_FORBIDDEN_CHARS = ("<", ">", "&")
 
-# Accession IDs are interpolated directly into XNAT URLs issued with the XNAT
-# service-admin session, so a traversal payload ("../../") would reach XNAT
-# before any filesystem guard could run. Keep the charset conservative until
-# the production PACS accession distribution is confirmed (see #908): letters,
-# digits, dot, underscore and hyphen only — no path separators, percent escapes,
-# whitespace, query/fragment delimiters, or double-dot segments.
-_ACCESSION_ID_ALLOWED_CHARS = frozenset("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789._-")
+# Accession IDs, scan IDs and resource IDs are all interpolated directly into
+# XNAT URLs issued with the XNAT service-admin session, so a traversal payload
+# would reach XNAT before any filesystem guard could run.
+#
+# Charset: RFC 3986 §2.3 *unreserved* characters — the only characters that
+# are never percent-encoded and never a URL delimiter, so a value composed
+# solely of them cannot change the structure of a URL.  They also contain no
+# path separator on any OS, which is why the same set covers the filesystem
+# cache path. (see #908)
+#
+# Dot-segment: RFC 3986 §5.2.4 — only a segment that is *entirely* "." or ".."
+# is collapsed during path resolution, which is the urllib3 behaviour that made
+# the original blind-SSRF possible.  A value like "ACC..123" is harmless in
+# both a URL and a filesystem path.
+_URL_UNRESERVED = frozenset(string.ascii_letters + string.digits + "-._~")
 
-# Known XNAT resource labels accepted on the download route. Deliberately a
-# closed list for now — custom resource labels were previously accepted and
-# should be re-confirmed against production XNAT projects before widening.
-ResourceType = Literal["DICOM", "NIFTI", "SEG", "ALL"]
 
-
-def _validate_accession_id(value: str) -> str:
-    """Rejects accession IDs that could traverse or inject into an XNAT URL.
+def _validate_url_path_segment(value: str) -> str:
+    """Rejects values that could traverse or inject into an XNAT URL.
 
     Args:
-        value (str): The caller-supplied accession ID.
+        value (str): The caller-supplied identifier.
 
     Returns:
-        str: The unchanged accession ID when it is safe.
+        str: The unchanged value when it is safe.
 
     Raises:
-        ValueError: If the value is empty, contains a character outside the
-            conservative ``[A-Za-z0-9._-]`` set, or contains a double-dot
-            segment.
+        ValueError: If the value is empty, an RFC 3986 §5.2.4 dot-segment, or
+            contains a character outside the RFC 3986 §2.3 unreserved set.
     """
     if not value:
-        raise ValueError("accession_id must not be empty")
-    if any(char not in _ACCESSION_ID_ALLOWED_CHARS for char in value):
-        raise ValueError("accession_id must contain only [A-Za-z0-9._-]")
-    if ".." in value:
-        raise ValueError("accession_id must not contain '..'")
+        raise ValueError("must not be empty")
+    if value in (".", ".."):
+        raise ValueError("must not be a dot-segment ('.' or '..')")
+    if not set(value) <= _URL_UNRESERVED:
+        raise ValueError("must contain only RFC 3986 unreserved characters [A-Za-z0-9._~-]")
     return value
+
+
+# Known XNAT resource labels accepted on the download route. Matches the
+# flip-utils ResourceType enum (flip/constants/flip_constants.py: DICOM, NIFTI,
+# SEG, ALL) — the only in-tree caller of this route — kept in sync here.
+ResourceType = Literal["DICOM", "NIFTI", "SEG", "ALL"]
 
 
 class _AccessionIdRequest(BaseModel):
@@ -75,7 +84,7 @@ class _AccessionIdRequest(BaseModel):
     @field_validator("accession_id")
     @classmethod
     def _reject_unsafe_accession_id(cls, v: str) -> str:
-        return _validate_accession_id(v)
+        return _validate_url_path_segment(v)
 
 # #########################
 # Users
@@ -386,3 +395,8 @@ class UploadDataRequest(_AccessionIdRequest):
     resource_id: str
     files: list[str]
     exist_ok: bool = False
+
+    @field_validator("scan_id", "resource_id")
+    @classmethod
+    def _reject_unsafe_path_segment(cls, v: str) -> str:
+        return _validate_url_path_segment(v)

--- a/trust/imaging-api/imaging_api/routers/schemas.py
+++ b/trust/imaging-api/imaging_api/routers/schemas.py
@@ -275,6 +275,16 @@ class ImportStudy(BaseModel):
     accession_number: str = Field(..., alias="accessionNumber")
     relabel_map: dict[str, str] = Field(default={}, alias="relabelMap")
 
+    # The accession number becomes XNAT's session label via set_relabel_map();
+    # it then round-trips the same download URL accession_id has to pass, so
+    # enforce that rule at import time — a value that passed import but fails
+    # the route validator would 422 on every download for the life of the
+    # experiment ("silently dropped study", #908) rather than at the boundary.
+    @field_validator("accession_number")
+    @classmethod
+    def _validate_accession_number(cls, v: str) -> str:
+        return _validate_url_path_segment(v)
+
     def set_relabel_map(self) -> None:
         """Sets the relabel_map dictionary for subject and session."""
         self.relabel_map = {

--- a/trust/imaging-api/imaging_api/services/retrieval.py
+++ b/trust/imaging-api/imaging_api/services/retrieval.py
@@ -14,6 +14,7 @@ from typing import Annotated
 
 import pandas as pd
 from fastapi import Depends, HTTPException, status
+from pydantic import ValidationError
 
 from imaging_api.db.get_direct_archive_sessions_by_project import (
     get_direct_archive_sessions_by_project,
@@ -131,10 +132,22 @@ async def retrieve_images_for_project(project_id: str, query: str, headers: XNAT
                     f"Multiple studies found for accession number {idx}/{total_accessions}. Using the first one."
                 )
 
-        import_study = ImportStudy(
-            studyInstanceUid=study.study_instance_uid,
-            accessionNumber=study.accession_number,
-        )
+        # The accession number is validated as a URL path segment here (#908). PACS
+        # accession numbers are DICOM SH values and may carry characters outside
+        # that rule, so treat a rejection like a failed query: skip this study and
+        # keep the rest of the batch. Letting it raise would abort the whole import
+        # from inside a background task, with nothing but a server-log traceback.
+        try:
+            import_study = ImportStudy(
+                studyInstanceUid=study.study_instance_uid,
+                accessionNumber=study.accession_number,
+            )
+        except ValidationError as e:
+            logger.error(
+                f"Skipping accession number {idx}/{total_accessions}: the PACS returned an accession number that "
+                f"is not a valid XNAT session label / URL path segment: {e}"
+            )
+            continue
         studies_list.append(import_study)
 
     # Check that we have at least one study to import
@@ -369,10 +382,22 @@ async def retry_retrieve_images_for_project(project_id: str, query: str, headers
 
         logger.info(f"Study found for accession number {idx}/{total_retries}")
 
-        import_study = ImportStudy(
-            studyInstanceUid=study.study_instance_uid,
-            accessionNumber=study.accession_number,
-        )
+        # The accession number is validated as a URL path segment here (#908). PACS
+        # accession numbers are DICOM SH values and may carry characters outside
+        # that rule, so treat a rejection like a failed query: skip this study and
+        # keep the rest of the batch. Letting it raise would abort the whole import
+        # from inside a background task, with nothing but a server-log traceback.
+        try:
+            import_study = ImportStudy(
+                studyInstanceUid=study.study_instance_uid,
+                accessionNumber=study.accession_number,
+            )
+        except ValidationError as e:
+            logger.error(
+                f"Skipping accession number {idx}/{total_retries}: the PACS returned an accession number that "
+                f"is not a valid XNAT session label / URL path segment: {e}"
+            )
+            continue
         studies_list.append(import_study)
 
     # Check that we have at least one study to import

--- a/trust/imaging-api/tests/routers/test_download.py
+++ b/trust/imaging-api/tests/routers/test_download.py
@@ -65,6 +65,49 @@ def test_download_images_force_refresh_defaults_to_false(client):
     assert mock_service.await_args.kwargs["force_refresh"] is False
 
 
+def test_download_images_rejects_accession_id_traversal_before_service_call(client):
+    """A traversal accession_id must fail body validation (422) and never reach
+    the download service, which would otherwise issue an admin-authenticated
+    XNAT request to the traversed URL."""
+    body = {**_REQUEST_BODY, "accession_id": "../../etc/passwd"}
+    with patch(
+        "imaging_api.routers.download.download_and_unzip_images",
+        new_callable=AsyncMock,
+    ) as mock_service:
+        response = client.post("/download/images/net1", json=body)
+
+    assert response.status_code == 422
+    mock_service.assert_not_called()
+
+
+def test_download_images_rejects_resource_type_outside_allow_list_before_service_call(client):
+    """resource_type is interpolated into the XNAT download URL; anything outside
+    the known resource-type allow-list must 422 before the service is invoked."""
+    with patch(
+        "imaging_api.routers.download.download_and_unzip_images",
+        new_callable=AsyncMock,
+    ) as mock_service:
+        response = client.post("/download/images/net1?resource_type=../../etc/passwd", json=_REQUEST_BODY)
+
+    assert response.status_code == 422
+    mock_service.assert_not_called()
+
+
+def test_download_images_accepts_known_resource_type(client):
+    with (
+        patch("imaging_api.routers.download.decrypt", return_value="decrypted-project-id"),
+        patch(
+            "imaging_api.routers.download.download_and_unzip_images",
+            new_callable=AsyncMock,
+            return_value="/tmp/images/net1/ACC123",
+        ) as mock_service,
+    ):
+        response = client.post("/download/images/net1?resource_type=DICOM", json=_REQUEST_BODY)
+
+    assert response.status_code == 200
+    assert mock_service.await_args.kwargs["resource_type"] == "DICOM"
+
+
 def test_download_images_not_found(client):
     with (
         patch("imaging_api.routers.download.decrypt", return_value="decrypted-project-id"),

--- a/trust/imaging-api/tests/routers/test_schemas.py
+++ b/trust/imaging-api/tests/routers/test_schemas.py
@@ -15,7 +15,12 @@ from uuid import uuid4
 import pytest
 from pydantic import ValidationError
 
-from imaging_api.routers.schemas import CentralHubProject, ImportStudyRequest
+from imaging_api.routers.schemas import (
+    CentralHubProject,
+    DownloadImagesRequestData,
+    ImportStudyRequest,
+    UploadDataRequest,
+)
 
 
 def test_central_hub_project_defaults_dicom_to_nifti_true():
@@ -52,6 +57,51 @@ def test_central_hub_project_rejects_xml_control_chars_in_name(bad_name: str):
             query="SELECT 1",
             users=[],
         )
+
+
+@pytest.mark.parametrize(
+    "bad_accession_id",
+    [
+        "../../etc/passwd",
+        "ACC/123",
+        "ACC\\123",
+        "ACC%2F123",
+        "ACC 123",
+        "ACC?format=json",
+        "ACC#frag",
+        "..",
+        "ACC..123",
+    ],
+)
+def test_accession_id_rejects_traversal_and_url_metacharacters(bad_accession_id: str):
+    """Traversal/URL-injection payloads must fail validation before any XNAT call."""
+    with pytest.raises(ValidationError, match="accession_id"):
+        DownloadImagesRequestData(encrypted_central_hub_project_id="enc", accession_id=bad_accession_id)
+
+    with pytest.raises(ValidationError, match="accession_id"):
+        UploadDataRequest(
+            encrypted_central_hub_project_id="enc",
+            accession_id=bad_accession_id,
+            scan_id="SCAN1",
+            resource_id="NIFTI",
+            files=["scan.nii"],
+            exist_ok=False,
+        )
+
+
+@pytest.mark.parametrize(
+    "good_accession_id",
+    [
+        "ACC123",
+        "ACC-123",
+        "ACC_123",
+        "ACC.123",
+        "1.2.840.113619.2.55.3",
+    ],
+)
+def test_accession_id_accepts_safe_charset(good_accession_id: str):
+    request = DownloadImagesRequestData(encrypted_central_hub_project_id="enc", accession_id=good_accession_id)
+    assert request.accession_id == good_accession_id
 
 
 def test_import_study_request_deduplicates_studies():

--- a/trust/imaging-api/tests/routers/test_schemas.py
+++ b/trust/imaging-api/tests/routers/test_schemas.py
@@ -18,6 +18,7 @@ from pydantic import ValidationError
 from imaging_api.routers.schemas import (
     CentralHubProject,
     DownloadImagesRequestData,
+    ImportStudy,
     ImportStudyRequest,
     UploadDataRequest,
 )
@@ -105,6 +106,19 @@ def test_accession_id_accepts_safe_charset(good_accession_id: str):
     """RFC 3986 §2.3 unreserved charset must be accepted."""
     request = DownloadImagesRequestData(encrypted_central_hub_project_id="enc", accession_id=good_accession_id)
     assert request.accession_id == good_accession_id
+
+
+@pytest.mark.parametrize("bad_accession_number", ["", ".", "..", "../../OTHER", "ACC/123", "ACC 123"])
+def test_import_study_rejects_unsafe_accession_number(bad_accession_number: str):
+    """The accession number becomes the XNAT session label and later the download URL's
+    accession_id, so the same path-segment rule applies at import time (#908)."""
+    with pytest.raises(ValidationError, match="accessionNumber"):
+        ImportStudy(studyInstanceUid="1.2.3", accessionNumber=bad_accession_number)
+
+
+def test_import_study_accepts_safe_accession_number():
+    study = ImportStudy(studyInstanceUid="1.2.3", accessionNumber="ACC..123")
+    assert study.relabel_map["Session"] == "ACC..123"
 
 
 def test_import_study_request_deduplicates_studies():

--- a/trust/imaging-api/tests/routers/test_schemas.py
+++ b/trust/imaging-api/tests/routers/test_schemas.py
@@ -62,6 +62,7 @@ def test_central_hub_project_rejects_xml_control_chars_in_name(bad_name: str):
 @pytest.mark.parametrize(
     "bad_accession_id",
     [
+        "",
         "../../etc/passwd",
         "ACC/123",
         "ACC\\123",
@@ -70,7 +71,7 @@ def test_central_hub_project_rejects_xml_control_chars_in_name(bad_name: str):
         "ACC?format=json",
         "ACC#frag",
         "..",
-        "ACC..123",
+        ".",
     ],
 )
 def test_accession_id_rejects_traversal_and_url_metacharacters(bad_accession_id: str):
@@ -96,10 +97,12 @@ def test_accession_id_rejects_traversal_and_url_metacharacters(bad_accession_id:
         "ACC-123",
         "ACC_123",
         "ACC.123",
+        "ACC..123",  # embedded dots are fine — only an entire "." or ".." segment traverses
         "1.2.840.113619.2.55.3",
     ],
 )
 def test_accession_id_accepts_safe_charset(good_accession_id: str):
+    """RFC 3986 §2.3 unreserved charset must be accepted."""
     request = DownloadImagesRequestData(encrypted_central_hub_project_id="enc", accession_id=good_accession_id)
     assert request.accession_id == good_accession_id
 

--- a/trust/imaging-api/tests/routers/test_upload.py
+++ b/trust/imaging-api/tests/routers/test_upload.py
@@ -47,6 +47,20 @@ def test_upload_data_decrypt_failure(client):
     assert "Failed to decrypt" in response.json()["detail"]
 
 
+def test_upload_data_rejects_accession_id_traversal_before_service_call(client):
+    """A traversal accession_id must fail body validation (422) and never reach
+    the upload service, which would issue an admin-authenticated XNAT request."""
+    body = {**_REQUEST_BODY, "accession_id": "../../etc/passwd"}
+    with patch(
+        "imaging_api.routers.upload.upload_data_to_xnat",
+        new_callable=AsyncMock,
+    ) as mock_service:
+        response = client.put("/upload/images/net1", json=body)
+
+    assert response.status_code == 422
+    mock_service.assert_not_called()
+
+
 def test_upload_data_not_found(client):
     with (
         patch("imaging_api.routers.upload.decrypt", return_value="decrypted-project-id"),

--- a/trust/imaging-api/tests/routers/test_upload.py
+++ b/trust/imaging-api/tests/routers/test_upload.py
@@ -61,6 +61,34 @@ def test_upload_data_rejects_accession_id_traversal_before_service_call(client):
     mock_service.assert_not_called()
 
 
+def test_upload_data_rejects_scan_id_traversal_before_service_call(client):
+    """A traversal scan_id must fail body validation (422) and never reach the
+    upload service, which would issue an admin-authenticated XNAT request."""
+    body = {**_REQUEST_BODY, "scan_id": "../../OTHER"}
+    with patch(
+        "imaging_api.routers.upload.upload_data_to_xnat",
+        new_callable=AsyncMock,
+    ) as mock_service:
+        response = client.put("/upload/images/net1", json=body)
+
+    assert response.status_code == 422
+    mock_service.assert_not_called()
+
+
+def test_upload_data_rejects_resource_id_traversal_before_service_call(client):
+    """A traversal resource_id must fail body validation (422) and never reach
+    the upload service."""
+    body = {**_REQUEST_BODY, "resource_id": "../../OTHER"}
+    with patch(
+        "imaging_api.routers.upload.upload_data_to_xnat",
+        new_callable=AsyncMock,
+    ) as mock_service:
+        response = client.put("/upload/images/net1", json=body)
+
+    assert response.status_code == 422
+    mock_service.assert_not_called()
+
+
 def test_upload_data_not_found(client):
     with (
         patch("imaging_api.routers.upload.decrypt", return_value="decrypted-project-id"),

--- a/trust/imaging-api/tests/services/test_retrieval.py
+++ b/trust/imaging-api/tests/services/test_retrieval.py
@@ -189,6 +189,35 @@ async def test_retrieve_images_query_exception_skips_study(
 @patch("imaging_api.services.retrieval.get_accession_ids", new_callable=AsyncMock)
 @patch("imaging_api.services.retrieval.encrypt")
 @patch("imaging_api.services.retrieval.get_project")
+async def test_retrieve_images_skips_study_with_unsafe_accession_number(
+    mock_get_project, mock_encrypt, mock_get_accession_ids, mock_query, mock_queue, headers,
+):
+    """A PACS-returned accession number that fails the #908 path-segment rule must be
+    skipped like a failed query, not abort the whole batch: the remaining studies queue."""
+    mock_get_project.return_value = MagicMock()
+    mock_encrypt.return_value = "encrypted_id"
+    mock_get_accession_ids.return_value = ["ACC1", "ACC 2", "ACC3"]
+    mock_query.side_effect = [
+        [_make_study("ACC1", "1.2.3.1")],
+        [_make_study("ACC 2", "1.2.3.2")],
+        [_make_study("ACC3", "1.2.3.3")],
+    ]
+    mock_queue.return_value = [_make_import_response("ACC1"), _make_import_response("ACC3")]
+
+    result = await retrieve_images_for_project("proj1", "SELECT *", headers)
+
+    assert result is True
+    mock_queue.assert_called_once()
+    queued = [study.accession_number for study in mock_queue.call_args[0][0].studies]
+    assert queued == ["ACC1", "ACC3"]
+
+
+@pytest.mark.asyncio
+@patch("imaging_api.services.retrieval.queue_image_import_request")
+@patch("imaging_api.services.retrieval.query_by_accession_number")
+@patch("imaging_api.services.retrieval.get_accession_ids", new_callable=AsyncMock)
+@patch("imaging_api.services.retrieval.encrypt")
+@patch("imaging_api.services.retrieval.get_project")
 async def test_retrieve_images_partial_queue_failure(
     mock_get_project, mock_encrypt, mock_get_accession_ids,
     mock_query, mock_queue, headers,
@@ -593,6 +622,34 @@ async def test_retry_all_queries_fail(mock_get_project, mock_get_status, mock_qu
 
     result = await retry_retrieve_images_for_project("proj1", "SELECT *", headers)
     assert result is False
+
+
+@pytest.mark.asyncio
+@patch("imaging_api.services.retrieval.queue_image_import_request")
+@patch("imaging_api.services.retrieval.query_by_accession_number")
+@patch("imaging_api.services.retrieval.get_import_status", new_callable=AsyncMock)
+@patch("imaging_api.services.retrieval.get_project")
+async def test_retry_skips_study_with_unsafe_accession_number(
+    mock_get_project, mock_get_status, mock_query, mock_queue, headers,
+):
+    """Same guarantee as the first-pass import: one unsafe accession number does not
+    take the rest of the retry batch down with it."""
+    mock_get_project.return_value = MagicMock()
+    mock_get_status.return_value = ImportStatus(
+        successful=[], failed=["ACC_FAIL", "ACC BAD"], queue_failed=[], queued=[], processing=[],
+    )
+    mock_query.side_effect = [
+        [_make_study("ACC_FAIL", "1.2.3.1")],
+        [_make_study("ACC BAD", "1.2.3.2")],
+    ]
+    mock_queue.return_value = [_make_import_response("ACC_FAIL")]
+
+    result = await retry_retrieve_images_for_project("proj1", "SELECT *", headers)
+
+    assert result is True
+    mock_queue.assert_called_once()
+    queued = [study.accession_number for study in mock_queue.call_args[0][0].studies]
+    assert queued == ["ACC_FAIL"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #908.

## What

`trust/imaging-api` interpolated a caller-supplied `accession_id` straight into an XNAT URL issued with the XNAT service-admin session, before the filesystem `realpath` guard ran. `resource_type` was interpolated the same way in the download URL. This PR rejects traversal/injection payloads at the FastAPI validation boundary, so no outbound XNAT request is made.

- `accession_id` in both `DownloadImagesRequestData` and `UploadDataRequest` is now validated by a shared pydantic `field_validator` (conservative charset + double-dot rejection).
- `resource_type` on the download route is now a `Literal` allow-list of known XNAT resource labels (`DICOM`, `NIFTI`, `SEG`, `ALL`).
- Added router-level tests asserting `../` traversal payloads return 422 and the download/upload service is never invoked.

## Decisions

- Path-segment charset: RFC 3986 §2.3 unreserved (`[A-Za-z0-9._~-]`), with `.` and `..` rejected as exact values per §5.2.4 (so `ACC..123` is accepted — it is not a dot-segment). The same rule now applies to `accession_id`, `scan_id` and `resource_id` on the upload route, and to `ImportStudy.accession_number` at import time, via a single shared validator.
- PACS accession numbers are DICOM SH and may fall outside that set. At import, a rejection is treated like a failed PACS query — the study is skipped with a logged error and the rest of the batch still queues — rather than aborting the whole background import.
- `resource_type`: closed allow-list `DICOM` / `NIFTI` / `SEG` / `ALL`. This deliberately drops the previously-documented "custom XNAT resource label" support and case-insensitive `all`; confirm the set before widening.
- `assessor_type`: deliberately deferred (still a bare `str` with the existing `assert` in `format_download_url`, not an enum yet) — API contract unchanged in this PR.
- Sink-side quoting of XNAT URL path segments (defence in depth alongside this PR's boundary validation) is tracked in #1193.

## Verification

- `uv run pytest tests -q` → 331 passed
- `uv run ruff check imaging_api` → clean
- `uv run mypy imaging_api --ignore-missing-imports` → clean

## Acceptance Criteria

*Imported from issue #908*

- [x] `accession_id` validated against an agreed charset at the router, before any URL construction
- [x] `resource_type` constrained (allow-list or enum)
- [x] Decision recorded on `assessor_type` — enum now, or deliberately deferred
- [x] A test asserts a traversal payload is rejected before any outbound request is made
