### PR TITLE
fix(fl): split transient vs fatal dispatch failures — requeue on transient (#735 C2)

### DIFF
--- a/flip-api/src/flip_api/fl_services/services/fl_scheduler_service.py
+++ b/flip-api/src/flip_api/fl_services/services/fl_scheduler_service.py
@@ -48,7 +48,7 @@ from flip_api.fl_services.services.fl_service import (
     validate_client_availability,
 )
 from flip_api.model_services.services.model_service import add_log, update_model_status, validate_trust_ids
-from flip_api.utils.exceptions import DatabaseError, JobAbortedError, NotFoundError
+from flip_api.utils.exceptions import DatabaseError, JobAbortedError, NotFoundError, TransientDispatchError
 from flip_api.utils.logger import logger
 
 
@@ -85,6 +85,46 @@ def remove_job(job_id: UUID, session: Session) -> None:
         session.rollback()
         logger.error(f"Error reverting job pickup: {e}")
         raise DatabaseError("Error reverting job pickup") from e
+
+
+def requeue_job(job_id: UUID, session: Session) -> None:
+    """
+    Returns a picked-up job to QUEUED after a transient dispatch failure.
+
+    This is the inverse of ``remove_job``: instead of marking the job DELETED, it keeps the row
+    and clears the pickup timestamps and backend job id (which was never written when the
+    dispatch failed transiently), so the next scheduler tick can select it again.
+
+    Args:
+        job_id (UUID): The ID of the job to requeue.
+        session (Session): SQLModel session.
+
+    Returns:
+        None
+
+    Raises:
+        flip_api.utils.exceptions.NotFoundError: If no ``FLJob`` exists with the given ID.
+        DatabaseError: If the update fails at the DB layer.
+    """
+    logger.info(f"Requeuing job pickup: {job_id}")
+    try:
+        job = session.get(FLJob, job_id)
+        if not job:
+            logger.error(f"FLJob with id {job_id} not found")
+            raise NotFoundError(f"FLJob with id {job_id} not found")
+
+        job.status = JobStatus.QUEUED
+        job.started = None
+        job.fl_backend_job_id = None
+
+        session.commit()
+
+        logger.info("Requeued job pickup")
+
+    except SQLAlchemyError as e:
+        session.rollback()
+        logger.error(f"Error requeuing job pickup: {e}")
+        raise DatabaseError("Error requeuing job pickup") from e
 
 
 def remove_job_from_queue(model_id: UUID, session: Session) -> None:
@@ -651,11 +691,12 @@ def prepare_and_start_training(model_id: UUID, fl_job_id: UUID, trust_ids: list[
         bool: True when the job was submitted to the fl-server; False when a concurrent abort
             (#787) deleted the job before or during prepare — an abort gate at the top of the
             function catches aborts landed since the pickup commit — in which case submission
-            was skipped and the net released.
+            was skipped and the net released; also False when a transient dispatch failure
+            requeued the job for the next tick.
 
     Raises:
-        Exception: If the FL backend is unsupported, the net endpoint cannot be resolved, client
-            availability validation fails, or training fails to start. On failure the job is
+        Exception: If the FL backend is unsupported, the net endpoint cannot be resolved, or
+            training fails to start with a genuine (fatal) error. On fatal failure the job is
             removed, the model is marked as errored, the net is released, and the original
             exception is re-raised.
     """
@@ -730,6 +771,16 @@ def prepare_and_start_training(model_id: UUID, fl_job_id: UUID, trust_ids: list[
         # error. The job is already DELETED and the model STOPPED — just make sure the net is
         # free (the abort usually released it already; this is an idempotent belt-and-braces).
         logger.info(f"Job {fl_job_id} for model {model_id} was aborted mid-prepare; skipping submission.")
+        release_scheduler_for_model(model_id, session)
+        return False
+
+    except TransientDispatchError as e:
+        # A transient dispatch failure (client mid-restart, FL API cold-start, connection
+        # refused/timeout) must not destroy the job: requeue it so the next scheduler tick
+        # retries, and free the net. The model status is deliberately left alone.
+        logger.warning(f"Transient dispatch failure for job {fl_job_id} (model {model_id}); requeueing: {e}")
+        requeue_job(fl_job_id, session)
+        add_log(model_id, f"Transient dispatch failure; job requeued: {e}", session, success=False)
         release_scheduler_for_model(model_id, session)
         return False
 

--- a/flip-api/src/flip_api/fl_services/services/fl_service.py
+++ b/flip-api/src/flip_api/fl_services/services/fl_service.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from typing import Any, cast
 from uuid import UUID
 
+import httpx
 from fastapi import Request
 from sqlalchemy import Column
 from sqlmodel import Session, col, select
@@ -34,7 +35,7 @@ from flip_api.domain.interfaces.fl import (
 from flip_api.domain.schemas.status import FLJobStatus, FLTargets, JobStatus
 from flip_api.domain.schemas.types import FLBackend
 from flip_api.utils.encryption import encrypt
-from flip_api.utils.exceptions import JobAbortedError, NotFoundError
+from flip_api.utils.exceptions import JobAbortedError, NotFoundError, TransientDispatchError
 from flip_api.utils.http import http_delete, http_get, http_post
 from flip_api.utils.logger import logger
 from flip_api.utils.s3_client import S3Client
@@ -343,17 +344,23 @@ def validate_client_availability(clients: list[str], endpoint: str, fl_backend: 
         None
 
     Raises:
-        ValueError: If any client is unavailable (NVFLARE backend only).
+        TransientDispatchError: If the FL API cannot be reached, its client status cannot be
+            fetched, or any client is unavailable (NVFLARE backend only). These are transient
+            dispatch failures: a client or the FL API may be mid-restart and retry can succeed.
     """
     is_flower = fl_backend == FLBackend.FLOWER
 
-    client_statuses = check_client_status(endpoint)
+    try:
+        client_statuses = check_client_status(endpoint)
+    except httpx.RequestError as e:
+        raise TransientDispatchError(f"Unable to reach the FL API at {endpoint}: {e}") from e
+
     if not client_statuses:
         if is_flower:
             logger.warning(f"No client status response from FL API at {endpoint} — Flower will handle client selection")
             return
         logger.error(f"No response from FL API for clients at endpoint {endpoint}")
-        raise ValueError("Unable to fetch client statuses to validate client availability")
+        raise TransientDispatchError("Unable to fetch client statuses to validate client availability")
 
     logger.info(f"Client status: {client_statuses}")
 
@@ -363,7 +370,7 @@ def validate_client_availability(clients: list[str], endpoint: str, fl_backend: 
         if is_flower:
             logger.warning(f"Clients unavailable: {', '.join(unavailable)} — Flower will handle client selection")
             return
-        raise ValueError(f"Clients unavailable: {', '.join(unavailable)}")
+        raise TransientDispatchError(f"Clients unavailable: {', '.join(unavailable)}")
 
 
 def abort_job(endpoint: str, job_id: str) -> dict:
@@ -441,10 +448,16 @@ def start_training(
     # is the side effect that creates the backend run, so a job aborted mid-prepare (#787) must
     # never reach it.
     _raise_if_job_aborted(fl_job_id, session)
-    upload_app(model_id, training_details, endpoint)
+    try:
+        upload_app(model_id, training_details, endpoint)
+    except httpx.RequestError as e:
+        raise TransientDispatchError(f"Unable to upload the application to the FL API at {endpoint}: {e}") from e
     _raise_if_job_aborted(fl_job_id, session)
     logger.info(f"Submitting job for training for model {model_id} with FL job ID {fl_job_id}")
-    submit_job(fl_job_id, endpoint, model_id, session)
+    try:
+        submit_job(fl_job_id, endpoint, model_id, session)
+    except httpx.RequestError as e:
+        raise TransientDispatchError(f"Unable to submit the job to the FL API at {endpoint}: {e}") from e
 
 
 def bundle_nvflare_application(model_id: UUID, job_type: str = DEFAULT_JOB_TYPE) -> str:

--- a/flip-api/src/flip_api/utils/exceptions.py
+++ b/flip-api/src/flip_api/utils/exceptions.py
@@ -20,3 +20,12 @@ class DatabaseError(Exception):
 
 class JobAbortedError(Exception):
     """Raised when a queued FL job was aborted (DELETED) before submission to the fl-server."""
+
+
+class TransientDispatchError(Exception):
+    """Raised when dispatching an FL job fails transiently (client/server mid-restart, cold start).
+
+    Unlike a genuine backend submission error, a transient failure leaves the system in a state
+    where retrying the same job on the next scheduler tick can succeed — so callers requeue the
+    job instead of deleting it and erroring the model.
+    """

--- a/flip-api/tests/unit/fl_services/services/test_fl_scheduler_service.py
+++ b/flip-api/tests/unit/fl_services/services/test_fl_scheduler_service.py
@@ -26,7 +26,7 @@ from flip_api.domain.interfaces.fl import (
 from flip_api.domain.schemas.status import JobStatus, ModelStatus, NetStatus
 from flip_api.domain.schemas.types import FLBackend, FLLogEvent
 from flip_api.fl_services.services import fl_scheduler_service
-from flip_api.utils.exceptions import DatabaseError, JobAbortedError, NotFoundError
+from flip_api.utils.exceptions import DatabaseError, JobAbortedError, NotFoundError, TransientDispatchError
 
 
 @pytest.fixture
@@ -112,6 +112,130 @@ def test_prepare_and_start_training_failure(fake_session, model_id, fl_job_id):
         mock_log.assert_called_once_with(model_id, "bundle failed", fake_session, success=False)
         # The failure handler must actually free the BUSY net, not leave it to the watchdog.
         mock_release.assert_called_once_with(model_id, fake_session)
+
+
+def test_prepare_and_start_training_transient_client_availability_failure_requeues(
+    fake_session, model_id, fl_job_id
+):
+    """A transient availability failure requeues the job and leaves the model alone."""
+    with (
+        patch(
+            "flip_api.fl_services.services.fl_scheduler_service.bundle_nvflare_application",
+            return_value="s3://dest/model",
+        ),
+        patch("flip_api.fl_services.services.fl_scheduler_service.get_net_by_model_id") as mock_get_net,
+        patch(
+            "flip_api.fl_services.services.fl_scheduler_service.validate_client_availability",
+            side_effect=TransientDispatchError("Clients unavailable: Trust_1"),
+        ),
+        patch("flip_api.fl_services.services.fl_scheduler_service.requeue_job") as mock_requeue,
+        patch("flip_api.fl_services.services.fl_scheduler_service.add_log") as mock_log,
+        patch("flip_api.fl_services.services.fl_scheduler_service.remove_job") as mock_remove,
+        patch("flip_api.fl_services.services.fl_scheduler_service.update_model_status") as mock_status,
+        patch(
+            "flip_api.fl_services.services.fl_scheduler_service.release_scheduler_for_model"
+        ) as mock_release,
+    ):
+        mock_get_net.return_value = INetDetails(endpoint="endpoint", name="net-name", fl_backend=FLBackend.NVFLARE)
+
+        started = fl_scheduler_service.prepare_and_start_training(
+            model_id=model_id,
+            fl_job_id=fl_job_id,
+            trust_ids=[uuid4()],
+            session=fake_session,
+        )
+
+    assert started is False
+    mock_requeue.assert_called_once_with(fl_job_id, fake_session)
+    mock_release.assert_called_once_with(model_id, fake_session)
+    mock_log.assert_called_once()
+    assert mock_log.call_args.kwargs["success"] is False
+    mock_remove.assert_not_called()
+    mock_status.assert_not_called()
+
+
+def test_prepare_and_start_training_transient_submit_failure_requeues(fake_session, model_id, fl_job_id):
+    """A transient submit failure (e.g. fl-server cold-start) requeues the job."""
+    with (
+        patch(
+            "flip_api.fl_services.services.fl_scheduler_service.bundle_nvflare_application",
+            return_value="s3://dest/model",
+        ),
+        patch("flip_api.fl_services.services.fl_scheduler_service.get_net_by_model_id") as mock_get_net,
+        patch("flip_api.fl_services.services.fl_scheduler_service.validate_client_availability"),
+        patch("flip_api.fl_services.services.fl_scheduler_service.get_bundle_urls", return_value=["url1"]),
+        patch(
+            "flip_api.fl_services.services.fl_scheduler_service.start_training",
+            side_effect=TransientDispatchError("Unable to submit the job"),
+        ),
+        patch("flip_api.fl_services.services.fl_scheduler_service.requeue_job") as mock_requeue,
+        patch("flip_api.fl_services.services.fl_scheduler_service.add_log") as mock_log,
+        patch("flip_api.fl_services.services.fl_scheduler_service.remove_job") as mock_remove,
+        patch("flip_api.fl_services.services.fl_scheduler_service.update_model_status") as mock_status,
+        patch(
+            "flip_api.fl_services.services.fl_scheduler_service.release_scheduler_for_model"
+        ) as mock_release,
+    ):
+        mock_get_net.return_value = INetDetails(endpoint="endpoint", name="net-name", fl_backend=FLBackend.NVFLARE)
+
+        started = fl_scheduler_service.prepare_and_start_training(
+            model_id=model_id,
+            fl_job_id=fl_job_id,
+            trust_ids=[uuid4()],
+            session=fake_session,
+        )
+
+    assert started is False
+    mock_requeue.assert_called_once_with(fl_job_id, fake_session)
+    mock_release.assert_called_once_with(model_id, fake_session)
+    mock_log.assert_called_once()
+    assert mock_log.call_args.kwargs["success"] is False
+    mock_remove.assert_not_called()
+    mock_status.assert_not_called()
+
+
+def test_prepare_and_start_training_fatal_submit_error_still_errors(fake_session, model_id, fl_job_id):
+    """A genuine backend submission error stays fatal: job DELETED, model ERROR, net released."""
+    with (
+        patch(
+            "flip_api.fl_services.services.fl_scheduler_service.bundle_nvflare_application",
+            return_value="s3://dest/model",
+        ),
+        patch("flip_api.fl_services.services.fl_scheduler_service.get_net_by_model_id") as mock_get_net,
+        patch("flip_api.fl_services.services.fl_scheduler_service.validate_client_availability"),
+        patch("flip_api.fl_services.services.fl_scheduler_service.get_bundle_urls", return_value=["url1"]),
+        patch(
+            "flip_api.fl_services.services.fl_scheduler_service.start_training",
+            side_effect=ValueError("No backend job id returned or invalid format"),
+        ),
+        patch("flip_api.fl_services.services.fl_scheduler_service.requeue_job") as mock_requeue,
+        patch("flip_api.fl_services.services.fl_scheduler_service.add_log") as mock_log,
+        patch("flip_api.fl_services.services.fl_scheduler_service.remove_job") as mock_remove,
+        patch("flip_api.fl_services.services.fl_scheduler_service.update_model_status") as mock_status,
+        patch(
+            "flip_api.fl_services.services.fl_scheduler_service.release_scheduler_for_model"
+        ) as mock_release,
+    ):
+        mock_get_net.return_value = INetDetails(endpoint="endpoint", name="net-name", fl_backend=FLBackend.NVFLARE)
+
+        with pytest.raises(ValueError, match="No backend job id returned or invalid format"):
+            fl_scheduler_service.prepare_and_start_training(
+                model_id=model_id,
+                fl_job_id=fl_job_id,
+                trust_ids=[uuid4()],
+                session=fake_session,
+            )
+
+    mock_requeue.assert_not_called()
+    mock_remove.assert_called_once_with(fl_job_id, fake_session)
+    mock_status.assert_called_once_with(model_id, ModelStatus.ERROR, fake_session)
+    mock_log.assert_called_once_with(
+        model_id,
+        "No backend job id returned or invalid format",
+        fake_session,
+        success=False,
+    )
+    mock_release.assert_called_once_with(model_id, fake_session)
 
 
 def test_prepare_and_start_training_aborted_mid_prepare_returns_false(fake_session, model_id, fl_job_id):
@@ -287,6 +411,25 @@ def test_remove_job_not_found(fake_session):
     missing_job_id = "missing-id"
     with pytest.raises(NotFoundError, match=f"FLJob with id {missing_job_id} not found"):
         fl_scheduler_service.remove_job(missing_job_id, fake_session)
+
+
+def test_requeue_job_success(fake_session, fl_job_id):
+    job = MagicMock()
+    fake_session.get.return_value = job
+
+    fl_scheduler_service.requeue_job(fl_job_id, fake_session)
+
+    assert job.status == JobStatus.QUEUED
+    assert job.started is None
+    assert job.fl_backend_job_id is None
+    fake_session.commit.assert_called_once()
+
+
+def test_requeue_job_not_found(fake_session):
+    fake_session.get.return_value = None
+    missing_job_id = "missing-id"
+    with pytest.raises(NotFoundError, match=f"FLJob with id {missing_job_id} not found"):
+        fl_scheduler_service.requeue_job(missing_job_id, fake_session)
 
 
 def test_remove_job_from_queue(fake_session, model_id):

--- a/flip-api/tests/unit/fl_services/services/test_fl_service.py
+++ b/flip-api/tests/unit/fl_services/services/test_fl_service.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 from uuid import UUID, uuid4
 
+import httpx
 import pytest
 
 from flip_api.config import Settings
@@ -28,7 +29,7 @@ from flip_api.domain.interfaces.fl import (
 from flip_api.domain.schemas.status import ClientStatus, JobStatus
 from flip_api.domain.schemas.types import FLBackend
 from flip_api.fl_services.services import fl_service
-from flip_api.utils.exceptions import DatabaseError, JobAbortedError, NotFoundError
+from flip_api.utils.exceptions import DatabaseError, JobAbortedError, NotFoundError, TransientDispatchError
 
 
 @pytest.fixture
@@ -176,7 +177,7 @@ def test_validate_client_availability_all_offline(mock_get_status):
         IClientStatus(name="Trust_1", status=ClientStatus.NO_JOBS),
     ]
 
-    with pytest.raises(ValueError, match="Clients unavailable: trust-1"):
+    with pytest.raises(TransientDispatchError, match="Clients unavailable: trust-1"):
         fl_service.validate_client_availability(["trust-1"], "endpoint", FLBackend.NVFLARE)
 
 
@@ -188,7 +189,7 @@ def test_validate_client_availability_some_online(mock_get_status):
     ]
 
     # This has to raise an error for Trust_2 only.
-    with pytest.raises(ValueError, match="Clients unavailable: Trust_2"):
+    with pytest.raises(TransientDispatchError, match="Clients unavailable: Trust_2"):
         fl_service.validate_client_availability(["Trust_2", "Trust_1"], "endpoint", FLBackend.NVFLARE)
 
 
@@ -196,8 +197,17 @@ def test_validate_client_availability_some_online(mock_get_status):
 def test_validate_client_availability_empty_statuses(mock_get_status):
     mock_get_status.return_value = []
 
-    with pytest.raises(ValueError, match="Unable to fetch client statuses"):
+    with pytest.raises(TransientDispatchError, match="Unable to fetch client statuses"):
         fl_service.validate_client_availability(["trust-1"], "endpoint", FLBackend.NVFLARE)
+
+
+@patch("flip_api.fl_services.services.fl_service.check_client_status")
+def test_validate_client_availability_connection_error_is_transient(mock_get_status):
+    """Connection refused/timeout while checking client status is transient, not fatal."""
+    mock_get_status.side_effect = httpx.ConnectError("connection refused")
+
+    with pytest.raises(TransientDispatchError, match="Unable to reach the FL API"):
+        fl_service.validate_client_availability(["Trust_1"], "endpoint", FLBackend.NVFLARE)
 
 
 @patch("flip_api.fl_services.services.fl_service.check_client_status")
@@ -222,10 +232,10 @@ def test_validate_client_availability_flower_soft_on_unavailable(mock_get_status
 
 @patch("flip_api.fl_services.services.fl_service.check_client_status")
 def test_validate_client_availability_nvflare_still_raises(mock_get_status):
-    """NVFLARE backend: empty client statuses still raises ValueError."""
+    """NVFLARE backend: empty client statuses still raises TransientDispatchError."""
     mock_get_status.return_value = []
 
-    with pytest.raises(ValueError, match="Unable to fetch client statuses"):
+    with pytest.raises(TransientDispatchError, match="Unable to fetch client statuses"):
         fl_service.validate_client_availability(["Trust_1"], "endpoint", FLBackend.NVFLARE)
 
 
@@ -329,6 +339,72 @@ def test_start_training_skips_submit_when_job_deleted_during_upload(
 
     mock_upload.assert_called_once()
     mock_submit.assert_not_called()
+
+
+@patch("flip_api.fl_services.services.fl_service.submit_job")
+@patch("flip_api.fl_services.services.fl_service.upload_app")
+@patch("flip_api.fl_services.services.fl_service.encrypt")
+@patch("flip_api.fl_services.services.fl_scheduler_service.get_required_training_details")
+def test_start_training_transient_upload_request_error_is_requeued(
+    mock_get_required,
+    mock_encrypt,
+    mock_upload,
+    mock_submit,
+    model_id,
+    fl_job_id,
+    fake_session,
+):
+    """Connection refused/timeout during upload_app is transient — not a fatal backend error."""
+    mock_get_required.return_value = MagicMock(project_id="proj", cohort_query="query")
+    mock_encrypt.return_value = "encrypted"
+    fake_session.exec.return_value.one_or_none.return_value = JobStatus.IN_PROGRESS
+    mock_upload.side_effect = httpx.ConnectError("connection refused")
+
+    with pytest.raises(TransientDispatchError, match="Unable to upload the application"):
+        fl_service.start_training(
+            model_id=model_id,
+            fl_job_id=fl_job_id,
+            clients=["client1"],
+            endpoint="endpoint",
+            bundle_urls=["url"],
+            session=fake_session,
+        )
+
+    mock_upload.assert_called_once()
+    mock_submit.assert_not_called()
+
+
+@patch("flip_api.fl_services.services.fl_service.submit_job")
+@patch("flip_api.fl_services.services.fl_service.upload_app")
+@patch("flip_api.fl_services.services.fl_service.encrypt")
+@patch("flip_api.fl_services.services.fl_scheduler_service.get_required_training_details")
+def test_start_training_transient_submit_request_error_is_requeued(
+    mock_get_required,
+    mock_encrypt,
+    mock_upload,
+    mock_submit,
+    model_id,
+    fl_job_id,
+    fake_session,
+):
+    """Connection refused/timeout during submit_job is transient — not a fatal backend error."""
+    mock_get_required.return_value = MagicMock(project_id="proj", cohort_query="query")
+    mock_encrypt.return_value = "encrypted"
+    fake_session.exec.return_value.one_or_none.return_value = JobStatus.IN_PROGRESS
+    mock_submit.side_effect = httpx.ConnectError("connection refused")
+
+    with pytest.raises(TransientDispatchError, match="Unable to submit the job"):
+        fl_service.start_training(
+            model_id=model_id,
+            fl_job_id=fl_job_id,
+            clients=["client1"],
+            endpoint="endpoint",
+            bundle_urls=["url"],
+            session=fake_session,
+        )
+
+    mock_upload.assert_called_once()
+    mock_submit.assert_called_once()
 
 
 @patch("flip_api.fl_services.services.fl_service.JobRequiredFiles.is_valid_job_type", return_value=True)


### PR DESCRIPTION
Closes #1133.
Part of #735 (per-job fl-server, C2).

## What

`prepare_and_start_training` used to treat every dispatch failure as fatal: delete the FL job and mark the model `ERROR`. A transient failure during dispatch — client mid-restart, FL API cold-start, connection refused/timeout — therefore destroyed the job with no recovery.

This change splits dispatch failures by exception type:

- **Transient** (`TransientDispatchError`): requeue the job (`QUEUED`, `fl_backend_job_id` NULL), release the scheduler, log a failure entry, and return `False`. No `remove_job`, no `ERROR`.
- **Fatal** (everything else): unchanged — `remove_job` + `ERROR` + release + re-raise.

### Classification (with evidence)

- `validate_client_availability` (`fl_service.py:330`): NVFLARE raises `ValueError` when client status cannot be fetched or clients are unavailable; a connection refused/timeout from the FL API also propagates as `httpx.RequestError`. All are transient → now `TransientDispatchError`.
- `start_training` (`fl_service.py:404`): `httpx.RequestError` while `upload_app` or `submit_job` runs is a transport failure (connection refused/timeout) → transient. A genuine backend rejection (`httpx.HTTPStatusError`) or `ValueError("No backend job id returned or invalid format")` remains fatal.
- Unsupported backend, unresolvable net endpoint, and bundle failures remain fatal.

## Tests

Added unit tests covering both branches in `prepare_and_start_training` (transient → job stays queued, scheduler released, no `remove_job`/`ERROR`; fatal → job deleted, model errored), plus `TransientDispatchError` classification at `validate_client_availability` and `start_training`.

## Verification

- `uv run pytest tests/unit/fl_services -q` — 205 passed
- `uv run ruff check src/flip_api/fl_services tests/unit/fl_services` — passed
- `uv run mypy src/flip_api/fl_services` — no issues