### PR TITLE
fix(deploy/aws): gate the orphaned CloudFront satellites on LZA (FLIP#749)

### DIFF
--- a/deploy/providers/AWS/cloudfront.tf
+++ b/deploy/providers/AWS/cloudfront.tf
@@ -207,6 +207,7 @@ moved {
 ############################
 
 resource "aws_s3_bucket" "cloudfront_logs" {
+  count = var.lza_managed_network ? 0 : 1
   # Derived-name-with-override, same rationale as access_logs_bucket_name in
   # s3_logging.tf (global bucket names vs the shared subdomain, FLIP#749).
   bucket = var.CF_LOGS_BUCKET_NAME != "" ? var.CF_LOGS_BUCKET_NAME : "flip-cf-logs-${var.flip_alb_subdomain}"
@@ -217,15 +218,17 @@ resource "aws_s3_bucket" "cloudfront_logs" {
 }
 
 resource "aws_s3_bucket_ownership_controls" "cloudfront_logs" {
-  bucket = aws_s3_bucket.cloudfront_logs.id
+  count  = var.lza_managed_network ? 0 : 1
+  bucket = aws_s3_bucket.cloudfront_logs[0].id
   rule {
     object_ownership = "BucketOwnerPreferred"
   }
 }
 
 resource "aws_s3_bucket_acl" "cloudfront_logs" {
-  depends_on = [aws_s3_bucket_ownership_controls.cloudfront_logs]
-  bucket     = aws_s3_bucket.cloudfront_logs.id
+  count      = var.lza_managed_network ? 0 : 1
+  depends_on = [aws_s3_bucket_ownership_controls.cloudfront_logs[0]]
+  bucket     = aws_s3_bucket.cloudfront_logs[0].id
 
   access_control_policy {
     owner {
@@ -256,7 +259,8 @@ resource "aws_s3_bucket_acl" "cloudfront_logs" {
 }
 
 resource "aws_s3_bucket_lifecycle_configuration" "cloudfront_logs" {
-  bucket = aws_s3_bucket.cloudfront_logs.id
+  count  = var.lza_managed_network ? 0 : 1
+  bucket = aws_s3_bucket.cloudfront_logs[0].id
 
   rule {
     id     = "expire-cf-logs-after-30-days"
@@ -271,7 +275,8 @@ resource "aws_s3_bucket_lifecycle_configuration" "cloudfront_logs" {
 }
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "cloudfront_logs" {
-  bucket = aws_s3_bucket.cloudfront_logs.id
+  count  = var.lza_managed_network ? 0 : 1
+  bucket = aws_s3_bucket.cloudfront_logs[0].id
 
   rule {
     apply_server_side_encryption_by_default {
@@ -285,7 +290,8 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "cloudfront_logs" 
 # Neither is "public" under PAB semantics, so blocking public ACLs and
 # policies is safe regardless of which delivery mechanism is in use.
 resource "aws_s3_bucket_public_access_block" "cloudfront_logs" {
-  bucket                  = aws_s3_bucket.cloudfront_logs.id
+  count                   = var.lza_managed_network ? 0 : 1
+  bucket                  = aws_s3_bucket.cloudfront_logs[0].id
   block_public_acls       = true
   block_public_policy     = true
   ignore_public_acls      = true
@@ -295,7 +301,8 @@ resource "aws_s3_bucket_public_access_block" "cloudfront_logs" {
 # Enforce HTTPS-only access to the CloudFront logs bucket.
 # CloudFront log delivery uses HTTPS only, so this is safe.
 resource "aws_s3_bucket_policy" "cloudfront_logs_https_only" {
-  bucket = aws_s3_bucket.cloudfront_logs.id
+  count  = var.lza_managed_network ? 0 : 1
+  bucket = aws_s3_bucket.cloudfront_logs[0].id
 
   policy = jsonencode({
     Version = "2012-10-17"
@@ -305,8 +312,8 @@ resource "aws_s3_bucket_policy" "cloudfront_logs_https_only" {
       Principal = "*"
       Action    = "s3:*"
       Resource = [
-        aws_s3_bucket.cloudfront_logs.arn,
-        "${aws_s3_bucket.cloudfront_logs.arn}/*",
+        aws_s3_bucket.cloudfront_logs[0].arn,
+        "${aws_s3_bucket.cloudfront_logs[0].arn}/*",
       ]
       Condition = {
         Bool = {
@@ -561,6 +568,7 @@ resource "aws_cloudfront_origin_request_policy" "flip_api" {
 # with no false positives, flip its `override_action` (for managed groups)
 # or `action` (for the custom rate-limit) to `block` / `none` + `block`.
 resource "aws_wafv2_web_acl" "flip_ui_cloudfront" {
+  count = var.lza_managed_network ? 0 : 1
   # checkov:skip=CKV_AWS_192:AWSManagedRulesKnownBadInputsRuleSet (the Log4j AMR) is attached; count-mode rollout is deliberate — flip to block after sampled-traffic review
   provider = aws.us_east_1
   name     = "flip-ui-${replace(var.flip_alb_subdomain, "/[^a-zA-Z0-9]/", "-")}"
@@ -674,15 +682,17 @@ resource "aws_wafv2_web_acl" "flip_ui_cloudfront" {
 # WAF logging destination. Name MUST start with `aws-waf-logs-` per AWS —
 # otherwise PutLoggingConfiguration rejects it.
 resource "aws_cloudwatch_log_group" "flip_ui_waf" {
+  count             = var.lza_managed_network ? 0 : 1
   provider          = aws.us_east_1
   name              = "aws-waf-logs-flip-ui-${replace(var.flip_alb_subdomain, "/[^a-zA-Z0-9]/", "-")}"
   retention_in_days = 30
 }
 
 resource "aws_wafv2_web_acl_logging_configuration" "flip_ui_cloudfront" {
+  count                   = var.lza_managed_network ? 0 : 1
   provider                = aws.us_east_1
-  resource_arn            = aws_wafv2_web_acl.flip_ui_cloudfront.arn
-  log_destination_configs = [aws_cloudwatch_log_group.flip_ui_waf.arn]
+  resource_arn            = aws_wafv2_web_acl.flip_ui_cloudfront[0].arn
+  log_destination_configs = [aws_cloudwatch_log_group.flip_ui_waf[0].arn]
 }
 
 ############################
@@ -961,7 +971,7 @@ resource "aws_cloudfront_distribution" "flip_ui" {
   # MANAGE_DNS flips to true.
   aliases    = var.manage_dns ? [var.flip_alb_subdomain] : []
   comment    = "flip-ui at ${var.flip_alb_subdomain}"
-  web_acl_id = aws_wafv2_web_acl.flip_ui_cloudfront.arn
+  web_acl_id = aws_wafv2_web_acl.flip_ui_cloudfront[0].arn
 
   origin {
     domain_name              = aws_s3_bucket.flip_ui.bucket_regional_domain_name
@@ -1078,7 +1088,7 @@ resource "aws_cloudfront_distribution" "flip_ui" {
   }
 
   logging_config {
-    bucket          = aws_s3_bucket.cloudfront_logs.bucket_domain_name
+    bucket          = aws_s3_bucket.cloudfront_logs[0].bucket_domain_name
     include_cookies = false
     prefix          = "standard-logs/"
   }
@@ -1163,4 +1173,61 @@ output "CloudfrontDistributionDomain" {
 output "FlipUiBucketName" {
   description = "S3 bucket holding the UI static assets"
   value       = aws_s3_bucket.flip_ui.bucket
+}
+
+# State migration for the counts added above (FLIP#749): keeps existing legacy
+# states aligned without a manual `terraform state mv`. Adding `count` renames
+# each resource from X to X[0], which Terraform would otherwise plan as
+# destroy-and-recreate — harmless on LZA where these are orphans, destructive on
+# legacy where the WAF fronts live production traffic and the log bucket holds
+# real objects under a 30-day lifecycle. Safe to remove once every live state
+# file has been migrated.
+moved {
+  from = aws_wafv2_web_acl.flip_ui_cloudfront
+  to   = aws_wafv2_web_acl.flip_ui_cloudfront[0]
+}
+
+moved {
+  from = aws_wafv2_web_acl_logging_configuration.flip_ui_cloudfront
+  to   = aws_wafv2_web_acl_logging_configuration.flip_ui_cloudfront[0]
+}
+
+moved {
+  from = aws_cloudwatch_log_group.flip_ui_waf
+  to   = aws_cloudwatch_log_group.flip_ui_waf[0]
+}
+
+moved {
+  from = aws_s3_bucket.cloudfront_logs
+  to   = aws_s3_bucket.cloudfront_logs[0]
+}
+
+moved {
+  from = aws_s3_bucket_ownership_controls.cloudfront_logs
+  to   = aws_s3_bucket_ownership_controls.cloudfront_logs[0]
+}
+
+moved {
+  from = aws_s3_bucket_acl.cloudfront_logs
+  to   = aws_s3_bucket_acl.cloudfront_logs[0]
+}
+
+moved {
+  from = aws_s3_bucket_lifecycle_configuration.cloudfront_logs
+  to   = aws_s3_bucket_lifecycle_configuration.cloudfront_logs[0]
+}
+
+moved {
+  from = aws_s3_bucket_server_side_encryption_configuration.cloudfront_logs
+  to   = aws_s3_bucket_server_side_encryption_configuration.cloudfront_logs[0]
+}
+
+moved {
+  from = aws_s3_bucket_public_access_block.cloudfront_logs
+  to   = aws_s3_bucket_public_access_block.cloudfront_logs[0]
+}
+
+moved {
+  from = aws_s3_bucket_policy.cloudfront_logs_https_only
+  to   = aws_s3_bucket_policy.cloudfront_logs_https_only[0]
 }


### PR DESCRIPTION
## What

Gates ten orphaned CloudFront-satellite resources on `lza_managed_network`, with `moved` blocks so legacy state is unaffected.

Stacked on #979 (`749-lza-terraform-env`), since that is where `lza_managed_network` lives.

## Why

`cloudfront.tf` gates the distribution, its VPC origin and one security-group rule on LZA — but not the resources that exist only to serve them. So on LZA the front door is switched off while its fittings are still built.

**Verified in the LZA production account:**

| | |
| --- | --- |
| CloudFront distributions | **0** |
| WAF web ACL `flip-ui-app-flip-aicentre-co-uk` | 4 rules, `ResourceArns: []` — **associated with nothing** |
| `flip-lza-cf-logs` | exists, **0 objects** |
| CloudFront functions / OACs | 2 / 1, attached to nothing |

AWS bills a web ACL at **$5/month plus $1 per rule** regardless of traffic. That is roughly **$9/month for a firewall in front of nothing** — about 5.5% of the estate's monthly cost.

This was found while investigating why `flip-lza-cf-logs` was empty. The bucket turned out to be a symptom, not the problem: the WAF is the part that costs money.

## Scope

Gated (10): the WAF trio — `aws_wafv2_web_acl.flip_ui_cloudfront`, its logging configuration, and `aws_cloudwatch_log_group.flip_ui_waf` — plus the `cloudfront_logs` bucket family (bucket, ownership controls, ACL, lifecycle, encryption, public-access block, HTTPS-only policy).

**Deliberately not gated:** `aws_cloudfront_function.spa_rewrite`, `aws_cloudfront_origin_access_control.flip_ui`, the response-headers and origin-request policies. They are orphaned too, but they cost nothing, and each extra gated resource is another reference to rewrite and another `moved` block to get right in a change that already has to be verified against two state files. Worth a follow-up if the clutter bothers anyone; not worth the blast radius here.

Left alone on purpose: `aws_s3_bucket.flip_ui` and its policy/PAB/encryption/versioning. Those **are** needed on LZA — the networking account's distribution serves that bucket by cross-account OAC — and the bucket carries `prevent_destroy = true`.

## The `moved` blocks are the load-bearing part

Adding `count` renames each resource from `X` to `X[0]`, which Terraform plans as **destroy-and-recreate**. Harmless on LZA, where these are orphans we want gone — **destructive on legacy**, where the WAF fronts live production traffic and `flip-cf-logs-app.flip.aicentre.co.uk` holds ~9,830 real log objects under a 30-day lifecycle.

Every gated resource has a `moved` block, following the convention already in this file and in `certificate.tf` (which did exactly this for the `manage_dns` counts, also under FLIP#749). All 15 `moved` blocks in the file are unique; no duplicates.

## How to verify — this one needs TWO plans

Unusually, **the correct plan differs by environment**, so a single plan cannot validate it:

| Environment | Expected |
| --- | --- |
| `PROD=true` (legacy production) | **0 to add, 0 to change, 0 to destroy** — moves only |
| `PROD=lza` | ~10 to destroy, 0 to add |

If the legacy plan shows *any* destroy, the `moved` blocks are wrong — do not apply.

`validate_terraform.yml` runs fmt/validate/checkov without credentials, so neither plan is automated. Both are manual, against two different state files.

## Checks

`terraform fmt` clean, `terraform validate` Success (the three warnings are pre-existing deprecations in `service_discovery.tf`), `make checkov-lint` **115 passed / 0 failed / 18 skipped** — confirming the `# checkov:skip=` comments still bind with `count` above them.
