### PR TITLE
K8s trusts self-serve their FL kit from S3 by default, giving every trust AWS credentials

### DIFF
--- a/deploy/providers/kubernetes/templates/NOTES.txt
+++ b/deploy/providers/kubernetes/templates/NOTES.txt
@@ -54,3 +54,27 @@ Check the stack is up:
     For a functional FL trust, set sharedImagesPvc.enabled=true (RWX-capable
     storage class) and re-run `helm upgrade`.
 {{- end }}
+{{- if and .Values.flClient.enabled (not (include "flip-trust.flClientKitFromS3" .)) (not .Values.flClient.kitHostPath) }}
+
+⚠️  FL client has NO participant kit
+
+    Neither flClient.kitHostPath nor the active backend's kitFromS3 is set, so
+    the kit volume is empty and the client will die on a missing
+    startup/start.sh rather than joining the federation.
+
+    Kits are delivered OUT OF BAND for production — a trust holding credentials
+    into the AI Centre's S3 account to fetch its own kit is the thing FLIP#922
+    removed, and the on-prem flow already works this way. Stage the kit and
+    point the chart at it:
+
+        make -C deploy/providers/AWS package-onprem-trust-kit KIT=<CODE> PROD=<env>
+        # copy the kit onto the node, then:
+        --set flClient.kitHostPath=/opt/fl-kit/<slot>
+
+    Or, as a dev convenience only, opt back in to fetching it from S3:
+
+        --set flClient.{{ .Values.flBackend }}.kitFromS3.enabled=true \
+        --set flClient.{{ .Values.flBackend }}.kitFromS3.bucket=<bucket>
+
+    See deploy/providers/kubernetes/README.md → "FL participant kits".
+{{- end }}

--- a/deploy/providers/kubernetes/templates/fl-client.yaml
+++ b/deploy/providers/kubernetes/templates/fl-client.yaml
@@ -198,11 +198,6 @@ spec:
               mountPath: /opt/fl-client/kit
             - name: images
               mountPath: {{ .Values.flClient.imagesDir }}
-{{- if .Values.flClient.hostAwsMount.enabled }}
-            - name: host-aws
-              mountPath: /root/.aws
-              readOnly: {{ .Values.flClient.hostAwsMount.readOnly }}
-{{- end }}
       {{- end }}
       containers:
         - name: fl-client
@@ -380,11 +375,5 @@ spec:
             type: Directory
 {{- else }}
           emptyDir: {}
-{{- end }}
-{{- if .Values.flClient.hostAwsMount.enabled }}
-        - name: host-aws
-          hostPath:
-            path: {{ .Values.flClient.hostAwsMount.hostPath | quote }}
-            type: Directory
 {{- end }}
 {{- end }}

--- a/deploy/providers/kubernetes/templates/fl-client.yaml
+++ b/deploy/providers/kubernetes/templates/fl-client.yaml
@@ -374,6 +374,11 @@ spec:
             path: {{ .Values.flClient.kitHostPath | quote }}
             type: Directory
 {{- else }}
+          # No kit source configured: neither flClient.kitHostPath nor the active
+          # backend's kitFromS3. The client will start against an EMPTY kit and
+          # die on a missing startup/start.sh — NOTES.txt says so at install
+          # time, because the chart's default values are a template rather than
+          # a deployable config and must still render.
           emptyDir: {}
 {{- end }}
 {{- end }}

--- a/deploy/providers/kubernetes/templates/omop-db-init-job.yaml
+++ b/deploy/providers/kubernetes/templates/omop-db-init-job.yaml
@@ -91,7 +91,7 @@ spec:
         {{- if .Values.omopDb.initJob.hostAwsMount.enabled }}
         - name: host-aws
           hostPath:
-            path: {{ .Values.omopDb.initJob.hostAwsMount.hostPath | quote }}
+            path: {{ required "omopDb.initJob.hostAwsMount.hostPath is required when hostAwsMount is enabled — set it to the AWS config dir ON THE NODE (on kind, the path an extraMount maps ~/.aws to), e.g. --set omopDb.initJob.hostAwsMount.hostPath=$HOME/.aws" .Values.omopDb.initJob.hostAwsMount.hostPath | quote }}
             type: Directory
         {{- end }}
 {{- end }}

--- a/deploy/providers/kubernetes/templates/orthanc-init-job.yaml
+++ b/deploy/providers/kubernetes/templates/orthanc-init-job.yaml
@@ -93,7 +93,7 @@ spec:
         {{- if .Values.orthanc.initJob.hostAwsMount.enabled }}
         - name: host-aws
           hostPath:
-            path: {{ .Values.orthanc.initJob.hostAwsMount.hostPath | quote }}
+            path: {{ required "orthanc.initJob.hostAwsMount.hostPath is required when hostAwsMount is enabled — set it to the AWS config dir ON THE NODE, e.g. --set orthanc.initJob.hostAwsMount.hostPath=$HOME/.aws" .Values.orthanc.initJob.hostAwsMount.hostPath | quote }}
             type: Directory
         {{- end }}
 {{- end }}

--- a/deploy/providers/kubernetes/values.yaml
+++ b/deploy/providers/kubernetes/values.yaml
@@ -302,8 +302,17 @@ flClient:
   # NVFLARE client.
   kitHostPath: ""
   nvflare:
+    # Fetching the kit from S3 requires this trust to hold credentials into the
+    # AI Centre's account, which is at odds with the platform's own boundary —
+    # FL clients deliberately carry no Central Hub credentials, and a cloud
+    # credential is the same category of secret (FLIP#922). Kits are therefore
+    # delivered OUT OF BAND for production, exactly as the on-prem flow already
+    # does (`make -C deploy/providers/AWS package-onprem-trust-kit`): stage the
+    # kit on the node and point flClient.kitHostPath at it. Turn this on only as
+    # a dev convenience, and only against a bucket the cluster should be able to
+    # read.
     kitFromS3:
-      enabled: true
+      enabled: false
       # S3 bucket holding the FL participant kits (the AI Centre bucket,
       # AICENTRE_BUCKET_NAME). Required, but deployment-specific — supply it via
       # the kit override (`make sync-kit` writes it from the kit file). Empty here
@@ -325,8 +334,17 @@ flClient:
       percentile: ""
       gamma: ""
   flower:
+    # Fetching the kit from S3 requires this trust to hold credentials into the
+    # AI Centre's account, which is at odds with the platform's own boundary —
+    # FL clients deliberately carry no Central Hub credentials, and a cloud
+    # credential is the same category of secret (FLIP#922). Kits are therefore
+    # delivered OUT OF BAND for production, exactly as the on-prem flow already
+    # does (`make -C deploy/providers/AWS package-onprem-trust-kit`): stage the
+    # kit on the node and point flClient.kitHostPath at it. Turn this on only as
+    # a dev convenience, and only against a bucket the cluster should be able to
+    # read.
     kitFromS3:
-      enabled: true
+      enabled: false
       # See the nvflare note above — supply via the kit override (`make sync-kit`).
       bucket: ""
       kitDate: "20260401"

--- a/deploy/providers/kubernetes/values.yaml
+++ b/deploy/providers/kubernetes/values.yaml
@@ -282,9 +282,6 @@ flClient:
   netId: "net-1"
   s3EndpointOverride: ""
   imagesDir: /app/data/images
-  hostAwsMount:
-    enabled: false
-    readOnly: true
   hostAliases:
     - ip: "13.43.162.56"
       hostnames:
@@ -495,7 +492,14 @@ omopDb:
     # Enabled for local K8s clusters; disable for EKS (use IRSA instead)
     hostAwsMount:
       enabled: false
-      hostPath: "/home/rd24/.aws"
+    # Path to an AWS config directory ON THE NODE (a hostPath, not your
+    # workstation). On a single-node k3s/on-prem cluster the node IS the
+    # workstation, so this is $HOME/.aws. On kind the node is a container, so
+    # the cluster must be created with an extraMount mapping ~/.aws to this
+    # path. Deliberately empty: Helm templates cannot read $HOME, and a
+    # hardcoded personal path only ever works on one machine. Required when
+    # enabled — the render fails rather than emitting an empty hostPath.
+      hostPath: ""
       readOnly: true
 
 # ---------------------------------------------------------------------------
@@ -554,7 +558,14 @@ orthanc:
     # Enabled for local K8s clusters; disable for EKS (use IRSA instead)
     hostAwsMount:
       enabled: false
-      hostPath: "/home/rd24/.aws"
+    # Path to an AWS config directory ON THE NODE (a hostPath, not your
+    # workstation). On a single-node k3s/on-prem cluster the node IS the
+    # workstation, so this is $HOME/.aws. On kind the node is a container, so
+    # the cluster must be created with an extraMount mapping ~/.aws to this
+    # path. Deliberately empty: Helm templates cannot read $HOME, and a
+    # hardcoded personal path only ever works on one machine. Required when
+    # enabled — the render fails rather than emitting an empty hostPath.
+      hostPath: ""
 
 # ---------------------------------------------------------------------------
 # XNAT — Neuroimaging platform (multi-component)


### PR DESCRIPTION
Closes #922.
Closes #904.

## What

Reworks how the Kubernetes trust chart handles AWS host mounts and FL participant kits.

- **Do not fetch FL kits from S3 by default (#922).** `flClient.{nvflare,flower}.kitFromS3.enabled` now defaults to `false` so a trust no longer holds credentials into the AI Centre's account just to fetch its own kit. The chart follows the existing vocabulary-warning idiom: render cleanly, and warn in `NOTES.txt` when neither `kitHostPath` nor the active backend's `kitFromS3` is configured.
- **AWS posture fixes (#904).** Drop the hardcoded personal `hostAwsMount` default (`/home/rd24/.aws`); require an explicit node path for the omop-db/orthanc init jobs; remove the unused `flClient.hostAwsMount` entirely (the fl-client's only S3 consumer, `kit-init`, already takes credentials from the Secret).

## Commits

- `fix(k8s): stop hardcoding a personal AWS host path, drop the unused fl-client mount`
- `fix(k8s): do not fetch FL kits from S3 by default (#922)`

(A third commit — `fix(k8s): fail the render when the vocab-load AWS mount has no host path` — landed on develop independently and was dropped during rebase.)

## Verification

- `helm lint deploy/providers/kubernetes` — pass.
- `helm template deploy/providers/kubernetes` — pass (default, S3-enabled, and hostPath render paths checked).

## Acceptance Criteria

*Imported from issue #904*

- [ ] Decide whether the K8s grant should match the Compose path (`USAGE` on `omop` + `SELECT` on its tables) or whether something legitimately needs wider read
- [ ] If narrowing: apply and verify the cohort + imaging paths against a real Kubernetes trust
- [ ] Both provisioning paths documented as granting the same thing, or the difference documented deliberately