### PR TITLE
feat(fl): per-job fl-server — flip-api scales fl-server to zero between training jobs (NVFLARE)

### DIFF
--- a/deploy/providers/AWS/README.md
+++ b/deploy/providers/AWS/README.md
@@ -996,7 +996,8 @@ the direction of the request flow.
 ### Central Hub Infrastructure
 
 - **VPC**: Custom VPC (`10.0.0.0/16` by default) across 2 AZs, with public + private subnets and a single shared NAT Gateway
-- **ECS Fargate cluster**: Runs the Central Hub application services (`flip-api`, `fl-api-net-1`, `fl-server-net-1`) as awsvpc tasks in **private subnets**. Task definitions, services, and per-service security groups live in `ecs*.tf` and `iam_ecs.tf`.
+- **ECS Fargate cluster**: Runs the Central Hub application services (`flip-api`, `fl-api-net-1`, `fl-server-net-1`) as awsvpc tasks in **private subnets**. Task definitions, services, and per-service security groups live in `ecs*.tf` and `iam_ecs.tf`. The `fl-server-net-1` service declares `lifecycle { ignore_changes = [desired_count] }` — once flip-api scales it to zero between FL jobs (#735), its runtime scale state is app-managed, not Terraform-owned, so an unrelated `terraform apply` cannot spin it back up mid-idle.
+- **ECS task-role IAM**: `iam_ecs.tf` gives flip-api's task role a scoped `ecs:UpdateService` + `ecs:DescribeServices` grant on the single `fl-server-net-1` service ARN (no `ecs:*`, no `Resource="*"`) so the future per-job scale-to-zero call is authorised.
 - **Central Hub SSM bastion**: t3.micro instance with a 10 GB root volume in a **private subnet**. It carries only the SSM managed IAM policy and a PostgreSQL client for ad-hoc RDS operations; application workloads run on ECS Fargate.
 - **Trust EC2**: Separate t3.xlarge instance in a **private subnet**, running Trust services via Docker Compose
   - Deployed using custom Terraform module (`modules/trust_ec2`)

--- a/deploy/providers/AWS/ecs_services.tf
+++ b/deploy/providers/AWS/ecs_services.tf
@@ -162,6 +162,14 @@ resource "aws_ecs_service" "fl_server_net_1" {
   launch_type            = "FARGATE"
   enable_execute_command = var.ecs_exec_enabled
 
+  # desired_count becomes app-managed once flip-api scales the FL server to
+  # zero between jobs and back up on demand (#735). Terraform must not
+  # reconcile it, or an unrelated `terraform apply` mid-idle spins the
+  # service back up. The app is the source of truth for runtime scale state.
+  lifecycle {
+    ignore_changes = [desired_count]
+  }
+
   network_configuration {
     subnets          = module.flip_vpc.private_subnets
     security_groups  = [aws_security_group.ecs_fl_server.id]

--- a/deploy/providers/AWS/iam_ecs.tf
+++ b/deploy/providers/AWS/iam_ecs.tf
@@ -219,6 +219,19 @@ data "aws_iam_policy_document" "ecs_flip_api_task" {
     actions   = ["ssm:GetParameter"]
     resources = [aws_ssm_parameter.fl_kit_slot_names.arn]
   }
+
+  # Per-job fl-server scale-to-zero (#735): flip-api will call ECS UpdateService
+  # to set desired_count to 0 between FL jobs and back to 1 when a job lands,
+  # plus DescribeServices to read the current scale state first. Scoped to the
+  # single fl-server ECS service ARN — deliberately no ecs:* and no
+  # Resource="*", matching the rest of this policy's least-privilege shape.
+  statement {
+    sid     = "EcsFlServerScale"
+    actions = ["ecs:UpdateService", "ecs:DescribeServices"]
+    resources = [
+      "arn:aws:ecs:${var.AWS_REGION}:${data.aws_caller_identity.current.account_id}:service/${aws_ecs_cluster.flip.name}/fl-server-net-1",
+    ]
+  }
 }
 
 resource "aws_iam_role_policy" "ecs_flip_api_task" {


### PR DESCRIPTION
Part of #735 (Phase 1, does not close it).

## What

Infra prerequisites for flip-api to scale the ECS `fl-server-net-1` service to zero between FL jobs and back up on demand:

- **C3 — `desired_count` no longer Terraform-reconciled.** `aws_ecs_service.fl_server_net_1` now declares `lifecycle { ignore_changes = [desired_count] }`. Once flip-api owns runtime scale state, an unrelated `terraform apply` mid-idle can no longer spin the service back up.
- **C4 — scoped ECS IAM for flip-api.** Added a statement to the flip-api task-role policy granting `ecs:UpdateService` + `ecs:DescribeServices` on the single fl-server service ARN (`arn:aws:ecs:…:service/flip-cluster/fl-server-net-1`). No `ecs:*`, no `Resource="*"` — matching the policy's existing least-privilege shape.
- Documented both in `deploy/providers/AWS/README.md`.

## Verification

- `cd deploy/providers/AWS && tofu init -backend=false && tofu validate` → Success (pre-existing deprecation warnings only)
- `make checkov-lint` → Passed checks: 113, Failed checks: 0, Skipped checks: 14

## Note

The pre-existing task-definition drift noted in #735 (TF says 1024 CPU/2048 MiB for fl-server, deployed runs 2048/8192) is left untouched to keep this diff minimal.