### PR TITLE
NVFLARE: local (epsilon, delta) differential-privacy filter — parity with Flower

### DIFF
--- a/docs/source/components/component-fl-nodes.rst
+++ b/docs/source/components/component-fl-nodes.rst
@@ -304,9 +304,15 @@ The server will also use the package to update the status, as well as to upload 
 Privacy filters on shared model updates
 ---------------------------------------
 
-Both backends privatise a client's training result before it leaves the site, but with different
-mechanisms: NVFLARE sparsifies and clips without noise, while Flower clips and adds calibrated
-Gaussian noise for a formal ``(epsilon, delta)`` guarantee.
+Both backends privatise a client's training result before it leaves the site. Each offers a formal
+``(epsilon, delta)`` mechanism — clip the update to an L2 norm, then add calibrated Gaussian noise —
+and NVFLARE additionally defaults to a heuristic sparsifier that predates it. Which one an NVFLARE
+job runs is a recipe choice; the two are alternatives rather than a chain.
+
+.. note::
+
+   Neither backend accounts for composition across rounds: each round spends the budget again. The
+   parameters below describe one round's mechanism, not a per-run guarantee.
 
 NVFLARE: percentile sparsification
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -336,10 +342,44 @@ run with ``off: true``. Two caveats for anyone changing them:
   ``(epsilon, delta)`` guarantee. It complements — rather than replaces — FLIP's primary output controls
   (review of the uploaded app code and aggregate-only results).
 
+NVFLARE: local ``(epsilon, delta)`` differential privacy
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Since FLIP#1145 an NVFLARE job can run the same mechanism as a Flower one. Pass
+``FlipFedAvgRecipe(local_dp=LocalDp(...))`` and the recipe wires
+``flip.nvflare.components.LocalDifferentialPrivacy`` as the train-task result filter **in place of**
+the percentile sparsifier: the client's weight diff is clipped to ``clipping_norm`` and Gaussian
+noise of standard deviation ``sensitivity * sqrt(2 ln(1.25 / delta)) / epsilon`` is added before the
+result leaves the site. That is the analytic Gaussian mechanism, and it is the same expression
+``flip.flower.privacy`` uses, so a job configured with the same numbers gets the same mechanism on
+either backend — a unit test asserts the two agree element-for-element.
+
+Defaults match the Flower mod's (``clipping_norm=1.0``, ``sensitivity=1e-4``, ``epsilon=10.0``,
+``delta=1e-5``) and are deliberately utility-first, so a DP-on tutorial still converges. They are not
+a defensible budget: a real one calibrates ``sensitivity`` to the local dataset
+(``2 * clipping_norm / |D|`` for an average-of-examples update). ``off=True`` makes the filter a
+pass-through so DP-on and DP-off runs use an identical job, and it logs a warning, because a raw
+update leaving a trust is the event an operator audits for.
+
+The filter fails closed. A result that is not a weight diff, an array whose dtype it cannot classify
+(a bool mask or complex weights may hold learned values), or an update with no floating-point array
+at all is refused rather than forwarded — integer step counters such as BatchNorm's
+``num_batches_tracked`` are the one thing passed through untouched. On a head-only job it is ordered
+after ``KeepOnlyVars``, so the clipped norm covers the trainable parameters only.
+
+.. note::
+
+   NVFLARE also ships ``SVTPrivacy``, the only filter NVIDIA labels differential privacy. FLIP does
+   not use it, and the reason is measured in FLIP#1145: it is a *selection* primitive whose whole
+   advantage is that below-threshold queries cost nothing, which never applies to FedAvg's dense
+   per-round update. On a real 7M-parameter update it left a cosine similarity of 0.001 with the
+   true update at every setting tried, scoring no better than on a structureless one, because it
+   clips each released value to ``±gamma`` before adding noise calibrated in units of ``gamma``.
+
 Site-enforced privacy policy (per trust)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The filter above is part of the **app**: it is configured in the job's ``config_fed_client.json``, so its
+The filters above are part of the **app**: it is configured in the job's ``config_fed_client.json``, so its
 parameters — including ``off: true`` — are chosen on the researcher's side. Since FLIP#851 each trust can
 additionally enforce its **own** update-privacy filter through NVFLARE's site privacy policy
 (``local/privacy.json`` in the client's workspace), configured entirely on the trust's side:
@@ -444,4 +484,3 @@ the description above:
   the per-job-type implementations under `fl-apps/ <https://github.com/londonaicentre/FLIP/tree/develop/fl-apps/nvflare>`__.
 - every NVFLARE job type takes a plain training/evaluation script that calls
   ``nvflare.client`` directly (`fed_opt` reuses `standard`'s trainer contract unchanged).
-

--- a/flip-utils/flip/nvflare/components/__init__.py
+++ b/flip-utils/flip/nvflare/components/__init__.py
@@ -30,6 +30,7 @@ Exports:
     - ValidationJsonGenerator: Validation results JSON generator
     - EvaluationJsonGenerator: Evaluation results JSON generator
     - PersistToS3AndCleanup: S3 persistence and cleanup component
+    - LocalDifferentialPrivacy: Local (epsilon, delta) DP filter — clip + Gaussian noise
     - PercentilePrivacy: Percentile-based privacy filter
     - StagePercentilePrivacy: Stage-aware percentile-based privacy filter
     - CleanupImages: Image cleanup executor
@@ -47,6 +48,7 @@ from flip.nvflare.components.flip_analytics_bridge import FlipAnalyticsBridge
 from flip.nvflare.components.flip_client_event_handler import ClientEventHandler
 from flip.nvflare.components.flip_server_event_handler import ServerEventHandler
 from flip.nvflare.components.keep_vars_filter import KeepOnlyVars
+from flip.nvflare.components.local_dp import LocalDifferentialPrivacy
 from flip.nvflare.components.persist_and_cleanup import PersistToS3AndCleanup
 from flip.nvflare.components.pt_model_locator import (
     EvaluationModelLocator,
@@ -74,6 +76,7 @@ __all__ = [
     "ValidationJsonGenerator",
     "EvaluationJsonGenerator",
     "PersistToS3AndCleanup",
+    "LocalDifferentialPrivacy",
     "PercentilePrivacy",
     "StagePercentilePrivacy",
     "CleanupImages",

--- a/flip-utils/flip/nvflare/components/local_dp.py
+++ b/flip-utils/flip/nvflare/components/local_dp.py
@@ -1,0 +1,239 @@
+# Copyright (c) 2026 Guy's and St Thomas' NHS Foundation Trust & King's College London
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Local ``(epsilon, delta)`` differential privacy for NVFLARE clients.
+
+The NVFLARE counterpart of :mod:`flip.flower.privacy`: a client result filter that clips the local
+update to a fixed L2 norm and adds calibrated Gaussian noise before the result leaves the site, so
+the FL server only ever receives a privatised update.
+
+This exists because FLIP's two backends otherwise offer different things under the same name.
+``PercentilePrivacy`` — NVFLARE's default here — zeroes the smallest-magnitude components of the
+update and truncates the survivors. That bounds what one round reveals, but adds no noise and
+carries no ``(epsilon, delta)`` guarantee; NVIDIA's own documentation calls it "truncation of
+weights by percentile" and reserves the differential-privacy label for its sparse-vector filter.
+That sparse-vector filter is not the answer either: it is a *selection* primitive whose advantage is
+that below-threshold queries are free, which never applies to FedAvg's dense per-round update. See
+FLIP#1145 for the measurements.
+
+Two limits worth stating plainly, both shared with the Flower mod:
+
+* **No composition accounting.** Each round spends the budget again. The parameters describe one
+  round's mechanism, not a per-run guarantee.
+* **Sensitivity is a parameter, not a derivation.** A defensible budget calibrates it to the local
+  dataset (``2 * clipping_norm / |D|`` for an average-of-examples update); the default is
+  utility-first so a DP-on tutorial still converges.
+
+The numerics deliberately mirror ``flwr.supercore.differential_privacy``'s ``clip_inputs_inplace``
+and ``add_gaussian_noise_inplace`` rather than importing them: ``flwr`` is a dev-group dependency of
+flip-utils, never a runtime one, so the NVFLARE path must not import it. A parity test asserts the
+two implementations agree element-for-element wherever ``flwr`` is installed.
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+from nvflare.apis.dxo import DXO, DataKind
+from nvflare.apis.dxo_filter import DXOFilter
+from nvflare.apis.fl_context import FLContext
+from nvflare.apis.shareable import Shareable
+
+__all__ = ["LocalDifferentialPrivacy"]
+
+
+def _global_l2_norm(arrays: list[np.ndarray]) -> float:
+    """The L2 norm of the arrays taken together, as one flat vector.
+
+    Reduced per array and combined in Python floats, exactly as Flower's ``get_norm`` does. One
+    concatenated ``np.linalg.norm`` is the same quantity mathematically but rounds differently in
+    float32, which would put the two backends' clipped updates a few ulps apart.
+    """
+    return float(math.sqrt(sum(float(np.linalg.norm(np.asarray(array).flat)) ** 2 for array in arrays)))
+
+
+def _clip_inplace(arrays: list[np.ndarray], clipping_norm: float) -> float:
+    """Scale ``arrays`` in place so their combined L2 norm is at most ``clipping_norm``.
+
+    The FlatClip of https://arxiv.org/abs/1710.06963, matching Flower's ``clip_inputs_inplace``: one
+    scaling factor across the whole update, so the update's direction is preserved exactly and only
+    its length is bounded.
+
+    Args:
+        arrays (list[np.ndarray]): Floating-point arrays making up the update. Modified in place.
+        clipping_norm (float): The L2 bound.
+
+    Returns:
+        float: The scaling factor applied — 1.0 when the update was already inside the bound.
+    """
+    norm = _global_l2_norm(arrays)
+    # Flower divides unguarded and relies on `min(1, inf)` for the all-zero update; the guard is
+    # explicit here so an empty round cannot raise a warning storm. Same resulting factor.
+    scaling_factor = 1.0 if norm == 0.0 else min(1.0, clipping_norm / norm)
+    for array in arrays:
+        array *= scaling_factor
+    return scaling_factor
+
+
+def _add_gaussian_noise_inplace(arrays: list[np.ndarray], std_dev: float) -> None:
+    """Add ``N(0, std_dev)`` noise to every element, in place.
+
+    Mirrors Flower's ``add_gaussian_noise_inplace``, including drawing from numpy's global RNG and
+    casting the noise to each array's dtype before adding, so a seeded run reproduces exactly.
+
+    Args:
+        arrays (list[np.ndarray]): Floating-point arrays to noise. Modified in place.
+        std_dev (float): Standard deviation of the noise.
+    """
+    for array in arrays:
+        array += np.random.normal(0, std_dev, array.shape).astype(array.dtype)
+
+
+class LocalDifferentialPrivacy(DXOFilter):
+    """Clip and noise a client's weight diff before it leaves the site.
+
+    Wired as a client ``TASK_RESULT`` filter on the train task. It must be ordered AFTER
+    ``KeepOnlyVars`` on a head-only job, so the norm is computed over the trainable parameters
+    rather than the frozen backbone's all-zero diffs.
+    """
+
+    def __init__(
+        self,
+        clipping_norm: float = 1.0,
+        sensitivity: float = 1e-4,
+        epsilon: float = 10.0,
+        delta: float = 1e-5,
+        off: bool = False,
+    ) -> None:
+        """Initialise the filter.
+
+        Args:
+            clipping_norm (float): L2 norm the update is clipped to before noise is added. Defaults
+                to 1.0, matching ``flip.flower.privacy``.
+            sensitivity (float): How much one training example can move the update. Defaults to
+                1e-4. See the module docstring: this is a parameter, not a derivation.
+            epsilon (float): Privacy budget for one round. Smaller means more privacy and more
+                noise. Defaults to 10.0.
+            delta (float): Probability the guarantee fails outright. Defaults to 1e-5.
+            off (bool): When True the filter is a pass-through, mirroring ``PercentilePrivacy``'s
+                ``off`` so DP-on and DP-off runs use an identical job. Defaults to False.
+
+        Raises:
+            ValueError: If any parameter is outside its permitted range.
+        """
+        super().__init__(
+            supported_data_kinds=[DataKind.WEIGHTS, DataKind.WEIGHT_DIFF],
+            # WEIGHTS is declared filterable so it reaches process_dxo and can be REFUSED there.
+            # Leaving it out would make the filter skip such a result silently, which is exactly
+            # the unprivatised release this component exists to prevent.
+            data_kinds_to_filter=[DataKind.WEIGHTS, DataKind.WEIGHT_DIFF],
+        )
+        # isfinite guards are load-bearing: NaN compares False against everything, so a bare range
+        # check waves it through and poisons the noise stddev; inf silently disables clipping or
+        # zeroes the noise. Delta needs none — NaN and inf both fail its interval test already.
+        if not math.isfinite(clipping_norm) or clipping_norm <= 0:
+            raise ValueError(f"clipping_norm must be positive and finite, got {clipping_norm}.")
+        if not math.isfinite(sensitivity) or sensitivity < 0:
+            raise ValueError(f"sensitivity must be non-negative and finite, got {sensitivity}.")
+        if not math.isfinite(epsilon) or epsilon <= 0:
+            raise ValueError(f"epsilon must be positive and finite, got {epsilon}.")
+        if not 0 < delta < 1:
+            raise ValueError(f"delta must lie in (0, 1), got {delta}.")
+        self.clipping_norm = clipping_norm
+        self.sensitivity = sensitivity
+        self.epsilon = epsilon
+        self.delta = delta
+        self.off = off
+
+    @property
+    def noise_stddev(self) -> float:
+        """Standard deviation of the Gaussian noise, in the units of the model parameters.
+
+        The analytic Gaussian mechanism's ``sensitivity * sqrt(2 ln(1.25 / delta)) / epsilon`` —
+        the same expression ``flip.flower.privacy.LocalDpConfig.noise_stddev`` uses, so a job
+        configured identically on either backend gets the same mechanism.
+
+        Returns:
+            float: The noise standard deviation.
+        """
+        return self.sensitivity * math.sqrt(2 * math.log(1.25 / self.delta)) / self.epsilon
+
+    def process_dxo(self, dxo: DXO, shareable: Shareable, fl_ctx: FLContext) -> None | DXO:
+        """Clip and noise the update carried by ``dxo``.
+
+        Args:
+            dxo (DXO): The client's training result.
+            shareable (Shareable): The shareable the DXO belongs to.
+            fl_ctx (FLContext): Context provided by the workflow.
+
+        Returns:
+            None | DXO: The privatised DXO, or the unchanged DXO when the filter is off.
+
+        Raises:
+            ValueError: If the result is not a weight diff, carries an array whose dtype cannot be
+                classified, or carries no floating-point array at all. Each of those is refused
+                rather than forwarded: releasing a raw update from a trust is the failure this
+                component exists to prevent, so it fails closed.
+        """
+        if self.off:
+            # WARNING, not INFO: a raw update leaving the trust is the event an operator audits for.
+            self.log_warning(fl_ctx, "FLIP local DP is off: the update is released unprivatised.")
+            return dxo
+
+        if dxo.data_kind != DataKind.WEIGHT_DIFF:
+            raise ValueError(
+                f"FLIP local DP privatises a weight diff, but this result is {dxo.data_kind}. The "
+                "mechanism clips the UPDATE's norm, which absolute weights do not carry, and this "
+                "filter has no copy of the global model to subtract. Return the result with "
+                'params_type="DIFF"; the update is not being released.'
+            )
+
+        float_names: list[str] = []
+        passthrough_names: list[str] = []
+        unclassifiable: dict[str, str] = {}
+        for name, value in dxo.data.items():
+            dtype = np.asarray(value).dtype
+            if np.issubdtype(dtype, np.floating):
+                float_names.append(name)
+            elif np.issubdtype(dtype, np.integer):
+                # BatchNorm's num_batches_tracked and friends are step counters, not learned
+                # parameters, and float noise cannot be written back into them. Integer-QUANTISED
+                # weights would also land here; dtype alone cannot tell the two apart.
+                passthrough_names.append(name)
+            else:
+                unclassifiable[name] = str(dtype)
+        if unclassifiable:
+            raise ValueError(
+                "FLIP local DP privatises floating-point arrays and passes through integer step "
+                f"counters, but the update carries arrays it cannot classify ({unclassifiable}); "
+                "they may hold learned values, so the update is not being released."
+            )
+        if not float_names:
+            raise ValueError(
+                "FLIP local DP found no floating-point arrays in the update, so there is nothing "
+                "it can privatise; the update is not being released."
+            )
+
+        updates = [np.array(dxo.data[name], copy=True) for name in float_names]
+        scaling_factor = _clip_inplace(updates, self.clipping_norm)
+        _add_gaussian_noise_inplace(updates, self.noise_stddev)
+        for name, array in zip(float_names, updates, strict=True):
+            dxo.data[name] = array
+
+        self.log_info(
+            fl_ctx,
+            f"FLIP local DP: update clipped to L2 norm {self.clipping_norm:.4f} "
+            f"(scaling factor {scaling_factor:.4f}) and Gaussian noise of stddev "
+            f"{self.noise_stddev:.3e} added across {len(float_names)} array(s); "
+            f"{len(passthrough_names)} integer array(s) passed through.",
+        )
+        return dxo

--- a/flip-utils/flip/nvflare/recipes/flip_fedavg_recipe.py
+++ b/flip-utils/flip/nvflare/recipes/flip_fedavg_recipe.py
@@ -78,6 +78,9 @@ from flip.nvflare.components import (
     ValidationJsonGenerator,
 )
 from flip.nvflare.components import (
+    LocalDifferentialPrivacy as LocalDifferentialPrivacyFilter,
+)
+from flip.nvflare.components import (
     PercentilePrivacy as PercentilePrivacyFilter,
 )
 from flip.nvflare.controllers import BroadcastTask, InitTraining, ScatterAndGather
@@ -89,8 +92,39 @@ _DEV_MODEL_ID = "00000000-0000-0000-0000-000000000001"
 
 
 @dataclass
+class LocalDp:
+    """Local ``(epsilon, delta)`` differential privacy — the parity counterpart of Flower's mod.
+
+    Clips the client's weight diff to ``clipping_norm`` and adds Gaussian noise at the analytic
+    mechanism's ``sensitivity * sqrt(2 ln(1.25 / delta)) / epsilon``, the same expression
+    ``flip.flower.privacy.LocalDpConfig`` uses, so a job configured identically on either backend
+    gets the same mechanism (FLIP#1145). Defaults match that module's.
+
+    Neither backend accounts for composition across rounds: each round spends the budget again, so
+    these parameters describe one round's mechanism rather than a per-run guarantee.
+
+    Attributes:
+        clipping_norm: L2 bound the update is clipped to before noise. Defaults to 1.0.
+        sensitivity: How much one training example can move the update. Defaults to 1e-4.
+        epsilon: Budget for one round; smaller means more privacy and more noise. Defaults to 10.0.
+        delta: Probability the guarantee fails outright. Defaults to 1e-5.
+        off: Pass-through toggle, so DP-on and DP-off runs use an identical job. Defaults to False.
+    """
+
+    clipping_norm: float = 1.0
+    sensitivity: float = 1e-4
+    epsilon: float = 10.0
+    delta: float = 1e-5
+    off: bool = False
+
+
+@dataclass
 class PercentilePrivacy:
-    """Percentile-based DP noise filter configuration.
+    """Percentile sparsification filter configuration.
+
+    Not differential privacy and not noise, despite the historical name: NVIDIA documents this
+    filter as "truncation of weights by percentile" and reserves the differential-privacy label for
+    its sparse-vector filter. For a formal ``(epsilon, delta)`` mechanism use ``local_dp`` below.
 
     Stock NVFLARE semantics (Shokri & Shmatikov "largest percentile to share"): components of the
     per-step weight diff with magnitude BELOW the ``percentile``-th percentile are zeroed (only the
@@ -126,7 +160,12 @@ class FlipFedAvgRecipe(Recipe):
         model_id: Real UUID for SimEnv/PocEnv runs. Written into ``meta.json['custom_props']``
             so FLIP components can resolve it lazily at first task. Production runs override
             this via the FLIP-API which writes the real model id into the same key.
-        percentile_privacy: Configuration for the percentile-based DP noise filter.
+        percentile_privacy: Configuration for the percentile sparsification filter (not DP; see
+            its dataclass). Ignored when ``local_dp`` is set — the two are alternatives.
+        local_dp: When set, wire the local (epsilon, delta) DP filter on train results instead
+            of the percentile sparsifier, giving NVFLARE the mechanism Flower already has.
+            Ordered after KeepOnlyVars on a head-only job, so the clipped norm covers the
+            trainable parameters only. Defaults to None (percentile sparsifier, as before).
         heart_beat_timeout, validation_timeout, wait_time_after_min_received: NVFlare timing knobs.
         project_id, query: Top-level keys on the client config (consumed by the FLIP-API
             placeholder substitution and read by the trainer at runtime).
@@ -176,6 +215,7 @@ class FlipFedAvgRecipe(Recipe):
         train_args: str = "--project_id {project_id}",
         model_id: str = _DEV_MODEL_ID,
         percentile_privacy: PercentilePrivacy | None = None,
+        local_dp: LocalDp | None = None,
         heart_beat_timeout: int = 600,
         validation_timeout: int = 12000,
         wait_time_after_min_received: int = 10,
@@ -206,6 +246,7 @@ class FlipFedAvgRecipe(Recipe):
         self.train_args = train_args
         self.model_id = model_id
         self.percentile_privacy = percentile_privacy or PercentilePrivacy()
+        self.local_dp = local_dp
         self.heart_beat_timeout = heart_beat_timeout
         self.validation_timeout = validation_timeout
         self.wait_time_after_min_received = wait_time_after_min_received
@@ -370,16 +411,30 @@ class FlipFedAvgRecipe(Recipe):
                 id="reconstruct_full_model",
             )
 
-        # Clients: percentile-privacy DP noise on training results.
-        job.to_clients(
-            PercentilePrivacyFilter(
+        # Clients: one privacy filter on training results — a formal (epsilon, delta) mechanism
+        # when local_dp is configured, otherwise the percentile sparsifier. They are
+        # alternatives rather than a chain: stacking them would compound the utility cost while
+        # muddying which guarantee, if any, the released update carries.
+        privacy_filter = (
+            LocalDifferentialPrivacyFilter(
+                clipping_norm=self.local_dp.clipping_norm,
+                sensitivity=self.local_dp.sensitivity,
+                epsilon=self.local_dp.epsilon,
+                delta=self.local_dp.delta,
+                off=self.local_dp.off,
+            )
+            if self.local_dp is not None
+            else PercentilePrivacyFilter(
                 gamma=self.percentile_privacy.gamma,
                 percentile=self.percentile_privacy.percentile,
                 off=self.percentile_privacy.off,
-            ),
+            )
+        )
+        job.to_clients(
+            privacy_filter,
             filter_type=FilterType.TASK_RESULT,
             tasks=[self.train_task_name],
-            id="percentile_privacy",
+            id="local_dp" if self.local_dp is not None else "percentile_privacy",
         )
 
         # Clients: event handlers — client event handler + analytics bridge.

--- a/flip-utils/tests/unit/nvflare/components/test_local_dp.py
+++ b/flip-utils/tests/unit/nvflare/components/test_local_dp.py
@@ -1,0 +1,193 @@
+# Copyright (c) 2026 Guy's and St Thomas' NHS Foundation Trust & King's College London
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Unit tests for the NVFLARE local ``(epsilon, delta)`` differential-privacy filter (FLIP#1145).
+
+The refusal tests matter as much as the arithmetic ones: every path that cannot privatise an update
+must raise rather than forward it, because forwarding means a raw update leaves the trust.
+"""
+
+import math
+
+import numpy as np
+import pytest
+from nvflare.apis.dxo import DXO, DataKind
+from nvflare.apis.fl_context import FLContext
+from nvflare.apis.shareable import Shareable
+
+from flip.nvflare.components.local_dp import LocalDifferentialPrivacy
+
+
+def _diff(**arrays: np.ndarray) -> DXO:
+    return DXO(data_kind=DataKind.WEIGHT_DIFF, data=dict(arrays))
+
+
+def _run(filt: LocalDifferentialPrivacy, dxo: DXO) -> DXO:
+    return filt.process_dxo(dxo, Shareable(), FLContext())
+
+
+@pytest.fixture
+def update() -> dict[str, np.ndarray]:
+    """A float update well outside the clipping norm, plus an integer step counter."""
+    rng = np.random.default_rng(0)
+    return {
+        "layer.weight": rng.normal(0, 0.5, (40, 8)).astype(np.float32),
+        "layer.bias": rng.normal(0, 0.5, (40,)).astype(np.float32),
+        "bn.num_batches_tracked": np.array([7], dtype=np.int64),
+    }
+
+
+class TestMechanism:
+    def test_clipping_bounds_the_norm_and_preserves_direction(self, update):
+        """FlatClip scales the whole update by one factor, so only its length changes."""
+        original = np.concatenate([update["layer.weight"].ravel(), update["layer.bias"].ravel()])
+        # sensitivity=0 isolates the clipping step: a zero stddev means no noise is added.
+        out = _run(LocalDifferentialPrivacy(clipping_norm=1.0, sensitivity=0.0), _diff(**update))
+
+        clipped = np.concatenate([out.data["layer.weight"].ravel(), out.data["layer.bias"].ravel()])
+        assert np.linalg.norm(original) > 1.0, "fixture must start outside the bound to test clipping"
+        assert np.linalg.norm(clipped) == pytest.approx(1.0, rel=1e-5)
+        cosine = float(original @ clipped / (np.linalg.norm(original) * np.linalg.norm(clipped)))
+        assert cosine == pytest.approx(1.0, rel=1e-6)
+
+    def test_an_update_inside_the_bound_is_not_scaled(self):
+        """min(1, C/norm) leaves a short update alone; only noise should move it."""
+        small = np.full((10,), 0.01, dtype=np.float32)
+        out = _run(LocalDifferentialPrivacy(clipping_norm=1.0, sensitivity=0.0), _diff(w=small))
+        np.testing.assert_allclose(out.data["w"], small)
+
+    def test_noise_is_added_and_scales_with_the_budget(self, update):
+        """A smaller epsilon means more noise: the mechanism is not clipping alone."""
+        np.random.seed(0)
+        loose = _run(LocalDifferentialPrivacy(sensitivity=1e-2, epsilon=10.0), _diff(**update))
+        np.random.seed(0)
+        tight = _run(LocalDifferentialPrivacy(sensitivity=1e-2, epsilon=0.1), _diff(**update))
+
+        clipped_only = _run(
+            LocalDifferentialPrivacy(sensitivity=0.0), _diff(**{k: v.copy() for k, v in update.items()})
+        )
+        loose_delta = float(np.abs(loose.data["layer.weight"] - clipped_only.data["layer.weight"]).mean())
+        tight_delta = float(np.abs(tight.data["layer.weight"] - clipped_only.data["layer.weight"]).mean())
+        assert loose_delta > 0.0
+        assert tight_delta > loose_delta
+
+    def test_integer_counters_pass_through_untouched(self, update):
+        out = _run(LocalDifferentialPrivacy(), _diff(**update))
+        np.testing.assert_array_equal(out.data["bn.num_batches_tracked"], np.array([7], dtype=np.int64))
+        assert out.data["bn.num_batches_tracked"].dtype == np.int64
+
+    def test_float32_stays_float32(self, update):
+        """Noise is cast to the array's dtype, so the payload does not silently double in size."""
+        out = _run(LocalDifferentialPrivacy(), _diff(**update))
+        assert out.data["layer.weight"].dtype == np.float32
+
+    def test_noise_stddev_is_the_analytic_gaussian_mechanism(self):
+        filt = LocalDifferentialPrivacy(sensitivity=1e-4, epsilon=10.0, delta=1e-5)
+        assert filt.noise_stddev == pytest.approx(1e-4 * math.sqrt(2 * math.log(1.25 / 1e-5)) / 10.0)
+
+
+class TestRefusals:
+    """Every path that cannot privatise must raise; forwarding would release a raw update."""
+
+    def test_a_weights_result_is_refused(self, update):
+        dxo = DXO(data_kind=DataKind.WEIGHTS, data={"layer.weight": update["layer.weight"]})
+        with pytest.raises(ValueError, match="weight diff"):
+            _run(LocalDifferentialPrivacy(), dxo)
+
+    def test_an_unclassifiable_dtype_is_refused(self):
+        """A bool mask or complex weight may carry learned values; dtype alone cannot clear it."""
+        with pytest.raises(ValueError, match="cannot classify"):
+            _run(LocalDifferentialPrivacy(), _diff(w=np.ones((4,), dtype=np.float32), mask=np.ones((4,), dtype=bool)))
+
+    def test_an_update_with_no_float_arrays_is_refused(self):
+        with pytest.raises(ValueError, match="no floating-point arrays"):
+            _run(LocalDifferentialPrivacy(), _diff(counter=np.array([1], dtype=np.int64)))
+
+    @pytest.mark.parametrize(
+        ("kwargs", "match"),
+        [
+            ({"clipping_norm": 0.0}, "clipping_norm"),
+            ({"clipping_norm": -1.0}, "clipping_norm"),
+            ({"clipping_norm": math.inf}, "clipping_norm"),
+            ({"clipping_norm": math.nan}, "clipping_norm"),
+            ({"sensitivity": -1e-9}, "sensitivity"),
+            ({"sensitivity": math.nan}, "sensitivity"),
+            ({"epsilon": 0.0}, "epsilon"),
+            ({"epsilon": math.inf}, "epsilon"),
+            ({"epsilon": math.nan}, "epsilon"),
+            ({"delta": 0.0}, "delta"),
+            ({"delta": 1.0}, "delta"),
+            ({"delta": math.nan}, "delta"),
+        ],
+    )
+    def test_invalid_parameters_raise_at_construction(self, kwargs, match):
+        with pytest.raises(ValueError, match=match):
+            LocalDifferentialPrivacy(**kwargs)
+
+
+class TestOffToggle:
+    def test_off_is_a_pass_through(self, update):
+        """DP-on and DP-off runs use an identical job, as PercentilePrivacy's `off` allows."""
+        out = _run(LocalDifferentialPrivacy(off=True), _diff(**update))
+        np.testing.assert_array_equal(out.data["layer.weight"], update["layer.weight"])
+
+    def test_off_does_not_refuse_a_weights_result(self, update):
+        """Off means off: the filter is inert, not a validator."""
+        dxo = DXO(data_kind=DataKind.WEIGHTS, data={"layer.weight": update["layer.weight"]})
+        assert _run(LocalDifferentialPrivacy(off=True), dxo) is dxo
+
+
+class TestFlowerParity:
+    """The two backends must implement the same mechanism, not merely similar ones.
+
+    ``flwr`` is a dev-group dependency of flip-utils and deliberately not a runtime one, so the
+    NVFLARE filter reimplements the arithmetic rather than importing it. These tests are what stop
+    the two copies drifting: they run wherever ``flwr`` is installed, which includes CI.
+    """
+
+    def test_noise_stddev_matches_the_flower_config(self):
+        pytest.importorskip("flwr")
+        from flip.flower.privacy import LocalDpConfig
+
+        for sensitivity, epsilon, delta in [(1e-4, 10.0, 1e-5), (1e-2, 0.5, 1e-6)]:
+            flower = LocalDpConfig(sensitivity=sensitivity, epsilon=epsilon, delta=delta)
+            nvflare = LocalDifferentialPrivacy(sensitivity=sensitivity, epsilon=epsilon, delta=delta)
+            assert nvflare.noise_stddev == flower.noise_stddev
+
+    def test_defaults_match_the_flower_defaults(self):
+        pytest.importorskip("flwr")
+        from flip.flower.privacy import LocalDpConfig
+
+        flower, nvflare = LocalDpConfig(), LocalDifferentialPrivacy()
+        assert (nvflare.clipping_norm, nvflare.sensitivity, nvflare.epsilon, nvflare.delta) == (
+            flower.clipping_norm,
+            flower.sensitivity,
+            flower.epsilon,
+            flower.delta,
+        )
+
+    def test_clip_and_noise_agree_with_flowers_helpers_element_for_element(self, update):
+        pytest.importorskip("flwr")
+        from flwr.supercore.differential_privacy import add_gaussian_noise_inplace, clip_inputs_inplace
+
+        filt = LocalDifferentialPrivacy(clipping_norm=1.0, sensitivity=1e-2, epsilon=1.0)
+        floats = ["layer.weight", "layer.bias"]
+
+        np.random.seed(1234)
+        ours = _run(filt, _diff(**{k: v.copy() for k, v in update.items()}))
+
+        np.random.seed(1234)
+        theirs = [update[name].copy() for name in floats]
+        clip_inputs_inplace(theirs, filt.clipping_norm)
+        add_gaussian_noise_inplace(theirs, filt.noise_stddev)
+
+        for name, expected in zip(floats, theirs, strict=True):
+            np.testing.assert_array_equal(ours.data[name], expected)

--- a/flip-utils/tests/unit/nvflare/recipes/test_flip_fedavg_recipe.py
+++ b/flip-utils/tests/unit/nvflare/recipes/test_flip_fedavg_recipe.py
@@ -24,7 +24,7 @@ _stub_models.get_model = lambda: object()
 sys.modules.setdefault("models", _stub_models)
 
 from flip.nvflare.recipes import FlipFedAvgRecipe  # noqa: E402
-from flip.nvflare.recipes.flip_fedavg_recipe import _DEV_MODEL_ID, PercentilePrivacy  # noqa: E402
+from flip.nvflare.recipes.flip_fedavg_recipe import _DEV_MODEL_ID, LocalDp, PercentilePrivacy  # noqa: E402
 from flip.nvflare.runtime import FLIP_CUSTOM_PROPS_KEY, FLIP_MODEL_ID_KEY  # noqa: E402
 
 
@@ -302,3 +302,56 @@ class TestFlipFedAvgRecipeBestModel:
         """num_rounds=2 is the minimum where selection can fire; the selector is wired normally."""
         server_cfg = self._export_server_cfg(tmp_path, num_rounds=2, best_model_metric="VAL_DICE")
         assert any("IntimeModelSelector" in c.get("path", "") for c in server_cfg["components"])
+
+
+class TestLocalDifferentialPrivacyWiring:
+    """FLIP#1145: the recipe can wire a formal (epsilon, delta) mechanism instead of the sparsifier."""
+
+    @staticmethod
+    def _train_result_filters(tmp_path, recipe) -> list[dict]:
+        import torch
+
+        sys.modules["models"].get_model = lambda: torch.nn.Linear(1, 1)
+        recipe.export(tmp_path)
+        client_cfg = json.loads(
+            (tmp_path / recipe.job.name / "app" / "config" / "config_fed_client.json").read_text()
+        )
+        return [
+            entry
+            for chain in client_cfg["task_result_filters"]
+            if "train" in chain["tasks"]
+            for entry in chain["filters"]
+        ]
+
+    def test_percentile_sparsifier_is_still_the_default(self, tmp_path: Path):
+        """Existing jobs are untouched: no local_dp means exactly the filter chain shipped today."""
+        paths = [f["path"] for f in self._train_result_filters(tmp_path, FlipFedAvgRecipe())]
+        assert any(path.endswith("PercentilePrivacy") for path in paths)
+        assert not any(path.endswith("LocalDifferentialPrivacy") for path in paths)
+
+    def test_local_dp_replaces_the_sparsifier_and_carries_its_parameters(self, tmp_path: Path):
+        """The two are alternatives — stacking them would muddy which guarantee the update carries."""
+        recipe = FlipFedAvgRecipe(local_dp=LocalDp(clipping_norm=2.0, sensitivity=1e-3, epsilon=0.5, delta=1e-6))
+        filters = self._train_result_filters(tmp_path, recipe)
+        paths = [f["path"] for f in filters]
+
+        assert any(path.endswith("LocalDifferentialPrivacy") for path in paths)
+        assert not any(path.endswith("PercentilePrivacy") for path in paths)
+        args = next(f["args"] for f in filters if f["path"].endswith("LocalDifferentialPrivacy"))
+        assert args["clipping_norm"] == 2.0
+        assert args["sensitivity"] == 1e-3
+        assert args["epsilon"] == 0.5
+        assert args["delta"] == 1e-6
+
+    def test_local_dp_defaults_match_the_flower_mechanism(self):
+        """Same knobs and same values on both backends, or the parity claim is empty."""
+        pytest.importorskip("flwr")
+        from flip.flower.privacy import LocalDpConfig
+
+        flower, nvflare = LocalDpConfig(), LocalDp()
+        assert (nvflare.clipping_norm, nvflare.sensitivity, nvflare.epsilon, nvflare.delta) == (
+            flower.clipping_norm,
+            flower.sensitivity,
+            flower.epsilon,
+            flower.delta,
+        )


### PR DESCRIPTION
Closes #1145.

## What

FLIP's two backends privatised a client's update with different mechanisms, and only one of them was
differential privacy. Flower clips the update to an L2 norm and adds Gaussian noise calibrated to
`(epsilon, delta)`. NVFLARE applied `PercentilePrivacy`, which zeroes the smallest-magnitude
components and truncates the survivors — no noise, no guarantee. NVIDIA documents that filter as
"truncation of weights by percentile" and reserves the differential-privacy label for a different one.

This gives NVFLARE the same mechanism Flower already has.

- **`flip.nvflare.components.LocalDifferentialPrivacy`** — a client `TASK_RESULT` filter on the train
  task. Clips the weight diff to `clipping_norm`, then adds Gaussian noise of standard deviation
  `sensitivity * sqrt(2 ln(1.25 / delta)) / epsilon`. Same expression and same defaults as
  `flip.flower.privacy`, so a job configured with the same numbers gets the same mechanism either side.
- **Fails closed**, matching the Flower mod. A result that is not a weight diff, an array whose dtype
  it cannot classify, or an update with no floating-point array is refused rather than forwarded —
  forwarding is how a raw update leaves a trust. Integer step counters pass through. `off` is a
  pass-through and logs a warning, because that is the event an operator audits for.
- **`FlipFedAvgRecipe(local_dp=LocalDp(...))`** wires it *in place of* the percentile sparsifier. They
  are alternatives, not a chain: stacking compounds the utility cost while muddying which guarantee the
  update carries. Default `None`, so existing jobs and the generated templates are untouched — the
  template-drift test confirms byte-identical output.

## Why not NVFLARE's own `SVTPrivacy`

It is the only DP mechanism in the pinned `nvflare==2.8.1`, and it is the wrong tool. Measured against
a real 7M-parameter DenseNet update (three Adam steps, kurtosis 179, top 1% of components carrying 47%
of the L1 mass):

| Filter | cosine with the true update | non-zero | epsilon spent, one round |
| --- | --- | --- | --- |
| `PercentilePrivacy` (today's default) | +0.809 | 90% | n/a |
| `SVTPrivacy` stock defaults | +0.001 | 9% | 70,333 |
| `SVTPrivacy` 1% released, tiny noise | +0.001 | 1% | 1.07 |
| `SVTPrivacy` on an i.i.d. update, same settings | +0.000 | 1% | 1.07 |

The last row is the point: the update's structure makes no difference, so no model or tutorial would
do better. The release step clips each selected value to `±gamma` *before* adding Laplace noise scaled
in units of `gamma`, so a released component's signal-to-noise ratio is fixed by `epsilon` alone while
the total spend scales with the number released. The sparse vector technique is a *selection*
primitive whose advantage is that below-threshold queries are free; FedAvg's dense per-round update
never gets that discount. NVFLARE ships it for the 2019 federated BraTS paper's selective
parameter-sharing regime, which is not how FLIP trains.

## Parity is tested, not asserted

`flwr` is a dev-group dependency of flip-utils and deliberately not a runtime one, so the NVFLARE path
reimplements the arithmetic instead of importing it. Two tests stop the copies drifting: they run
wherever `flwr` is installed, which includes CI, and assert the clip and the noise agree with Flower's
own helpers **element-for-element**. Matching Flower's per-array norm reduction, rather than one
concatenated norm, is what makes that exact in float32.

## Also in here

- Three descriptions of `PercentilePrivacy` as a "DP noise filter" in the recipe are corrected. It
  adds no noise, and upstream does not call it differential privacy. The published docs page was
  already right; the code comments were not.
- `component-fl-nodes` gains the NVFLARE local-DP section, says plainly that **neither** backend
  accounts for composition across rounds, and records why `SVTPrivacy` is not the route.

## Verification

- flip-utils: 897 unit tests pass (26 new for the filter, 3 new for the recipe wiring), ruff clean
- Sphinx build succeeded
- Not run: a live FL job with `local_dp` enabled. The filter is unit-tested against real
  `DXO`/`FLContext` objects, and the default keeps every existing job on today's behaviour.

## Follow-ups

- Let a trust enforce this from its kit file, as `FL_SITE_PRIVACY_POLICY` already allows for
  `percentile` (#851); Flower's site-side parity is #852.
- #1122: the Flower mod is opt-in, so an uploaded `client_app.py` decides whether the control applies.


## Acceptance Criteria

*Imported from issue #1145*

- [ ] `flip.nvflare.components` gains a local-DP `DXOFilter` that clips the update to an L2 norm and
      adds Gaussian noise at `sensitivity * sqrt(2 ln(1.25/delta)) / epsilon` — the same analytic
      Gaussian expression `flip.flower.privacy.LocalDpConfig.noise_stddev` uses, so the two backends'
      guarantees are comparable by construction
- [ ] Same failure posture as the Flower mod: integer step counters (BatchNorm `num_batches_tracked`)
      pass through, any other non-float dtype raises rather than being released unprivatised, an
      `off` toggle logs a WARNING (a raw update leaving a trust is the auditable event), and invalid
      parameters raise at construction
- [ ] Scoped to `WEIGHT_DIFF` on the train task; a `WEIGHTS` result raises rather than passing through
      (FLIP's NVFLARE apps return `params_type="DIFF"`; `fl-apps/nvflare/standard/README.md` already
      states a `WEIGHTS` return is rejected)
- [ ] `FlipFedAvgRecipe` accepts a local-DP configuration and wires the filter as a client
      TASK_RESULT filter on train, ordered AFTER `KeepOnlyVars` so the norm is computed over the
      trainable parameters only; default off, so existing jobs are unchanged
- [ ] Unit tests mirroring `tests/unit/flower/test_privacy.py`: clipping actually bounds the norm,
      noise is applied, integers pass through, unclassifiable dtypes and `WEIGHTS` raise, `off` is a
      pass-through, parameter validation
- [ ] `docs/source/components/component-fl-nodes.rst` privacy section updated: NVFLARE gains a formal
      option, with the honest statement that neither mechanism composes a budget across rounds
- [ ] The recipe's three "DP noise filter" descriptions of `PercentilePrivacy` corrected — it adds no
      noise and upstream does not call it differential privacy