### PR TITLE
feat(aws): align CloudWatch log retention with the LZA baseline

### DIFF
--- a/deploy/providers/AWS/cloudfront.tf
+++ b/deploy/providers/AWS/cloudfront.tf
@@ -611,7 +611,7 @@ resource "aws_wafv2_web_acl" "flip_ui_cloudfront" {
 resource "aws_cloudwatch_log_group" "flip_ui_waf" {
   provider          = aws.us_east_1
   name              = "aws-waf-logs-flip-ui-${replace(var.flip_alb_subdomain, "/[^a-zA-Z0-9]/", "-")}"
-  retention_in_days = 30
+  retention_in_days = local.log_retention_days
 }
 
 resource "aws_wafv2_web_acl_logging_configuration" "flip_ui_cloudfront" {

--- a/deploy/providers/AWS/ecs.tf
+++ b/deploy/providers/AWS/ecs.tf
@@ -44,15 +44,15 @@ resource "aws_ecs_cluster_capacity_providers" "flip" {
 
 resource "aws_cloudwatch_log_group" "ecs_flip_api" {
   name              = "/ecs/flip-api"
-  retention_in_days = 7
+  retention_in_days = local.log_retention_days
 }
 
 resource "aws_cloudwatch_log_group" "ecs_fl_api_net_1" {
   name              = "/ecs/fl-api-net-1"
-  retention_in_days = 7
+  retention_in_days = local.log_retention_days
 }
 
 resource "aws_cloudwatch_log_group" "ecs_fl_server_net_1" {
   name              = "/ecs/fl-server-net-1"
-  retention_in_days = 7
+  retention_in_days = local.log_retention_days
 }

--- a/deploy/providers/AWS/locals.tf
+++ b/deploy/providers/AWS/locals.tf
@@ -215,3 +215,31 @@ locals {
     }
   }
 }
+
+# CloudWatch log retention, applied to every log group this root owns.
+#
+# 365 days is not an arbitrary choice: it is the organisation's own Landing
+# Zone Accelerator baseline (`cloudwatchLogRetentionInDays` in the LZA
+# `global-config.yaml`), which LZA already applies to every log group it
+# creates in the FLIPProduction and FLIPStaging accounts. FLIP's groups sat at
+# 7 days — 52x below that baseline, and far short of any realistic
+# incident-detection window. A group that has aged out cannot support the
+# incident triage claimed under the CAF-aligned DSPT (C1.d).
+#
+# Staging deliberately deviates to 90 days. Its trust data is mock, but its
+# IAM, Cognito and authentication events are real, and a staging compromise is
+# a genuine incident with a plausible pivot toward production — so the window
+# stays long enough to investigate one rather than returning to 7 days. LZA
+# itself does not distinguish the environments (it applies 365 to both), so
+# this is a documented deviation, recorded under "Retention and deletion" in
+# docs/source/governance-and-compliance.rst. An undocumented deviation is
+# indistinguishable from the drift this change is correcting.
+#
+# Cost is not a consideration at FLIP's volume. The hub emits roughly 11 MB of
+# logs per day, so a 365-day window is about 4 GB retained — cents per month
+# at CloudWatch's storage rate. Do not trade retention against storage here,
+# and do not build an export-to-S3/Glacier pipeline for it: at this volume the
+# pipeline costs more than the storage it saves.
+locals {
+  log_retention_days = var.environment == "prod" ? 365 : 90
+}

--- a/deploy/providers/AWS/main.tf
+++ b/deploy/providers/AWS/main.tf
@@ -390,7 +390,7 @@ resource "aws_iam_role_policy" "trust_ec2_s3" {
 # logs through its CloudWatch agent. The Central Hub bastion has no app logs.
 resource "aws_cloudwatch_log_group" "flip_trust_log_group" {
   name              = "/aws/ec2/flip-trust"
-  retention_in_days = 7
+  retention_in_days = local.log_retention_days
 }
 
 # Retain the keypair for SSH-over-SSM (`ssh flip`) and Ansible. No inbound SSH

--- a/docs/source/governance-and-compliance.rst
+++ b/docs/source/governance-and-compliance.rst
@@ -222,6 +222,32 @@ in versioned cloud storage and are retained until an operator removes them. Ther
 no automated end-of-project purge today. A deployment that requires one should record
 the manual deletion step in its project-closure procedure, naming who deletes what.
 
+**Logs are retained per class, and the classes are not alike.** No UK health policy
+sets a retention period for system logs; the CAF-aligned DSPT asks for coverage
+sufficient to investigate an incident (C1.a, C1.d) and UK GDPR's storage limitation
+principle asks that whatever period is chosen be defined and justified rather than
+open-ended. FLIP's positions:
+
+- **Hub infrastructure logs** — the ECS, trust EC2 and WAF log groups — are retained
+  for **365 days in production**, matching the retention baseline the organisation's
+  Landing Zone Accelerator already applies to every log group it creates in the same
+  accounts. Staging deliberately deviates to **90 days**: its trust data is mock, but
+  its authentication and IAM events are real and a staging compromise is a genuine
+  incident, so the window stays long enough to investigate one.
+- **Trust-side application logs** are held for **30 days** in each trust's own Loki
+  instance, sized for operational debugging rather than incident forensics.
+- **Object-storage access logs** are held for **90 days**.
+- **Edge access logs are deliberately the shortest.** CloudFront logs record request
+  URIs, query strings and client IP addresses, so their window is a disclosure
+  decision before it is a cost or forensics one, and it is kept short on purpose
+  rather than raised to match the infrastructure baseline.
+- **Audit records are not logs and are not on this clock.** The project, model, trust
+  and user audit tables record who approved what and which data trained which model.
+  That is provenance: it supports reproducibility, research-integrity expectations and
+  — where a trained model is later taken forward as a medical device by its
+  manufacturer — traceability obligations measured in years, not months. It is
+  retained accordingly, and deliberately, rather than aged out with the telemetry.
+
 **********************************
 Assurance and independent scrutiny
 **********************************


### PR DESCRIPTION
# Description

FLIP's CloudWatch log groups were retained for **7 days** (30 for the WAF group) against an
organisation-wide baseline of **365**. Retention now derives from the existing `var.environment`:
**365 in production, 90 in staging**.

## Why

The baseline is not aspirational — it is already live in our own accounts.
`cloudwatchLogRetentionInDays: 365` in the LZA `global-config.yaml` is applied by LZA to every log
group it creates, and in `lza-stag` 24 accelerator-managed groups sit at 365 while FLIP's
`/aws/ec2/flip-trust` sits at 7 **in the same account**.

Seven days is also far short of any realistic incident-detection window. A log group that has aged
out cannot support the incident triage claimed under the CAF-aligned DSPT (`C1.d`), nor the `C1.a` /
`C1.b` positions recorded in `governance-and-compliance.rst`.

Measured before this change (prod):

| Log group | Retention | Stored |
| --- | --- | --- |
| `/ecs/flip-api` | 7 | 73.4 MB |
| `/ecs/fl-api-net-1` | 7 | 3.2 MB |
| `/aws/ec2/flip-trust` | 7 | 3.2 MB |
| `/ecs/fl-server-net-1` | 7 | 2.7 KB |
| WAF (`cloudfront.tf`) | 30 | — |

## Three decisions worth reviewing

**Why derive from `var.environment` rather than add a `TF_VAR_`.** `environment` is already exported
by the Makefile and already reaches CI. A new `TF_VAR_` would mean updating
`scripts/compose-ci-env.sh`'s manifest, all three workflow `env:` blocks and both GitHub
environments, or `test_compose_ci_env.sh` fails the build. This buys the same per-environment control
for none of that.

**Why staging is 90 and not 365.** Staging's trust data is mock, but its IAM, Cognito and
authentication events are real, and a staging compromise is a genuine incident with a plausible pivot
toward production — so the window stays long enough to investigate one rather than returning to 7
days. LZA itself does not distinguish the environments, so this is a deliberate deviation and is
written down in `governance-and-compliance.rst` rather than left implicit. An undocumented deviation
is indistinguishable from the drift this PR corrects.

**Why not export to S3 with a Glacier lifecycle.** Considered and rejected on measured numbers. The
hub emits ~11 MB/day, so 365 days is ~4 GB — cents per month. A Firehose→S3→Glacier pipeline costs
about the same in ingestion alone, and adds a subscription filter per group, a delivery stream, IAM
and new failure modes. Glacier IR also carries a 90-day minimum billable duration, and S3's default
128 KB transition floor would skip most log objects. Raising the number is the whole fix.

## Not in this PR

Two log groups are created implicitly by AWS and still carry no retention:
`/aws/rds/proxy/flip-database-proxy` (~23 MB and growing) and `/aws/lambda/flip-sg-drift-filter`.
They are **deliberately excluded** — see #1155.

`terraform_apply.yml` applies on merge, and those groups exist in some accounts but not others
(the Lambda group is present in `stag`/`prod`, absent in `lza-stag`/`lza-prod`). A bare resource
fails with `ResourceAlreadyExistsException` where the group exists; an `import` block fails where it
does not. No single static config applies cleanly to all four, so shipping it here would have broken
the staging apply on merge. It needs a per-account import sequenced around the merge.

## Effect on apply

All five changes are in-place updates to already-managed resources — no replacement, no data loss.
On merge to `develop` staging moves 7→90 (WAF 30→90); on merge to `main` production moves 7→365
(WAF 30→365).

## Verification

| Check | Result |
| --- | --- |
| `terraform fmt -check -recursive` | clean |
| `terraform validate` | valid (pre-existing `failure_threshold` deprecation warnings only) |
| `make checkov-lint` | 177 passed, 0 failed, 26 skipped |
| AWS deploy tests (`pytest tests/`) | 88 passed |
| `make -C docs docs` | build succeeded |

## Linked Issues

Fixes #1154

## Checklist

- [x] Follows the project's coding conventions and style guide
- [x] Updates documentation
- [ ] I have added tests that prove my fix is effective or that my feature works — no new test: the
      change is a Terraform value, covered by the existing checkov lint and AWS deploy test suites
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Type of Change

- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] In-line docstrings updated.
- [x] Documentation updated, tested `make -C docs/ docs`.


## Acceptance Criteria

*Imported from issue #1154*

- Hub log groups are retained for 365 days in production.
- Staging may use a shorter window, but not the previous 7 days, and the deviation is written down
  rather than left implicit — LZA itself applies 365 to both environments.
- The retention value is expressed once rather than repeated at each call site, and derives from
  configuration already plumbed through to CI (no new `TF_VAR_`, which would otherwise require
  updating `scripts/compose-ci-env.sh`, three workflow `env:` blocks and both GitHub environments).
- The written retention position covers every log class the platform holds — hub infrastructure,
  trust-side application logs, object-storage access logs, edge access logs and audit records — and
  is stated in `docs/source/governance-and-compliance.rst` under *Retention and deletion*.
- `terraform validate`, `make checkov-lint`, the AWS deploy tests and `make -C docs docs` all pass.