### PR TITLE
Terraform CI: make a held apply and the not-yet-on-main drift dispatch legible

### DIFF
--- a/.github/workflows/terraform_drift.yml
+++ b/.github/workflows/terraform_drift.yml
@@ -315,6 +315,13 @@ jobs:
   # Deliberately not `continue-on-error`: if the dispatch fails, production drift
   # silently stops being checked, which is the failure this whole arrangement
   # exists to avoid. The staging leg above is a separate job and still reports.
+  #
+  # One exception, handled in the step: `main` does not carry this workflow until
+  # the first develop -> main release, and GitHub resolves `--ref` against the
+  # workflow file on that ref, so the dispatch 422s until then. That is a known
+  # precondition rather than the breakage this job watches for, and failing on it
+  # would leave the nightly run permanently red — which is how a real dispatch
+  # failure comes to be ignored.
   dispatch-prod:
     name: Dispatch the production drift run on main
     if: github.ref_name != 'main'
@@ -329,5 +336,21 @@ jobs:
           GH_REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
+
+          if ! gh api "repos/${GH_REPO}/contents/.github/workflows/terraform_drift.yml?ref=main" \
+              --silent >/dev/null 2>&1; then
+            echo "::warning title=Production drift is not being checked::terraform_drift.yml is not on main yet, so the production leg cannot be dispatched. This resolves itself at the first develop -> main release. Staging drift is unaffected and reported separately."
+            {
+              echo "### Production drift not checked"
+              echo
+              echo "\`terraform_drift.yml\` is not on \`main\` yet, so the production leg could not be"
+              echo "dispatched. GitHub resolves \`--ref\` against the workflow file on that ref."
+              echo
+              echo "This resolves itself at the first \`develop\` → \`main\` release. **Production drift"
+              echo "is not being checked until then.** The staging leg is unaffected."
+            } >>"${GITHUB_STEP_SUMMARY}"
+            exit 0
+          fi
+
           gh workflow run terraform_drift.yml --ref main
           echo "Dispatched terraform_drift.yml on main — that run checks production."

--- a/deploy/providers/AWS/README.md
+++ b/deploy/providers/AWS/README.md
@@ -1061,6 +1061,34 @@ rotated. Every `tf-via-pr` step now sets `upload-plan: false`, and
 keeps the plan on the runner's disk so the FL gate and the apply step can read
 it. That never leaves the job.
 
+### Reading a red Terraform CI run
+
+Two of these are not faults, and both now say so in the run's summary rather than
+only in the log.
+
+**"Apply held — FL infrastructure would be disturbed."** The plan succeeded and
+was deliberately not applied, because it would recreate `fl-server-net-1` /
+`fl-api-net-1` or delete EFS (FLIP#770). The step still exits non-zero — a hold
+means the apply did not happen, and that must not read as green — but the job
+summary names the resources and the remedy. Clear it by enabling deployment mode
+on the hub, waiting until `GET /fl/quiesce` reports deployment mode ON with no
+BUSY net, then re-running `terraform_apply.yml` via `workflow_dispatch` with
+`fl_quiesced: true`. A plain re-run reads the same plan and holds again.
+
+Note this recurs on *every* apply while a piece of out-of-band drift touches the
+FL services — staging currently carries `enable_execute_command: true -> false`
+on all three — so one quiesced apply clears the backlog rather than each push
+needing its own.
+
+**"Production drift is not being checked."** The nightly run fires from the
+default branch and dispatches itself with `--ref main` for the production leg.
+GitHub resolves `--ref` against the workflow file *on that ref*, so until `main`
+carries `terraform_drift.yml` the dispatch returns HTTP 422. That is a known
+precondition, not a broken pipeline, so the job warns and passes instead of
+failing — a permanently red nightly is how a real dispatch failure comes to be
+ignored. Any other dispatch failure still fails hard. It resolves itself at the
+first `develop` → `main` release.
+
 ### Recovering an environment's true values
 
 The operator `.env` files drift, and seeding GitHub from a stale one bakes that

--- a/deploy/providers/AWS/scripts/check-fl-plan-impact.sh
+++ b/deploy/providers/AWS/scripts/check-fl-plan-impact.sh
@@ -157,4 +157,38 @@ cat >&2 <<'EOF'
    Runbook: deploy/providers/AWS/README.md, "Terraform CI: plan on PR, apply on
    merge" > "What an automated apply will not do".
 EOF
+
+# In Actions, stderr alone renders as a bare red X on the step: a hold looks
+# exactly like a broken pipeline until someone opens the log. The distinction
+# matters because holding is the guard working, and because a persistent piece of
+# out-of-band drift makes it recur on every apply until one quiesced apply clears
+# it. Still exit 1 — the apply did not happen and that must not read as green —
+# but say so where it can be seen without digging.
+if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+    {
+        echo "### 🛑 Apply held — FL infrastructure would be disturbed"
+        echo
+        echo "This is the guard working, not a build failure. The plan was produced"
+        echo "successfully; it was **not** applied."
+        echo
+        echo "| Action | Resource |"
+        echo "| --- | --- |"
+        [[ -n "${ecs_hits}" ]] && while IFS=$'\t' read -r action address; do
+            echo "| \`${action}\` | \`${address}\` |"
+        done <<<"${ecs_hits}"
+        [[ -n "${efs_hits}" ]] && while IFS=$'\t' read -r action address; do
+            echo "| \`${action}\` | \`${address}\` |"
+        done <<<"${efs_hits}"
+        echo
+        echo "**To proceed:** enable deployment mode on the hub, wait until"
+        echo "\`GET /fl/quiesce\` reports deployment mode ON and no BUSY net, then re-run"
+        echo "\`terraform_apply.yml\` via \`workflow_dispatch\` with \`fl_quiesced: true\`."
+        echo "A plain re-run reads the same plan and holds again."
+    } >>"${GITHUB_STEP_SUMMARY}"
+fi
+
+if [[ -n "${GITHUB_ACTIONS:-}" ]]; then
+    echo "::warning title=Apply held — FL infrastructure would be disturbed::The plan succeeded but was not applied, because it would recreate FL services or delete EFS. Quiesce FL, then re-run terraform_apply.yml via workflow_dispatch with fl_quiesced set to true. See the job summary."
+fi
+
 exit 1

--- a/deploy/providers/AWS/scripts/tests/test_check_fl_plan_impact.sh
+++ b/deploy/providers/AWS/scripts/tests/test_check_fl_plan_impact.sh
@@ -205,6 +205,48 @@ run_on "hold message carries no plan values" "$(plan_with \
     "aws_ecs_service fl_server_net_1 aws_ecs_service.fl_server_net_1[0] delete,create")"
 expect_silent_about "format_version" "prints a summary, not the plan document"
 
+# 12. ACTIONS SURFACE. Without these a hold renders as a bare red X on the step,
+#     indistinguishable from a broken pipeline — which matters because a single
+#     piece of out-of-band drift makes the hold recur on every apply until one
+#     quiesced apply clears it.
+echo ""
+echo "-- a held plan writes a job summary and an annotation"
+held_plan="$(plan_with \
+    "aws_ecs_service fl_server_net_1 aws_ecs_service.fl_server_net_1[0] update")"
+summary="${TEST_ROOT}/summary-held.md"
+: >"${summary}"
+out="$(GITHUB_STEP_SUMMARY="${summary}" GITHUB_ACTIONS=true bash "${SCRIPT}" "${held_plan}" 2>&1)"
+rc=$?
+[[ "${rc}" -eq 1 ]] && ok "still exits 1 — a hold must not read as green" \
+    || no "still exits 1" "got ${rc}"
+grep -q 'Apply held' "${summary}" && ok "summary says the apply was held" \
+    || no "summary says the apply was held" "$(cat "${summary}")"
+grep -q 'fl_server_net_1' "${summary}" && ok "summary names the offending resource" \
+    || no "summary names the offending resource"
+grep -q 'fl_quiesced' "${summary}" && ok "summary carries the remedy" \
+    || no "summary carries the remedy"
+printf '%s' "${out}" | grep -q '::warning title=' && ok "emits a warning annotation" \
+    || no "emits a warning annotation" "${out}"
+
+echo ""
+echo "-- a safe plan writes neither"
+safe_plan="$(plan_with "aws_s3_bucket logs aws_s3_bucket.logs update")"
+summary_safe="${TEST_ROOT}/summary-safe.md"
+: >"${summary_safe}"
+out="$(GITHUB_STEP_SUMMARY="${summary_safe}" GITHUB_ACTIONS=true bash "${SCRIPT}" "${safe_plan}" 2>&1)"
+rc=$?
+[[ "${rc}" -eq 0 ]] && ok "exits 0" || no "exits 0" "got ${rc}"
+[[ ! -s "${summary_safe}" ]] && ok "writes no job summary" \
+    || no "writes no job summary" "$(cat "${summary_safe}")"
+printf '%s' "${out}" | grep -q '::warning' && no "emits no annotation" "${out}" \
+    || ok "emits no annotation"
+
+echo ""
+echo "-- outside Actions it stays quiet on both channels"
+out="$(bash "${SCRIPT}" "${held_plan}" 2>&1)" || true
+printf '%s' "${out}" | grep -q '::warning' && no "no annotation without GITHUB_ACTIONS" "${out}" \
+    || ok "no annotation without GITHUB_ACTIONS"
+
 echo ""
 echo "==== ${PASS} passed, ${FAIL} failed ===="
 [[ "${FAIL}" -eq 0 ]]


### PR DESCRIPTION
# Description

Two follow-ups from the first live runs of the Terraform CI pipeline (#962). Neither changes what the pipeline *decides* — both decisions have been correct — only how a red run reads.

## Linked Issues

Fixes #1161

## 1. The nightly drift run failed on a precondition that cannot be met yet

`terraform_drift.yml` fires from the default branch and dispatches itself with `--ref main` for the production leg. GitHub resolves `--ref` against the workflow file *on that ref*, and `main` does not carry this workflow yet — it is ~460 commits behind `develop`. So every night:

```
could not create workflow dispatch event: HTTP 422:
Workflow does not have 'workflow_dispatch' trigger
```

The staging leg succeeds and raises its issue normally (#1160); only the dispatch job fails.

Failing hard was deliberate — the comment said so, on the grounds that a silent dispatch failure means production drift stops being checked. That reasoning still holds for a *real* dispatch failure. It does not hold for a precondition that cannot be met yet, and a permanently red nightly is precisely how a genuine dispatch failure comes to be ignored.

The step now probes for the workflow on `main` first. Absent → warning annotation plus a job summary saying production drift is not being checked and why, then pass. Present → dispatch as before. **Any other failure still fails hard.** Verified against the live API: `ref=main` → absent, `ref=develop` → present.

## 2. A held apply was indistinguishable from a broken one

`check-fl-plan-impact.sh` wrote only to stderr, so a hold rendered as a bare red X on the step. Whether the pipeline was working correctly or broken could only be determined by opening the log.

It now also writes a `$GITHUB_STEP_SUMMARY` block naming the offending resources and the remedy, plus a `::warning::` annotation. **It still exits 1** — a hold means the apply did not happen, and that must not read as green.

This matters more than it sounds: staging carries out-of-band `enable_execute_command: true -> false` drift on all three ECS services, so the hold recurs on *every* apply until one quiesced apply clears the backlog. Three runs have hit it so far.

## Checklist

- [x] Follows the project's coding conventions and style guide
- [x] Updates documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Type of Change

- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] New tests added to cover the changes.
- [x] Documentation updated.

## Testing

- `test_check_fl_plan_impact.sh`: **35 pass, up from 26.** Nine new assertions cover the summary content (held, names the resource, carries the remedy), the annotation, that a safe plan writes neither, that the exit code is still 1, and that both channels stay quiet outside Actions.
- All five deploy-script harnesses pass; 88 pytest in `deploy/providers/AWS`; all three workflow YAMLs parse.
- The drift probe was exercised against the live GitHub API for both refs.

## Additional Notes

The three failing **Terraform Apply** runs on `develop` are not fixed by this PR, because they are not faults — the FL guard is holding them correctly, exactly as designed. They are cleared operationally, by one quiesced apply, not by a code change. This PR only makes the reason legible without opening the log.

`README.md` gains a "Reading a red Terraform CI run" section covering both cases, so the next person to see one does not have to rediscover which reds are real.
