### PR TITLE
[Bug]: dev hub loses its database on every `make down` (flip-db data dir is an anonymous volume)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,6 +76,7 @@ make build                 # Build all Docker images (standalone, --no-cache; do
 make lock                  # Regenerate every uv.lock from its pyproject.toml
 make ui                    # Start UI only
 make clean                 # Remove all stopped containers, networks, and images
+make reset-hub-db          # Drop the dev hub database (flip-db's named volume); `clean` does not
 make ci                    # Run CI pipeline locally using act
 make central-hub           # Start flip-api + database (no UI)
 make debug SERVICE=<name>  # Restart service in debug mode (port 5678)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,6 +76,7 @@ make build                 # Build all Docker images (standalone, --no-cache; do
 make lock                  # Regenerate every uv.lock from its pyproject.toml
 make ui                    # Start UI only
 make clean                 # Remove all stopped containers, networks, and images
+make reset-hub-db          # Drop the dev hub database (flip-db's named volume); `clean` does not
 make ci                    # Run CI pipeline locally using act
 make central-hub           # Start flip-api + database (no UI)
 make debug SERVICE=<name>  # Restart service in debug mode (port 5678)

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@
 
 .PHONY: build build-fl dev prod clean stop up down up-no-trust up-trusts central-fl central-hub \
 		restart restart-fl restart-no-trust ci tests debug create-networks remove-networks recreate-networks consolidate-deps \
+		reset-hub-db \
 		check-aws-access generate-internal-service-key generate-xnat-credentials \
 		register-trust register-trusts new-trust _wait-for-hub integration_test \
 		sync-trust-kit sync-trust-kits lock checkov-lint \
@@ -252,11 +253,28 @@ down:
 	${DOCKER_COMMAND} down --remove-orphans
 	@echo "🛌 All services stopped successfully!"
 
-# Clean Docker resources
+# Clean Docker resources.
+#
+# Deliberately does NOT remove the hub database volume. Everything this reclaims —
+# containers, locally built images, dangling artifacts — is reproducible; the database is
+# not. Someone running `clean` to free disk space or unstick a bad image should not lose
+# their projects. Use `reset-hub-db` for that, the way trust/xnat has `xnat-reset`.
 clean:
 	${DOCKER_COMMAND} down --rmi local && \
 	docker system prune -f && \
 	rm -rf ./flip-fl-api/*/transfer/*/
+
+# Drop the development hub database and start over. The counterpart to flip-db's named
+# volume: data persists by default, and this is the explicit way to discard it. Trusts are
+# re-registered automatically by the next `make up`, so only projects, models and cohort
+# queries are lost.
+reset-hub-db:
+	@echo "🗑️  Resetting the hub database ($(COMPOSE_PROJECT)_flip_db_data)..."
+	@${DOCKER_COMMAND} rm -sf flip-db >/dev/null 2>&1 || true
+	@docker volume rm $(COMPOSE_PROJECT)_flip_db_data >/dev/null 2>&1 \
+		&& echo "   removed volume $(COMPOSE_PROJECT)_flip_db_data" \
+		|| echo "   no volume $(COMPOSE_PROJECT)_flip_db_data to remove"
+	@echo "✅ Hub database reset. Run 'make up' to recreate and re-register the trusts."
 
 # Stop all services and remove the containers
 restart: down up

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -60,11 +60,15 @@ recreate** — projects, models and cohort queries are still there when the stac
 Reset it deliberately when you want a genuinely empty hub:
 
 ```bash
-make down && docker volume rm deploy_flip_db_data && make up
+make reset-hub-db && make up
 ```
 
 `make up` re-runs `register-trusts`, so the trusts and their FL kit slots come back on their own;
-everything else starts empty.
+only projects, models and cohort queries are lost.
+
+`make clean` does **not** remove the volume. What it reclaims — containers, locally built images,
+dangling artifacts — is all reproducible, whereas the database is not, so freeing disk space or
+unsticking a bad image never costs you your projects.
 
 This applies to development only. Neither production compose defines `flip-db` — the hub talks to
 RDS through RDS Proxy there, so there is no local volume in play.

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -51,6 +51,24 @@ Only **trusts** have more than one deployment target (AWS EC2, on-prem Ubuntu, K
 supported production target — AWS ECS Fargate — so it needs no provider of its own. See
 [`providers/README.md`](providers/README.md) for the per-provider scope.
 
+## Hub database persistence (development)
+
+`flip-db` keeps its data on the named volume `flip_db_data`, which compose creates as
+`deploy_flip_db_data`. It therefore **survives `make down`, `make restart` and any container
+recreate** — projects, models and cohort queries are still there when the stack comes back.
+
+Reset it deliberately when you want a genuinely empty hub:
+
+```bash
+make down && docker volume rm deploy_flip_db_data && make up
+```
+
+`make up` re-runs `register-trusts`, so the trusts and their FL kit slots come back on their own;
+everything else starts empty.
+
+This applies to development only. Neither production compose defines `flip-db` — the hub talks to
+RDS through RDS Proxy there, so there is no local volume in play.
+
 ## Supported PostgreSQL Versions
 
 FLIP uses AWS RDS PostgreSQL with the following version support policy:

--- a/deploy/compose.development.yml
+++ b/deploy/compose.development.yml
@@ -249,6 +249,15 @@ services:
       - FOWNER
       - SETUID
       - SETGID
+    volumes:
+      # Without this the postgres image's own `VOLUME /var/lib/postgresql/data` puts the
+      # hub database on a fresh ANONYMOUS volume per container, so every `make down` (and
+      # `make restart`, which calls it) silently started the hub with an empty database —
+      # losing projects, models and cohort queries while the trusts kept the DICOM those
+      # rows referenced. `make down` passes no `-v`, so each wipe also orphaned the old
+      # volume rather than reclaiming it. Named so the data survives a recreate; remove the
+      # volume to reset deliberately (see below). Sibling of the xnat-db fix in FLIP#1048.
+      - flip_db_data:/var/lib/postgresql/data
     networks:
       - default
 
@@ -276,6 +285,11 @@ services:
 
 volumes:
   pgadmin_data:
+  # The hub database. Reset it deliberately with:
+  #   make down && docker volume rm deploy_flip_db_data && make up
+  # (compose prefixes the volume with the project name, so a second stack started with
+  # FLIP_INSTANCE gets its own.)
+  flip_db_data:
 
 # Every network here is created outside compose by `make create-networks` —
 # trust-network-* as swarm overlays (`--driver overlay --attachable`) because the


### PR DESCRIPTION
## Description

`flip-db` declared no `volumes:` in `deploy/compose.development.yml`. The `postgres:17` image
carries `VOLUME /var/lib/postgresql/data` in its own Dockerfile, so every container got a fresh
**anonymous** volume — and any recreate that removed the container (`make down` + `make up`, and
`make restart`, which calls down) silently started the hub with an **empty database**.

Nothing announced it. `make up` re-runs `register-trusts`, so the trusts came back and the stack
looked healthy, while projects, models and cohort queries were gone — on the dev box that was 16
projects and 20 models. The state is *half* gone in the same way #1048 describes for XNAT: the
trusts' Orthanc and XNAT still hold the DICOM those projects pulled, and S3 still holds the
uploaded model files, but the hub no longer has the rows referencing any of it. That also defeats
`e2e_smoke --project-id` reuse, whose whole purpose is skipping the ~6 min pull.

`make down` passes no `-v`, so each wipe orphaned the old volume rather than reclaiming it. The dev
box currently has **1031 dangling volumes**.

The same file already gave **pgadmin** a named volume — so pgadmin's UI preferences outlived the
hub database.

## Change

Direction matches #1048's for `xnat-db`: **persist by default, reset explicitly.**

- `deploy/compose.development.yml` — mount `flip_db_data` (rendered `deploy_flip_db_data`) on
  `flip-db`, declared beside the existing `pgadmin_data`.
- `Makefile` — add `reset-hub-db`, the explicit counterpart. `clean` deliberately does **not**
  touch the volume, and its recipe now says so, since the omission should read as a decision.
- `deploy/README.md`, `CLAUDE.md` / `AGENTS.md` — document both.

```bash
make reset-hub-db && make up
```

### Why `clean` leaves it alone

`clean` reclaims containers, locally built images and dangling artifacts — all reproducible. A
database is not. Someone running it to free disk space or unstick a bad image should not lose
their projects, which is the same class of surprise this PR exists to remove. (It does not remove
volumes today either: `down --rmi local` passes no `-v`, and `docker system prune -f` no
`--volumes`.)

`reset-hub-db` stops flip-db first so the volume is free, reports whether it removed anything, is
idempotent, and uses `$(COMPOSE_PROJECT)` so a second stack under `FLIP_INSTANCE` resets its own.

## Verification

Run in an isolated compose project (`-p vol1165test`, `DB_PORT` overridden) against this compose
file, so the live stack was untouched throughout:

| | |
| --- | --- |
| Volume type | `vol1165test_flip_db_data` — **named**, not anonymous |
| Rendered config | `docker compose config` shows `source: flip_db_data` → `/var/lib/postgresql/data`, `name: deploy_flip_db_data` under the default project |
| Survives `down` + `up` | marker row read back intact |
| Deliberate reset | after `docker volume rm`, `to_regclass('persistence_probe') is null` → `t` |
| `make reset-hub-db` | removed the container and the volume, reported both |
| …run again | `no volume … to remove`, exit 0 |

## Technical considerations

- **Dev only.** Neither production compose defines `flip-db`; the hub reaches RDS through RDS Proxy,
  so no local volume is in play and stag/prod are unaffected.
- **The switch does not migrate existing data.** Moving from an anonymous to a named volume means
  the first `up` after this lands starts empty, once. Anyone mid-project should finish or dump
  first (`docker exec deploy-flip-db-1 pg_dump -U "$POSTGRES_USER" -Fc "$POSTGRES_DB"`).
- The 1031 orphaned volumes are a pre-existing consequence, not cleaned up here — `docker volume
  prune` is the separate remedy and folding it in would make this change riskier than it needs to be.

Closes #1165


## Acceptance Criteria

*Imported from issue #1165*

1. `deploy/compose.development.yml` gives `flip-db` a named volume mounted at
   `/var/lib/postgresql/data`, declared alongside the existing `pgadmin_data`.
2. `make down` followed by `make up` preserves projects, models and cohort queries.
3. A deliberate reset path exists and is documented — removing the named volume gives a
   genuinely clean database, the way `xnat-reset` does for XNAT in #1048.
4. No change to stag/prod: neither production compose defines `flip-db` (the hub uses RDS
   Proxy there), so this is dev-only.