### PR TITLE
[Task]: upgrade nvflare 2.8.0 -> 2.9.0 at GA (closes Dependabot #258/#400)

### DIFF
--- a/fl-apps/nvflare/diffusion_model/README.md
+++ b/fl-apps/nvflare/diffusion_model/README.md
@@ -19,7 +19,7 @@ This is the NVFLARE **Client API** latent-diffusion job type (`JOB_TYPE=diffusio
 It runs a **two-stage** federated training — an autoencoder (+ GAN discriminator)
 FedAvg stage followed by a diffusion-model FedAvg stage over the frozen autoencoder's latent space,
 each stage with its own cross-site validation — driving the clients through the NVFLARE Client
-API (`InProcessClientAPIExecutor`). It replaced the retired Executor-based `diffusion_model`
+API (`ClientAPIExecutor` in `in_process` mode). It replaced the retired Executor-based `diffusion_model`
 template, which drove the clients through the legacy `RUN_TRAINER`/`RUN_VALIDATOR` executor pairs.
 
 The base configs (`app/config/config_fed_server.json`, `app/config/config_fed_client.json`) and
@@ -71,7 +71,7 @@ script stamps on the outgoing `FLModel`.
 
 - `init_training`, `post_validation` → `flip.nvflare.components.CleanupImages`
 - `train_ae`, `train_dm`, `validate_ae`, `validate_dm` → ONE
-  `nvflare.app_common.executors.InProcessClientAPIExecutor` running `custom/trainer.py`
+  `nvflare.app_common.executors.client_api_executor.ClientAPIExecutor` (`execution_mode: in_process`` running `custom/trainer.py`
 - `train_ae`/`train_dm` results → `flip.nvflare.components.StagePercentilePrivacy` (stage-aware DP
   noise filter)
 - Event handlers: `ClientEventHandler`, `FlipAnalyticsBridge`

--- a/fl-apps/nvflare/diffusion_model/app/config/config_fed_client.json
+++ b/fl-apps/nvflare/diffusion_model/app/config/config_fed_client.json
@@ -19,10 +19,12 @@
         "validate_dm"
       ],
       "executor": {
-        "path": "nvflare.app_common.executors.in_process_client_api_executor.InProcessClientAPIExecutor",
+        "path": "nvflare.app_common.executors.client_api_executor.ClientAPIExecutor",
         "args": {
+          "execution_mode": "in_process",
           "task_script_path": "custom/trainer.py",
-          "task_script_args": "--project_id {project_id}"
+          "task_script_args": "--project_id {project_id}",
+          "params_exchange_format": "numpy"
         }
       }
     }

--- a/fl-apps/nvflare/evaluation/README.md
+++ b/fl-apps/nvflare/evaluation/README.md
@@ -38,7 +38,7 @@ regenerate via `recipe.py` after any recipe change and commit the result.
    and validates that `config.json` declares the model(s) to evaluate.
 2. `GlobalModelEval` loads the uploaded checkpoint via `EvaluationModelLocator` and broadcasts it to
    every site as a single `FLModel` (`validate` task).
-3. Each site runs the user's `evaluator.py` via `InProcessClientAPIExecutor`, using the NVFLARE Client
+3. Each site runs the user's `evaluator.py` via `ClientAPIExecutor`, using the NVFLARE Client
    API `is_evaluate()` path (`flare.receive()` / `flare.send()`) to receive the model and return
    **aggregate-only** metrics (`DataKind.METRICS`).
 4. `EvaluationJsonGenerator` collects the metrics into `evaluation_results.json` and every failed
@@ -88,7 +88,7 @@ with the failed tasks recorded in `evaluation_failures.json`.
 **Client — `config_fed_client.json` `executors`:**
 
 - `init_task`, `post_validation` → `flip.nvflare.components.CleanupImages`
-- `validate` → `nvflare.app_common.executors.InProcessClientAPIExecutor`
+- `validate` → `nvflare.app_common.executors.client_api_executor.ClientAPIExecutor` (`execution_mode: in_process``
 - Event handler: `ClientEventHandler`
 
 ## What does the user upload?

--- a/fl-apps/nvflare/evaluation/app/config/config_fed_client.json
+++ b/fl-apps/nvflare/evaluation/app/config/config_fed_client.json
@@ -16,10 +16,12 @@
         "validate"
       ],
       "executor": {
-        "path": "nvflare.app_common.executors.in_process_client_api_executor.InProcessClientAPIExecutor",
+        "path": "nvflare.app_common.executors.client_api_executor.ClientAPIExecutor",
         "args": {
+          "execution_mode": "in_process",
           "task_script_path": "custom/evaluator.py",
-          "task_script_args": "--project_id {project_id}"
+          "task_script_args": "--project_id {project_id}",
+          "params_exchange_format": "numpy"
         }
       }
     }

--- a/fl-apps/nvflare/fed_opt/README.md
+++ b/fl-apps/nvflare/fed_opt/README.md
@@ -65,7 +65,7 @@ order.
 **Client — `config_fed_client.json` `executors` (by task):**
 
 - `init_training`, `post_validation` → `flip.nvflare.components.CleanupImages`
-- `train`, `validate` → `nvflare.app_common.executors.InProcessClientAPIExecutor` running
+- `train`, `validate` → `nvflare.app_common.executors.client_api_executor.ClientAPIExecutor` (`execution_mode: in_process`` running
   `custom/trainer.py`
 
 Post-training evaluation covers only the aggregated global model at each participating trust;

--- a/fl-apps/nvflare/fed_opt/app/config/config_fed_client.json
+++ b/fl-apps/nvflare/fed_opt/app/config/config_fed_client.json
@@ -17,11 +17,13 @@
         "validate"
       ],
       "executor": {
-        "path": "nvflare.app_common.executors.in_process_client_api_executor.InProcessClientAPIExecutor",
+        "path": "nvflare.app_common.executors.client_api_executor.ClientAPIExecutor",
         "args": {
+          "execution_mode": "in_process",
           "task_script_path": "custom/trainer.py",
           "task_script_args": "--project_id {project_id}",
-          "submit_model_task_name": ""
+          "submit_model_task_name": "",
+          "params_exchange_format": "numpy"
         }
       }
     }

--- a/fl-apps/nvflare/standard/README.md
+++ b/fl-apps/nvflare/standard/README.md
@@ -17,7 +17,7 @@
 
 This is the NVFLARE **Client API** federated-training job type (`JOB_TYPE=standard`). It performs a
 **Federated Averaging** round-trip, driving client training through the NVFLARE Client API
-(`InProcessClientAPIExecutor`). It replaced the retired Executor-based `standard` template, which
+(`ClientAPIExecutor` in `in_process` mode). It replaced the retired Executor-based `standard` template, which
 drove the clients through the legacy `RUN_TRAINER`/`RUN_VALIDATOR` executor pair.
 The server side is: `InitTraining` → `ScatterAndGather` → stock `GlobalModelEval` → `BroadcastTask` cleanup.
 
@@ -30,7 +30,7 @@ hand-edit them — regenerate via `recipe.py` after any recipe change and commit
 For each global round (`num_rounds` in the recipe / `ScatterAndGather` args):
 
 1. The server sends the current global model to every site.
-2. Each site runs the user's `trainer.py` via `InProcessClientAPIExecutor`, using the NVFLARE
+2. Each site runs the user's `trainer.py` via `ClientAPIExecutor`, using the NVFLARE
    Client API (`flare.receive()` / `flare.send()`) to receive and return model params.
 3. Sites return their update as a weight **diff** — `FLModel(params=<local minus global>,
    params_type="DIFF")` → `DataKind.WEIGHT_DIFF` (a `WEIGHTS` return is rejected by the
@@ -54,7 +54,7 @@ There is **no `validator.py`** — validation is orchestrated server-side via `G
 **Client — `config_fed_client.json` `executors` / `filters`:**
 
 - `init_training`, `post_validation` → `flip.nvflare.components.CleanupImages`
-- `train`, `validate` → `nvflare.app_common.executors.InProcessClientAPIExecutor`
+- `train`, `validate` → `nvflare.app_common.executors.client_api_executor.ClientAPIExecutor` (`execution_mode: in_process``
 - `train` result → `flip.nvflare.components.PercentilePrivacy` (DP noise filter)
 - Event handlers: `ClientEventHandler`, `FlipAnalyticsBridge`
 

--- a/fl-apps/nvflare/standard/app/config/config_fed_client.json
+++ b/fl-apps/nvflare/standard/app/config/config_fed_client.json
@@ -17,11 +17,13 @@
         "validate"
       ],
       "executor": {
-        "path": "nvflare.app_common.executors.in_process_client_api_executor.InProcessClientAPIExecutor",
+        "path": "nvflare.app_common.executors.client_api_executor.ClientAPIExecutor",
         "args": {
+          "execution_mode": "in_process",
           "task_script_path": "custom/trainer.py",
           "task_script_args": "--project_id {project_id}",
-          "submit_model_task_name": ""
+          "submit_model_task_name": "",
+          "params_exchange_format": "numpy"
         }
       }
     }

--- a/fl-services/nvflare/fl-api-base/pyproject.toml
+++ b/fl-services/nvflare/fl-api-base/pyproject.toml
@@ -18,7 +18,7 @@ readme = "README.md"
 requires-python = ">=3.12,<3.14"
 dependencies = [
     "fastapi[standard]>=0.115.11",
-    "nvflare==2.8.1",
+    "nvflare==2.9.0",
     "pydantic-settings>=2.11.0",
 ]
 
@@ -40,10 +40,7 @@ exclude-newer = "3 days"
 constraint-dependencies = [
     "aiohttp>=3.14.3",           # CVE-2026-47265, CVE-2026-34993, CVE-2026-34525/16/15/14/13/12, CVE-2026-22815, CVE-2026-21860
     "cryptography>=50.0.0",      # CVE-2026-26007, CVE-2026-39892, CVE-2026-34073
-    # flask>=3.1.3 omitted: nvflare==2.8.1 hard-pins flask==3.0.2, so no constraint can lift
-    # it. nvflare 2.9.0rc1 pins flask==3.1.3, so the fix lands with that upgrade (#1037);
-    # until then Dependabot #258/#400 stay open. FLIP imports no flask and never launches
-    # nvflare's dashboard/edge modules, its only flask consumers.
+    "flask>=3.1.3",              # GHSA-68rp-wp8r-4726 (Vary: Cookie); nvflare 2.9.0 pins flask==3.1.3
     "idna>=3.15",                # CVE-2026-45409
     "protobuf>=6.33.5",          # CVE-2026-0994, CVE-2025-4565
     "pygments>=2.20.0",          # CVE-2026-4539

--- a/fl-services/nvflare/fl-api-base/uv.lock
+++ b/fl-services/nvflare/fl-api-base/uv.lock
@@ -14,6 +14,7 @@ exclude-newer-span = "P3D"
 constraints = [
     { name = "aiohttp", specifier = ">=3.14.3" },
     { name = "cryptography", specifier = ">=50.0.0" },
+    { name = "flask", specifier = ">=3.1.3" },
     { name = "idna", specifier = ">=3.15" },
     { name = "protobuf", specifier = ">=6.33.5" },
     { name = "pygments", specifier = ">=2.20.0" },
@@ -550,18 +551,19 @@ wheels = [
 
 [[package]]
 name = "flask"
-version = "3.0.2"
+version = "3.1.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "blinker" },
     { name = "click" },
     { name = "itsdangerous" },
     { name = "jinja2" },
+    { name = "markupsafe" },
     { name = "werkzeug" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3f/e0/a89e8120faea1edbfca1a9b171cff7f2bf62ec860bbafcb2c2387c0317be/flask-3.0.2.tar.gz", hash = "sha256:822c03f4b799204250a7ee84b1eddc40665395333973dfb9deebfe425fefcb7d", size = 675248, upload-time = "2024-02-03T21:11:44.79Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/26/00/35d85dcce6c57fdc871f3867d465d780f302a175ea360f62533f12b27e2b/flask-3.1.3.tar.gz", hash = "sha256:0ef0e52b8a9cd932855379197dd8f94047b359ca0a78695144304cb45f87c9eb", size = 759004, upload-time = "2026-02-19T05:00:57.678Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/93/a6/aa98bfe0eb9b8b15d36cdfd03c8ca86a03968a87f27ce224fb4f766acb23/flask-3.0.2-py3-none-any.whl", hash = "sha256:3232e0e9c850d781933cf0207523d1ece087eb8d87b23777ae38456e2fbe7c6e", size = 101300, upload-time = "2024-02-03T21:11:42.661Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/9c/34f6962f9b9e9c71f6e5ed806e0d0ff03c9d1b0b2340088a0cf4bce09b18/flask-3.1.3-py3-none-any.whl", hash = "sha256:f4bcbefc124291925f1a26446da31a5178f9483862233b23c0c96a20701f670c", size = 103424, upload-time = "2026-02-19T05:00:56.027Z" },
 ]
 
 [[package]]
@@ -615,7 +617,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "fastapi", extras = ["standard"], specifier = ">=0.115.11" },
-    { name = "nvflare", specifier = "==2.8.1" },
+    { name = "nvflare", specifier = "==2.9.0" },
     { name = "pydantic-settings", specifier = ">=2.11.0" },
 ]
 
@@ -1122,7 +1124,7 @@ wheels = [
 
 [[package]]
 name = "nvflare"
-version = "2.8.1"
+version = "2.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -1144,7 +1146,7 @@ dependencies = [
     { name = "safetensors" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ca/33/172857cbd2258970bc23acec5c39d62535537304f678672298409b9e75ff/nvflare-2.8.1-py3-none-any.whl", hash = "sha256:55d1b77af3f5125ade0532fa1c6821902b6eae6a101c4d8b6c6efbb77096cd20", size = 3262630, upload-time = "2026-07-20T16:20:47.84Z" },
+    { url = "https://files.pythonhosted.org/packages/13/74/72afe401c43b659f198a041efb0df7f708a3fb3c1b42e784c27fe8b5562a/nvflare-2.9.0-py3-none-any.whl", hash = "sha256:5f2b6739d332c32bfe82176e7b23757fff718e4b83563f829ee42c761bb15c2d", size = 3619563, upload-time = "2026-09-04T20:52:15.505Z" },
 ]
 
 [[package]]

--- a/fl-tutorials/nvflare/image_classification/arkplus_fine_tuning/README.md
+++ b/fl-tutorials/nvflare/image_classification/arkplus_fine_tuning/README.md
@@ -25,7 +25,7 @@ legacy Executor API to the Client API. The job is defined entirely in Python via
 
 `config.json["job_type"] = "standard"`. Each client runs [`app_files/trainer.py`](app_files/trainer.py)
 as an in-process Client-API script (`flare.init()` → `flare.receive()`/`flare.send()` round loop) via
-NVFLARE's `InProcessClientAPIExecutor`. There is **no `validator.py`** — the held-out validation folds
+NVFLARE's `ClientAPIExecutor` (`in_process` mode). There is **no `validator.py`** — the held-out validation folds
 into the trainer's `flare.is_evaluate()` branch (server-driven cross-site evaluation).
 
 ## Target labels

--- a/fl-tutorials/nvflare/image_synthesis/latent_diffusion_model/README.md
+++ b/fl-tutorials/nvflare/image_synthesis/latent_diffusion_model/README.md
@@ -12,7 +12,7 @@ flow; what changed is the NVFLARE plumbing — noted here for anyone migrating a
 
 - **One client script serves four task names.** The job's two training phases (`train_ae`,
   `train_dm`) and two cross-site validation passes (`validate_ae`, `validate_dm`) all run through a
-  single `InProcessClientAPIExecutor` driving `app_files/trainer.py`. The single-name
+  single `ClientAPIExecutor` driving `app_files/trainer.py`. The single-name
   `flare.is_train()` / `flare.is_evaluate()` predicates cannot distinguish the two train phases, so
   the script dispatches on `nvflare.client.api.get_task_name()`.
 - **`validator.py` is a plain module**, not an Executor: it holds the validation passes and the

--- a/fl-tutorials/nvflare/image_synthesis/latent_diffusion_model/app_files/requirements.txt
+++ b/fl-tutorials/nvflare/image_synthesis/latent_diffusion_model/app_files/requirements.txt
@@ -1,7 +1,7 @@
 boto3>=1.38.31
 monai>=1.4.0
 nibabel>=5.3.2
-nvflare==2.8.1
+nvflare==2.9.0
 pandas>=2.3.0
 pydantic>=2.11.7
 pydantic-settings>=2.10.1

--- a/flip-utils/flip/nvflare/components/flip_analytics_bridge.py
+++ b/flip-utils/flip/nvflare/components/flip_analytics_bridge.py
@@ -26,7 +26,7 @@ class FlipAnalyticsBridge(FLComponent):
     FLIP's ``FlipEvents.SEND_RESULT`` federated events.
 
     Trainer scripts written against the NVFLARE Client API publish metrics
-    through ``SummaryWriter`` / ``flare.log``. The ``InProcessClientAPIExecutor``
+    through ``SummaryWriter`` / ``flare.log``. The ``ClientAPIExecutor``
     forwards those records onto the client process as ``ANALYTIC_EVENT_TYPE``
     events. This widget rewraps each record as a ``DataKind.METRICS`` DXO and
     re-fires it under ``FlipEvents.SEND_RESULT`` with federation scope, so the

--- a/flip-utils/flip/nvflare/recipes/base.py
+++ b/flip-utils/flip/nvflare/recipes/base.py
@@ -1,0 +1,35 @@
+# Copyright (c) 2026 Guy's and St Thomas' NHS Foundation Trust & King's College London
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Common base for the FLIP recipes.
+
+Exists for one reason: NVFLARE 2.9.0 renamed ``Recipe.job`` to the private ``Recipe._job``
+(``nvflare/recipe/spec.py``) with no public alias. ``recipe.job`` is FLIP's own published
+surface — every tutorial's ``job.py`` calls ``stage_app_files(recipe.job)`` — so the rename is
+absorbed here rather than pushed out to tutorial authors, and rather than scattering reads of a
+private upstream attribute through the recipes.
+"""
+
+from nvflare.job_config.api import FedJob
+from nvflare.recipe.spec import Recipe
+
+
+class FlipRecipe(Recipe):
+    """A :class:`~nvflare.recipe.spec.Recipe` that keeps ``job`` public.
+
+    Subclass this instead of NVFLARE's ``Recipe`` directly. If a future NVFLARE restores a public
+    ``job``, this property becomes redundant but stays harmless — it returns the same object.
+    """
+
+    @property
+    def job(self) -> FedJob:
+        """The recipe's underlying :class:`~nvflare.job_config.api.FedJob`."""
+        return self._job

--- a/flip-utils/flip/nvflare/recipes/flip_diffusion_recipe.py
+++ b/flip-utils/flip/nvflare/recipes/flip_diffusion_recipe.py
@@ -25,7 +25,7 @@ The two :class:`~flip.nvflare.controllers.ScatterAndGatherLDM` instances share o
 ``train_dm`` controller seeds its phase with the autoencoder weights the ``train_ae`` controller
 persisted (the phase-1 → phase-2 handoff, unchanged from the legacy job).
 
-Client-side, a **single** stock ``InProcessClientAPIExecutor`` serves all four ML task names
+Client-side, a **single** stock ``ClientAPIExecutor`` serves all four ML task names
 (``train_ae`` / ``train_dm`` / ``validate_ae`` / ``validate_dm``): the executor forwards the actual
 task name to the script, which dispatches on ``flare.get_task_name()`` (the single-name
 ``flare.is_train()`` / ``flare.is_evaluate()`` predicates cannot distinguish the two train phases).
@@ -49,12 +49,11 @@ from typing import Any
 
 from nvflare import FedJob
 from nvflare.app_common.aggregators import InTimeAccumulateWeightedAggregator
-from nvflare.app_common.executors.in_process_client_api_executor import InProcessClientAPIExecutor
+from nvflare.app_common.executors.client_api_executor import ClientAPIExecutor, ExecutionMode
 from nvflare.app_common.shareablegenerators.full_model_shareable_generator import FullModelShareableGenerator
 from nvflare.app_common.workflows.global_model_eval import GlobalModelEval
 from nvflare.app_opt.pt.file_model_persistor import PTFileModelPersistor
 from nvflare.job_config.defs import FilterType
-from nvflare.recipe.spec import Recipe
 
 from flip.constants import FlipTasks
 from flip.nvflare.components import (
@@ -70,6 +69,7 @@ from flip.nvflare.components import (
     ValidationJsonGenerator,
 )
 from flip.nvflare.controllers import BroadcastTask, InitTraining, ScatterAndGatherLDM
+from flip.nvflare.recipes.base import FlipRecipe
 from flip.nvflare.recipes.flip_fedavg_recipe import PercentilePrivacy
 from flip.nvflare.runtime import FLIP_CUSTOM_PROPS_KEY, FLIP_MODEL_ID_KEY
 
@@ -83,7 +83,7 @@ VALIDATE_AE_TASK = "validate_ae"
 VALIDATE_DM_TASK = "validate_dm"
 
 
-class FlipDiffusionRecipe(Recipe):
+class FlipDiffusionRecipe(FlipRecipe):
     """FLIP latent-diffusion recipe wired for the NVFLARE Client API.
 
     Args:
@@ -228,7 +228,8 @@ class FlipDiffusionRecipe(Recipe):
         # executor's own train/evaluate task-name knobs are single-valued, so they are left at
         # their stock defaults and intentionally unused.
         job.to_clients(
-            InProcessClientAPIExecutor(
+            ClientAPIExecutor(
+                execution_mode=ExecutionMode.IN_PROCESS,
                 task_script_path=self.train_script,
                 task_script_args=self.train_args,
                 params_exchange_format=self.params_exchange_format,

--- a/flip-utils/flip/nvflare/recipes/flip_eval_recipe.py
+++ b/flip-utils/flip/nvflare/recipes/flip_eval_recipe.py
@@ -25,7 +25,7 @@ single-model ``validate`` task and reuses the same cross-site validation path th
   :class:`~flip.nvflare.components.EvaluationJsonGenerator` collects the returned metrics
   into ``evaluation_results.json`` (unchanged output contract); ``PersistToS3AndCleanup`` zips + uploads
   the run dir to S3.
-* client: the stock ``InProcessClientAPIExecutor`` runs the evaluator script, which is the canonical
+* client: the stock ``ClientAPIExecutor`` runs the evaluator script, which is the canonical
   Client-API ``is_evaluate()`` loop — receive the global model, score it on local data, send back an
   aggregate-only metrics ``FLModel``. No ``Executor``/``Shareable`` plumbing, no ``COLLECTION`` unwrap.
 
@@ -42,11 +42,10 @@ from pathlib import Path
 from typing import Any
 
 from nvflare import FedJob
-from nvflare.app_common.executors.in_process_client_api_executor import InProcessClientAPIExecutor
+from nvflare.app_common.executors.client_api_executor import ClientAPIExecutor, ExecutionMode
 from nvflare.app_common.workflows.global_model_eval import GlobalModelEval
 from nvflare.app_opt.pt.file_model_persistor import PTFileModelPersistor
 from nvflare.job_config.defs import FilterType
-from nvflare.recipe.spec import Recipe
 
 from flip.constants import FlipTasks
 from flip.nvflare.components import (
@@ -59,6 +58,7 @@ from flip.nvflare.components import (
     ServerEventHandler,
 )
 from flip.nvflare.controllers import BroadcastTask, InitEvaluation
+from flip.nvflare.recipes.base import FlipRecipe
 from flip.nvflare.runtime import FLIP_CUSTOM_PROPS_KEY, FLIP_MODEL_ID_KEY
 
 # Default UUID used by SimEnv/PocEnv runs when the caller doesn't pass one. Pinned so dev runs are
@@ -66,7 +66,7 @@ from flip.nvflare.runtime import FLIP_CUSTOM_PROPS_KEY, FLIP_MODEL_ID_KEY
 _DEV_MODEL_ID = "00000000-0000-0000-0000-000000000001"
 
 
-class FlipEvalRecipe(Recipe):
+class FlipEvalRecipe(FlipRecipe):
     """FLIP evaluation recipe wired for the NVFLARE Client API.
 
     Args:
@@ -158,7 +158,8 @@ class FlipEvalRecipe(Recipe):
 
         # Clients: Client API evaluator for the validate task.
         job.to_clients(
-            InProcessClientAPIExecutor(
+            ClientAPIExecutor(
+                execution_mode=ExecutionMode.IN_PROCESS,
                 task_script_path=self.eval_script,
                 task_script_args=self.eval_args,
                 evaluate_task_name=self.evaluate_task_name,

--- a/flip-utils/flip/nvflare/recipes/flip_fedavg_recipe.py
+++ b/flip-utils/flip/nvflare/recipes/flip_fedavg_recipe.py
@@ -54,13 +54,12 @@ from typing import Any
 
 from nvflare import FedJob
 from nvflare.app_common.aggregators import InTimeAccumulateWeightedAggregator
-from nvflare.app_common.executors.in_process_client_api_executor import InProcessClientAPIExecutor
+from nvflare.app_common.executors.client_api_executor import ClientAPIExecutor, ExecutionMode
 from nvflare.app_common.shareablegenerators.full_model_shareable_generator import FullModelShareableGenerator
 from nvflare.app_common.widgets.intime_model_selector import IntimeModelSelector
 from nvflare.app_common.workflows.cross_site_model_eval import CrossSiteModelEval
 from nvflare.app_common.workflows.global_model_eval import GlobalModelEval
 from nvflare.job_config.defs import FilterType
-from nvflare.recipe.spec import Recipe
 
 from flip.constants import FlipTasks
 from flip.nvflare.components import (
@@ -81,6 +80,7 @@ from flip.nvflare.components import (
     PercentilePrivacy as PercentilePrivacyFilter,
 )
 from flip.nvflare.controllers import BroadcastTask, InitTraining, ScatterAndGather
+from flip.nvflare.recipes.base import FlipRecipe
 from flip.nvflare.runtime import FLIP_CUSTOM_PROPS_KEY, FLIP_MODEL_ID_KEY
 
 # Default UUID used by SimEnv/PocEnv runs when the caller doesn't pass one. Pinned so dev runs
@@ -105,7 +105,7 @@ class PercentilePrivacy:
     off: bool = False
 
 
-class FlipFedAvgRecipe(Recipe):
+class FlipFedAvgRecipe(FlipRecipe):
     """FLIP FedAvg recipe wired for the NVFLARE Client API.
 
     Head-only (frozen-backbone) aggregation is canonically driven in production by the fl-server's
@@ -340,7 +340,8 @@ class FlipFedAvgRecipe(Recipe):
         if self.submit_model_task_name:
             executor_tasks.insert(1, self.submit_model_task_name)
         job.to_clients(
-            InProcessClientAPIExecutor(
+            ClientAPIExecutor(
+                execution_mode=ExecutionMode.IN_PROCESS,
                 task_script_path=self.train_script,
                 task_script_args=self.train_args,
                 train_task_name=self.train_task_name,

--- a/flip-utils/pyproject.toml
+++ b/flip-utils/pyproject.toml
@@ -49,7 +49,7 @@ classifiers = [
 ]
 dependencies = [
     "boto3>=1.38.31",
-    "nvflare==2.8.1",
+    "nvflare==2.9.0",
     "pandas>=2.3.0",
     "pydantic>=2.11.7",
     "pydantic-settings>=2.10.1",
@@ -108,10 +108,7 @@ constraint-dependencies = [
     "click>=8.3.3",              # CVE-2026-7246
     "cryptography>=50.0.0",      # CVE-2026-26007, CVE-2026-39892, CVE-2026-34073
     "filelock>=3.20.3",          # CVE-2025-68146, CVE-2026-22701
-    # flask>=3.1.3 omitted: nvflare==2.8.1 hard-pins flask==3.0.2, so no constraint can lift
-    # it. nvflare 2.9.0rc1 pins flask==3.1.3, so the fix lands with that upgrade (#1037);
-    # until then Dependabot #258/#400 stay open. FLIP imports no flask and never launches
-    # nvflare's dashboard/edge modules, its only flask consumers.
+    "flask>=3.1.3",              # GHSA-68rp-wp8r-4726 (Vary: Cookie); nvflare 2.9.0 pins flask==3.1.3
     "fonttools>=4.62.0",         # arbitrary code execution (dev-only, via matplotlib)
     "idna>=3.15",                # CVE-2026-45409
     "pillow>=12.3.0",            # CVE-2026-42311/42310/42309/42308/40192/25990

--- a/flip-utils/tests/unit/nvflare/recipes/test_flip_diffusion_recipe.py
+++ b/flip-utils/tests/unit/nvflare/recipes/test_flip_diffusion_recipe.py
@@ -145,7 +145,10 @@ class TestFlipDiffusionRecipe:
             client_blob = json.dumps(client_cfg)
             # Client uses ONE stock Client-API executor for all four ML tasks; no RUN_TRAINER /
             # RUN_VALIDATOR executor pairs.
-            assert "InProcessClientAPIExecutor" in client_blob
+            assert "ClientAPIExecutor" in client_blob
+            # NVFLARE 2.9.0 folded the in-process executor into ClientAPIExecutor, where the mode
+            # is an argument rather than the class identity — so the mode is what needs pinning.
+            assert '"execution_mode": "in_process"' in client_blob
             assert "RUN_TRAINER" not in client_blob
             assert "RUN_VALIDATOR" not in client_blob
             executor_tasks = [t for e in client_cfg["executors"] for t in e["tasks"]]

--- a/flip-utils/tests/unit/nvflare/recipes/test_flip_eval_recipe.py
+++ b/flip-utils/tests/unit/nvflare/recipes/test_flip_eval_recipe.py
@@ -110,7 +110,10 @@ class TestFlipEvalRecipe:
             client_cfg = json.loads(client_cfg_path.read_text())
             client_blob = json.dumps(client_cfg)
             # Client uses the stock Client-API executor for the validate task; no RUN_EVALUATOR.
-            assert "InProcessClientAPIExecutor" in client_blob
+            assert "ClientAPIExecutor" in client_blob
+            # NVFLARE 2.9.0 folded the in-process executor into ClientAPIExecutor, where the mode
+            # is an argument rather than the class identity — so the mode is what needs pinning.
+            assert '"execution_mode": "in_process"' in client_blob
             assert "RUN_EVALUATOR" not in client_blob
             # validate task is registered on the executor.
             executor_tasks = [t for e in client_cfg["executors"] for t in e["tasks"]]

--- a/flip-utils/uv.lock
+++ b/flip-utils/uv.lock
@@ -12,6 +12,7 @@ constraints = [
     { name = "click", specifier = ">=8.3.3" },
     { name = "cryptography", specifier = ">=50.0.0" },
     { name = "filelock", specifier = ">=3.20.3" },
+    { name = "flask", specifier = ">=3.1.3" },
     { name = "fonttools", specifier = ">=4.62.0" },
     { name = "idna", specifier = ">=3.15" },
     { name = "pillow", specifier = ">=12.3.0" },
@@ -690,18 +691,19 @@ wheels = [
 
 [[package]]
 name = "flask"
-version = "3.0.2"
+version = "3.1.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "blinker" },
     { name = "click" },
     { name = "itsdangerous" },
     { name = "jinja2" },
+    { name = "markupsafe" },
     { name = "werkzeug" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3f/e0/a89e8120faea1edbfca1a9b171cff7f2bf62ec860bbafcb2c2387c0317be/flask-3.0.2.tar.gz", hash = "sha256:822c03f4b799204250a7ee84b1eddc40665395333973dfb9deebfe425fefcb7d", size = 675248, upload-time = "2024-02-03T21:11:44.79Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/26/00/35d85dcce6c57fdc871f3867d465d780f302a175ea360f62533f12b27e2b/flask-3.1.3.tar.gz", hash = "sha256:0ef0e52b8a9cd932855379197dd8f94047b359ca0a78695144304cb45f87c9eb", size = 759004, upload-time = "2026-02-19T05:00:57.678Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/93/a6/aa98bfe0eb9b8b15d36cdfd03c8ca86a03968a87f27ce224fb4f766acb23/flask-3.0.2-py3-none-any.whl", hash = "sha256:3232e0e9c850d781933cf0207523d1ece087eb8d87b23777ae38456e2fbe7c6e", size = 101300, upload-time = "2024-02-03T21:11:42.661Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/9c/34f6962f9b9e9c71f6e5ed806e0d0ff03c9d1b0b2340088a0cf4bce09b18/flask-3.1.3-py3-none-any.whl", hash = "sha256:f4bcbefc124291925f1a26446da31a5178f9483862233b23c0c96a20701f670c", size = 103424, upload-time = "2026-02-19T05:00:56.027Z" },
 ]
 
 [[package]]
@@ -780,7 +782,7 @@ requires-dist = [
     { name = "lpips", marker = "extra == 'full'", specifier = "==0.1.4" },
     { name = "monai", extras = ["pyyaml", "scipy", "skimage"], marker = "extra == 'full'", specifier = ">=1.6.0" },
     { name = "nibabel", marker = "extra == 'full'", specifier = ">=5.3.2" },
-    { name = "nvflare", specifier = "==2.8.1" },
+    { name = "nvflare", specifier = "==2.9.0" },
     { name = "pandas", specifier = ">=2.3.0" },
     { name = "pydantic", specifier = ">=2.11.7" },
     { name = "pydantic-settings", specifier = ">=2.10.1" },
@@ -1849,7 +1851,7 @@ wheels = [
 
 [[package]]
 name = "nvflare"
-version = "2.8.1"
+version = "2.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -1871,7 +1873,7 @@ dependencies = [
     { name = "safetensors" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ca/33/172857cbd2258970bc23acec5c39d62535537304f678672298409b9e75ff/nvflare-2.8.1-py3-none-any.whl", hash = "sha256:55d1b77af3f5125ade0532fa1c6821902b6eae6a101c4d8b6c6efbb77096cd20", size = 3262630, upload-time = "2026-07-20T16:20:47.84Z" },
+    { url = "https://files.pythonhosted.org/packages/13/74/72afe401c43b659f198a041efb0df7f708a3fb3c1b42e784c27fe8b5562a/nvflare-2.9.0-py3-none-any.whl", hash = "sha256:5f2b6739d332c32bfe82176e7b23757fff718e4b83563f829ee42c761bb15c2d", size = 3619563, upload-time = "2026-09-04T20:52:15.505Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Description

Upgrades `nvflare` 2.8.1 → **2.9.0**, which reached GA on 2026-09-04. 2.9.0 pins `Flask==3.1.3`, so this closes Dependabot **#258** and **#400** — the two alerts 2.8.x could not fix, because every 2.8.x release hard-pins the vulnerable `Flask==3.0.2` and no `constraint-dependencies` floor can lift a hard pin.

This is not a relock. It is a minor NVFLARE bump, and two upstream API changes reach FLIP — both found by resolving, against the installed 2.9.0, every nvflare symbol FLIP imports (76) and every dotted class path its config files reference (5), rather than by reading release notes.

### 1. `InProcessClientAPIExecutor` is removed

2.9.0 folds the in-process, external-process and attach executors into a single `ClientAPIExecutor` whose `execution_mode` argument selects the backend. There is no alias — the old module is simply gone. It is referenced from **two independent surfaces**, and missing either one leaves half the platform broken:

| surface | files | used by |
| --- | --- | --- |
| Python | the three recipes in `flip-utils/flip/nvflare/recipes/` | the simulator / tutorial path (`job.py`) |
| JSON | the four `fl-apps/nvflare/*/app/config/config_fed_client.json` | the platform path flip-api bundles and deploys to trusts |

The JSON templates additionally now pin `"params_exchange_format": "numpy"`. They had relied on the stock default, which changed `NUMPY` → `RAW` in 2.9.0; setting it explicitly keeps their behaviour identical to 2.8.1 instead of silently switching exchange format on every deployed app. The recipes already passed it explicitly, so they were never exposed to that default.

### 2. `Recipe.job` became the private `Recipe._job`

Also with no public alias. `recipe.job` is FLIP's *own* published surface — every tutorial's `job.py` calls `stage_app_files(recipe.job)` — so pushing the rename outward would break every tutorial and every app a researcher has written against them. The rename is absorbed behind a new `FlipRecipe` base (`flip-utils/flip/nvflare/recipes/base.py`) that re-exposes `job` as a read-only property. That also keeps the recipes off a private upstream attribute, so if a future NVFLARE restores a public `job` the property becomes redundant rather than wrong.

### Verified unaffected

- **The `FLIP_Session` contract holds.** `flip_session.py` subclasses `nvflare.fuel.flare_api.flare_api.Session`, calls `Session.__init__` positionally and overrides the private `_do_command` — none of which mocked unit tests would catch a signature change in. Under 2.9.0, `Session.__init__(username, startup_path, secure_mode=True, debug=False, study='default')`, `_do_command(command, enforce_meta=True, props=None)` and `try_connect(timeout)` are unchanged from 2.8.1, `enforce_meta` is still the only keyword upstream passes to `_do_command`, and `__init__` still stores every attribute `_reconnect` reads back off the base.
- **The recipe-serialisation `*args`/`**kwargs` rule still applies** — `_retrieve_parameters` still gates base-class parameter inheritance on the subclass declaring both.
- **The class allow-list stays inert**, for the same reason as at 2.8.1: every client participant in `fl-services/nvflare/provision/*.yml` sets `enable_byoc: true`.

### The flask constraint

The `# flask>=3.1.3 omitted: ...` comment blocks in both pyprojects become a real `flask>=3.1.3` constraint entry. The pin did not loosen — 2.9.0 hard-pins the patched 3.1.3 — so the floor is satisfiable today, and it now fails the lock loudly if an upstream bump ever drops back below it.

`cryptography`'s floor also moves `>=36.0.0` → `>=45.0.0` upstream, which is below the `>=50.0.0` both projects already constrain to, so nothing changes there.

## Linked Issues

Fixes #1037

## Checklist

- [x] Follows the project's coding conventions and style guide
- [x] Updates documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Type of Change

- [ ] Non-breaking change (fix or new feature that would not break existing functionality).
- [x] Breaking change (fix or new feature that would cause existing functionality to change).
- [x] New tests added to cover the changes.
- [x] In-line docstrings updated.
- [ ] Documentation updated, tested `make -C docs/ docs`.

**On "breaking":** nothing in FLIP's own API changes, and `recipe.job` is deliberately preserved. It is marked breaking because the FL images must be rebuilt together with the hub — an app pinned to 2.8.x cannot run against a 2.9.0 client, and any operator-provided app template referencing `nvflare.app_common.executors.in_process_client_api_executor.InProcessClientAPIExecutor` by path will stop resolving and needs the same two-line migration applied here.

## Testing

- [x] `flip-utils`: ruff clean, **868 passed**.
- [x] `fl-services/nvflare/fl-api-base`: ruff clean, mypy clean (40 files), **190 passed**.
- [x] `make -C fl-tutorials test`: **117 passed**, 12 skipped.
- [x] `uv lock --check` passes for both projects; the relock moves **only** `nvflare` and `flask`, and the `exclude-newer` / `exclude-newer-span = "P3D"` cooldown block survives in both lockfiles.

Beyond the unit layer, both affected surfaces were exercised for real — the unit tests cover neither a live simulator run nor a deployed app:

- [x] **Simulator**, every NVFLARE tutorial: `make -C fl-tutorials run-tutorial TUTORIAL=…`
- [x] **Dev deployment**, `make e2e_smoke` on the NVFLARE backend, against FL images rebuilt from this branch

<!-- SMOKE_RESULTS -->

## Additional Notes

`#1037` was closed by accident on 2026-08-28: PR #1046 was titled *"…(interim stable patch; **does not close #1037**)"*, and GitHub parsed the closing keyword out of the merge commit message with no negation handling. Reopened. Worth avoiding that phrasing in a future PR title — write `#1037` or "separate from #1037" instead.


## Acceptance Criteria

### From issue #1037

1. `nvflare==2.9.0` in `flip-utils/pyproject.toml` and `fl-services/nvflare/fl-api-base/pyproject.toml`, with both lockfiles relocked and resolving `flask >= 3.1.3`.
2. The `# flask>=3.1.3 omitted: ...` comment blocks are replaced by a real `flask>=3.1.3` constraint entry in both pyprojects (2.9.0 pins exactly 3.1.3, so the floor is satisfiable and guards against an upstream regression below it).
3. Dependabot #258 and #400 close on their own once the lockfiles land.
4. Every NVFLARE tutorial passes in **simulator** mode, and the platform path passes a dev **e2e smoke** — the two surfaces are affected differently (see below).

### From issue #1037

1. `nvflare==2.9.0` in `flip-utils/pyproject.toml` and `fl-services/nvflare/fl-api-base/pyproject.toml`, with both lockfiles relocked and resolving `flask >= 3.1.3`.
2. The `# flask>=3.1.3 omitted: ...` comment blocks are replaced by a real `flask>=3.1.3` constraint entry in both pyprojects (2.9.0 pins exactly 3.1.3, so the floor is satisfiable and guards against an upstream regression below it).
3. Dependabot #258 and #400 close on their own once the lockfiles land.
4. Every NVFLARE tutorial passes in **simulator** mode, and the platform path passes a dev **e2e smoke** — the two surfaces are affected differently (see below).

