### PR TITLE
Suggestions for nvflare 2.8.0 -> 2.9.0

### DIFF
--- a/docs/source/components/component-fl-nodes.rst
+++ b/docs/source/components/component-fl-nodes.rst
@@ -372,7 +372,7 @@ has no ``off`` switch:
        any positive value; a larger ``gamma`` merely weakens the truncation.
      - ``10`` / ``0.01``
 
-Semantics — verified against NVFLARE 2.8.0:
+Semantics — verified against NVFLARE 2.9.0:
 
 - **The site policy composes with, and cannot be bypassed by, the app config.** NVFLARE applies site scope
   filters *before* the job's ``task_result_filters`` in one chain (``nvflare/apis/utils/task_utils.py``);
@@ -444,4 +444,3 @@ the description above:
   the per-job-type implementations under `fl-apps/ <https://github.com/londonaicentre/FLIP/tree/develop/fl-apps/nvflare>`__.
 - every NVFLARE job type takes a plain training/evaluation script that calls
   ``nvflare.client`` directly (`fed_opt` reuses `standard`'s trainer contract unchanged).
-

--- a/fl-apps/nvflare/diffusion_model/recipe.py
+++ b/fl-apps/nvflare/diffusion_model/recipe.py
@@ -83,7 +83,7 @@ def main() -> None:
     with tempfile.TemporaryDirectory() as tmp:
         recipe = FlipDiffusionRecipe()
         recipe.export(tmp)
-        exported_root = Path(tmp) / recipe._job.name
+        exported_root = Path(tmp) / recipe.job.name
         exported_config = exported_root / "app" / "config"
         for name in ("config_fed_server.json", "config_fed_client.json"):
             _copy_json(exported_config / name, dest_config / name)

--- a/fl-apps/nvflare/evaluation/recipe.py
+++ b/fl-apps/nvflare/evaluation/recipe.py
@@ -59,7 +59,7 @@ def main() -> None:
     with tempfile.TemporaryDirectory() as tmp:
         recipe = FlipEvalRecipe()
         recipe.export(tmp)
-        exported_root = Path(tmp) / recipe._job.name
+        exported_root = Path(tmp) / recipe.job.name
         exported_config = exported_root / "app" / "config"
         for name in ("config_fed_server.json", "config_fed_client.json"):
             _copy_json_2space(exported_config / name, dest_config / name)

--- a/fl-apps/nvflare/fed_opt/recipe.py
+++ b/fl-apps/nvflare/fed_opt/recipe.py
@@ -72,7 +72,7 @@ def main() -> None:
     with tempfile.TemporaryDirectory() as tmp:
         recipe = FlipFedOptRecipe()
         recipe.export(tmp)
-        exported_root = Path(tmp) / recipe._job.name
+        exported_root = Path(tmp) / recipe.job.name
         exported_config = exported_root / "app" / "config"
         for name in ("config_fed_server.json", "config_fed_client.json"):
             _copy_json(exported_config / name, dest_config / name)

--- a/fl-apps/nvflare/standard/recipe.py
+++ b/fl-apps/nvflare/standard/recipe.py
@@ -72,7 +72,7 @@ def main() -> None:
     with tempfile.TemporaryDirectory() as tmp:
         recipe = FlipFedAvgRecipe()
         recipe.export(tmp)
-        exported_root = Path(tmp) / recipe._job.name
+        exported_root = Path(tmp) / recipe.job.name
         exported_config = exported_root / "app" / "config"
         for name in ("config_fed_server.json", "config_fed_client.json"):
             _copy_json(exported_config / name, dest_config / name)

--- a/fl-tutorials/nvflare/image_classification/arkplus_fine_tuning/README.md
+++ b/fl-tutorials/nvflare/image_classification/arkplus_fine_tuning/README.md
@@ -25,7 +25,7 @@ legacy Executor API to the Client API. The job is defined entirely in Python via
 
 `config.json["job_type"] = "standard"`. Each client runs [`app_files/trainer.py`](app_files/trainer.py)
 as an in-process Client-API script (`flare.init()` → `flare.receive()`/`flare.send()` round loop) via
-NVFLARE's `InProcessClientAPIExecutor`. There is **no `validator.py`** — the held-out validation folds
+NVFLARE's `ClientAPIExecutor` (`in_process` mode). There is **no `validator.py`** — the held-out validation folds
 into the trainer's `flare.is_evaluate()` branch (server-driven cross-site evaluation).
 
 ## Target labels

--- a/fl-tutorials/nvflare/image_synthesis/latent_diffusion_model/README.md
+++ b/fl-tutorials/nvflare/image_synthesis/latent_diffusion_model/README.md
@@ -12,7 +12,7 @@ flow; what changed is the NVFLARE plumbing — noted here for anyone migrating a
 
 - **One client script serves four task names.** The job's two training phases (`train_ae`,
   `train_dm`) and two cross-site validation passes (`validate_ae`, `validate_dm`) all run through a
-  single `InProcessClientAPIExecutor` driving `app_files/trainer.py`. The single-name
+  single `ClientAPIExecutor` driving `app_files/trainer.py`. The single-name
   `flare.is_train()` / `flare.is_evaluate()` predicates cannot distinguish the two train phases, so
   the script dispatches on `nvflare.client.api.get_task_name()`.
 - **`validator.py` is a plain module**, not an Executor: it holds the validation passes and the

--- a/flip-utils/flip/nvflare/recipes/base.py
+++ b/flip-utils/flip/nvflare/recipes/base.py
@@ -18,7 +18,7 @@ absorbed here rather than pushed out to tutorial authors, and rather than scatte
 private upstream attribute through the recipes.
 """
 
-from nvflare.job_config.api import FedJob
+from nvflare import FedJob
 from nvflare.recipe.spec import Recipe
 
 

--- a/flip-utils/flip/nvflare/recipes/base.py
+++ b/flip-utils/flip/nvflare/recipes/base.py
@@ -1,0 +1,35 @@
+# Copyright (c) 2026 Guy's and St Thomas' NHS Foundation Trust & King's College London
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Common base for the FLIP recipes.
+
+Exists for one reason: NVFLARE 2.9.0 renamed ``Recipe.job`` to the private ``Recipe._job``
+(``nvflare/recipe/spec.py``) with no public alias. ``recipe.job`` is FLIP's own published
+surface — every tutorial's ``job.py`` calls ``stage_app_files(recipe.job)`` — so the rename is
+absorbed here rather than pushed out to tutorial authors, and rather than scattering reads of a
+private upstream attribute through the recipes.
+"""
+
+from nvflare.job_config.api import FedJob
+from nvflare.recipe.spec import Recipe
+
+
+class FlipRecipe(Recipe):
+    """A :class:`~nvflare.recipe.spec.Recipe` that keeps ``job`` public.
+
+    Subclass this instead of NVFLARE's ``Recipe`` directly. If a future NVFLARE restores a public
+    ``job``, this property becomes redundant but stays harmless — it returns the same object.
+    """
+
+    @property
+    def job(self) -> FedJob:
+        """The recipe's underlying :class:`~nvflare.job_config.api.FedJob`."""
+        return self._job

--- a/flip-utils/flip/nvflare/recipes/flip_diffusion_recipe.py
+++ b/flip-utils/flip/nvflare/recipes/flip_diffusion_recipe.py
@@ -54,7 +54,6 @@ from nvflare.app_common.shareablegenerators.full_model_shareable_generator impor
 from nvflare.app_common.workflows.global_model_eval import GlobalModelEval
 from nvflare.app_opt.pt.file_model_persistor import PTFileModelPersistor
 from nvflare.job_config.defs import FilterType
-from nvflare.recipe.spec import Recipe
 
 from flip.constants import FlipTasks
 from flip.nvflare.components import (
@@ -70,6 +69,7 @@ from flip.nvflare.components import (
     ValidationJsonGenerator,
 )
 from flip.nvflare.controllers import BroadcastTask, InitTraining, ScatterAndGatherLDM
+from flip.nvflare.recipes.base import FlipRecipe
 from flip.nvflare.recipes.flip_fedavg_recipe import PercentilePrivacy
 from flip.nvflare.runtime import FLIP_CUSTOM_PROPS_KEY, FLIP_MODEL_ID_KEY
 
@@ -83,7 +83,7 @@ VALIDATE_AE_TASK = "validate_ae"
 VALIDATE_DM_TASK = "validate_dm"
 
 
-class FlipDiffusionRecipe(Recipe):
+class FlipDiffusionRecipe(FlipRecipe):
     """FLIP latent-diffusion recipe wired for the NVFLARE Client API.
 
     Args:
@@ -264,7 +264,7 @@ class FlipDiffusionRecipe(Recipe):
         optionally rewrites ``meta.json['custom_props']`` with the real model_id at submit time, and
         forwards the job to the fl-server stack.
         """
-        self._job.export_job(str(job_dir))
+        self.job.export_job(str(job_dir))
         self._write_client_config_params(Path(job_dir))
 
     def _write_client_config_params(self, job_dir: Path) -> None:
@@ -280,7 +280,7 @@ class FlipDiffusionRecipe(Recipe):
         ignored (data comes from the ``DEV_DATAFRAME`` / ``DEV_IMAGES_DIR`` env). Mirrors the
         hand-written ``diffusion_model`` template.
         """
-        client_cfg = job_dir / self._job.name / "app" / "config" / "config_fed_client.json"
+        client_cfg = job_dir / self.job.name / "app" / "config" / "config_fed_client.json"
         if not client_cfg.exists():
             return
         config = json.loads(client_cfg.read_text())

--- a/flip-utils/flip/nvflare/recipes/flip_eval_recipe.py
+++ b/flip-utils/flip/nvflare/recipes/flip_eval_recipe.py
@@ -47,7 +47,6 @@ from nvflare.app_common.executors.client_api_executor import ClientAPIExecutor, 
 from nvflare.app_common.workflows.global_model_eval import GlobalModelEval
 from nvflare.app_opt.pt.file_model_persistor import PTFileModelPersistor
 from nvflare.job_config.defs import FilterType
-from nvflare.recipe.spec import Recipe
 
 from flip.constants import FlipTasks
 from flip.nvflare.components import (
@@ -60,6 +59,7 @@ from flip.nvflare.components import (
     ServerEventHandler,
 )
 from flip.nvflare.controllers import BroadcastTask, InitEvaluation
+from flip.nvflare.recipes.base import FlipRecipe
 from flip.nvflare.runtime import FLIP_CUSTOM_PROPS_KEY, FLIP_MODEL_ID_KEY
 
 # Default UUID used by SimEnv/PocEnv runs when the caller doesn't pass one. Pinned so dev runs are
@@ -67,7 +67,7 @@ from flip.nvflare.runtime import FLIP_CUSTOM_PROPS_KEY, FLIP_MODEL_ID_KEY
 _DEV_MODEL_ID = "00000000-0000-0000-0000-000000000001"
 
 
-class FlipEvalRecipe(Recipe):
+class FlipEvalRecipe(FlipRecipe):
     """FLIP evaluation recipe wired for the NVFLARE Client API.
 
     Args:
@@ -183,7 +183,7 @@ class FlipEvalRecipe(Recipe):
         rewrites ``meta.json['custom_props']`` with the real model_id at submit time, and forwards the
         job to the fl-server stack.
         """
-        self._job.export_job(str(job_dir))
+        self.job.export_job(str(job_dir))
         self._write_client_config_params(Path(job_dir))
 
     def _write_client_config_params(self, job_dir: Path) -> None:
@@ -198,7 +198,7 @@ class FlipEvalRecipe(Recipe):
         with the real submission values; in SimEnv/LOCAL_DEV they're ignored (data comes from the
         ``DEV_DATAFRAME`` / ``DEV_IMAGES_DIR`` env). Mirrors the hand-written ``evaluation`` template.
         """
-        client_cfg = job_dir / self._job.name / "app" / "config" / "config_fed_client.json"
+        client_cfg = job_dir / self.job.name / "app" / "config" / "config_fed_client.json"
         if not client_cfg.exists():
             return
         config = json.loads(client_cfg.read_text())

--- a/flip-utils/flip/nvflare/recipes/flip_fedavg_recipe.py
+++ b/flip-utils/flip/nvflare/recipes/flip_fedavg_recipe.py
@@ -60,7 +60,6 @@ from nvflare.app_common.widgets.intime_model_selector import IntimeModelSelector
 from nvflare.app_common.workflows.cross_site_model_eval import CrossSiteModelEval
 from nvflare.app_common.workflows.global_model_eval import GlobalModelEval
 from nvflare.job_config.defs import FilterType
-from nvflare.recipe.spec import Recipe
 
 from flip.constants import FlipTasks
 from flip.nvflare.components import (
@@ -81,6 +80,7 @@ from flip.nvflare.components import (
     PercentilePrivacy as PercentilePrivacyFilter,
 )
 from flip.nvflare.controllers import BroadcastTask, InitTraining, ScatterAndGather
+from flip.nvflare.recipes.base import FlipRecipe
 from flip.nvflare.runtime import FLIP_CUSTOM_PROPS_KEY, FLIP_MODEL_ID_KEY
 
 # Default UUID used by SimEnv/PocEnv runs when the caller doesn't pass one. Pinned so dev runs
@@ -105,7 +105,7 @@ class PercentilePrivacy:
     off: bool = False
 
 
-class FlipFedAvgRecipe(Recipe):
+class FlipFedAvgRecipe(FlipRecipe):
     """FLIP FedAvg recipe wired for the NVFLARE Client API.
 
     Head-only (frozen-backbone) aggregation is canonically driven in production by the fl-server's
@@ -397,7 +397,7 @@ class FlipFedAvgRecipe(Recipe):
         consumes this directory, optionally rewrites ``meta.json['custom_props']`` with
         the real model_id at submit time, and forwards the job to the fl-server stack.
         """
-        self._job.export_job(str(job_dir))
+        self.job.export_job(str(job_dir))
         self._write_client_config_params(Path(job_dir))
 
     def _write_client_config_params(self, job_dir: Path) -> None:
@@ -414,7 +414,7 @@ class FlipFedAvgRecipe(Recipe):
         values at job-assembly; in SimEnv/LOCAL_DEV they're ignored (data comes from the
         ``DEV_DATAFRAME`` / ``DEV_IMAGES_DIR`` env). Mirrors the hand-written ``standard`` template.
         """
-        client_cfg = job_dir / self._job.name / "app" / "config" / "config_fed_client.json"
+        client_cfg = job_dir / self.job.name / "app" / "config" / "config_fed_client.json"
         if not client_cfg.exists():
             return
         config = json.loads(client_cfg.read_text())


### PR DESCRIPTION
# Description

Suggestions for #1174, based on running that branch rather than reading it. **Targets `1037-nvflare-2-9-0-upgrade`**, so merging it folds these changes into that PR.

The 2.9.0 upgrade itself is right, and I arrived at the same two breaking changes independently: `InProcessClientAPIExecutor` → `ClientAPIExecutor(execution_mode=…)`, and `Recipe.job` → `Recipe._job`. This PR changes how the **second** one is absorbed, and clears three stale doc references.

## The problem: every NVFLARE tutorial is broken on #1174

`recipe.job` is not an internal detail — it is FLIP's own published surface. All **seven** tutorial `job.py` drivers call it:

```
fl-tutorials/nvflare/image_classification/xray_classification/job.py:125
fl-tutorials/nvflare/image_classification/arkplus_fine_tuning/job.py:136
fl-tutorials/nvflare/image_segmentation/3d_spleen_segmentation/job.py:125
fl-tutorials/nvflare/image_evaluation/3d_spleen_segmentation_evaluation/job.py:109
fl-tutorials/nvflare/image_evaluation/arkplus_baseline_classification_evaluation/job.py:109
fl-tutorials/nvflare/image_evaluation/arkplus_multimodel_classification_evaluation/job.py:121
fl-tutorials/nvflare/image_synthesis/latent_diffusion_model/job.py:119
```

Following the upstream rename inward leaves every one of them raising, before a single round runs:

```
File ".../xray_classification/job.py", line 125, in main
    stage_app_files(recipe.job)
                    ^^^^^^^^^^
AttributeError: 'FlipFedAvgRecipe' object has no attribute 'job'. Did you mean: '_job'?
```

That is also what a researcher writes against when building an app on these recipes, so the same break reaches user code that never appears in this repo.

**Nothing in CI sees it.** On #1174 as it stands, `flip-utils` is 868 passed, `fl-api-base` 190 passed + mypy clean, `fl-tutorials` 117 passed, ruff clean — a fully green unit layer over seven broken tutorials. The tests construct recipes directly and never execute a tutorial `job.py`. This is the gap that makes the simulator runs below non-optional for an NVFLARE bump.

## The fix

A `FlipRecipe` base (`flip-utils/flip/nvflare/recipes/base.py`) re-exposes `job` as a read-only property over the base's `_job`. The three recipes subclass it and go back to `self.job`.

Two things fall out of that:

- The four `fl-apps/nvflare/*/recipe.py` template drivers go back to `recipe.job` and need **no** knowledge of the rename — the four edits #1174 makes there become unnecessary.
- FLIP's recipes stay off a private upstream attribute. If a later NVFLARE restores a public `job`, the property is redundant rather than wrong; today, reading `_job` is a second thing to fix on the next bump.

## Also fixed

- `fl-tutorials/nvflare/image_classification/arkplus_fine_tuning/README.md` and `.../latent_diffusion_model/README.md` still name `InProcessClientAPIExecutor`.
- `docs/source/components/component-fl-nodes.rst` still said its site-privacy semantics were "verified against NVFLARE 2.8.0". Re-verified against 2.9.0 and updated. `apply_filters` gained lazy-download-ref materialisation and the filter-list build was extracted into `get_filters`, but site-scope filters are still applied before the job's and still appended rather than substituted, the unknown-scope rejection message is unchanged, and `TASK_RESULT_FILTER_ERROR` still exists — all four documented claims hold.

## Deliberately not changed

`fl-apps/nvflare/evaluation/app/config/config_fed_server.json` on #1174 carries a regeneration artefact rather than a semantic change: the filter entry's key order flips and its `tasks` list re-sorts to `["post_validation", "validate"]`. That list is set-derived inside NVFLARE, which is why the drivers pin `PYTHONHASHSEED=0` for byte-stable committed files (see `test_template_drift.py`'s docstring). The drift test canonicalises `tasks` order so it passes either way, and the change is harmless — but regenerating with `PYTHONHASHSEED=0` would keep the committed file stable. Left alone here to keep this diff to the defect.

## Linked Issues

Refs #1037 — the closing keyword stays on #1174.

## Checklist

- [x] Follows the project's coding conventions and style guide
- [x] Updates documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Type of Change

- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [x] In-line docstrings updated.
- [x] Documentation updated, tested `make -C docs/ docs`.

No new unit test is added, deliberately: a test that constructs a recipe and asserts `hasattr(r, "job")` would restate the fix rather than exercise it, and would not have caught the original break either — the break lives in the tutorial `job.py` layer, which no unit test executes. The real guard is the simulator matrix below, which is why it was run in full.

## Testing

Everything below was run on **this branch** (#1174 + this commit).

**Unit**

- `flip-utils`: ruff clean, **868 passed**
- `fl-services/nvflare/fl-api-base`: ruff clean, mypy clean (40 files), **190 passed**
- `make -C fl-tutorials test`: **117 passed**, 12 skipped
- `make -C docs docs`: build succeeded

**NVFLARE simulator — all seven tutorials** (`make -C fl-tutorials run-tutorial TUTORIAL=…`), the layer that was broken:

| tutorial | recipe exercised | result |
| --- | --- | --- |
| `xray_classification` | `FlipFedAvgRecipe` | ✅ RESULTS_UPLOADED |
| `3d_spleen_segmentation` | `FlipFedAvgRecipe` | ✅ |
| `3d_spleen_segmentation_evaluation` | `FlipEvalRecipe` | ✅ |
| `arkplus_fine_tuning` | `FlipFedAvgRecipe` | ✅ |
| `arkplus_baseline_classification_evaluation` | `FlipEvalRecipe` | ✅ |
| `arkplus_multimodel_classification_evaluation` | `FlipEvalRecipe` | ✅ |
| `latent_diffusion_model` | `FlipDiffusionRecipe` | ❌ — **pre-existing on develop, not this upgrade** (below) |

Every one of these fails on #1174 as it stands, at `stage_app_files(recipe.job)`, before any of the above runs.

### The one failure, and why it does not block this

`latent_diffusion_model` aborts with FLIP's own empty-aggregate guard
(`flip/nvflare/controllers/scatter_and_gather.py:189`):

```
FATAL_SYSTEM_ERROR: Training round 2 accepted 0 of 2 client results — aborting instead of
applying an empty aggregate (the run would otherwise complete with an untrained global model).
```

while the aggregator has in fact accepted both contributions in the same second:

```
16:04:47,638  Contribution from site-2 ACCEPTED by the aggregator at round 0.
16:04:47,741  Contribution from site-1 ACCEPTED by the aggregator at round 0.
16:04:47,939  ERROR ... accepted 0 of 2 client results
16:04:47,939  aggregating 2 update(s) at round 0
```

The guard keys acceptances by `_current_round` and reports round 2 while the aggregator is on
round 0 — a round-accounting divergence. LDM is the only two-phase controller
(`ScatterAndGatherLDM`, train_ae → train_dm), which is why it alone trips it.

**This is not a 2.9.0 regression.** Ran the same tutorial on **develop at nvflare 2.8.1**
(worktree at tip `5be4920d`) as a baseline; it aborts identically:

```
BASELINE nvflare 2.8.1
16:11:14,868  FATAL_SYSTEM_ERROR: Training round 2 accepted 0 of 2 client results — aborting
              instead of applying an empty aggregate ...
16:11:14,868  aggregating 2 update(s) at round 0
```

Same message, same contradiction, on the version FLIP ships today. It deserves its own issue;
it is not this PR's to fix, and it is not made worse by it. Worth knowing it is also not
covered by CI — no unit test executes this controller's two-phase round bookkeeping.

It is also **not** the known bf16 CPU-autocast flake: both runs were on `cuda:0`.

**Dev deployment e2e** (`make e2e_smoke FL_BACKEND=nvflare`), against FL `:dev` images rebuilt from this branch — fl-server, fl-api and both trusts' fl-clients all confirmed running nvflare 2.9.0, and flip-api confirmed serving the migrated templates:

```
project_id   = 7fcebca4-8e5c-4017-8cf2-d765f7507080
final_status = RESULTS_UPLOADED
exit         = 0
```

Full lifecycle: cohort submit → approval → 300-study DICOM pull per trust (GSTT + KCH) →
model create → file upload + malware/picklescan → FL training → results download.

This also settles the `require_signed_jobs` question below empirically: the run submits, deploys
and trains against 2.9.0 kits provisioned before the flag existed.

## Additional Notes

Two upstream details found while verifying, neither requiring a change here:

- **The `FLIP_Session` contract is intact.** `fl-services/nvflare/fl-api-base/fl_api/utils/flip_session.py` subclasses `nvflare.fuel.flare_api.flare_api.Session`, calls `__init__` positionally and overrides the private `_do_command` — none of which mocked tests would catch a signature change in. Under 2.9.0, `Session.__init__(username, startup_path, secure_mode=True, debug=False, study='default')`, `_do_command(command, enforce_meta=True, props=None)` and `try_connect(timeout)` are unchanged from 2.8.1, `enforce_meta` is still the only keyword upstream passes to `_do_command`, and `__init__` still stores every attribute `_reconnect` reads back off the base.
- **`require_signed_jobs` is new in 2.9.0 and defaults to `True` whenever `rootCA.pem` is present** — which is every FLIP kit, and existing kits carry no such key, so they inherit the new default. FLIP is safe because the admin upload path signs job folders whenever a client key is present, and the fl-api's provisioned admin kit has one (`client.key` + `client.crt` chaining to `rootCA.pem`). Worth knowing that signing is now load-bearing rather than incidental: a kit provisioned without a client key would submit unsigned and be rejected.
