### PR TITLE
feat(deploy/AWS): LZA web leg on the internal NLB — static targets, no relay Lambda (#749)

### DIFF
--- a/deploy/providers/AWS/AGENTS.md
+++ b/deploy/providers/AWS/AGENTS.md
@@ -6,7 +6,7 @@
 |------|-----------|
 | `main.tf` | Provider config, VPC, subnets, IGW, NAT, route tables, RDS instance, Secrets Manager, SES |
 | `network_lza.tf` | LZA platform-managed network (FLIP#749): VPC/subnet data lookups + the `local.vpc_id` / `local.app_subnet_ids` / `local.data_subnet_ids` locals both paths consume |
-| `fl_ingress_lza.tf` | LZA-only ingress (FLIP#749 WP3, ported from the #829 e2e harness): internal FL NLB with static per-subnet IPs + its TG/SG, the ALB ingress rule for the networking-account relay path, and the `/flip/networking/*` edge-handoff SSM params |
+| `fl_ingress_lza.tf` | LZA-only ingress (FLIP#749 WP3, ported from the #829 e2e harness): internal FL NLB with static per-subnet IPs + its TG/SG, the internal NLB's `:443` web listener + flip-api target group for the networking-account relay path (the ALB is gated off on LZA), and the `/flip/networking/*` edge-handoff SSM params |
 | `services.tf` | S3 buckets, Cognito |
 | `rds_proxy.tf` | RDS Proxy + IAM DB auth (proxy, IAM role/policy, SG, `rds-db:connect`) — see FLIP#556 |
 | `ecs.tf` | ECS cluster, capacity providers, ECS CloudWatch log groups (ALB / NLB / target groups / listener rules live in `main.tf`) |

--- a/deploy/providers/AWS/CLAUDE.md
+++ b/deploy/providers/AWS/CLAUDE.md
@@ -6,7 +6,7 @@
 |------|-----------|
 | `main.tf` | Provider config, VPC, subnets, IGW, NAT, route tables, RDS instance, Secrets Manager, SES |
 | `network_lza.tf` | LZA platform-managed network (FLIP#749): VPC/subnet data lookups + the `local.vpc_id` / `local.app_subnet_ids` / `local.data_subnet_ids` locals both paths consume |
-| `fl_ingress_lza.tf` | LZA-only ingress (FLIP#749 WP3, ported from the #829 e2e harness): internal FL NLB with static per-subnet IPs + its TG/SG, the ALB ingress rule for the networking-account relay path, and the `/flip/networking/*` edge-handoff SSM params |
+| `fl_ingress_lza.tf` | LZA-only ingress (FLIP#749 WP3, ported from the #829 e2e harness): internal FL NLB with static per-subnet IPs + its TG/SG, the internal NLB's `:443` web listener + flip-api target group for the networking-account relay path (the ALB is gated off on LZA), and the `/flip/networking/*` edge-handoff SSM params |
 | `services.tf` | S3 buckets, Cognito |
 | `rds_proxy.tf` | RDS Proxy + IAM DB auth (proxy, IAM role/policy, SG, `rds-db:connect`) — see FLIP#556 |
 | `ecs.tf` | ECS cluster, capacity providers, ECS CloudWatch log groups (ALB / NLB / target groups / listener rules live in `main.tf`) |

--- a/deploy/providers/AWS/README.md
+++ b/deploy/providers/AWS/README.md
@@ -780,7 +780,9 @@ fixed per account by design.
   the UI bucket via cross-account OAC and relays `/api/*` to the internal NLB's `:443` web listener, and the edge
   NLB forwards FL traffic over TGW to the same internal NLB's `:8002` listener (`fl_ingress_lza.tf`; static
   per-subnet IPs the edge registers once as targets for BOTH legs — no target-sync Lambda). The ALB (`module.alb`)
-  is therefore gated off on LZA too.
+  is therefore gated off on LZA too. Behavioural deltas versus the ALB on LZA: no `/api`-only path filter or
+  default 404 at the load balancer (CloudFront's behaviours and WAF are the only L7 gate), no ALB-injected
+  `X-Forwarded-*` headers (flip-api reads none), and an NLB idle timeout of 350s rather than 60s.
 
 Everything else (ECS Fargate, RDS + Proxy, Cognito, S3 + CMK, Secrets Manager, SES, EFS, Cloud Map)
 remains FLIP-managed exactly as on legacy prod; the legacy WAF/OAC/CloudFront-function components stay standing

--- a/deploy/providers/AWS/README.md
+++ b/deploy/providers/AWS/README.md
@@ -769,7 +769,7 @@ fixed per account by design.
   override the name via `LZA_VPC_NAME`). Subnet lookups match ALL `-app-*` / `-data-*` hits, so subnets the platform
   team adds later — as the second AZ's were — appear on the next plan with no code change;
 - **places by connectivity need**: RDS instances go to the isolated **data** subnets (local routes only — nothing
-  there can reach TGW/endpoints, and RDS doesn't need to); ECS tasks, the internal ALB, the RDS Proxy, EFS mount
+  there can reach TGW/endpoints, and RDS doesn't need to); ECS tasks, the internal NLB, the RDS Proxy, EFS mount
   targets and the EC2 hosts go to the TGW-routed **app** subnets (they need the central endpoints / image pulls);
 - **gates off**: the SG-drift CloudTrail→EventBridge→Lambda stack (`security.tf` — the org baseline of Control Tower
   org trail, GuardDuty, Security Hub and Config covers it), the public FL-server NLB + target group + DNS record +
@@ -777,18 +777,19 @@ fixed per account by design.
   distribution + its VPC origin (the `GRCLOUDFRONTVPCORIGIN` SCP denies VPC origins by design — a VPC origin dials
   the ALB inside the VPC, bypassing the TGW + central firewall). Ingress instead rides the networking account's
   two-tier edge (proven end-to-end in FLIP#829/PR#830 and now serving the real stack): the edge CloudFront serves
-  the UI bucket via cross-account OAC and relays `/api/*` to the internal ALB, and the edge NLB forwards FL traffic
-  over TGW to the internal FL NLB in `fl_ingress_lza.tf` (static per-subnet IPs the edge registers once as targets),
-  which fronts `fl-server-net-1`.
+  the UI bucket via cross-account OAC and relays `/api/*` to the internal NLB's `:443` web listener, and the edge
+  NLB forwards FL traffic over TGW to the same internal NLB's `:8002` listener (`fl_ingress_lza.tf`; static
+  per-subnet IPs the edge registers once as targets for BOTH legs — no target-sync Lambda). The ALB (`module.alb`)
+  is therefore gated off on LZA too.
 
-Everything else (ECS Fargate, RDS + Proxy, Cognito, S3 + CMK, Secrets Manager, SES, EFS, Cloud Map, internal ALB)
+Everything else (ECS Fargate, RDS + Proxy, Cognito, S3 + CMK, Secrets Manager, SES, EFS, Cloud Map)
 remains FLIP-managed exactly as on legacy prod; the legacy WAF/OAC/CloudFront-function components stay standing
 unused on LZA to keep legacy churn minimal.
 
 **Edge wiring is two-phase — by construction, not configuration.** The networking account's edge stack
 ([aicentre-lza-iac](https://github.com/londonaicentre/aicentre-lza-iac)) is built *from* this stack's outputs: the
-first workload `apply` publishes the `/flip/networking/*` SSM handoff params (FL NLB private IPs + port, ALB DNS
-name, web port) that the edge NLB and relay consume, so the workload account necessarily applies before the edge
+first workload `apply` publishes the `/flip/networking/*` SSM handoff params (NLB private IPs, FL port, web port,
+NLB DNS name) that the edge NLB and relay consume, so the workload account necessarily applies before the edge
 distribution exists. On that first apply `TF_VAR_lza_web_edge_domain` and `TF_VAR_lza_web_edge_distribution_arn`
 are still empty: the UI-bucket policy then grants no principal (fail-closed — the edge simply cannot read the
 bucket yet) and `local.ui_origin` is a placeholder. Once the edge stack is up, set both values in `.env.lza-prod`

--- a/deploy/providers/AWS/cloudfront.tf
+++ b/deploy/providers/AWS/cloudfront.tf
@@ -118,8 +118,9 @@ resource "aws_cloudfront_vpc_origin" "flip_api" {
   # cloudfront:CreateVpcOrigin in workload accounts -- deliberately, since a
   # VPC origin reaches the ALB inside the VPC and bypasses the TGW + central
   # firewall. On LZA the networking account's edge distribution is the front
-  # door (aicentre-lza-iac); fl_ingress_lza.tf admits its relay path onto the
-  # ALB instead of the SG rule below.
+  # door (aicentre-lza-iac); the LZA relay path terminates on the internal
+  # NLB's web listener instead (fl_ingress_lza.tf), so neither this VPC
+  # origin nor the SG rule below exist there.
   count = var.lza_managed_network ? 0 : 1
 
   vpc_origin_endpoint_config {

--- a/deploy/providers/AWS/ecs_services.tf
+++ b/deploy/providers/AWS/ecs_services.tf
@@ -85,12 +85,12 @@ resource "aws_ecs_service" "flip_api" {
     registry_arn = aws_service_discovery_service.flip_api[0].arn
   }
 
-  # Register each running task's ENI IP with the ALB target group so
-  # /api/* on the public ALB reaches the Fargate task. Without this block
-  # the ECS service stays invisible to the ALB and the listener rule
-  # falls back to its default action (or stale legacy target).
+  # Register each running task's ENI IP with the front door's target group so
+  # /api/* reaches the Fargate task: the ALB's HTTP TG on legacy, the internal
+  # NLB's TCP TG on LZA (fl_ingress_lza.tf, FLIP#749). Without this block the
+  # service stays invisible to the load balancer.
   load_balancer {
-    target_group_arn = aws_lb_target_group.ecs_flip_api.arn
+    target_group_arn = var.lza_managed_network ? aws_lb_target_group.ecs_flip_api_lza[0].arn : aws_lb_target_group.ecs_flip_api[0].arn
     container_name   = "flip-api"
     container_port   = local.api_container_port
   }

--- a/deploy/providers/AWS/ecs_services.tf
+++ b/deploy/providers/AWS/ecs_services.tf
@@ -99,9 +99,14 @@ resource "aws_ecs_service" "flip_api" {
   deployment_minimum_healthy_percent = 100
   deployment_maximum_percent         = 200
 
+  # module.fl_server_internal_nlb: on LZA the flip-api TG is only "associated with a load
+  # balancer" once the NLB's web-listener exists; without this the service update can race it
+  # (InvalidParameterException). The legacy guard is the listener rule, which is count-0 on
+  # LZA. On legacy the module creates nothing, so the plan is unchanged.
   depends_on = [
     aws_ecs_task_definition.flip_api,
     aws_lb_listener_rule.api_routing,
+    module.fl_server_internal_nlb,
   ]
 }
 

--- a/deploy/providers/AWS/fl_ingress_lza.tf
+++ b/deploy/providers/AWS/fl_ingress_lza.tf
@@ -159,8 +159,9 @@ module "fl_server_internal_nlb" {
     # ISSUED cert is impossible without a hosted zone (var.manage_dns=false),
     # so the listener is plain TCP until the zone lands, then TLS on the
     # DNS-validated cert. Same port either way so the relay never changes.
-    # Flipping to TLS is a cross-repo step: the relay is TCP passthrough, so the TLS client becomes CloudFront's VPC origin in the networking
-    # account (aicentre-lza-iac ingress_web.tf), which must switch to https-only with an origin host matching this cert's SAN at the same time.
+    # Flipping to TLS is a cross-repo step: the relay is TCP passthrough, so the TLS client becomes CloudFront's VPC
+    # origin in the networking account (aicentre-lza-iac ingress_web.tf), which must switch to https-only with an
+    # origin host matching this cert's SAN at the same time.
     "web-listener" = {
       port            = var.ALB_HTTPS_PORT
       protocol        = var.manage_dns ? "TLS" : "TCP"
@@ -261,7 +262,7 @@ resource "aws_ssm_parameter" "lza_web_nlb_dns_name" {
   # checkov:skip=CKV2_AWS_34:non-secret networking value read CROSS-ACCOUNT by the networking account's edge stack (aicentre-lza-iac) — an AWS-managed CMK cannot be decrypted from another account
   count       = var.lza_managed_network ? 1 : 0
   name        = "/flip/networking/web_nlb_dns_name"
-  description = "Internal NLB DNS name - the networking account's relay uses it only as the CloudFront origin host label (routing is by VPC origin id and the static IPs in fl_nlb_private_ips); no sync machinery"
+  description = "Internal NLB DNS name - informational (in-VPC verification, e.g. curl from a task); the networking-account edge does not consume it - it targets the static IPs in fl_nlb_private_ips"
   type        = "String"
   value       = module.fl_server_internal_nlb.dns_name
 }

--- a/deploy/providers/AWS/fl_ingress_lza.tf
+++ b/deploy/providers/AWS/fl_ingress_lza.tf
@@ -159,6 +159,8 @@ module "fl_server_internal_nlb" {
     # ISSUED cert is impossible without a hosted zone (var.manage_dns=false),
     # so the listener is plain TCP until the zone lands, then TLS on the
     # DNS-validated cert. Same port either way so the relay never changes.
+    # Flipping to TLS is a cross-repo step: the relay is TCP passthrough, so the TLS client becomes CloudFront's VPC origin in the networking
+    # account (aicentre-lza-iac ingress_web.tf), which must switch to https-only with an origin host matching this cert's SAN at the same time.
     "web-listener" = {
       port            = var.ALB_HTTPS_PORT
       protocol        = var.manage_dns ? "TLS" : "TCP"

--- a/deploy/providers/AWS/fl_ingress_lza.tf
+++ b/deploy/providers/AWS/fl_ingress_lza.tf
@@ -24,11 +24,13 @@
 #        its per-subnet IPs are assigned (not discovered) via subnet_mapping,
 #        so the networking account registers them once, with no sync
 #        machinery.
-#   Web: CloudFront + WAF → relay NLB (networking account, target-synced to
-#        this stack's ALB IPs) → firewall → TGW → module.alb. The ALB itself
-#        is unchanged; the only LZA addition is the ingress rule below —
-#        legacy admits CloudFront via the SG-drift stack, which is gated off
-#        here.
+#   Web: CloudFront + WAF → relay NLB (networking account) → firewall → TGW
+#        → the SAME internal NLB below on :{ALB_HTTPS_PORT} → flip-api ECS task.
+#        The ALB (module.alb) is gated off on LZA: ALB IPs rotate, which forced
+#        the networking account to run a target-sync Lambda per environment;
+#        the NLB's assigned IPs do not, so the relay registers them once —
+#        the FL leg's contract, now shared by both legs. Legacy prod/stag keep
+#        the ALB unchanged.
 #
 # Everything in this file is inert on legacy prod/stag (count/create-gated on
 # var.lza_managed_network, list arguments emptied) — the legacy plan is
@@ -99,6 +101,14 @@ module "fl_internal_nlb_security_group" {
       port        = var.FL_SERVER_PORT
       description = "FL TCP from the networking-account edge NLB path and VPC-internal callers"
       cidr_blocks = concat([local.vpc_cidr_block], var.networking_ingress_cidrs)
+    },
+    {
+      # Web leg: the networking-account relay NLB (CloudFront VPC origin →
+      # relay → firewall → TGW) dials the internal NLB's web listener. Same
+      # sources as the FL rule; the VPC CIDR keeps in-VPC probe curls working.
+      port        = var.ALB_HTTPS_PORT
+      description = "Web from the networking-account relay NLB path and VPC-internal callers"
+      cidr_blocks = concat([local.vpc_cidr_block], var.networking_ingress_cidrs)
     }
   ]
 }
@@ -143,6 +153,21 @@ module "fl_server_internal_nlb" {
         target_group_arn = var.lza_managed_network ? aws_lb_target_group.ecs_fl_server_tcp_lza[0].arn : null
       }
     }
+
+    # Web leg (FLIP#749): CloudFront's relay dials this listener; the ALB is
+    # gated off on LZA. Protocol mirrors the ALB's zone-less gating — an
+    # ISSUED cert is impossible without a hosted zone (var.manage_dns=false),
+    # so the listener is plain TCP until the zone lands, then TLS on the
+    # DNS-validated cert. Same port either way so the relay never changes.
+    "web-listener" = {
+      port            = var.ALB_HTTPS_PORT
+      protocol        = var.manage_dns ? "TLS" : "TCP"
+      certificate_arn = var.manage_dns ? aws_acm_certificate.flip[0].arn : null
+      ssl_policy      = var.manage_dns ? "ELBSecurityPolicy-TLS13-1-3-2021-06" : null
+      forward = {
+        target_group_arn = var.lza_managed_network ? aws_lb_target_group.ecs_flip_api_lza[0].arn : null
+      }
+    }
   }
 
   target_groups = {}
@@ -176,21 +201,37 @@ resource "aws_lb_target_group" "ecs_fl_server_tcp_lza" {
   deregistration_delay = 30
 }
 
-# Web leg: admit the networking-account relay (CloudFront VPC origin →
-# relay NLB → firewall → TGW) onto the ALB's main listener. Legacy admits
-# CloudFront through the SG-drift stack instead; empty ingress CIDRs create
-# nothing, so the stack still applies standalone.
-resource "aws_security_group_rule" "alb_ingress_web_from_networking" {
+# LZA web leg counterpart of aws_lb_target_group.ecs_flip_api (main.tf): the
+# internal NLB forwards its web listener here. NLB target groups are TCP, but
+# the health check is HTTP on the API's own liveness route so an unhealthy
+# task is pulled exactly as the ALB did. Registered by the ECS service's
+# load_balancer block (ecs_services.tf), never by Terraform.
+resource "aws_lb_target_group" "ecs_flip_api_lza" {
   count       = var.lza_managed_network ? 1 : 0
-  type        = "ingress"
-  description = "Web from the networking-account relay NLB path (CloudFront VPC origin) and VPC-internal callers"
-  protocol    = "tcp"
-  from_port   = var.ALB_HTTPS_PORT
-  to_port     = var.ALB_HTTPS_PORT
-  # VPC CIDR: in-VPC verification (probe curls) and internal callers -- the
-  # same shape as the FL NLB SG above. The networking CIDRs are the relay path.
-  cidr_blocks       = concat([local.vpc_cidr_block], var.networking_ingress_cidrs)
-  security_group_id = module.alb_security_group.security_group.id
+  name        = "ecs-flip-api-lza"
+  port        = local.api_container_port
+  protocol    = "TCP"
+  target_type = "ip"
+  vpc_id      = local.vpc_id
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  health_check {
+    enabled             = true
+    protocol            = "HTTP"
+    path                = "/api/health"
+    port                = "traffic-port"
+    matcher             = "200"
+    healthy_threshold   = 3
+    unhealthy_threshold = 3
+    interval            = 30
+  }
+
+  # Same drain as the ALB TG: long enough for in-flight requests, short
+  # enough not to stretch every ECS rollout.
+  deregistration_delay = 30
 }
 
 # SSM handoff parameters — the contract with the networking account's edge
@@ -200,7 +241,7 @@ resource "aws_ssm_parameter" "lza_fl_nlb_private_ips" {
   # checkov:skip=CKV2_AWS_34:non-secret networking value read CROSS-ACCOUNT by the networking account's edge stack (aicentre-lza-iac) — an AWS-managed CMK cannot be decrypted from another account
   count       = var.lza_managed_network ? 1 : 0
   name        = "/flip/networking/fl_nlb_private_ips"
-  description = "Internal FL NLB static private IPs (comma-separated, assigned via subnet_mapping so they are stable by construction; TGW-reachable AZs only) - registered as IP targets on the networking account's edge NLB FL listener"
+  description = "Internal NLB static private IPs (comma-separated, assigned via subnet_mapping so they are stable by construction; TGW-reachable AZs only) - registered ONCE as IP targets on the networking account's edge NLB FL listener AND its web relay target group"
   type        = "StringList"
   value       = join(",", local.lza_fl_nlb_published_ips)
 }
@@ -214,20 +255,20 @@ resource "aws_ssm_parameter" "lza_fl_port" {
   value       = tostring(var.FL_SERVER_PORT)
 }
 
-resource "aws_ssm_parameter" "lza_alb_dns_name" {
+resource "aws_ssm_parameter" "lza_web_nlb_dns_name" {
   # checkov:skip=CKV2_AWS_34:non-secret networking value read CROSS-ACCOUNT by the networking account's edge stack (aicentre-lza-iac) — an AWS-managed CMK cannot be decrypted from another account
   count       = var.lza_managed_network ? 1 : 0
-  name        = "/flip/networking/alb_dns_name"
-  description = "Internal web ALB DNS name - the networking account's target-sync Lambda resolves this on a cadence to keep the web relay NLB targets current (ALB IPs rotate)"
+  name        = "/flip/networking/web_nlb_dns_name"
+  description = "Internal NLB DNS name - the networking account's relay uses it only as the CloudFront origin host label (routing is by VPC origin id and the static IPs in fl_nlb_private_ips); no sync machinery"
   type        = "String"
-  value       = module.alb.dns_name
+  value       = module.fl_server_internal_nlb.dns_name
 }
 
 resource "aws_ssm_parameter" "lza_web_port" {
   # checkov:skip=CKV2_AWS_34:non-secret networking value read CROSS-ACCOUNT by the networking account's edge stack (aicentre-lza-iac) — an AWS-managed CMK cannot be decrypted from another account
   count       = var.lza_managed_network ? 1 : 0
   name        = "/flip/networking/web_port"
-  description = "Workload-side web ingress port (the ALB's main listener; plain HTTP on the zone-less bring-up) - the relay NLB's target port on the networking side"
+  description = "Workload-side web ingress port (the internal NLB's web listener; plain TCP on the zone-less bring-up, TLS once manage_dns is true) - the relay NLB's target port on the networking side"
   type        = "String"
   value       = tostring(var.ALB_HTTPS_PORT)
 }
@@ -248,6 +289,21 @@ resource "aws_security_group_rule" "ecs_fl_server_ingress_internal_nlb" {
   protocol                 = "tcp"
   source_security_group_id = module.fl_internal_nlb_security_group[0].security_group.id
   security_group_id        = aws_security_group.ecs_fl_server.id
+}
+
+# Same admission for flip-api: the internal NLB's web listener (relayed
+# CloudFront traffic + its HTTP health checks) reaches the task on the API
+# port. Without it the TG parks the task unhealthy exactly as the fl-server
+# rule above describes.
+resource "aws_security_group_rule" "ecs_flip_api_ingress_internal_nlb" {
+  count                    = var.lza_managed_network ? 1 : 0
+  type                     = "ingress"
+  description              = "HTTP from the internal NLB web listener (edge-relayed CloudFront traffic + health checks)"
+  from_port                = local.api_container_port
+  to_port                  = local.api_container_port
+  protocol                 = "tcp"
+  source_security_group_id = module.fl_internal_nlb_security_group[0].security_group.id
+  security_group_id        = aws_security_group.ecs_flip_api.id
 }
 
 # The NVFLARE admin kit (provisioned from net-1_project_prod.yml) targets the

--- a/deploy/providers/AWS/main.tf
+++ b/deploy/providers/AWS/main.tf
@@ -556,8 +556,13 @@ resource "aws_ec2_tag" "alb_security_group_flip_sg" {
 }
 
 module "alb" {
-  source                     = "terraform-aws-modules/alb/aws"
-  version                    = "~> 10.0"
+  source  = "terraform-aws-modules/alb/aws"
+  version = "~> 10.0"
+  # LZA (FLIP#749): the web leg terminates on the internal NLB's web listener
+  # (fl_ingress_lza.tf) — static IPs the networking relay registers once —
+  # so no ALB is created there. Legacy prod/stag are unchanged. Module create
+  # flag rather than count, to keep the state address stable on legacy.
+  create                     = !var.lza_managed_network
   name                       = "flip-alb"
   vpc_id                     = local.vpc_id
   internal                   = true
@@ -790,7 +795,17 @@ moved {
 # attach instance/IP targets here from terraform. target_type=ip is required
 # for awsvpc Fargate tasks (each task gets an ENI; the IP is what ECS
 # registers, not an instance id).
+# State migration for the count added below (FLIP#749): keeps existing legacy
+# states aligned without a manual `terraform state mv`.
+moved {
+  from = aws_lb_target_group.ecs_flip_api
+  to   = aws_lb_target_group.ecs_flip_api[0]
+}
+
 resource "aws_lb_target_group" "ecs_flip_api" {
+  # Legacy only: on LZA the ECS service registers with the NLB's TCP target
+  # group aws_lb_target_group.ecs_flip_api_lza (fl_ingress_lza.tf).
+  count       = var.lza_managed_network ? 0 : 1
   name        = "ecs-flip-api"
   port        = local.api_container_port
   protocol    = "HTTP"
@@ -815,13 +830,19 @@ resource "aws_lb_target_group" "ecs_flip_api" {
 # to the ECS Fargate target group above. The legacy `ec2-instance-api`
 # target group on the EC2 host is kept in module.alb for state continuity
 # but no longer wired to a listener rule.
+moved {
+  from = aws_lb_listener_rule.api_routing
+  to   = aws_lb_listener_rule.api_routing[0]
+}
+
 resource "aws_lb_listener_rule" "api_routing" {
+  count        = var.lza_managed_network ? 0 : 1
   listener_arn = module.alb.listeners["https-listener"].arn
   priority     = 98
 
   action {
     type             = "forward"
-    target_group_arn = aws_lb_target_group.ecs_flip_api.arn
+    target_group_arn = aws_lb_target_group.ecs_flip_api[0].arn
   }
 
   condition {

--- a/deploy/providers/AWS/network_lza.tf
+++ b/deploy/providers/AWS/network_lza.tf
@@ -29,7 +29,7 @@
 #   - app subnets (<vpc>-app-*): default-route 0.0.0.0/0 to the Transit
 #     Gateway, so they reach the central interface endpoints in the Network
 #     account. Anything that talks to AWS APIs, pulls images, or terminates
-#     traffic lives here: ECS tasks, the internal ALB, the RDS Proxy, EFS mount
+#     traffic lives here: ECS tasks, the internal NLB, the RDS Proxy, EFS mount
 #     targets, and the EC2 hosts.
 #   - data subnets (<vpc>-data-*): local routes only — fully isolated (same-VPC
 #     traffic works; no TGW, endpoint, or internet reach). Only the RDS

--- a/deploy/providers/AWS/tests/test_lza_web_ingress.py
+++ b/deploy/providers/AWS/tests/test_lza_web_ingress.py
@@ -38,6 +38,11 @@ MAIN_TF = (AWS_PROVIDER_DIR / "main.tf").read_text()
 ECS_SERVICES_TF = (AWS_PROVIDER_DIR / "ecs_services.tf").read_text()
 ALL_TF = "\n".join(p.read_text() for p in AWS_PROVIDER_DIR.glob("*.tf"))
 
+EXPECTED_ECS_TARGET_GROUP = (
+    "var.lza_managed_network ? aws_lb_target_group.ecs_flip_api_lza[0].arn"
+    " : aws_lb_target_group.ecs_flip_api[0].arn"
+)
+
 
 def _strip_comments(source: str) -> str:
     """Drop ``#`` comment lines so no assertion can be satisfied by prose."""
@@ -62,7 +67,7 @@ def _block(source: str, header: str) -> str:
 def test_internal_nlb_has_web_listener_on_https_port():
     nlb = _strip_comments(_block(FL_INGRESS_LZA_TF, 'module "fl_server_internal_nlb"'))
     listener = _block(nlb, '"web-listener"')
-    assert "port     = var.ALB_HTTPS_PORT" in listener or re.search(r"port\s*=\s*var\.ALB_HTTPS_PORT", listener)
+    assert re.search(r"port\s*=\s*var\.ALB_HTTPS_PORT", listener)
     assert re.search(r'protocol\s*=\s*var\.manage_dns \? "TLS" : "TCP"', listener)
     assert "aws_lb_target_group.ecs_flip_api_lza[0].arn" in listener
 
@@ -81,7 +86,7 @@ def test_lza_flip_api_target_group_is_tcp_with_http_health_check():
 def test_ecs_flip_api_registers_with_nlb_target_group_on_lza():
     service = _strip_comments(_block(ECS_SERVICES_TF, 'resource "aws_ecs_service" "flip_api"'))
     lb = _block(service, "load_balancer")
-    assert "var.lza_managed_network ? aws_lb_target_group.ecs_flip_api_lza[0].arn : aws_lb_target_group.ecs_flip_api[0].arn" in lb
+    assert EXPECTED_ECS_TARGET_GROUP in lb
 
 
 def test_alb_and_its_routing_are_gated_off_on_lza():
@@ -95,7 +100,7 @@ def test_alb_and_its_routing_are_gated_off_on_lza():
 
 def test_nlb_security_group_admits_web_port_from_networking_ingress():
     sg = _strip_comments(_block(FL_INGRESS_LZA_TF, 'module "fl_internal_nlb_security_group"'))
-    assert "port        = var.ALB_HTTPS_PORT" in sg or re.search(r"port\s*=\s*var\.ALB_HTTPS_PORT", sg)
+    assert re.search(r"port\s*=\s*var\.ALB_HTTPS_PORT", sg)
     assert sg.count("var.networking_ingress_cidrs") == 2, "both the FL and the web rule admit the relay path"
 
 

--- a/deploy/providers/AWS/tests/test_lza_web_ingress.py
+++ b/deploy/providers/AWS/tests/test_lza_web_ingress.py
@@ -118,3 +118,12 @@ def test_ssm_handoff_publishes_nlb_dns_not_alb_dns():
     assert "/flip/networking/alb_dns_name" not in stripped
     assert "/flip/networking/web_nlb_dns_name" in stripped
     assert 'resource "aws_security_group_rule" "alb_ingress_web_from_networking"' not in stripped
+
+
+def test_lza_only_resources_are_count_gated():
+    for header in (
+        'resource "aws_security_group_rule" "ecs_flip_api_ingress_internal_nlb"',
+        'resource "aws_ssm_parameter" "lza_web_nlb_dns_name"',
+    ):
+        block = _strip_comments(_block(FL_INGRESS_LZA_TF, header))
+        assert re.search(r"count\s*=\s*var\.lza_managed_network \? 1 : 0", block), header

--- a/deploy/providers/AWS/tests/test_lza_web_ingress.py
+++ b/deploy/providers/AWS/tests/test_lza_web_ingress.py
@@ -1,0 +1,115 @@
+# Copyright (c) 2026 Guy's and St Thomas' NHS Foundation Trust & King's College London
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Static guards on the LZA web-ingress shape (FLIP#749).
+
+On an LZA estate the web leg is CloudFront (networking account) -> relay NLB ->
+firewall/TGW -> the workload account's INTERNAL FL NLB on :443 -> flip-api. The
+NLB's per-subnet IPs are assigned via subnet_mapping, so the networking side
+registers them once; the ALB (whose IPs rotate and needed a target-sync Lambda)
+is gated off on LZA. Nothing in the runtime suites can see this wiring, so the
+invariants are asserted over the ``.tf`` source:
+
+* the internal NLB carries a ``web-listener`` on ``var.ALB_HTTPS_PORT`` forwarding
+  to an LZA-only TCP target group health-checked on ``/api/health``;
+* the flip-api ECS service registers with that target group on LZA;
+* the ALB module, its listener rule and its HTTP target group are gated off on LZA;
+* the SSM handoff no longer publishes an ALB DNS name (the networking relay must
+  not be able to fall back to resolving a rotating address).
+"""
+
+import re
+from pathlib import Path
+
+AWS_PROVIDER_DIR = Path(__file__).resolve().parent.parent
+FL_INGRESS_LZA_TF = (AWS_PROVIDER_DIR / "fl_ingress_lza.tf").read_text()
+MAIN_TF = (AWS_PROVIDER_DIR / "main.tf").read_text()
+ECS_SERVICES_TF = (AWS_PROVIDER_DIR / "ecs_services.tf").read_text()
+ALL_TF = "\n".join(p.read_text() for p in AWS_PROVIDER_DIR.glob("*.tf"))
+
+
+def _strip_comments(source: str) -> str:
+    """Drop ``#`` comment lines so no assertion can be satisfied by prose."""
+    return "\n".join(line for line in source.splitlines() if not line.lstrip().startswith("#"))
+
+
+def _block(source: str, header: str) -> str:
+    """Return the brace-balanced body of the first block opened by ``header``."""
+    start = source.index(header)
+    open_brace = source.index("{", start)
+    depth = 0
+    for index in range(open_brace, len(source)):
+        if source[index] == "{":
+            depth += 1
+        elif source[index] == "}":
+            depth -= 1
+            if depth == 0:
+                return source[open_brace + 1 : index]
+    raise AssertionError(f"unbalanced block for {header!r}")
+
+
+def test_internal_nlb_has_web_listener_on_https_port():
+    nlb = _strip_comments(_block(FL_INGRESS_LZA_TF, 'module "fl_server_internal_nlb"'))
+    listener = _block(nlb, '"web-listener"')
+    assert "port     = var.ALB_HTTPS_PORT" in listener or re.search(r"port\s*=\s*var\.ALB_HTTPS_PORT", listener)
+    assert re.search(r'protocol\s*=\s*var\.manage_dns \? "TLS" : "TCP"', listener)
+    assert "aws_lb_target_group.ecs_flip_api_lza[0].arn" in listener
+
+
+def test_lza_flip_api_target_group_is_tcp_with_http_health_check():
+    tg = _strip_comments(_block(FL_INGRESS_LZA_TF, 'resource "aws_lb_target_group" "ecs_flip_api_lza"'))
+    assert re.search(r"count\s*=\s*var\.lza_managed_network \? 1 : 0", tg)
+    assert re.search(r'protocol\s*=\s*"TCP"', tg)
+    assert re.search(r'target_type\s*=\s*"ip"', tg)
+    health = _block(tg, "health_check")
+    assert re.search(r'protocol\s*=\s*"HTTP"', health)
+    assert re.search(r'path\s*=\s*"/api/health"', health)
+    assert re.search(r'matcher\s*=\s*"200"', health)
+
+
+def test_ecs_flip_api_registers_with_nlb_target_group_on_lza():
+    service = _strip_comments(_block(ECS_SERVICES_TF, 'resource "aws_ecs_service" "flip_api"'))
+    lb = _block(service, "load_balancer")
+    assert "var.lza_managed_network ? aws_lb_target_group.ecs_flip_api_lza[0].arn : aws_lb_target_group.ecs_flip_api[0].arn" in lb
+
+
+def test_alb_and_its_routing_are_gated_off_on_lza():
+    alb = _strip_comments(_block(MAIN_TF, 'module "alb"'))
+    assert re.search(r"create\s*=\s*!var\.lza_managed_network", alb)
+    rule = _strip_comments(_block(MAIN_TF, 'resource "aws_lb_listener_rule" "api_routing"'))
+    assert re.search(r"count\s*=\s*var\.lza_managed_network \? 0 : 1", rule)
+    tg = _strip_comments(_block(MAIN_TF, 'resource "aws_lb_target_group" "ecs_flip_api"'))
+    assert re.search(r"count\s*=\s*var\.lza_managed_network \? 0 : 1", tg)
+
+
+def test_nlb_security_group_admits_web_port_from_networking_ingress():
+    sg = _strip_comments(_block(FL_INGRESS_LZA_TF, 'module "fl_internal_nlb_security_group"'))
+    assert "port        = var.ALB_HTTPS_PORT" in sg or re.search(r"port\s*=\s*var\.ALB_HTTPS_PORT", sg)
+    assert sg.count("var.networking_ingress_cidrs") == 2, "both the FL and the web rule admit the relay path"
+
+
+def test_flip_api_task_admits_the_internal_nlb():
+    rule = _strip_comments(
+        _block(FL_INGRESS_LZA_TF, 'resource "aws_security_group_rule" "ecs_flip_api_ingress_internal_nlb"')
+    )
+    assert "module.fl_internal_nlb_security_group[0].security_group.id" in rule
+    assert "aws_security_group.ecs_flip_api.id" in rule
+    assert re.search(r"from_port\s*=\s*local\.api_container_port", rule)
+
+
+def test_ssm_handoff_publishes_nlb_dns_not_alb_dns():
+    stripped = _strip_comments(ALL_TF)
+    assert "/flip/networking/alb_dns_name" not in stripped
+    assert "/flip/networking/web_nlb_dns_name" in stripped
+    assert 'resource "aws_security_group_rule" "alb_ingress_web_from_networking"' not in stripped

--- a/deploy/providers/AWS/variables.tf
+++ b/deploy/providers/AWS/variables.tf
@@ -43,7 +43,7 @@ variable "lza_vpc_name" {
 }
 
 variable "networking_ingress_cidrs" {
-  description = "CIDRs of the networking account's ingress-VPC subnets (the edge NLB and CloudFront relay path over the TGW), admitted onto the LZA FL NLB and the ALB's main listener (fl_ingress_lza.tf). Empty by default so the stack applies standalone; the value comes from the networking account. LZA-only — legacy prod/stag never reads it."
+  description = "CIDRs of the networking account's ingress-VPC subnets (the edge NLB and CloudFront relay path over the TGW), admitted onto the LZA internal NLB's FL and web listeners (fl_ingress_lza.tf). Empty by default so the stack applies standalone; the value comes from the networking account. LZA-only — legacy prod/stag never reads it."
   type        = list(string)
   default     = []
 }
@@ -422,7 +422,7 @@ variable "FL_SERVER_PORT" {
 
 
 variable "manage_dns" {
-  description = "Whether this account hosts the Route53 zone for flip_alb_subdomain. false (first LZA bring-up, before the zone moves in the platform DNS migration — FLIP#749) skips the zone lookup, every Route53 record, and both DNS-validated ACM certs: CloudFront then serves on its default *.cloudfront.net domain with the default viewer certificate (allowed only when no aliases are set), and the CloudFront→ALB origin leg falls back to plain HTTP over the private VPC-origin ENI, because an ALB HTTPS listener needs an ISSUED certificate and issuance needs DNS validation. Legacy prod/stag keep the default true."
+  description = "Whether this account hosts the Route53 zone for flip_alb_subdomain. false (first LZA bring-up, before the zone moves in the platform DNS migration — FLIP#749) skips the zone lookup, every Route53 record, and both DNS-validated ACM certs: CloudFront then serves on its default *.cloudfront.net domain with the default viewer certificate (allowed only when no aliases are set), and the CloudFront→ALB origin leg falls back to plain HTTP over the private VPC-origin ENI, because an ALB HTTPS listener needs an ISSUED certificate and issuance needs DNS validation (legacy; on LZA the same gating applies to the internal NLB's web listener — TCP until a cert can be ISSUED, then TLS). Legacy prod/stag keep the default true."
   type        = bool
   default     = true
 }


### PR DESCRIPTION
## Why

The networking account's web relay (aicentre-lza-iac `ingress_web.tf`) targets this stack's ALB by IP, and ALB IPs rotate — so every environment needed a `WebOriginTargetSync` Lambda re-resolving the ALB every minute. The FL leg never needed one: the internal NLB's IPs are assigned via `subnet_mapping` and registered once. This gives the web leg the same anchor.

## What changes (LZA only — legacy prod/stag plan No changes)

- `fl_ingress_lza.tf`: `web-listener` on `module.fl_server_internal_nlb` at `ALB_HTTPS_PORT` (TCP until `manage_dns`, then TLS on the ACM cert — the ALB's own gating), forwarding to a new TCP target group `ecs-flip-api-lza` health-checked on `/api/health`; NLB SG admits the port from the networking ingress CIDRs; the flip-api task SG admits the NLB SG; SSM `/flip/networking/alb_dns_name` → `/flip/networking/web_nlb_dns_name`.
- `main.tf` / `ecs_services.tf`: `module.alb` `create = !lza`, its listener rule + HTTP TG count-gated (with `moved` blocks), ECS service registers with the NLB TG on LZA.
- `tests/test_lza_web_ingress.py`: static guard over the `.tf` source.

## Companion

londonaicentre/aicentre-lza-iac#42 switches `web_origins` to static `target_ips` and deletes the Lambdas. **Apply order per account: the networking stack (aicentre-lza-iac#42) first, then this stack.** Today's relay health check (`/`, 200–399) can never pass the ALB's default 404, so prod has been living on NLB fail-open; after the networking apply the ALB IPs turn healthy under `/api/health` while the NLB's `.251` IPs stay unhealthy until this stack brings `:443` up — so traffic keeps flowing to the ALB, and the FLIP apply then swaps targets with at worst a ~90 s fail-open blip while the new targets pass three 30 s checks. The reverse order would delete the ALB with nothing healthy behind the relay for the whole networking apply. With the Lambda gone, an ALB IP rotation between the two applies breaks prod, so keep the gap short. Pre-cutover only either way.

## Expected LZA plan

Adds: TG `ecs-flip-api-lza`, NLB web listener, 2 SG rules, SSM `web_nlb_dns_name`. Destroys: ALB + its listeners, listener rule, HTTP TG, SSM `alb_dns_name`, the ALB web ingress rule. Changes: ECS service `load_balancer` (in place on provider 6.x — if the plan shows a replacement, that is acceptable pre-cutover and will be noted here).

Legacy invariance evidence on this stacked PR: `terraform validate` + the static guard `tests/test_lza_web_ingress.py` (103/103 in `tests/`) — the Terraform CI workflows only run against develop/main, so the legacy staging plan runs when #979 merges.

Legacy plan exit code: the two new `moved` blocks make `terraform plan -detailed-exitcode` return 2 with `0 to add, 0 to change, 0 to destroy` (moves are changes to state, not to resources), so `terraform_drift.yml` will report drift for stag until `terraform_apply.yml` records the moves on the develop merge — the same effect #979's route53/ACM `moved` blocks already have.

Part of #749


