### PR TITLE
Suggestions for #1137: skip unsafe PACS accession numbers at import instead of aborting the batch

### DIFF
--- a/trust/imaging-api/README.md
+++ b/trust/imaging-api/README.md
@@ -57,8 +57,11 @@ Download and unzip a XNAT dataset to a local folder.
 }
 ```
 
-Query parameters: `assessor_type` (`scan`, default, or `assessor`), `resource_type` (`NIFTI` default; `DICOM`, `ALL`,
-or a custom XNAT resource label) and `force_refresh` (default `false`).
+Query parameters: `assessor_type` (`scan`, default, or `assessor`), `resource_type` (`NIFTI` default; `DICOM`, `SEG`
+or `ALL` — a closed allow-list matching flip-utils' `ResourceType` enum, since the value is interpolated into the
+XNAT download URL; anything else is a 422) and `force_refresh` (default `false`). `accession_id`, like `scan_id` and
+`resource_id` on the upload route, must be a single RFC 3986 path segment (unreserved characters only, not `.` or
+`..`); other values are rejected with a 422 before any XNAT request is made (#908).
 
 Downloads are cached on the trust host. Extraction lands in
 `<BASE_IMAGES_DOWNLOAD_DIR>/<net_id>/<central_hub_project_id>/<accession_id>/` and a completeness sentinel

--- a/trust/imaging-api/imaging_api/services/retrieval.py
+++ b/trust/imaging-api/imaging_api/services/retrieval.py
@@ -14,6 +14,7 @@ from typing import Annotated
 
 import pandas as pd
 from fastapi import Depends, HTTPException, status
+from pydantic import ValidationError
 
 from imaging_api.db.get_direct_archive_sessions_by_project import (
     get_direct_archive_sessions_by_project,
@@ -131,10 +132,22 @@ async def retrieve_images_for_project(project_id: str, query: str, headers: XNAT
                     f"Multiple studies found for accession number {idx}/{total_accessions}. Using the first one."
                 )
 
-        import_study = ImportStudy(
-            studyInstanceUid=study.study_instance_uid,
-            accessionNumber=study.accession_number,
-        )
+        # The accession number is validated as a URL path segment here (#908). PACS
+        # accession numbers are DICOM SH values and may carry characters outside
+        # that rule, so treat a rejection like a failed query: skip this study and
+        # keep the rest of the batch. Letting it raise would abort the whole import
+        # from inside a background task, with nothing but a server-log traceback.
+        try:
+            import_study = ImportStudy(
+                studyInstanceUid=study.study_instance_uid,
+                accessionNumber=study.accession_number,
+            )
+        except ValidationError as e:
+            logger.error(
+                f"Skipping accession number {idx}/{total_accessions}: the PACS returned an accession number that "
+                f"is not a valid XNAT session label / URL path segment: {e}"
+            )
+            continue
         studies_list.append(import_study)
 
     # Check that we have at least one study to import
@@ -369,10 +382,22 @@ async def retry_retrieve_images_for_project(project_id: str, query: str, headers
 
         logger.info(f"Study found for accession number {idx}/{total_retries}")
 
-        import_study = ImportStudy(
-            studyInstanceUid=study.study_instance_uid,
-            accessionNumber=study.accession_number,
-        )
+        # The accession number is validated as a URL path segment here (#908). PACS
+        # accession numbers are DICOM SH values and may carry characters outside
+        # that rule, so treat a rejection like a failed query: skip this study and
+        # keep the rest of the batch. Letting it raise would abort the whole import
+        # from inside a background task, with nothing but a server-log traceback.
+        try:
+            import_study = ImportStudy(
+                studyInstanceUid=study.study_instance_uid,
+                accessionNumber=study.accession_number,
+            )
+        except ValidationError as e:
+            logger.error(
+                f"Skipping accession number {idx}/{total_retries}: the PACS returned an accession number that "
+                f"is not a valid XNAT session label / URL path segment: {e}"
+            )
+            continue
         studies_list.append(import_study)
 
     # Check that we have at least one study to import

--- a/trust/imaging-api/tests/routers/test_schemas.py
+++ b/trust/imaging-api/tests/routers/test_schemas.py
@@ -18,6 +18,7 @@ from pydantic import ValidationError
 from imaging_api.routers.schemas import (
     CentralHubProject,
     DownloadImagesRequestData,
+    ImportStudy,
     ImportStudyRequest,
     UploadDataRequest,
 )
@@ -105,6 +106,19 @@ def test_accession_id_accepts_safe_charset(good_accession_id: str):
     """RFC 3986 §2.3 unreserved charset must be accepted."""
     request = DownloadImagesRequestData(encrypted_central_hub_project_id="enc", accession_id=good_accession_id)
     assert request.accession_id == good_accession_id
+
+
+@pytest.mark.parametrize("bad_accession_number", ["", ".", "..", "../../OTHER", "ACC/123", "ACC 123"])
+def test_import_study_rejects_unsafe_accession_number(bad_accession_number: str):
+    """The accession number becomes the XNAT session label and later the download URL's
+    accession_id, so the same path-segment rule applies at import time (#908)."""
+    with pytest.raises(ValidationError, match="accessionNumber"):
+        ImportStudy(studyInstanceUid="1.2.3", accessionNumber=bad_accession_number)
+
+
+def test_import_study_accepts_safe_accession_number():
+    study = ImportStudy(studyInstanceUid="1.2.3", accessionNumber="ACC..123")
+    assert study.relabel_map["Session"] == "ACC..123"
 
 
 def test_import_study_request_deduplicates_studies():

--- a/trust/imaging-api/tests/services/test_retrieval.py
+++ b/trust/imaging-api/tests/services/test_retrieval.py
@@ -189,6 +189,35 @@ async def test_retrieve_images_query_exception_skips_study(
 @patch("imaging_api.services.retrieval.get_accession_ids", new_callable=AsyncMock)
 @patch("imaging_api.services.retrieval.encrypt")
 @patch("imaging_api.services.retrieval.get_project")
+async def test_retrieve_images_skips_study_with_unsafe_accession_number(
+    mock_get_project, mock_encrypt, mock_get_accession_ids, mock_query, mock_queue, headers,
+):
+    """A PACS-returned accession number that fails the #908 path-segment rule must be
+    skipped like a failed query, not abort the whole batch: the remaining studies queue."""
+    mock_get_project.return_value = MagicMock()
+    mock_encrypt.return_value = "encrypted_id"
+    mock_get_accession_ids.return_value = ["ACC1", "ACC 2", "ACC3"]
+    mock_query.side_effect = [
+        [_make_study("ACC1", "1.2.3.1")],
+        [_make_study("ACC 2", "1.2.3.2")],
+        [_make_study("ACC3", "1.2.3.3")],
+    ]
+    mock_queue.return_value = [_make_import_response("ACC1"), _make_import_response("ACC3")]
+
+    result = await retrieve_images_for_project("proj1", "SELECT *", headers)
+
+    assert result is True
+    mock_queue.assert_called_once()
+    queued = [study.accession_number for study in mock_queue.call_args[0][0].studies]
+    assert queued == ["ACC1", "ACC3"]
+
+
+@pytest.mark.asyncio
+@patch("imaging_api.services.retrieval.queue_image_import_request")
+@patch("imaging_api.services.retrieval.query_by_accession_number")
+@patch("imaging_api.services.retrieval.get_accession_ids", new_callable=AsyncMock)
+@patch("imaging_api.services.retrieval.encrypt")
+@patch("imaging_api.services.retrieval.get_project")
 async def test_retrieve_images_partial_queue_failure(
     mock_get_project, mock_encrypt, mock_get_accession_ids,
     mock_query, mock_queue, headers,
@@ -593,6 +622,34 @@ async def test_retry_all_queries_fail(mock_get_project, mock_get_status, mock_qu
 
     result = await retry_retrieve_images_for_project("proj1", "SELECT *", headers)
     assert result is False
+
+
+@pytest.mark.asyncio
+@patch("imaging_api.services.retrieval.queue_image_import_request")
+@patch("imaging_api.services.retrieval.query_by_accession_number")
+@patch("imaging_api.services.retrieval.get_import_status", new_callable=AsyncMock)
+@patch("imaging_api.services.retrieval.get_project")
+async def test_retry_skips_study_with_unsafe_accession_number(
+    mock_get_project, mock_get_status, mock_query, mock_queue, headers,
+):
+    """Same guarantee as the first-pass import: one unsafe accession number does not
+    take the rest of the retry batch down with it."""
+    mock_get_project.return_value = MagicMock()
+    mock_get_status.return_value = ImportStatus(
+        successful=[], failed=["ACC_FAIL", "ACC BAD"], queue_failed=[], queued=[], processing=[],
+    )
+    mock_query.side_effect = [
+        [_make_study("ACC_FAIL", "1.2.3.1")],
+        [_make_study("ACC BAD", "1.2.3.2")],
+    ]
+    mock_queue.return_value = [_make_import_response("ACC_FAIL")]
+
+    result = await retry_retrieve_images_for_project("proj1", "SELECT *", headers)
+
+    assert result is True
+    mock_queue.assert_called_once()
+    queued = [study.accession_number for study in mock_queue.call_args[0][0].studies]
+    assert queued == ["ACC_FAIL"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Suggestions PR for #1137, based on its head (35de2353). Merge it into `908-blind-ssrf` if you agree; nothing here changes the validator itself.

## What

The `ImportStudy.accession_number` validator added in 35de2353 is applied in `services/retrieval.py` outside the per-accession `try`/`except` that guards the PACS query, in both the first-pass and the retry loop. One PACS-returned accession number outside the RFC 3986 unreserved set raises `ValidationError` out of the loop: the remaining studies are never queried, `queue_image_import_request` is never called, and because `retrieve_images_for_project` runs as a background task the only trace is a server-log traceback. The project imports nothing. DICOM Accession Number is VR SH, which permits spaces and most printable characters, so this is a plausible production input, and the PR body itself still notes the charset is unconfirmed against the production PACS.

Reproduced at 35de2353 with a three-accession batch where the second is `ACC 2`: the loop dies at study 2/3 and nothing is queued.

- `services/retrieval.py`: wrap the `ImportStudy(...)` construction in `try`/`except ValidationError`, log the accession and `continue`, in both loops. Same treatment a failed PACS query already gets.
- `tests/routers/test_schemas.py`: the `ImportStudy` validator had no test (35de2353 touched only `schemas.py`). Adds rejection cases and one accepting case that also checks the relabel map.
- `tests/services/test_retrieval.py`: one test per loop asserting the unsafe accession is skipped and the rest of the batch still queues.
- `README.md`: the download-route paragraph still advertised `resource_type` as accepting "a custom XNAT resource label". Now documents the closed allow-list and the path-segment rule on `accession_id`, `scan_id`, `resource_id`.

Not addressed here (PR-body text, not code): the "Decisions" bullet in #1137 still describes the earlier `[A-Za-z0-9._-]` + `..` rule rather than the RFC 3986 restatement.

## Verification

This PR is stacked on `908-blind-ssrf`, so GitHub runs only the ~3 base-independent checks here (the service test workflows trigger on PRs targeting `develop`). The evidence is the local run below, plus #1137's own CI once merged there.

- `ruff check .` clean
- `mypy imaging_api --ignore-missing-imports` clean
- `pytest tests` → 344 passed (335 on #1137 head + 9 new)