### PR TITLE
Suggestions for #1072: fix the pre-split xnat-db recovery runbook

### DIFF
--- a/deploy/providers/kubernetes/README.md
+++ b/deploy/providers/kubernetes/README.md
@@ -470,25 +470,51 @@ loses its endpoint — XNAT is down, not merely mis-authenticating. Because the
 container lives only ~2 s per restart cycle, `kubectl exec` is not a reliable
 entry point.
 
-Recovery:
+The reason is easy to miss: the `FailedPostStartHook` event carries only the
+fixed text `PostStartHook failed`, `kubectl describe` shows `CrashLoopBackOff`
+except for the instant the hook error itself is being reported, and the hook's
+own stderr reaches only the kubelet journal. What is always there is Postgres's
+side of the refused connection, in the container log:
 
-1. Scale the StatefulSet to 0: `kubectl scale statefulset/<release>-xnat-db --replicas=0`
-2. Start a debug StatefulSet that mounts the same PVC (replicas 1, the same
-   `postgres:12`-era image, a single `volumeMounts` entry for the existing
-   volume — the PVC name is the volumeClaimTemplate's, i.e.
-   `data-<release>-xnat-db-0`) with no `lifecycle` block of its own.
+```bash
+kubectl logs <release>-flip-trust-xnat-db-0 --previous | grep FATAL
+# FATAL:  role "postgres" does not exist
+```
+
+Recovery (the names are the ones the chart renders, the same as in the
+rotation commands above — the StatefulSet is `<release>-flip-trust-xnat-db`
+and its volume `data-<release>-flip-trust-xnat-db-0`):
+
+1. Scale the StatefulSet to 0:
+   `kubectl scale statefulset/<release>-flip-trust-xnat-db --replicas=0`
+2. Start a debug Pod (or single-replica StatefulSet) on the same PVC with **no
+   `lifecycle` block**: copy the xnat-db container spec — same image *and* the
+   same two password env vars, because the image's entrypoint guard refuses to
+   start without them — and mount `data-<release>-flip-trust-xnat-db-0` as a
+   plain `persistentVolumeClaim` volume at `/var/lib/postgresql/data`. A stock
+   `postgres:12-alpine` with no env at all works on the volume too.
 3. Inside the debug pod, create the superuser role:
    `psql -U xnat -d postgres -c "CREATE ROLE postgres WITH SUPERUSER LOGIN;"`
    (on a pre-split volume `xnat` is the superuser, so this works without a
    password under the trusted local socket).
-4. Scale the debug StatefulSet to 0, then scale `xnat-db` back to 1. The
-   `postStart` hook can now connect as `postgres` and will sync the password
-   normally.
+4. Delete the debug pod, then scale `xnat-db` back to 1. The `postStart` hook
+   can now connect as `postgres` and will sync the password normally.
 
 If a scale-to-0 is not possible (e.g. no scheduling room), the fallback is to
 temporarily strip the `lifecycle.postStart` block from the StatefulSet pod
-template (`kubectl edit statefulset`), let the container start unguarded, run
-the `CREATE ROLE` fix from inside it, then re-add the block.
+template (`kubectl edit statefulset/<release>-flip-trust-xnat-db`) **and then
+delete the pod by hand**:
+
+```bash
+kubectl delete pod <release>-flip-trust-xnat-db-0
+```
+
+The edit alone changes nothing: with the default `OrderedReady` policy the
+StatefulSet controller will not roll a pod that is not Running and Ready, so
+the crash-looping pod stays on the old template indefinitely and only picks up
+the new one once it is deleted. Let the container start unguarded, run the
+`CREATE ROLE` fix from inside it, then re-add the block (or re-run `helm
+upgrade`) — with the pod now healthy, that update rolls on its own.
 
 Alternatively, keep the old install on the previous chart version and plan a
 full migration (export the XNAT database, re-initialise the PVC, re-import).


### PR DESCRIPTION
Suggestions PR into #1072's branch — README-only, touching just the recovery section added in 75b16843. Merge this and #1072 picks the changes up; the two open threads on #1072 can then be resolved.

Each point below was checked on kind (k8s 1.34) in a throwaway namespace, against a PVC initialised by the pre-`985563d8` chart (`POSTGRES_USER=xnat`, so `pg_roles` = `xnat(super=true)` only) with the StatefulSet rendered from #1072's head.

## 1. Resource names
The chart's `flip-trust.fullname` renders the StatefulSet as `<release>-flip-trust-xnat-db`, so the volume is `data-<release>-flip-trust-xnat-db-0` (the Makefile's default release `trust-release` gives `data-trust-release-flip-trust-xnat-db-0`). The runbook's step 1/2 names do not exist:

```
statefulset/pr1072-xnat-db             -> statefulsets.apps "pr1072-xnat-db" not found
pvc/data-pr1072-xnat-db-0              -> persistentvolumeclaims "data-pr1072-xnat-db-0" not found
statefulset/pr1072-flip-trust-xnat-db  -> statefulset.apps/pr1072-flip-trust-xnat-db
```

The rotation commands thirty lines up already use the long form, so the section now agrees with itself.

## 2. The `kubectl edit` fallback needs a pod delete
Stripping `lifecycle.postStart` from the template while the pod crash-loops does not roll it. Sampled every 30 s for 5 minutes after the patch: `updateRevision` moved to the new hash, `currentRevision` stayed on the old one, `updatedReplicas` empty, no StatefulSet events, pod still on the old revision (restarts climbing 3 → 6). The default `OrderedReady` policy will not update a pod that is not Running and Ready. After `kubectl delete pod <sts>-0` the unguarded pod came up Ready on the new template in seconds; once the `postgres` role exists, re-applying the block rolled on its own (pod healthy) and the hook logged `xnat role password synced`.

## 3. The debug pod's image
"The same `postgres:12`-era image" is underspecified. The xnat-db image's entrypoint guard refuses to start without both password env vars (`restarts=2`, log ends `Mint real credentials ... and redeploy`), so a debug pod on that image must carry the same env as the real container. A stock `postgres:12-alpine` with no env also works on the volume. `CREATE ROLE postgres WITH SUPERUSER LOGIN` succeeded (inside a rolled-back transaction) from both.

## 4. Where the failure reason is visible
The `FailedPostStartHook` event text is the fixed `PostStartHook failed`; `kubectl describe` shows `CrashLoopBackOff` / `Last State: Completed, Exit Code 0` outside the brief window in which the hook error itself is reported; the hook's stderr (`xnat-db postStart: FAILED to sync ...`) reaches only the kubelet journal. What is always there is Postgres's side of the refused connection, `FATAL:  role "postgres" does not exist`, in `kubectl logs` and `kubectl logs --previous`. Added a one-liner for that.

The primary path (scale to 0, debug pod on the PVC, `CREATE ROLE`, scale back) was verified as written and is unchanged apart from the names: Ready with 0 restarts, "synced" in the log, md5 auth from a sibling pod with the secret's password succeeds and a wrong password is refused.
