### PR TITLE
docs: fix the flip-utils function lists rendering, and describe FLIP as two parts

### DIFF
--- a/docs/source/components/component-fl-nets.rst
+++ b/docs/source/components/component-fl-nets.rst
@@ -116,6 +116,7 @@ that omits it is rejected before bundling rather than defaulted.
 Once uploaded, the UI will indicate which files are required for the specific job.
 
 Then, the Central Hub API will take care of bundling together:
+
 - The files the user has uploaded
 - The static (non-modifiable) files that are required for the specific job type.
 
@@ -337,12 +338,17 @@ Data access and communication with external services
 ****************************************************
 
 Though the user is allowed to upload the training script that will run on the client side, the access to data will have
-to be via the FLIP package (see `https://github.com/londonaicentre/FLIP/tree/develop/flip-utils/flip`).
+to be via the FLIP package (see `flip-utils/flip/
+<https://github.com/londonaicentre/FLIP/tree/develop/flip-utils/flip>`_).
 This package, installed by default in client and server nodes, will make a series of functions available to the user.
 
 For data access:
-- `flip.get_dataframe(project_id, query)`: retrieves the dataframe linked to the project ID and query that have been used on the project.
-- `flip.get_by_accession_number(project_id, accession_id, resource_type)`: retrieves data of a certain type (e.g. NIFTI) associated with an accession ID. ``resource_type`` defaults to ``ResourceType.NIFTI`` and can be a single type or a list.
+
+- ``flip.get_dataframe(project_id, query)``: retrieves the dataframe linked to the project ID and query that have been
+  used on the project.
+- ``flip.get_by_accession_number(project_id, accession_id, resource_type)``: retrieves data of a certain type
+  (e.g. NIFTI) associated with an accession ID. ``resource_type`` defaults to ``ResourceType.NIFTI`` and can be a
+  single type or a list.
 
 These calls - among others - communicate with the Imaging API and retrieve the data from the project's XNAT.
 
@@ -354,9 +360,20 @@ content changed in XNAT, the Imaging API's download route accepts ``force_refres
 ``flip.add_resource`` invalidate the cache automatically).
 
 For communication with the Central Hub:
-- `flip.update_status(model_id, new_model_status)`: these calls will update the Central Hub about status on the specific model that is running (example: when it started training, or if there's an error).
-- `flip.send_metrics(client_name, model_id, label, value, global_round, x_value=None, x_label=None)`: sends a metric to the central hub so that it can plot the training results. ``global_round`` is provenance — always the FL global round the metric is reported in. Where the point is *plotted* is the optional coordinate pair: ``x_value`` is the x-coordinate (any float, e.g. an epoch counter) and ``x_label`` names the x-axis (e.g. ``"epoch"``); both default to the global round on the "Global Rounds" axis. A plot is identified by the ``(label, x_label)`` pair, so the same metric logged against different x-labels is shown as separate plots.
-- `flip.send_event(model_id, event_type, global_round, ...)`: sends a typed round-progress **fact** to the Central Hub — one of ``ROUND_STARTED``, ``CLIENT_RESULT_RECEIVED`` (with the serialized update size in ``details.size_bytes``) or ``ROUND_AGGREGATED`` (with ``returned``/``expected`` counts). The hub composes the display text shown in the model page's Live activity feed at serve time, so wording changes ship with a flip-api redeploy and never require rebuilding FL images. Rounds are 1-based on both backends.
+
+- ``flip.update_status(model_id, new_model_status)``: these calls will update the Central Hub about status on the
+  specific model that is running (example: when it started training, or if there's an error).
+- ``flip.send_metrics(client_name, model_id, label, value, global_round, x_value=None, x_label=None)``: sends a metric
+  to the central hub so that it can plot the training results. ``global_round`` is provenance — always the FL global
+  round the metric is reported in. Where the point is *plotted* is the optional coordinate pair: ``x_value`` is the
+  x-coordinate (any float, e.g. an epoch counter) and ``x_label`` names the x-axis (e.g. ``"epoch"``); both default to
+  the global round on the "Global Rounds" axis. A plot is identified by the ``(label, x_label)`` pair, so the same
+  metric logged against different x-labels is shown as separate plots.
+- ``flip.send_event(model_id, event_type, global_round, ...)``: sends a typed round-progress **fact** to the Central
+  Hub — one of ``ROUND_STARTED``, ``CLIENT_RESULT_RECEIVED`` (with the serialized update size in
+  ``details.size_bytes``) or ``ROUND_AGGREGATED`` (with ``returned``/``expected`` counts). The hub composes the display
+  text shown in the model page's Live activity feed at serve time, so wording changes ship with a flip-api redeploy and
+  never require rebuilding FL images. Rounds are 1-based on both backends.
 
 The fl-server emits these events automatically — NVFLARE via the FLIP ``ScatterAndGather``/``ServerEventHandler`` components (wired by path in each template's server config, so no app-template changes were required), Flower via the ``flip.flower.strategy.FlipFedAvg`` base strategy the app templates subclass. User training code never calls ``send_event`` directly. Pre-existing **Flower** apps (whose uploaded strategy subclasses stock ``FedAvg``) keep working and simply emit no round telemetry; pre-existing **NVFLARE** apps reference the FLIP components by path from the baked ``flip`` package, so they start emitting as soon as the fl-server image carries this version — with no app change.
 

--- a/docs/source/components/overview.rst
+++ b/docs/source/components/overview.rst
@@ -8,16 +8,16 @@ Overview
 Architecture
 ************
 
-The overall FLIP solution comprises three parts:
+The overall FLIP solution comprises two parts:
 
 1. A **cloud-hosted Central Hub** providing researchers with the capability to define machine learning
    projects, discover appropriate datasets at participating Trusts and federate the testing and training of
    models across Trusts, culminating in the aggregation of a consensus model.
 2. A **Secure Enclave** (a *FLIP node*) hosted at each individual Trust, designed to permit only requests for
    training that the Trust itself has fetched from the Central Hub. A set of FLIP microservices runs inside the
-   enclave to serve those requests, alongside the Trust's imaging archive and its :term:`OMOP` database.
-3. **GPU compute at each Trust**, used by that Trust's FL client and nothing else: model training and evaluation
-   run on the Trust's own hardware, against the Trust's own data, and only model updates leave.
+   enclave to serve those requests, alongside the Trust's imaging archive, its :term:`OMOP` database and the GPU
+   compute its FL client trains on — so training and evaluation happen inside the enclave, against the Trust's
+   own data, and only model updates leave.
 
 .. figure:: ../assets/support/flip_architecture-flip_architecture.png
    :align: center


### PR DESCRIPTION
# Description

Two documentation fixes, both reported from the published ReadTheDocs pages.

**1. `component-fl-nets.rst` — the flip-utils function lists rendered as run-on paragraphs**
([Data access and communication with external services](https://londonaicentreflip.readthedocs.io/en/latest/components/component-fl-nets.html#id15))

Three markup defects in that section, all confirmed against a local Sphinx build:

- **No blank line before the bullet lists.** reStructuredText requires one, so both `For data access:` and `For communication with the Central Hub:` swallowed their `- ` items into the preceding paragraph — published as a single `<p>` with literal hyphens mid-sentence instead of a `<ul>`.
- **Single backticks on the signatures.** With no `default_role` set in `conf.py`, docutils falls back to `title_reference`, so `` `flip.get_dataframe(...)` `` rendered as `<cite>` (italic prose) rather than inline code — while the rest of the same paragraph correctly used double backticks for ``resource_type``, ``global_round`` and so on.
- **The flip-utils URL rendered as italic text, not a link** — same single-backtick cause, in the section's opening sentence.

Fixed by adding the blank lines, double-backticking every signature, rewrapping the items to the page's line width, and turning the URL into a proper external link matching the `` `fl-apps/ <...>`_ `` style used elsewhere on the page.

A scan of all of `docs/source/` (docutils parse, looking for paragraphs containing literal bullet lines) found exactly one other instance of the missing-blank-line defect — the app-bundling list further up the same page — so that is fixed here too. The detector now reports zero remaining across the docs tree.

**2. `components/overview.rst` — Architecture described FLIP as three parts**

The list gave GPU compute at each Trust as a third part alongside the Central Hub and the Secure Enclave. It is not a third part: the enclave already includes the compute its FL client trains on, and the point's "run on the Trust's own hardware" wording implied on-premise deployment, which is only one of the supported targets — a node also runs inside a TRE or on Kubernetes, as the Deployment targets section on the same page says.

The architecture figure directly below the list already draws two boundaries (the cloud-hosted FLIP Hub, and the FLIP node holding the Secure enclave and the FL Client), so the three-part framing did not match the picture either.

Point 3 is dropped and its surviving claims — compute inside the enclave, only model updates leave — folded into point 2.

## Stacking

This PR is **stacked on #979** (`749-lza-terraform-env`) and targets that branch, not `develop`, because #979 also edits `components/overview.rst`. The two sets of changes touch different sections and coexist without conflict; rebase or retarget onto `develop` once #979 merges.

## Linked Issues

None — both reported directly against the published pages.

## Checklist

- [x] Follows the project's coding conventions and style guide
- [x] Updates documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Type of Change

- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] In-line docstrings updated.
- [x] Documentation updated, tested `make -C docs/ docs`.

## Testing

Documentation-only change; no application code touched, so no unit or integration suite applies.

- Built the Sphinx HTML before and after each change and diffed the output for the affected sections. Both listings now emit `<ul class="simple">` with `<code>` signatures, and both GitHub URLs are real `<a class="reference external">` links.
- Confirmed the `#id15` anchor is unchanged, so existing links into that section still land in the right place.
- Build reports no new warnings — only the pre-existing missing-diagram warnings from building with `FLIP_DOCS_SKIP_DIAGRAMS=1` on a host without graphviz.
- Rebuilt again after rebasing onto `749-lza-terraform-env` to confirm the stack builds clean.

Reproduce with `make -C docs docs` (or `FLIP_DOCS_SKIP_DIAGRAMS=1` without graphviz on PATH).

## Additional Notes

One related thing deliberately left alone, for the author to decide: in the *Secure Enclave* subsection of `overview.rst`, the line "to facilitate the secure training and testing of models on **the Trust's own GPU hardware**" carries the same on-premise flavour as the sentence removed above. It is defensible — a TRE's GPUs are provisioned for the Trust, so "the Trust's own" can be read as control rather than location — so it is untouched here.

Similarly, the NVFLARE/Flower tutorial lists further up `component-fl-nets.rst` use single backticks for job-type names (`` `standard` ``, `` `evaluation` ``), which renders them italic rather than as code. Cosmetic rather than broken, and outside the reported section, so not changed in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M6qsY5gom47xkMzJhwN18W

---
_Generated by [Claude Code](https://claude.ai/code/session_01M6qsY5gom47xkMzJhwN18W)_