### PR TITLE
docs: write 'Create a FLIP app from a FLARE app' walkthrough; correct the Flower twin (#462)

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -25,6 +25,10 @@
 | `source/deploy-flip/` | Per-target deployment guides (central hub, TRE, on-prem) |
 | `source/working-with-flip-apps/` | Step-by-step FLARE / Flower app authoring |
 
+## Paired pages
+
+`source/working-with-flip-apps/create-flip-app-from-flare.rst` and `create-flip-app-from-flower.rst` are twins: same section order, same SDK touchpoints, each ending in a `Common pitfalls` list, and each carrying a note at the top pointing at the other. When one page changes — a new SDK call, a renamed run-config key, a new pitfall, a restructured section — check whether the other needs the same change, and make both edits in the same PR. The backend-specific facts differ (the comparison table at the top of the FLARE page summarises them), but the *shape* of the two pages should not drift apart.
+
 ## How to Read
 
 When implementing a feature that touches documentation, read the relevant `.rst` file(s) above. These are ReStructuredText format used by Sphinx for ReadTheDocs builds.

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -25,6 +25,10 @@
 | `source/deploy-flip/` | Per-target deployment guides (central hub, TRE, on-prem) |
 | `source/working-with-flip-apps/` | Step-by-step FLARE / Flower app authoring |
 
+## Paired pages
+
+`source/working-with-flip-apps/create-flip-app-from-flare.rst` and `create-flip-app-from-flower.rst` are twins: same section order, same SDK touchpoints, each ending in a `Common pitfalls` list, and each carrying a note at the top pointing at the other. When one page changes — a new SDK call, a renamed run-config key, a new pitfall, a restructured section — check whether the other needs the same change, and make both edits in the same PR. The backend-specific facts differ (the comparison table at the top of the FLARE page summarises them), but the *shape* of the two pages should not drift apart.
+
 ## How to Read
 
 When implementing a feature that touches documentation, read the relevant `.rst` file(s) above. These are ReStructuredText format used by Sphinx for ReadTheDocs builds.

--- a/docs/source/working-with-flip-apps/create-flip-app-from-flare.rst
+++ b/docs/source/working-with-flip-apps/create-flip-app-from-flare.rst
@@ -2,15 +2,546 @@
 Create a FLIP app from a FLARE app
 ###################################
 
+.. warning::
+
+   This page assumes you are familiar with the :ref:`flip-fl-nets` component page and with the project / model lifecycle described in :doc:`/user-guides/user-common`. Before starting, you must already have: a FLIP account with the ``researcher`` role, an approved project with a saved cohort query, and a model created under that project (so you have a model ID).
+
 .. note::
 
-   This page is a placeholder. The NVIDIA FLARE walkthrough is still being written.
-   For the FLARE-specific SDK calls and app layout, see the migrated FL code under
-   `flip-utils/flip/nvflare <https://github.com/londonaicentre/FLIP/tree/develop/flip-utils/flip/nvflare>`_
-   the per-job-type apps under
-   `fl-apps/ <https://github.com/londonaicentre/FLIP/tree/develop/fl-apps/nvflare>`_, and the tutorials under
-   `fl-tutorials/ <https://github.com/londonaicentre/FLIP/tree/develop/fl-tutorials/nvflare>`_ in
-   the meantime.
+   This page is the NVIDIA FLARE twin of :doc:`create-flip-app-from-flower` and follows the same
+   structure. If you change one page, check whether the other needs the same change.
 
-   The Flower equivalent is available now — see
-   :doc:`create-flip-app-from-flower`.
+This page walks through the code changes required to adapt a stock NVIDIA FLARE **Client API** training script (for example, one copied from the official `NVFLARE examples <https://github.com/NVIDIA/NVFlare/tree/main/examples/hello-world>`_ or pulled from the internal FLIP app hub) so that it can run on FLIP. Every NVFLARE job type on FLIP drives the client code through the Client API (``nvflare.client``) — a plain Python script that FLIP's ``ClientAPIExecutor`` runs in-process on each Trust. The walkthrough covers the FLIP touchpoints such a script needs:
+
+- ``flip.get_dataframe(...)`` to retrieve the project's cohort DataFrame
+- ``flip.get_by_accession_number(...)`` to pull imaging resources for each accession
+- ``SummaryWriter.add_scalar(...)`` (NVFLARE's own tracking API) to publish per-epoch metrics, which FLIP forwards to the model page
+- the ``FLModel`` contract for what the trainer receives and returns each round
+
+There is no ``flip.update_status(...)`` to call: on NVFLARE the whole server side is FLIP's, and its ``ServerEventHandler`` drives the model lifecycle for you (see :ref:`flare-server-side`).
+
+A full, runnable reference is available in-tree:
+
+- ``fl-apps/nvflare/standard/`` — the platform-side base template for job type ``standard``: the recipe-generated ``config_fed_server.json`` / ``config_fed_client.json`` and ``meta.json``. ``trainer.py``, ``models.py`` and ``config.json`` are user-supplied (see ``fl-apps/nvflare/standard/required_files.json``).
+- ``fl-tutorials/nvflare/image_classification/xray_classification/`` — a complete chest X-ray classification example whose labels come from OMOP via ``query.sql`` (no data enrichment needed).
+- ``fl-tutorials/nvflare/image_segmentation/3d_spleen_segmentation/`` — a MONAI spleen-segmentation example that exercises every touchpoint covered below, including best-model selection.
+
+.. list-table:: How the two backends divide the work
+   :widths: 30 35 35
+   :header-rows: 1
+
+   * -
+     - Flower
+     - NVIDIA FLARE
+   * - What you upload
+     - ``client_app.py``, ``models.py``, ``config.json`` (+ optional ``config.toml``)
+     - ``trainer.py``, ``models.py``, ``config.json`` (+ helper modules)
+   * - Server side
+     - FLIP template ``ServerApp`` (you write one only for local runs)
+     - FLIP template workflows and components (nothing to write)
+   * - Model lifecycle status
+     - ``flip.update_status`` calls in the ``ServerApp``
+     - Fired automatically by FLIP's ``ServerEventHandler``
+   * - Run configuration
+     - ``config.toml`` overriding ``[tool.flwr.app.config]``
+     - ``config.json`` (``GLOBAL_ROUNDS``, ``LOCAL_ROUNDS``, …)
+   * - Per-epoch metrics
+     - ``MetricRecord`` in the reply, forwarded by the server
+     - ``SummaryWriter.add_scalar``, forwarded by ``FlipAnalyticsBridge``
+   * - Client identity
+     - ``SUPERNODE_NAME`` env var placed in the reply's ``ConfigRecord``
+     - NVFLARE site name, resolved from the event origin (nothing to do)
+   * - Privacy filter on updates
+     - ``flip_local_dp_mod`` registered by the uploaded ``client_app.py``
+     - ``PercentilePrivacy`` wired by the template (nothing to do)
+   * - Local run
+     - ``fl-services/flower`` compose stack
+     - ``job.py`` recipe: ``make export`` / ``make sim``
+
+*****************
+Starting point
+*****************
+
+A FLARE app that FLIP can run is a folder of user files plus, for local runs only, a ``job.py`` that describes the job with FLIP's ``FlipFedAvgRecipe``. The minimum layout, following the tutorials, is:
+
+.. code-block:: text
+
+   my-flare-app/
+   ├── app_files/
+   │   ├── config.json
+   │   ├── models.py
+   │   ├── trainer.py
+   │   └── transforms.py      # optional helper modules travel with the upload
+   ├── job.py
+   ├── .env.app               # local-run environment (see Local testing)
+   └── query.sql              # the cohort query you save on the project (not uploaded)
+
+``trainer.py``, ``models.py`` and ``config.json`` are the files you upload — see :ref:`fl-required-files`. Any other file you upload alongside them (``transforms.py``, ``data_utils.py``, …) is bundled into the same ``custom/`` directory on every site, so plain ``from transforms import ...`` imports work. ``job.py`` is shown here because you need it to run the app locally; on-platform the job is assembled by FLIP from the ``standard`` template and your uploaded files, and a ``job.py`` you upload is simply carried along unused.
+
+.. note::
+
+   Unlike a hand-written NVFLARE job, you do **not** write ``config_fed_server.json``, ``config_fed_client.json`` or ``meta.json``. Those come from the platform's template for the job type (``fl-apps/nvflare/<job_type>/``), which is itself generated from ``flip.nvflare.recipes``; an uploaded copy lands in ``custom/`` and is never read as a config file. Researchers cannot change what happens on the server side — see the *Job types* section of :ref:`flip-fl-nets`.
+
+.. note::
+
+   The ``flip-utils`` package (imported as ``flip``) ships inside every FLIP FL node image, alongside ``nvflare``, ``torch`` and ``monai``. On-platform the trainer runs against those pre-installed packages — there is no per-run dependency installation, so an app can only import what the FL image already carries. If your app needs a dependency the image does not provide, ask the platform operators. For local runs, the tutorials use the ``flip-utils`` project environment with its ``full`` extra (``uv run --project flip-utils --extra full``), which installs the same package set as the ``flare-fl-base`` image.
+
+.. _flare-server-side:
+
+*****************************************
+The server side is FLIP's (nothing to do)
+*****************************************
+
+On NVFLARE, FLIP owns the entire server side. The ``standard`` template runs four workflows in order — ``InitTraining`` → ``ScatterAndGather`` (federated averaging) → NVFLARE's stock ``GlobalModelEval`` → ``BroadcastTask`` (post-run cleanup) — and wires the FLIP components that talk to the Central Hub. The pieces that matter to an app author:
+
+- **Model lifecycle.** ``ServerEventHandler`` moves the model through ``INITIATED`` → ``PREPARED`` → ``RUNNING`` → ``RESULTS_UPLOADED`` (or ``ERROR`` / ``STOPPED``) on NVFLARE's own events, and ``PersistToS3AndCleanup`` zips the run directory — ``FL_global_model.pt``, ``cross_val_results.json`` and, when selection is on, ``best_FL_global_model.pt`` — and uploads it at the end of the run. This is what drives the progress bar and downloads on the model page (see :ref:`view-results`).
+- **Round telemetry.** ``ScatterAndGather`` and ``ServerEventHandler`` emit the round-started / result-received / round-aggregated facts shown in the model page's Live activity feed. Your code never calls ``flip.send_event``.
+- **Your ``models.py`` runs on the server too.** The persistor and the model locator instantiate ``models.get_model()`` on the FL server to seed the round-0 global model and to load it for post-training evaluation — so ``models.py`` must import cleanly without data, GPUs or your trainer's dependencies (see :ref:`flare-models-py`).
+- **Aggregation.** Clients return a weight **diff**; the server averages the diffs (``InTimeAccumulateWeightedAggregator``, weighted by the ``NUM_STEPS_CURRENT_ROUND`` each client reports) and adds the average onto the global model. This fixes the return contract of your trainer (see :ref:`the diff warning below <flare-return-diff>`).
+- **Privacy filter.** Every training result passes through ``PercentilePrivacy`` before it leaves the Trust; you do not register anything in the trainer. The mechanism and its caveats are described under *Privacy filters on shared model updates* on :ref:`flip-fl-nets`.
+
+The template's ``README.md`` (``fl-apps/nvflare/standard/README.md``) lists every workflow, executor and filter by path if you need the full picture.
+
+*****************************************
+trainer.py: the Client API loop
+*****************************************
+
+On the client side, the trainer is a plain script that FLIP's ``ClientAPIExecutor`` runs in-process for the ``train`` and ``validate`` tasks. It builds the data pipeline once, then loops on ``flare.receive()`` until the job ends.
+
+Imports
+=======
+
+.. code-block:: python
+
+   import argparse
+   import json
+   from pathlib import Path
+
+   import nvflare.client as flare
+   import torch
+   from flip import FLIP
+   from flip.constants import ResourceType
+   from models import get_model
+   from nvflare.client.tracking import SummaryWriter
+
+Reading the FLIP run values
+===========================
+
+FLIP hands the trainer two values at run time, and they arrive through different channels because NVFLARE's ``TaskScriptRunner`` whitespace-splits the executor's ``task_script_args``:
+
+- The **project ID** arrives as a CLI flag. The template's executor is configured with ``task_script_args = "--project_id {project_id}"``, and NVFLARE resolves ``{project_id}`` against the top-level ``project_id`` key of ``config_fed_client.json``, which FLIP's FL API writes at submit time.
+- The **cohort query** cannot be a CLI flag — SQL contains spaces — so it is read straight out of the same file's top-level ``query`` key.
+
+.. code-block:: python
+
+   def parse_args() -> argparse.Namespace:
+       parser = argparse.ArgumentParser()
+       parser.add_argument("--project_id", type=str, default="")
+       return parser.parse_args()
+
+
+   def load_query() -> str:
+       """Cohort query, written into config_fed_client.json by the FL API at submit time."""
+       client_cfg = Path(__file__).parent.parent / "config" / "config_fed_client.json"
+       if client_cfg.exists():
+           return json.loads(client_cfg.read_text()).get("query", "")
+       return ""
+
+
+   def load_config() -> dict:
+       """Your own config.json, which sits next to this script in custom/."""
+       with open(Path(__file__).parent / "config.json") as f:
+           return json.load(f)
+
+Both loaders use paths relative to ``__file__`` because on-platform the script runs from NVFLARE's job workspace, not from your project directory: ``trainer.py`` is at ``<app>/custom/trainer.py`` and the client config at ``<app>/config/config_fed_client.json``.
+
+Fetching the FLIP DataFrame
+===========================
+
+The cohort DataFrame is fetched once, before the round loop, via ``flip.get_dataframe``. The call runs against the project's saved cohort query (see :ref:`create-cohort-query`) and returns a pandas ``DataFrame`` containing at minimum an ``accession_id`` column plus whatever other columns the SQL ``SELECT`` projected — the X-ray tutorial's ``query.sql`` projects the OMOP labels this way.
+
+.. code-block:: python
+
+   args = parse_args()
+   config = load_config()
+
+   flip = FLIP()
+   dataframe = flip.get_dataframe(args.project_id, load_query())
+   if "accession_id" not in dataframe.columns:
+       raise ValueError("The dataframe must contain 'accession_id' column.")
+
+A fresh ``FLIP()`` instance picks up its Imaging API connection from the environment the FLIP-managed fl-client provides, so no additional configuration is needed. In local development (``LOCAL_DEV``) the same call ignores ``project_id`` and ``query`` and reads the CSV named by ``DEV_DATAFRAME`` instead — see :ref:`flare-local-testing`.
+
+Fetching images by accession
+============================
+
+Once you have the cohort DataFrame, iterate its ``accession_id`` column and call ``flip.get_by_accession_number`` to pull the imaging resources for each study. The call returns a ``pathlib.Path`` pointing at a local directory containing files named ``input_*.nii.gz`` (and, if you also requested ``ResourceType.SEGMENTATION``, or the labels were uploaded during data enrichment, ``label_*.nii.gz``).
+
+.. code-block:: python
+
+   datalist = []
+   for accession_id in dataframe["accession_id"]:
+       try:
+           accession_folder_path = flip.get_by_accession_number(
+               args.project_id,
+               accession_id,
+               resource_type=[ResourceType.NIFTI],
+           )
+       except Exception as err:
+           print(f"Could not get image data for {accession_id}: {err}")
+           continue
+
+       for img in accession_folder_path.rglob("input_*.nii.gz"):
+           seg = str(img).replace("/input_", "/label_")
+           if not Path(seg).exists():
+               continue
+           datalist.append({"image": str(img), "label": seg})
+
+.. warning::
+
+   Always wrap ``get_by_accession_number`` in a ``try / except`` loop and ``continue`` on failure. A single Trust may be missing a resource type for a specific accession (for example, a study with imaging but no segmentation), and you should not abort the whole job on one bad accession. Do fail loudly if the loop ends with an **empty** datalist, though: the spleen tutorial raises a ``RuntimeError`` naming the likely cause (the data-enrichment label upload was skipped), because the ``num_samples=0`` error torch would otherwise raise reads like an app bug.
+
+.. note::
+
+   ``ResourceType`` is an enum in ``flip.constants``. The samples use ``ResourceType.NIFTI`` and ``ResourceType.SEGMENTATION``; you may pass either a single value or a list. The first call per (project, accession, resource type) downloads the study out of XNAT; later calls — including the same loop running in local development — return the cached local copy, so there is no need to build your own on-disk guards.
+
+The round loop
+==============
+
+After the data pipeline is built, call ``flare.init()`` and loop on ``flare.receive()``. Each received ``FLModel`` carries the current global weights in ``params`` (as numpy arrays, since the template sets ``params_exchange_format = "numpy"``) and the 0-based round index in ``current_round``. Two task types reach the trainer: ``train`` (one per global round) and, after the last round, ``validate`` — NVFLARE's ``GlobalModelEval`` broadcasting the final aggregated model for cross-site evaluation.
+
+.. code-block:: python
+
+   model = get_model().to(device)
+   optimizer = torch.optim.Adam(model.parameters(), lr=config["LEARNING_RATE"])
+
+   flare.init()
+   writer = SummaryWriter()
+
+   while flare.is_running():
+       input_model = flare.receive()
+       if input_model is None:
+           break
+
+       if flare.is_train():
+           global_round = input_model.current_round or 0
+           global_weights = {k: torch.as_tensor(v) for k, v in input_model.params.items()}
+           model.load_state_dict(global_weights)
+
+           n_iterations = 0
+           for epoch in range(config["LOCAL_ROUNDS"]):
+               train_loss, n_batches = train_one_epoch(model, train_loader, loss_fn, optimizer, device)
+               n_iterations += n_batches
+               # ... validation and metrics — see below
+
+           # Return the update as a DIFF (local minus global) — see the warning below.
+           new_state = {k: v.detach().cpu().numpy() for k, v in model.state_dict().items()}
+           diff = {k: new_state[k] - global_weights[k].detach().cpu().numpy() for k in new_state}
+           flare.send(
+               flare.FLModel(
+                   params=diff,
+                   params_type="DIFF",
+                   meta={"NUM_STEPS_CURRENT_ROUND": n_iterations},
+               )
+           )
+
+       elif flare.is_evaluate():
+           model.load_state_dict({k: torch.as_tensor(v) for k, v in input_model.params.items()})
+           test_loss, test_dice = validate(model, val_loader, ...)
+           writer.add_scalar("TEST_DICE", test_dice, global_step=0)
+           flare.send(flare.FLModel(metrics={"val_acc": test_dice}))
+
+       else:
+           print("Received unknown task; ignoring.")
+
+Create the optimizer **once**, outside the loop: the trainer process lives for the whole job, and the tutorials keep optimizer state (and learning-rate schedules) across global rounds rather than resetting it each round.
+
+.. _flare-return-diff:
+
+.. warning::
+
+   **Return a diff, not full weights.** The ``standard`` template's aggregator averages ``WEIGHT_DIFF`` updates and the shareable generator adds the average onto the global model. A trainer that sends ``params_type="FULL"`` is rejected by the aggregator, and the round fails. Always compute ``local - global`` per key and send it with ``params_type="DIFF"``. Report the number of local optimisation steps in ``meta["NUM_STEPS_CURRENT_ROUND"]``: it is the weight the aggregator gives your update, and the privacy filter's clipping bound scales with it.
+
+The ``is_evaluate()`` branch's metrics land, per site, in ``cross_val_results.json`` inside the results zip via ``ValidationJsonGenerator``. ``val_acc`` is the key the tutorials use; any numeric keys are accepted.
+
+**Optional: cross-site evaluation of client models.** By default post-training evaluation covers only the aggregated global model, so the trainer never sees a ``submit_model`` task. The X-ray tutorial handles it anyway, returning the current local weights with ``params_type="FULL"`` under ``flare.is_submit_model()`` — harmless on the platform, and it makes the script work unchanged with a recipe constructed with ``submit_model_task_name="submit_model"`` locally.
+
+*****************************************
+trainer.py: sending per-epoch metrics
+*****************************************
+
+Per-epoch, per-site metrics are published through NVFLARE's own tracking API — ``SummaryWriter.add_scalar`` (``flare.log`` works too). The template's ``FlipAnalyticsBridge`` component catches the analytics events the Client API fires and re-emits them to the FL server, whose ``ScatterAndGather`` controller forwards them to the Central Hub with ``flip.send_metrics``. This is what populates the graphs on the model page (see the "Metrics" section of :doc:`/user-guides/user-common`).
+
+.. code-block:: python
+
+   for epoch in range(config["LOCAL_ROUNDS"]):
+       train_loss, n_batches = train_one_epoch(...)
+       val_loss, val_dice = validate(...)
+
+       # "@epoch" names the x-axis; global_step is the x-coordinate (the cumulative epoch count).
+       # The FL global round is stamped server-side as provenance.
+       cumulative_epoch = global_round * config["LOCAL_ROUNDS"] + epoch + 1
+       writer.add_scalar("TRAIN_LOSS@epoch", float(train_loss), global_step=cumulative_epoch)
+       writer.add_scalar("VAL_LOSS@epoch", float(val_loss), global_step=cumulative_epoch)
+       writer.add_scalar("VAL_DICE@epoch", float(val_dice), global_step=cumulative_epoch)
+
+.. warning::
+
+   Do **not** call ``flip.send_metrics`` (or ``flip.update_status``) from the trainer. FL clients deliberately do not hold the credentials needed to reach the Central Hub — only the FL server does — so a direct call fails on-platform. The bridge is the supported path.
+
+.. note::
+
+   The site name shown against each metric in the FLIP UI is resolved automatically from the NVFLARE event origin — the Trust's FL kit slot (``Trust_1``, ``Trust_2``, …), which the hub maps back to the owning Trust. There is no client-name variable to set, unlike Flower's ``SUPERNODE_NAME``.
+
+.. note::
+
+   Use stable, upper-case ``label`` strings (``TRAIN_LOSS``, ``VAL_LOSS``, ``VAL_DICE`` are the conventions used in the tutorials) so that metrics from repeated runs line up on the same chart in the UI.
+
+.. note::
+
+   **Arbitrary x-axis.** The tag grammar is ``<label>[@<x_label>]``: the part after ``@`` names the x-axis and ``global_step`` is the coordinate on it. With no ``@`` suffix the metric is plotted at its FL global round on an axis titled "Global Rounds" — pass ``global_step=0`` (or omit it) for a once-per-run value such as ``TEST_DICE``. A plot is identified by the ``(label, x_label)`` pair, so the same metric logged under two different x-labels is shown as two separate plots in the UI. This is the same grammar the Flower metric keys use; the ``.x_<V>`` suffix is not needed here because ``global_step`` carries the coordinate.
+
+.. _flare-models-py:
+
+*****************************************
+models.py: the architecture
+*****************************************
+
+``models.py`` must expose ``get_model()`` returning a ``torch.nn.Module``. It is the one user file that runs on **both** sides: the trainer calls it to build the network the received weights are loaded into, and the FL server's persistor instantiates it (by path, ``models.get_model``) to produce the round-0 global model, so the state-dict keys the server broadcasts are exactly the keys your trainer's model expects.
+
+.. code-block:: python
+
+   import json
+   from pathlib import Path
+
+   from monai.networks.nets import UNet
+   from torch import nn
+
+
+   def load_net_config() -> dict:
+       with open(Path(__file__).parent / "config.json") as f:
+           return json.load(f).get("net_config", {})
+
+
+   class SegmentationNetwork(nn.Module):
+       def __init__(self, num_classes: int = 1):
+           super().__init__()
+           net_config = load_net_config()
+           self.net = UNet(
+               spatial_dims=net_config["spatial_dims"],
+               in_channels=1,
+               out_channels=num_classes + 1,
+               num_res_units=2,
+               norm="batch",
+               channels=(16, 32, 64, 128, 256),
+               strides=(2, 2, 2, 2),
+           )
+
+       def forward(self, x):
+           return self.net(x)
+
+
+   def get_model() -> nn.Module:
+       return SegmentationNetwork()
+
+Keep it self-contained: import only the model library, read any architecture parameters from ``config.json`` relative to ``__file__`` (both files sit in ``custom/`` on every site, including the server), and do not import ``trainer.py`` or anything that needs data or a GPU at import time. ``get_model()`` is also what an ``evaluation`` job loads a checkpoint into, so an architecture shared between a training app and its evaluation app should live in an identical ``models.py``.
+
+.. note::
+
+   **Fine-tuning from a pretrained backbone.** Declare the checkpoint's filename in ``config.json`` under ``SERVER_CHECKPOINT`` and upload it with the app. FLIP stages it on the FL server only (never on the Trusts) and loads it into ``get_model()`` to seed the round-0 global model, so clients receive the backbone plus freshly initialised heads at round 0 and build only the bare architecture themselves. Pair it with ``AGGREGATE_ONLY_REGEX`` to send back only the trainable head each round. The Ark+ fine-tuning tutorial (``fl-tutorials/nvflare/image_classification/arkplus_fine_tuning/``) shows both.
+
+*****************************************
+config.json: job type and run settings
+*****************************************
+
+``config.json`` is required for every job type on both backends. On NVFLARE it carries the platform-recognised training settings **and** whatever your own code reads from it:
+
+.. code-block:: json
+
+   {
+     "job_type": "standard",
+     "GLOBAL_ROUNDS": 2,
+     "LOCAL_ROUNDS": 4,
+     "BEST_MODEL_METRIC": "VAL_DICE",
+     "BEST_MODEL_METRIC_MINIMIZE": false,
+     "LEARNING_RATE": 5e-5,
+     "VAL_SPLIT": 0.1,
+     "BATCH_SIZE": 3,
+     "VALIDATE_EVERY": 1,
+     "net_config": { "spatial_dims": 3 }
+   }
+
+- ``job_type`` selects the template that is bundled (``standard`` here; see *Job types* on :ref:`flip-fl-nets`).
+- ``GLOBAL_ROUNDS`` is read by the platform and written into the server workflow at submit time — it is the only way to set the round count of a platform run.
+- ``LOCAL_ROUNDS`` is **not** read by the platform: your trainer reads it (``config["LOCAL_ROUNDS"]``), so the value reaches your code verbatim.
+- ``BEST_MODEL_METRIC`` (optional) turns on best-global-model selection — see the next section.
+- Everything else (``LEARNING_RATE``, ``VAL_SPLIT``, ``net_config``, …) is an app convention: passed through untouched, neither validated nor defaulted.
+
+The full list of platform keys, their defaults and validation rules — including ``AGGREGATOR``, ``AGGREGATION_WEIGHTS``, ``AGGREGATE_ONLY_REGEX`` and ``SERVER_CHECKPOINT`` — is on :ref:`fl-training-configuration`.
+
+Best-model selection (optional)
+===============================
+
+When ``config.json`` names a ``BEST_MODEL_METRIC``, FLIP injects NVFLARE's stock ``IntimeModelSelector`` server-side and saves ``best_FL_global_model.pt`` next to the final model whenever the averaged metric improves. The trainer's part is to **evaluate the received global model before training mutates it** and report that metric on the returned ``FLModel``:
+
+.. code-block:: python
+
+   if flare.is_train():
+       model.load_state_dict(global_weights)
+
+       global_val_metrics = None
+       if config.get("BEST_MODEL_METRIC"):
+           g_loss, g_dice = validate(model, val_loader, ...)
+           global_val_metrics = {"VAL_LOSS": g_loss, "VAL_DICE": g_dice}
+
+       # ... local training ...
+
+       flare.send(
+           flare.FLModel(
+               params=diff,
+               params_type="DIFF",
+               metrics=global_val_metrics,  # metrics of the *received* global model
+               meta={"NUM_STEPS_CURRENT_ROUND": n_iterations},
+           )
+       )
+
+Selection skips round 0 (no aggregated model exists yet), so ``BEST_MODEL_METRIC`` requires ``GLOBAL_ROUNDS >= 2``; the platform rejects the upload otherwise. Set ``BEST_MODEL_METRIC_MINIMIZE`` to ``true`` for loss-like metrics. The final aggregated model is never re-evaluated for selection, so "best" means best among the intermediate global models.
+
+************************************
+Submitting the app to FLIP
+************************************
+
+Once your app runs locally (see the next section), upload the contents of ``app_files/`` through the FLIP UI's model page. FLIP validates the required files for the job type (``trainer.py``, ``models.py``, ``config.json`` for ``standard`` — see :ref:`fl-required-files` for the canonical list), bundles them with the template into each site's ``custom/`` directory, and then lets you click **Initiate Training**.
+
+At submit time, the FLIP FL API:
+
+- Writes the model UUID into ``meta.json`` (``custom_props.model_id``) and the server config. FLIP's server components resolve it lazily from there, which is why nothing in your files carries a model ID.
+- Writes ``project_id`` and ``query`` (the project's saved cohort query) as top-level keys of ``config_fed_client.json`` — the two values the trainer reads.
+- Sets ``min_clients`` to the participating-Trust count and ``num_rounds`` to ``config.json``'s ``GLOBAL_ROUNDS`` in the ``ScatterAndGather`` workflow, and applies ``AGGREGATOR`` / ``AGGREGATION_WEIGHTS`` / ``IGNORE_RESULT_ERROR``.
+- Injects the optional server- and client-side components that ``config.json`` asks for: the head-only filter chain for ``AGGREGATE_ONLY_REGEX`` and the model selector for ``BEST_MODEL_METRIC``.
+- Stages any ``SERVER_CHECKPOINT`` (or an evaluation job's ``models`` checkpoints) on the FL server only, keeping it out of the bundle shipped to the Trusts.
+- Submits the job to the net's FL server, which deploys it to every approved Trust's fl-client.
+
+.. _flare-local-testing:
+
+************************************
+Local testing before upload
+************************************
+
+The tutorials describe the job in Python with ``FlipFedAvgRecipe`` — the same class the platform's ``standard`` template is generated from — and run it through NVFLARE's ``Recipe.execute``. A minimal ``job.py``, abridged from ``fl-tutorials/nvflare/image_segmentation/3d_spleen_segmentation/job.py``:
+
+.. code-block:: python
+
+   import argparse
+   import json
+   import os
+   import sys
+   from pathlib import Path
+
+   _APP_FILES_DIR = Path(__file__).parent / "app_files"
+   sys.path.insert(0, str(_APP_FILES_DIR))  # so the recipe can resolve models.get_model
+
+   from flip.nvflare.recipes import FlipFedAvgRecipe  # noqa: E402
+   from nvflare import FedJob  # noqa: E402
+   from nvflare.recipe import SimEnv  # noqa: E402
+
+
+   def stage_app_files(job: FedJob) -> None:
+       """Bundle every file in app_files/ into the job's server + client custom/ dirs."""
+       for src in sorted(_APP_FILES_DIR.iterdir()):
+           if src.is_file():
+               job.add_file_to_server(str(src))
+               job.add_file_to_clients(str(src))
+
+
+   def main() -> None:
+       parser = argparse.ArgumentParser()
+       parser.add_argument("--n_clients", type=int, default=2)
+       parser.add_argument("--num_rounds", type=int, default=2)
+       parser.add_argument("--workspace", type=str, default="/tmp/nvflare/my-app")
+       args = parser.parse_args()  # --export / --export-dir are consumed by Recipe.execute
+
+       config = json.loads((_APP_FILES_DIR / "config.json").read_text())
+       recipe = FlipFedAvgRecipe(
+           num_rounds=args.num_rounds,
+           min_clients=args.n_clients,
+           train_script="trainer.py",
+           train_args="--project_id {project_id}",
+           project_id=os.environ.get("FLIP_PROJECT_ID", ""),
+           query=os.environ.get("FLIP_QUERY", "SELECT * FROM Table;"),
+           best_model_metric=config.get("BEST_MODEL_METRIC"),
+           best_model_metric_minimize=config.get("BEST_MODEL_METRIC_MINIMIZE", False),
+       )
+       stage_app_files(recipe.job)
+
+       env = SimEnv(num_clients=args.n_clients, num_threads=args.n_clients, workspace_root=args.workspace)
+       run = recipe.execute(env)
+       print(f"Job status: {run.get_status()}")
+
+
+   if __name__ == "__main__":
+       main()
+
+Two execution modes come from that one script:
+
+**Export (no GPU, no data).** Writes the complete NVFLARE job — ``meta.json``, ``app/config/``, and ``app/custom/`` with your files staged — under ``./fl_job/flip_fedavg/``, so you can inspect exactly what the platform will run:
+
+.. code-block:: bash
+
+   make export            # or, from the app directory:
+   uv run --project ../../../../flip-utils --extra full \
+       python job.py --export --export-dir ./fl_job --n_clients 2 --num_rounds 2
+
+**Simulation (GPU + data).** Runs the job under the NVFLARE simulator against local data. ``LOCAL_DEV`` mode (the ``flip-utils`` default outside the platform) makes ``get_dataframe`` read a CSV and ``get_by_accession_number`` read a directory, both named in the app's ``.env.app``:
+
+.. code-block:: text
+
+   JOB_TYPE=standard
+   DEV_IMAGES_DIR=../../../data/spleen/images
+   DEV_DATAFRAME=../../../data/spleen/dataframe.csv
+   FLIP_PROJECT_ID=dev   # any non-empty token; LOCAL_DEV ignores it
+   FLIP_QUERY=
+
+.. code-block:: bash
+
+   make build-fl                                          # once: builds the flare-fl-base image
+   make -C fl-tutorials download-spleen-data              # reference dataset into fl-tutorials/data/
+   make -C fl-tutorials run-tutorial TUTORIAL=3d_spleen_segmentation
+   # or, inside the app directory: make sim NUM_ROUNDS=10 N_CLIENTS=2
+
+Run ``job.py`` in the ``flip-utils`` environment with the ``full`` extra, as the tutorial Makefiles do — a bare ``uv run`` from the repo root resolves to a venv without ``torch``/``nvflare``/``monai``. The tutorial harness (``run-tutorial``) runs the simulator inside the locally built ``flare-fl-base`` image, so ``make build-fl`` is a genuine prerequisite.
+
+.. note::
+
+   ``--num_rounds`` and ``--n_clients`` are **local knobs only**. On the platform the round count comes from ``config.json``'s ``GLOBAL_ROUNDS`` and the client count from the Trusts you approved — the FL API overrides whatever the recipe baked in. Likewise ``FLIP_PROJECT_ID`` / ``FLIP_QUERY`` only seed the exported client config; the FL API overwrites both at submit.
+
+.. note::
+
+   The standalone NVFLARE stack under ``fl-services/nvflare`` has no HTTP submit path (its FL API is admin-API based), so unlike Flower there is no compose-stack submit for a single app: use the simulator, or the full platform path (upload through the FLIP UI, or ``make e2e_smoke``).
+
+See ``fl-tutorials/nvflare/image_segmentation/3d_spleen_segmentation/README.md`` for the full local-run instructions, including the data-enrichment (label upload) step needed before the segmentation tutorials can train on a real FLIP project.
+
+************************************
+Other job types
+************************************
+
+The walkthrough above is for ``standard`` (federated averaging). The other NVFLARE job types keep the same Client API shape and change only what the script must return:
+
+- ``fed_opt`` — identical client contract to ``standard`` (a ``DIFF`` per round); only the server-side optimiser differs. Upload the same three files.
+- ``evaluation`` — no training. Upload ``evaluator.py``, ``models.py`` and ``config.json``, and list the checkpoints to evaluate under ``config.json``'s ``models`` (each entry naming a ``checkpoint`` file you upload with the app). The script handles ``flare.is_evaluate()`` only, returning aggregate metrics with ``flare.send(flare.FLModel(metrics={...}))`` — never per-patient values. Reference: ``fl-tutorials/nvflare/image_evaluation/3d_spleen_segmentation_evaluation/``.
+- ``diffusion_model`` — two-stage latent-diffusion training; adds ``validator.py`` and per-phase ``GLOBAL_ROUNDS_AE`` / ``GLOBAL_ROUNDS_DM`` keys. Reference: ``fl-tutorials/nvflare/image_synthesis/latent_diffusion_model/``.
+
+The manifests on :ref:`fl-required-files` are the authoritative list of required files per job type.
+
+***************************
+Common pitfalls
+***************************
+
+- **Returning full weights.** ``flare.send(FLModel(params=..., params_type="FULL"))`` from the ``train`` branch is rejected by the aggregator. Return ``local - global`` with ``params_type="DIFF"``, and report ``meta["NUM_STEPS_CURRENT_ROUND"]``.
+- **Calling ``flip.send_metrics`` / ``flip.update_status`` from the trainer.** Trusts hold no Central Hub credentials. Publish metrics with ``SummaryWriter.add_scalar``; the lifecycle statuses are the server template's job.
+- **``models.py`` that cannot import on the server.** The persistor instantiates ``models.get_model()`` on the FL server with no data mounted. Keep ``models.py`` free of trainer imports and of anything that opens files other than ``config.json`` next to it.
+- **Reading ``config.json`` from the working directory.** On-platform the trainer's CWD is not ``custom/``. Resolve ``config.json`` (and ``config_fed_client.json``) relative to ``__file__``.
+- **Expecting ``GLOBAL_ROUNDS`` to reach your code.** It is consumed by the platform; ``LOCAL_ROUNDS`` is the one your trainer reads. A ``GLOBAL_ROUNDS`` value outside 1–1000 is silently discarded and the run defaults to a **single** round — check it if training finishes suspiciously early.
+- **``BEST_MODEL_METRIC`` with one round.** Selection skips round 0, so the platform rejects the combination; use ``GLOBAL_ROUNDS >= 2`` or drop the key.
+- **Missing ``ResourceType`` or labels.** If a Trust does not have the resource type you requested for a given accession, ``get_by_accession_number`` raises — skip the accession. If *no* accession yields a usable sample, raise with a message pointing at the data-enrichment step rather than letting the DataLoader fail on ``num_samples=0``.
+- **Uploading NVFLARE config files.** ``config_fed_server.json``, ``config_fed_client.json``, ``meta.json`` and ``job.py`` are not read on the platform; the template's copies are used. Only the files under ``app_files/`` matter.

--- a/docs/source/working-with-flip-apps/create-flip-app-from-flare.rst
+++ b/docs/source/working-with-flip-apps/create-flip-app-from-flare.rst
@@ -203,7 +203,7 @@ Once you have the cohort DataFrame, iterate its ``accession_id`` column and call
 
 .. note::
 
-   ``ResourceType`` is an enum in ``flip.constants``. The samples use ``ResourceType.NIFTI`` and ``ResourceType.SEGMENTATION``; you may pass either a single value or a list. The first call per (project, accession, resource type) downloads the study out of XNAT; later calls — including the same loop running in local development — return the cached local copy, so there is no need to build your own on-disk guards.
+   ``ResourceType`` is an enum in ``flip.constants``. The samples use ``ResourceType.NIFTI`` and ``ResourceType.SEGMENTATION``; you may pass either a single value or a list. On-platform, the first call per (project, accession, resource type) downloads the study out of XNAT and later calls return the cached local copy, so there is no need to build your own on-disk guards. In local development (``LOCAL_DEV``) nothing is downloaded: the call returns ``DEV_IMAGES_DIR/<accession_id>`` and, if that directory is missing, silently **creates an empty one** rather than raising — so the ``except`` branch above is only exercised on the platform, and a local run with a missing accession folder just yields no samples for it.
 
 The round loop
 ==============
@@ -299,7 +299,7 @@ Per-epoch, per-site metrics are published through NVFLARE's own tracking API —
 
 .. note::
 
-   **Arbitrary x-axis.** The tag grammar is ``<label>[@<x_label>]``: the part after ``@`` names the x-axis and ``global_step`` is the coordinate on it. With no ``@`` suffix the metric is plotted at its FL global round on an axis titled "Global Rounds" — pass ``global_step=0`` (or omit it) for a once-per-run value such as ``TEST_DICE``. A plot is identified by the ``(label, x_label)`` pair, so the same metric logged under two different x-labels is shown as two separate plots in the UI. This is the same grammar the Flower metric keys use; the ``.x_<V>`` suffix is not needed here because ``global_step`` carries the coordinate.
+   **Arbitrary x-axis.** The tag grammar is ``<label>[@<x_label>]``: the part after ``@`` names the x-axis and ``global_step`` is the coordinate on it. With no ``@`` suffix the axis is titled "Global Rounds"; the coordinate is still ``global_step`` when you pass one, and only an *omitted* ``global_step`` is backfilled server-side with the current FL global round. So for a once-per-run value such as ``TEST_DICE`` either omit ``global_step`` (plotted at the final round) or pass ``global_step=0`` (plotted at x=0) — pick one convention and keep it, or repeated runs will not line up. A plot is identified by the ``(label, x_label)`` pair, so the same metric logged under two different x-labels is shown as two separate plots in the UI. This is the same grammar the Flower metric keys use; the ``.x_<V>`` suffix is not needed here because ``global_step`` carries the coordinate.
 
 .. _flare-models-py:
 
@@ -373,7 +373,7 @@ config.json: job type and run settings
 
 - ``job_type`` selects the template that is bundled (``standard`` here; see *Job types* on :ref:`flip-fl-nets`).
 - ``GLOBAL_ROUNDS`` is read by the platform and written into the server workflow at submit time — it is the only way to set the round count of a platform run.
-- ``LOCAL_ROUNDS`` is **not** read by the platform: your trainer reads it (``config["LOCAL_ROUNDS"]``), so the value reaches your code verbatim.
+- ``LOCAL_ROUNDS`` is not used by the server workflow: your trainer reads it (``config["LOCAL_ROUNDS"]``). The FL API does touch it at submit, though — it writes ``LOCAL_ROUNDS: 1`` into your ``config.json`` when the key is absent (so a ``config.get("LOCAL_ROUNDS", 5)`` fallback in the trainer never fires), and it requires the only local-rounds key to be named exactly ``LOCAL_ROUNDS`` (a ``LOCAL_ROUNDS_<stage>`` key needs a matching ``GLOBAL_ROUNDS_<stage>``). A key that is present but out of the 1–1000 range is left as written and reaches your code verbatim.
 - ``BEST_MODEL_METRIC`` (optional) turns on best-global-model selection — see the next section.
 - Everything else (``LEARNING_RATE``, ``VAL_SPLIT``, ``net_config``, …) is an app convention: passed through untouched, neither validated nor defaulted.
 
@@ -405,7 +405,7 @@ When ``config.json`` names a ``BEST_MODEL_METRIC``, FLIP injects NVFLARE's stock
            )
        )
 
-Selection skips round 0 (no aggregated model exists yet), so ``BEST_MODEL_METRIC`` requires ``GLOBAL_ROUNDS >= 2``; the platform rejects the upload otherwise. Set ``BEST_MODEL_METRIC_MINIMIZE`` to ``true`` for loss-like metrics. The final aggregated model is never re-evaluated for selection, so "best" means best among the intermediate global models.
+Selection skips round 0 (no aggregated model exists yet), so ``BEST_MODEL_METRIC`` requires ``GLOBAL_ROUNDS >= 2``. The check runs at **Initiate Training**, not at file upload: every file uploads and scans green, and the job is then refused with a ``ValueError`` naming the two keys. Set ``BEST_MODEL_METRIC_MINIMIZE`` to ``true`` for loss-like metrics. The final aggregated model is never re-evaluated for selection, so "best" means best among the intermediate global models.
 
 ************************************
 Submitting the app to FLIP
@@ -504,12 +504,11 @@ Two execution modes come from that one script:
 
 .. code-block:: bash
 
-   make build-fl                                          # once: builds the flare-fl-base image
    make -C fl-tutorials download-spleen-data              # reference dataset into fl-tutorials/data/
    make -C fl-tutorials run-tutorial TUTORIAL=3d_spleen_segmentation
    # or, inside the app directory: make sim NUM_ROUNDS=10 N_CLIENTS=2
 
-Run ``job.py`` in the ``flip-utils`` environment with the ``full`` extra, as the tutorial Makefiles do — a bare ``uv run`` from the repo root resolves to a venv without ``torch``/``nvflare``/``monai``. The tutorial harness (``run-tutorial``) runs the simulator inside the locally built ``flare-fl-base`` image, so ``make build-fl`` is a genuine prerequisite.
+Run ``job.py`` in the ``flip-utils`` environment with the ``full`` extra, as the tutorial Makefiles do — a bare ``uv run`` from the repo root resolves to a venv without ``torch``/``nvflare``/``monai``. The tutorial harness (``run-tutorial``) is just ``make -C <tutorial> run`` → ``sim`` on the host — no container is involved, so ``make build-fl`` is **not** a prerequisite; what you need is ``uv sync --extra full`` in ``flip-utils`` and a GPU visible to that venv.
 
 .. note::
 
@@ -542,6 +541,6 @@ Common pitfalls
 - **``models.py`` that cannot import on the server.** The persistor instantiates ``models.get_model()`` on the FL server with no data mounted. Keep ``models.py`` free of trainer imports and of anything that opens files other than ``config.json`` next to it.
 - **Reading ``config.json`` from the working directory.** On-platform the trainer's CWD is not ``custom/``. Resolve ``config.json`` (and ``config_fed_client.json``) relative to ``__file__``.
 - **Expecting ``GLOBAL_ROUNDS`` to reach your code.** It is consumed by the platform; ``LOCAL_ROUNDS`` is the one your trainer reads. A ``GLOBAL_ROUNDS`` value outside 1–1000 is silently discarded and the run defaults to a **single** round — check it if training finishes suspiciously early.
-- **``BEST_MODEL_METRIC`` with one round.** Selection skips round 0, so the platform rejects the combination; use ``GLOBAL_ROUNDS >= 2`` or drop the key.
+- **``BEST_MODEL_METRIC`` with one round.** Selection skips round 0, so the platform refuses the job at Initiate Training (after the files have uploaded cleanly); use ``GLOBAL_ROUNDS >= 2`` or drop the key.
 - **Missing ``ResourceType`` or labels.** If a Trust does not have the resource type you requested for a given accession, ``get_by_accession_number`` raises — skip the accession. If *no* accession yields a usable sample, raise with a message pointing at the data-enrichment step rather than letting the DataLoader fail on ``num_samples=0``.
 - **Uploading NVFLARE config files.** ``config_fed_server.json``, ``config_fed_client.json``, ``meta.json`` and ``job.py`` are not read on the platform; the template's copies are used. Only the files under ``app_files/`` matter.

--- a/docs/source/working-with-flip-apps/create-flip-app-from-flower.rst
+++ b/docs/source/working-with-flip-apps/create-flip-app-from-flower.rst
@@ -6,18 +6,24 @@ Create a FLIP app from a Flower app
 
    This page assumes you are familiar with the :ref:`flip-fl-nets` component page and with the project / model lifecycle described in :doc:`/user-guides/user-common`. Before starting, you must already have: a FLIP account with the ``researcher`` role, an approved project with a saved cohort query, and a model created under that project (so you have a ``flip-model-id``).
 
-This page walks through the code changes required to adapt a stock Flower app (for example, one copied from the official `Flower quickstart examples <https://flower.ai/docs/examples.html>`_ or pulled from the internal FLIP app hub) so that it can run on FLIP. The walkthrough covers the four first-class SDK calls a FLIP-compatible app needs:
+.. note::
 
-- ``flip.update_status(...)`` to signal model lifecycle transitions to the central hub
-- ``flip.get_dataframe(...)`` to retrieve the project's cohort DataFrame
-- ``flip.get_by_accession_number(...)`` to pull imaging resources for each accession
-- ``flip.send_metrics(...)`` to push per-round training metrics back to the FLIP UI
+   This page is the Flower twin of :doc:`create-flip-app-from-flare` and follows the same
+   structure. If you change one page, check whether the other needs the same change.
+
+This page walks through the code changes required to adapt a stock Flower app (for example, one copied from the official `Flower quickstart examples <https://flower.ai/docs/examples.html>`_ or pulled from the internal FLIP app hub) so that it can run on FLIP. The walkthrough covers the FLIP touchpoints a FLIP-compatible app needs:
+
+- ``flip.update_status(...)`` in the ``ServerApp`` to signal model lifecycle transitions to the central hub
+- ``flip.get_dataframe(...)`` in the ``ClientApp`` to retrieve the project's cohort DataFrame
+- ``flip.get_by_accession_number(...)`` in the ``ClientApp`` to pull imaging resources for each accession
+- ``flip_local_dp_mod`` registered on the ``ClientApp``'s training handler to privatise the update before it leaves the Trust
+- the reply ``MetricRecord`` / ``ConfigRecord`` convention through which per-epoch metrics reach the FLIP UI
 
 A full, runnable reference is available in-tree:
 
-- ``fl-apps/flower/standard/app/`` — the platform-side base bundle: a minimal ``ServerApp`` and strategy scaffold. ``client_app.py`` and ``models.py`` are user-supplied (see ``fl-apps/flower/standard/required_files.json``).
-- ``fl-tutorials/flower/xray_classification/`` — a complete training example with both ``ServerApp`` and ``ClientApp``.
-- ``fl-tutorials/flower/3d_spleen_segmentation/`` — a MONAI spleen-segmentation example that exercises every SDK call covered below.
+- ``fl-apps/flower/standard/app/`` — the platform-side base bundle: the ``ServerApp`` and the ``FedAvgWithClientMetrics`` strategy. ``client_app.py`` and ``models.py`` are user-supplied (see ``fl-apps/flower/standard/required_files.json``).
+- ``fl-tutorials/flower/xray_classification/`` — a complete chest X-ray classification example with both ``ServerApp`` and ``ClientApp``.
+- ``fl-tutorials/flower/3d_spleen_segmentation/`` — a MONAI spleen-segmentation example that exercises every touchpoint covered below, including best-model selection.
 
 *****************
 Starting point
@@ -32,11 +38,13 @@ A Flower app that FLIP can run is just a standard Flower project with a ``pyproj
    │   ├── __init__.py
    │   ├── client_app.py
    │   ├── config.json
+   │   ├── config.toml
    │   ├── models.py
-   │   └── server_app.py
+   │   ├── server_app.py
+   │   └── strategy.py
    └── pyproject.toml
 
-``client_app.py``, ``config.json`` and ``models.py`` are the files you upload — see :ref:`fl-required-files`. ``server_app.py`` is shown here because you need it to run the app locally; on-platform it comes from the FLIP template and an uploaded copy is ignored.
+``client_app.py``, ``config.json`` and ``models.py`` are the files you upload — see :ref:`fl-required-files` — plus ``config.toml`` if you want to override the template's run configuration (see :ref:`flower-config-toml`). Any other file you upload alongside them (``data_loading.py``, ``transforms.py``, …) is bundled into the app too, so ``from app.transforms import ...`` imports work. ``server_app.py`` and ``strategy.py`` are shown here because you need them to run the app locally; on-platform they come from the FLIP template, and uploaded copies are dropped because their names collide with the template's.
 
 The ``pyproject.toml`` wires the two entry points together:
 
@@ -46,17 +54,21 @@ The ``pyproject.toml`` wires the two entry points together:
    serverapp = "app.server_app:app"
    clientapp = "app.client_app:app"
 
-If you are starting from scratch, ``fl-apps/flower/standard/`` provides the platform-side ``ServerApp`` scaffold with the minimum FLIP integration described below; for a complete worked example including a matching ``ClientApp``, see ``fl-tutorials/flower/xray_classification/`` or ``fl-tutorials/flower/3d_spleen_segmentation/``.
+If you are starting from scratch, ``fl-apps/flower/standard/`` provides the platform-side ``ServerApp`` and strategy with the FLIP integration described below; for a complete worked example including a matching ``ClientApp``, see ``fl-tutorials/flower/xray_classification/`` or ``fl-tutorials/flower/3d_spleen_segmentation/``.
 
 .. note::
 
-   The ``flip-utils`` package (published on PyPI, imported as ``flip``) ships inside every FLIP FL node image and is installed per run from that in-image source (see the dependency-resolution note under *Wiring it up via pyproject.toml* below). You only need to declare it as a dependency in your ``pyproject.toml`` for local development — you do not have to vendor it.
+   ``config.json`` carries only ``job_type`` for a Flower app (``{"job_type": "standard"}``). The hub reads that key and nothing else from it, to pick which base template to bundle. Run configuration goes in ``config.toml``, not here — unlike NVFLARE, where ``config.json`` carries the training settings.
+
+.. note::
+
+   The ``flip-utils`` package (imported as ``flip``) is baked into every FLIP FL node image at ``/opt/flip-utils``, and the base template's ``pyproject.toml`` pins it to that path. Do **not** declare ``flip-utils`` as a dependency in your own ``pyproject.toml``: Flower runtime-installs an app's declared dependencies into a per-run environment that it prepends to ``sys.path``, so a declared ``flip-utils`` resolves from PyPI — where the published release lags the in-repo package — and shadows the image's copy (FLIP#767). Left undeclared, ``import flip`` falls through to the image's copy, which is what the platform runs. See the *Wiring it up* section below for how dependencies resolve on-platform.
 
 *******************************************
 ServerApp: reporting model lifecycle status
 *******************************************
 
-On the server side, the FLIP integration is a single object (``FLIP``) injected into the ``@app.main()`` function plus four status transitions around ``strategy.start(...)``.
+On the server side, the FLIP integration is a single object (``FLIP``) injected into the ``@app.main()`` function plus four status transitions around ``strategy.start(...)``. On-platform this ``ServerApp`` is the template's (``fl-apps/flower/standard/app/server_app.py``), not yours — this section explains what it does, so that your local ``server_app.py`` behaves the same way and you know what the platform reports on your behalf.
 
 Imports
 =======
@@ -115,18 +127,20 @@ Wrap your training entry point with four ``update_status`` calls. These drive th
 
    flip.update_status(model_id, ModelStatus.RUNNING)            # the rounds start here
 
-   strategy.start(grid=grid, initial_arrays=arrays, num_rounds=num_rounds)
+   result = strategy.start(grid=grid, initial_arrays=arrays, num_rounds=num_rounds)
 
-   flip.update_status(model_id, ModelStatus.RESULTS_UPLOADED)   # after post-training finalisation
+   # ... save FL_global_model.pt and cross_val_results.json under output_dir ...
+   flip.upload_results_to_s3(output_dir, model_id)
+   flip.update_status(model_id, ModelStatus.RESULTS_UPLOADED)   # after the results zip is uploaded
 
 .. warning::
 
-   Forgetting the final ``ModelStatus.RESULTS_UPLOADED`` transition will leave the model indefinitely in the "running" state in the FLIP UI even though execution has ended.
+   Forgetting the final ``ModelStatus.RESULTS_UPLOADED`` transition will leave the model indefinitely in the "running" state in the FLIP UI even though execution has ended. Conversely, do not report ``RESULTS_UPLOADED`` before ``flip.upload_results_to_s3`` has succeeded — the template reports ``ERROR`` if the save or upload fails, so the researcher never sees a "finished" model with nothing to download.
 
 Full minimal example
 =====================
 
-Schematic, based on ``fl-apps/flower/standard/app/server_app.py`` — simplified to the lifecycle calls. See the template for the full version, including the ``min_clients`` wiring described under *Strategy considerations* below, which a real app must not omit:
+Schematic, based on ``fl-apps/flower/standard/app/server_app.py`` — simplified to the lifecycle calls. See the template for the full version, including the ``min_clients`` wiring described under *Strategy considerations* below (which a real app must not omit), the best-model bookkeeping and the results-file layout:
 
 .. code-block:: python
 
@@ -157,8 +171,10 @@ Schematic, based on ``fl-apps/flower/standard/app/server_app.py`` — simplified
 
        flip.update_status(flip_model_id, ModelStatus.RUNNING)
 
-       strategy.start(grid=grid, initial_arrays=arrays, num_rounds=num_rounds)
+       result = strategy.start(grid=grid, initial_arrays=arrays, num_rounds=num_rounds)
 
+       output_dir = save_results(result)  # FL_global_model.pt + cross_val_results.json
+       flip.upload_results_to_s3(output_dir, flip_model_id)
        flip.update_status(flip_model_id, ModelStatus.RESULTS_UPLOADED)
 
 ***********************
@@ -167,18 +183,16 @@ Strategy considerations
 
 Most stock Flower strategies (``FedAvg``, ``FedProx``, and the other built-ins) work unchanged on FLIP because the FLIP touchpoints live in the ``ServerApp`` callable, not in the strategy itself. You can pick any strategy the `flwr.serverapp.strategy <https://flower.ai/docs/framework/ref-api/flwr.serverapp.strategy.html>`_ module exposes.
 
-If you subclass a strategy to add custom aggregation or post-round hooks, the ``flip`` and ``model_id`` values bound inside ``main()`` are free to close over: pass them into the subclass constructor and call ``flip.update_status`` or ``flip.send_metrics`` from aggregation callbacks as needed.
+For a platform run, though, the strategy is the template's ``FedAvgWithClientMetrics``, a subclass of ``flip.flower.strategy.FlipFedAvg``. ``FlipFedAvg`` is what forwards each client's reply metrics and exceptions to the hub and emits the round-progress facts shown in the Live activity feed (see :ref:`flip-fl-nets`); a strategy built on stock ``FedAvg`` trains correctly but reports nothing. Base it on ``FlipFedAvg`` locally too, so what you see in the UI matches what the platform will do:
 
 .. code-block:: python
 
-   class MyStrategy(FedAvg):
-       def __init__(self, *args, flip: FLIP, model_id: str, **kwargs):
-           super().__init__(*args, **kwargs)
-           self._flip = flip
-           self._model_id = model_id
+   from flip.flower.strategy import FlipFedAvg
 
+
+   class MyStrategy(FlipFedAvg):
        def aggregate_train(self, server_round, replies):
-           result = super().aggregate_train(server_round, replies)
+           result = super().aggregate_train(server_round, replies)  # forwards metrics to the hub
            # push any custom server-side signals here
            return result
 
@@ -206,7 +220,7 @@ If you subclass a strategy to add custom aggregation or post-round hooks, the ``
 ClientApp: fetching the FLIP DataFrame
 ****************************************
 
-On the client side, the cohort DataFrame is fetched once at the start of each training round via ``flip.get_dataframe``. The call runs against the project's saved cohort query (see :ref:`create-cohort-query`) and returns a pandas ``DataFrame`` containing at minimum an ``accession_id`` column plus whatever other columns the SQL ``SELECT`` projected.
+On the client side, the cohort DataFrame is fetched once at the start of each training round via ``flip.get_dataframe``. The call runs against the project's saved cohort query (see :ref:`create-cohort-query`) and returns a pandas ``DataFrame`` containing at minimum an ``accession_id`` column plus whatever other columns the SQL ``SELECT`` projected — the X-ray tutorial's ``query.sql`` projects the OMOP labels this way.
 
 Minimal in-line version
 ========================
@@ -224,11 +238,9 @@ Minimal in-line version
 Wrapper pattern (from the MONAI tutorial)
 ==========================================
 
-The MONAI tutorial bundles the FLIP client with cohort metadata into a small helper class. This makes it easier to thread data-loading state through the ``@app.train()`` callable:
+The MONAI tutorial bundles the FLIP client with cohort metadata into a small helper class (``app/data_loading.py``). This makes it easier to thread data-loading state through the ``@app.train()`` callable:
 
 .. code-block:: python
-
-   import logging
 
    from flip import FLIP
 
@@ -239,8 +251,6 @@ The MONAI tutorial bundles the FLIP client with cohort metadata into a small hel
            self.query = ""
            self.dataframe = None
            self.flip = FLIP()
-           self.logger = logging.getLogger(self.__class__.__name__)
-           self.logger.setLevel(logging.INFO)
 
 Then inside the ``ClientApp``:
 
@@ -262,7 +272,7 @@ Then inside the ``ClientApp``:
 ClientApp: fetching images by accession
 *******************************************
 
-Once you have the cohort DataFrame, iterate its ``accession_id`` column and call ``flip.get_by_accession_number`` to pull the imaging resources for each study. The call returns a ``pathlib.Path`` pointing at a local directory containing files named ``input_*.nii.gz`` (and, if you also requested ``ResourceType.SEGMENTATION``, ``label_*.nii.gz``).
+Once you have the cohort DataFrame, iterate its ``accession_id`` column and call ``flip.get_by_accession_number`` to pull the imaging resources for each study. The call returns a ``pathlib.Path`` pointing at a local directory containing files named ``input_*.nii.gz`` (and, if you also requested ``ResourceType.SEGMENTATION``, or the labels were uploaded during data enrichment, ``label_*.nii.gz``).
 
 .. code-block:: python
 
@@ -289,74 +299,117 @@ Once you have the cohort DataFrame, iterate its ``accession_id`` column and call
 
 .. warning::
 
-   Always wrap ``get_by_accession_number`` in a ``try / except`` loop and ``continue`` on failure. A single trust may be missing a resource type for a specific accession (for example, a study with imaging but no segmentation), and you should not abort the whole round on one bad accession.
+   Always wrap ``get_by_accession_number`` in a ``try / except`` loop and ``continue`` on failure. A single trust may be missing a resource type for a specific accession (for example, a study with imaging but no segmentation), and you should not abort the whole round on one bad accession. Do fail loudly if the loop ends with an **empty** datalist, though: an app that lets the DataLoader raise on ``num_samples=0`` produces an error that reads like an app bug, when the usual cause is that the data-enrichment (label upload) step was skipped.
 
 .. note::
 
-   ``ResourceType`` is an enum in ``flip.constants``. The samples use ``ResourceType.NIFTI`` and ``ResourceType.SEGMENTATION``; you may pass either a single value or a list.
+   ``ResourceType`` is an enum in ``flip.constants``. The samples use ``ResourceType.NIFTI`` and ``ResourceType.SEGMENTATION``; you may pass either a single value or a list. The first call per (project, accession, resource type) downloads the study out of XNAT; later calls — such as the same loop running again on the next round — return the cached local copy, so there is no need to build your own on-disk guards.
 
 ***************************************************
-ClientApp: sending per-round metrics to the hub
+ClientApp: privatising the update before it leaves
 ***************************************************
 
-Per-round, per-client metrics are pushed to the central hub with ``flip.send_metrics``. This is what populates the graphs on the model page (see the "Metrics" section of :doc:`/user-guides/user-common`). This push is independent of any ``MetricRecord`` you return inside the Flower ``Message`` — the ``MetricRecord`` is for in-network aggregation by the strategy, while ``send_metrics`` is for FLIP UI surfacing.
+FLIP's NVFLARE templates apply a privacy filter to every training result inside the platform-owned client config, so the app author does nothing. On Flower the ``ClientApp`` is the uploaded file, so the template cannot wire the filter — the uploaded ``client_app.py`` is expected to register FLIP's differential-privacy mod on its training handler:
+
+.. code-block:: python
+
+   from flip.flower.privacy import flip_local_dp_mod
+   from flwr.clientapp import ClientApp
+
+   app = ClientApp()
+
+
+   @app.train(mods=[flip_local_dp_mod])   # training only — leave @app.evaluate alone
+   def train(msg: Message, context: Context) -> Message:
+       ...
+
+The mod clips the local update to ``dp-clipping-norm`` and adds Gaussian noise calibrated to (``dp-epsilon``, ``dp-delta``) on the SuperNode, so the FL server only ever receives a privatised update; it is toggled by ``dp-enabled``. All four keys are declared in the template's ``[tool.flwr.app.config]``, so they can be overridden per run from ``config.toml``. Integer buffers (BatchNorm's ``num_batches_tracked`` counters) pass through untouched. See *Privacy filters on shared model updates* on :ref:`flip-fl-nets` for the mechanism and its caveats.
+
+.. warning::
+
+   This is a convention checked by code review before upload, not enforced by the platform: a ``client_app.py`` that omits the mod trains and aggregates perfectly happily while sharing raw model updates. Register it.
+
+***************************************************
+ClientApp: sending per-epoch metrics to the hub
+***************************************************
+
+Per-round, per-client metrics reach the FLIP UI through the reply ``Message``: put them in a ``MetricRecord`` under ``"metrics"``, and put the client's site name in a ``ConfigRecord`` under ``"config"``. The server-side ``FlipFedAvg`` strategy forwards every numeric metric to the Central Hub with ``flip.send_metrics`` on the client's behalf (``flip.flower.metrics.handle_client_metrics``). This is what populates the graphs on the model page (see the "Metrics" section of :doc:`/user-guides/user-common`).
 
 .. code-block:: python
 
    import os
 
+   from flwr.app import ArrayRecord, ConfigRecord, Message, MetricRecord, RecordDict
+
    client_name = os.getenv("SUPERNODE_NAME", "unknown_client")
-   model_id = run_config.get("flip-model-id")
 
    # global_round from server is 1-based; convert to 0-based for local epoch arithmetic
    global_round = int(msg.content["config"]["server-round"]) - 1
 
+   per_epoch_metrics = {}
    for epoch in range(local_epochs):
        train_loss = train_func(...)
        val_dice, val_loss = validate_func(...)
 
-       # Per-epoch points are plotted on an "epoch" axis at the cumulative epoch count; the FL
-       # global round is always recorded alongside as provenance (never overridden).
+       # "@epoch" names the x-axis and ".x_<N>" is the coordinate (the cumulative epoch count),
+       # so the server forwards one point per epoch. The FL global round is recorded alongside
+       # as provenance.
        cumulative_epoch = global_round * local_epochs + epoch + 1
-       flip_utils.flip.send_metrics(client_name, model_id, label="TRAIN_LOSS", value=train_loss,
-                                    global_round=global_round, x_value=cumulative_epoch, x_label="epoch")
-       flip_utils.flip.send_metrics(client_name, model_id, label="VAL_LOSS", value=val_loss,
-                                    global_round=global_round, x_value=cumulative_epoch, x_label="epoch")
-       flip_utils.flip.send_metrics(client_name, model_id, label="VAL_DICE", value=val_dice,
-                                    global_round=global_round, x_value=cumulative_epoch, x_label="epoch")
+       per_epoch_metrics[f"train_loss@epoch.x_{cumulative_epoch}"] = float(train_loss)
+       per_epoch_metrics[f"val_loss@epoch.x_{cumulative_epoch}"] = float(val_loss)
+       per_epoch_metrics[f"val_dice@epoch.x_{cumulative_epoch}"] = float(val_dice)
+
+   metrics = {
+       "train_loss": avg_train_loss,          # per-round summary, plotted at the global round
+       "val_loss": avg_val_loss,
+       "val_dice": avg_val_dice,
+       "num-examples": len(train_loader.dataset),  # bookkeeping — read by the strategy, not forwarded
+       **per_epoch_metrics,
+   }
+   content = RecordDict({
+       "arrays": ArrayRecord(model.state_dict()),
+       "metrics": MetricRecord(metrics),
+       "config": ConfigRecord({"site": client_name}),
+   })
+   return Message(content=content, reply_to=msg)
 
 .. warning::
 
-   ``SUPERNODE_NAME`` is the trust's **FL kit slot** (e.g. ``Trust_1``, ``Trust_2``) — the same slot name flip-api assigns to that trust in the FLKitSlot table — and **not** the trust's display name. The hub resolves the slot back to the owning trust when saving metrics (see ``resolve_trust_from_fl_client_name`` in ``flip_api.model_services``); a slot that matches no assignment is recorded against ``unknown_client`` and will not be attributable to the site in the FLIP UI. FLIP-provisioned SuperNode compose files set ``SUPERNODE_NAME=${FL_KIT_SLOT}`` for you; if you are running a SuperNode locally you must export the slot yourself.
+   Do **not** call ``flip.send_metrics`` (or ``flip.update_status``) from the ``ClientApp``. SuperNodes deliberately do not hold the credentials needed to reach the Central Hub — only the SuperLink does — so a direct call fails on-platform. The reply ``MetricRecord`` is the supported path.
+
+.. warning::
+
+   ``SUPERNODE_NAME`` is the trust's **FL kit slot** (e.g. ``Trust_1``, ``Trust_2``) — the same slot name flip-api assigns to that trust in the FLKitSlot table — and **not** the trust's display name. The hub resolves the slot back to the owning trust when saving metrics (see ``resolve_trust_from_fl_client_name`` in ``flip_api.model_services``); a ``site`` value that matches no assignment is recorded against ``unknown_client`` and will not be attributable to the site in the FLIP UI. A reply with no ``site`` at all is dropped by the forwarder. FLIP-provisioned SuperNode compose files set ``SUPERNODE_NAME=${FL_KIT_SLOT}`` for you; if you are running a SuperNode locally you must export the slot yourself.
 
 .. note::
 
-   Use stable, upper-case ``label`` strings (``TRAIN_LOSS``, ``VAL_LOSS``, ``VAL_DICE`` are the conventions used in the MONAI tutorial) so that metrics from repeated runs line up on the same chart in the UI.
+   Metric labels are upper-cased by the forwarder (``train_loss`` → ``TRAIN_LOSS``), so the tutorials write them in lower case in the reply. Keep the names stable so that metrics from repeated runs line up on the same chart in the UI.
 
 .. note::
 
-   **Arbitrary x-axis.** By default a metric is plotted at its FL global round, on an x-axis titled "Global Rounds". To plot it elsewhere, pass a coordinate pair to ``flip.send_metrics``: ``x_value`` (any float, e.g. a cumulative epoch count) and ``x_label`` (the axis name, e.g. ``"epoch"``). The ``global_round`` argument is provenance — always the true FL round, never the plot coordinate. If instead you let the server-side ``handle_client_metrics`` helper forward metrics from the reply ``MetricRecord``, encode the coordinate in the metric key as ``<label>[@<x_label>][.x_<V>]`` (e.g. ``"train_loss@epoch.x_5"`` or ``"loss@wall_clock_s.x_12.5"``; the older ``.round_<N>`` suffix still parses but is deprecated). A plot is identified by the ``(label, x_label)`` pair, so the same metric logged under two different x-labels is shown as two separate plots in the UI.
+   **Arbitrary x-axis.** The key grammar is ``<label>[@<x_label>][.x_<V>]``: ``@<x_label>`` names the x-axis (e.g. ``epoch``) and ``.x_<V>`` is the coordinate on it (any float, e.g. ``"loss@wall_clock_s.x_12.5"``). A key with neither suffix is plotted at its FL global round on an axis titled "Global Rounds". The older ``.round_<N>`` suffix still parses but is deprecated. A plot is identified by the ``(label, x_label)`` pair, so the same metric logged under two different x-labels is shown as two separate plots in the UI. This is the same grammar the NVFLARE ``SummaryWriter`` tags use, minus the ``.x_<V>`` part, which there is carried by ``global_step``.
 
-************************************
-Wiring it up via ``pyproject.toml``
-************************************
+.. _flower-config-toml:
 
-The ``pyproject.toml`` of a FLIP-compatible Flower app needs three things beyond a normal Flower project:
+****************************************************
+Wiring it up: ``pyproject.toml`` and ``config.toml``
+****************************************************
 
-1. ``flip-utils`` declared as a dependency.
-2. A ``[tool.flwr.app.config]`` block declaring the FLIP run-config keys, even if the values are placeholders.
-3. Training hyperparameters (``num-server-rounds``, ``local-epochs``, etc.) declared in the same block so you can override them via ``flwr run . --run-config "key=value"`` locally.
+Two files carry a FLIP-compatible Flower app's configuration, and they play different roles locally and on-platform.
 
-Abridged from ``fl-tutorials/flower/3d_spleen_segmentation/pyproject.toml``:
+``pyproject.toml`` — local development
+======================================
+
+Your own ``pyproject.toml`` drives local runs. Beyond a normal Flower project it needs a ``[tool.flwr.app.config]`` block declaring the FLIP run-config keys, even if the values are placeholders, plus the training hyperparameters (``num-server-rounds``, ``local-epochs``, etc.) so you can override them locally. Abridged from ``fl-tutorials/flower/3d_spleen_segmentation/pyproject.toml``:
 
 .. code-block:: toml
 
    [project]
-   name = "quickstart-monai"
+   name = "standard-app"
    version = "1.0.0"
    dependencies = [
-       "flip-utils>=0.1.8",
-       "flwr[simulation]>=1.26.1",
+       # flip-utils is deliberately NOT declared — see the note under "Starting point"
+       "flwr[simulation]>=1.36.0",
        # ... your model-framework deps (monai, torch, nibabel, ...)
    ]
 
@@ -368,21 +421,30 @@ Abridged from ``fl-tutorials/flower/3d_spleen_segmentation/pyproject.toml``:
    clientapp = "app.client_app:app"
 
    [tool.flwr.app.config]
-   num-server-rounds = 3
-   local-epochs = 1
+   num-server-rounds = 3   # equivalent to NVFLARE's GLOBAL_ROUNDS
+   local-epochs = 1        # equivalent to NVFLARE's LOCAL_ROUNDS
    learning-rate = 1e-4
    batch-size = 2
+   # Client-side DP knobs read by flip_local_dp_mod
+   dp-enabled = true
+   dp-clipping-norm = 1.0
+   dp-sensitivity = 1e-4
+   dp-epsilon = 10.0
+   dp-delta = 1e-5
    # FLIP-injected keys — declare placeholders so FLIP can override at submit time
    flip-model-id = "uuid"
    flip-project-id = "uuid"
    flip-cohort-query = "*"
+   flip-job-dir = "job-dir"
    flip-min-clients = 2  # placeholder matching flwr's default; FLIP injects the trust count
+   # Best-model selection (opt-in) — see below
+   best-model-metric = ""
+   best-model-metric-minimize = false
 
 .. note::
 
-   **How dependencies resolve on-platform.** Your own ``pyproject.toml`` drives *local* development
-   (``pip install -e .`` / ``flwr run .``). When you upload the app to FLIP, the platform bundles your
-   model files into its own base template (``fl-apps/flower/<job_type>/``), whose ``pyproject.toml``
+   **How dependencies resolve on-platform.** When you upload the app to FLIP, the platform bundles your
+   files into its own base template (``fl-apps/flower/<job_type>/``), whose ``pyproject.toml``
    governs the run — uploaded files cannot override it. At run time, Flower's runtime dependency
    installer resolves that template's dependencies fresh for every run (``uv sync`` into an isolated
    per-run environment) on the SuperLink (``ServerApp``) and on each SuperNode (``ClientApp``), with two
@@ -397,16 +459,36 @@ Abridged from ``fl-tutorials/flower/3d_spleen_segmentation/pyproject.toml``:
    and ``download.pytorch.org``. If your app needs a dependency the base template does not declare,
    ask the platform operators to add it to the template.
 
+``config.toml`` — run configuration on the platform
+====================================================
+
+Because the template's ``pyproject.toml`` governs a platform run, the way to set rounds, epochs, learning rate or the DP knobs for a platform run is a ``config.toml`` uploaded next to your code. The FL API merges it into the ``--run-config`` file it passes to ``flwr run`` at submission, so every top-level key in it overrides the template's ``[tool.flwr.app.config]``. From ``fl-tutorials/flower/3d_spleen_segmentation/app/config.toml``:
+
+.. code-block:: toml
+
+   num-server-rounds = 30
+   local-epochs = 5
+   learning-rate = 5e-5
+   best-model-metric = "test_dice"
+   best-model-metric-minimize = false
+
+``config.toml`` can only override keys the template's ``pyproject.toml`` already declares — Flower rejects a ``--run-config`` override for an undeclared key — so it cannot introduce new ones. An app uploaded without a ``config.toml`` runs with the template's defaults (three rounds, one local epoch). For local ``flwr run`` the same keys live in your own ``[tool.flwr.app.config]`` instead.
+
+Best-model selection (optional)
+===============================
+
+Set ``best-model-metric`` in ``config.toml`` to the name of an aggregated **evaluation** metric the clients report (``test_dice`` in the spleen tutorial) and the template saves ``best_FL_global_model.pt`` alongside the final model whenever that metric improves, recording ``best_model`` / ``best_round`` / ``best_metric`` in ``cross_val_results.json``. Set ``best-model-metric-minimize = true`` for loss-like metrics. Two consequences: the evaluate phase runs **every** round instead of only the last (one test-split inference pass per client per round), and the key must be one the clients actually emit — name a key nobody reports and the run completes with no best model, logging a warning per round rather than failing. Selection needs at least two rounds. This is the Flower analogue of NVFLARE's ``BEST_MODEL_METRIC`` in ``config.json``.
+
 ************************************
 Submitting the app to FLIP
 ************************************
 
-Once your app runs locally (see the next section), upload it through the FLIP UI's model page the same way you would upload a FLARE app. FLIP validates the required files for a Flower app (which differ from those required for a FLARE app, and depend on the job type — see :ref:`fl-required-files` for the canonical list) and then lets you click **Initiate Training**.
+Once your app runs locally (see the next section), upload it through the FLIP UI's model page the same way you would upload a FLARE app. FLIP validates the required files for a Flower app (which differ from those required for a FLARE app, and depend on the job type — see :ref:`fl-required-files` for the canonical list), bundles them with the job type's template, and then lets you click **Initiate Training**.
 
 At submit time, the FLIP FL API:
 
-- Injects ``flip-model-id``, ``flip-project-id``, ``flip-cohort-query`` and ``flip-min-clients``
-  (the participating-trust count) into your app's run config.
+- Injects ``flip-model-id``, ``flip-project-id``, ``flip-cohort-query``, ``flip-min-clients``
+  (the participating-trust count) and ``flip-job-dir`` (the app directory, which the ``evaluation`` ServerApp uses to find the uploaded checkpoint) into the run config, on top of whatever your ``config.toml`` sets.
 - Sets ``SUPERNODE_NAME`` on each participating trust's SuperNode container to the trust's assigned FL kit slot (e.g. ``Trust_1``).
 - Starts the ``ServerApp`` on the Central Hub's SuperLink and the ``ClientApp`` on each approved trust's SuperNode.
 
@@ -414,28 +496,37 @@ At submit time, the FLIP FL API:
 Local testing before upload
 ************************************
 
-From inside your app's root directory:
+The supported way to run a Flower app locally is the standalone compose stack under ``fl-services/flower`` — a SuperLink, two SuperNodes and an FL API, with the tutorial's dev data bind-mounted. ``LOCAL_DEV`` mode (the ``flip-utils`` default outside the platform) makes ``get_dataframe`` read a CSV and ``get_by_accession_number`` read a directory, named by ``DEV_DATAFRAME`` and ``DEV_IMAGES_DIR``, which the stack bind-mounts into every container at fixed paths so relative paths in tutorial code resolve the same way everywhere.
 
 .. code-block:: bash
 
-   pip install -e .
-   flwr run .
+   make -C fl-tutorials download-spleen-data FL_BACKEND=flower   # reference dataset into fl-tutorials/data/
+   make -C fl-tutorials run-tutorial TUTORIAL=3d_spleen_segmentation FL_BACKEND=flower
 
-The MONAI tutorial also supports offline smoke-tests by pointing the FLIP helpers at a local CSV + NIfTI directory via the ``DEV_DATAFRAME`` and ``DEV_IMAGES_DIR`` environment variables:
+The harness brings the stack up, submits the app to the FL API exactly as the platform does, waits for the run and tears the stack down. To iterate by hand instead:
 
 .. code-block:: bash
 
-   DEV_DATAFRAME="../../data/spleen/sample_get_dataframe_response.csv" \
-   DEV_IMAGES_DIR="../../data/spleen/accession-resources" \
-   flwr run .
+   cd fl-services/flower
+   make build                                 # fl-base / superlink / supernode images
+   make up                                    # fl-api, superlink, supernode-1, supernode-2
+   make submit APP=3d_spleen_segmentation     # POSTs to the fl-api inside the container
 
-See ``fl-tutorials/flower/3d_spleen_segmentation/README.md`` for the full local-run instructions.
+.. warning::
+
+   Do **not** test with ``flwr run`` / the Simulation Engine. It is technically possible but brittle for reasons specific to this project: the long-lived ``flower-superlink`` caches its environment (so changing ``DEV_DATAFRAME`` between runs has no effect until you kill it), ``flwr run`` executes the ``ClientApp`` from a snapshot under ``~/.flwr/apps/`` so relative data paths break, and FLIP's settings singleton is pinned at import time so mid-run path overrides are ignored. The compose stack has none of these problems. ``fl-tutorials/flower/3d_spleen_segmentation/README.md`` spells out the workarounds if you must experiment with it anyway.
+
+See the tutorial README for the full local-run instructions, including the data-enrichment (label upload) step needed before the segmentation tutorials can train on a real FLIP project.
 
 ***************************
 Common pitfalls
 ***************************
 
-- **Missing ``RESULTS_UPLOADED``.** Forgetting the final ``flip.update_status(model_id, ModelStatus.RESULTS_UPLOADED)`` call leaves the model stuck on "training" in the UI.
-- **Wrong ``SUPERNODE_NAME``.** ``SUPERNODE_NAME`` must be the trust's **FL kit slot** (``Trust_1``, ``Trust_2``, ...), not the trust display name — metrics pushed with any other value land under ``unknown_client`` and will not appear on the per-site chart.
-- **Undeclared run-config keys.** ``flwr run`` (and therefore FLIP's FL API) can only override keys already declared in ``[tool.flwr.app.config]``. Declaring ``flip-model-id``, ``flip-project-id``, ``flip-cohort-query`` and ``flip-min-clients`` with placeholder values is mandatory even though the real values are injected by FLIP. This matters in two places: your own ``pyproject.toml``, so a local ``flwr run .`` works; and — for the on-platform run — the base template's ``pyproject.toml`` under ``fl-apps/flower/<job_type>/``, which is the config FLIP's overrides are validated against, since an uploaded ``pyproject.toml`` does not become the app's project file.
+- **Missing ``RESULTS_UPLOADED``.** Forgetting the final ``flip.update_status(model_id, ModelStatus.RESULTS_UPLOADED)`` call in a local ``ServerApp`` leaves the model stuck on "running" in the UI.
+- **Calling ``flip.send_metrics`` / ``flip.update_status`` from the ``ClientApp``.** SuperNodes hold no Central Hub credentials. Put metrics in the reply ``MetricRecord`` with the site in the ``ConfigRecord``; the server forwards them.
+- **Wrong or missing ``site``.** ``SUPERNODE_NAME`` must be the trust's **FL kit slot** (``Trust_1``, ``Trust_2``, ...), not the trust display name — metrics forwarded with any other value land under ``unknown_client`` and will not appear on the per-site chart; a reply with no ``site`` is dropped.
+- **No DP mod.** A ``client_app.py`` without ``@app.train(mods=[flip_local_dp_mod])`` shares raw model updates. The platform does not enforce it.
+- **Run configuration in the wrong file.** ``config.json`` carries only ``job_type`` on Flower; rounds, epochs and hyperparameters for a platform run go in ``config.toml``. An app uploaded without one runs three rounds of one epoch, whatever your own ``pyproject.toml`` says.
+- **Declaring ``flip-utils`` as a dependency.** It resolves from PyPI and shadows the image's copy (FLIP#767). Leave it undeclared; the template pins it to ``/opt/flip-utils`` on-platform.
+- **Undeclared run-config keys.** ``flwr run`` (and therefore FLIP's FL API) can only override keys already declared in ``[tool.flwr.app.config]``. Declaring ``flip-model-id``, ``flip-project-id``, ``flip-cohort-query``, ``flip-job-dir`` and ``flip-min-clients`` with placeholder values is mandatory even though the real values are injected by FLIP. This matters in two places: your own ``pyproject.toml``, so a local run works; and — for the on-platform run — the base template's ``pyproject.toml`` under ``fl-apps/flower/<job_type>/``, which is the config FLIP's overrides and your ``config.toml`` are validated against, since an uploaded ``pyproject.toml`` does not become the app's project file.
 - **Missing ``ResourceType``.** If a trust does not have the resource type you requested for a given accession, ``get_by_accession_number`` will raise. Always wrap the call in ``try / except`` and skip the accession on failure so a single bad study does not abort the whole round.


### PR DESCRIPTION
# Description

Replaces the placeholder `docs/source/working-with-flip-apps/create-flip-app-from-flare.rst` with the NVIDIA FLARE walkthrough, written against `fl-apps/nvflare/standard`, `FlipFedAvgRecipe`, the spleen / X-ray Client API tutorials and the fl-api submit path. It mirrors the Flower page section for section and opens with a Flower-vs-FLARE comparison table; the main contrasts it draws are: no `update_status` (the server side is FLIP's), metrics via `SummaryWriter.add_scalar` → `FlipAnalyticsBridge`, return a `DIFF` not `FULL`, `models.py` also runs on the server, `job.py` / `make export` / `make sim` for local runs. Also covers `config.json` platform keys, best-model selection, `SERVER_CHECKPOINT`, and the other job types.

Reviewing the Flower page for parity turned up four claims that contradict the current tutorials, now fixed:

1. **Metrics** — told users to call `flip.send_metrics` from the `ClientApp`. SuperNodes hold no hub credentials; the tutorials put metrics in the reply `MetricRecord` + `site` in a `ConfigRecord`, forwarded server-side by `FlipFedAvg`.
2. **`flip-utils` dependency** — told users to declare `flip-utils>=0.1.8`; the tutorial `pyproject.toml` deliberately doesn't (FLIP#767).
3. **Local testing** — `pip install -e . && flwr run .`; the tutorial README says not to and why. Replaced with the compose-stack / `run-tutorial FL_BACKEND=flower` path.
4. **`config.toml` absent** — no way to set rounds/LR on a platform run from the page. Added, and noted `config.json` carries only `job_type` on Flower.

Plus: `flip_local_dp_mod` section (code-review convention, not platform-enforced), best-model selection, `flip-job-dir` injection, `flwr>=1.36.0`, `upload_results_to_s3` before `RESULTS_UPLOADED`.

`docs/CLAUDE.md` (+ `AGENTS.md` mirror) gains a "Paired pages" note so a change to one page prompts a check of the other; each page carries a top note pointing at its twin.

Two statements on the FLARE page are restated rather than re-verified in code, worth a reviewer's eye: the "`GLOBAL_ROUNDS` outside 1–1000 silently defaults to one round" pitfall (from the FL-nets page), and "the trainer's CWD is not `custom/`" (from NVFLARE workspace behaviour). If #1146 (NVFLARE local (ε, δ) DP filter) lands first, the FLARE page's *Privacy filter* bullet and the comparison-table row need updating.

## Linked Issues

Closes #462

## Checklist

- [x] Follows the project's coding conventions and style guide
- [x] Updates documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Type of Change

- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] In-line docstrings updated.
- [x] Documentation updated, tested `make -C docs/ docs`.

## Testing

I did the following tests to verify my changes:

- [x] `FLIP_DOCS_SKIP_DIAGRAMS=1 make -C docs/ docs` builds with no warnings on the two pages (all `:ref:` / `:doc:` targets resolve).
- [ ] Quick tests passed locally by running `make unit-test` (docs-only change).
- [ ] Integration tests pass (if applicable) by running `make integration-test` (n/a).

## Additional Notes

Docs-only. The `AGENTS.md` twin was regenerated from `CLAUDE.md` with the repo's `sed` rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017hpL7q8hEh4Wvqqh98BtUg

---
_Generated by [Claude Code](https://claude.ai/code/session_017hpL7q8hEh4Wvqqh98BtUg)_